### PR TITLE
fix: preserve full sync requests during active runs

### DIFF
--- a/context/retries-and-backoffs.md
+++ b/context/retries-and-backoffs.md
@@ -71,8 +71,9 @@ migrate ticker-driven sync or refresh loops into `backoff/v5`
 - Provider-index sync keeps at most one coalesced follow-up, atomically transfers
   its single-flight slot, and preserves nil-versus-empty scope; bursts neither
   drop accepted work nor create an unbounded queue. Scoped user bypasses stay
-  bound to stable repository identity when coalesced with full work.
-  (`internal/github/sync.go::runOnceWithSlot`)
+  bound to stable repository identity when coalesced with full work. Ad-hoc
+  triggers return only after admission; provider execution stays asynchronous.
+  (`internal/github/sync.go::triggerRunWithCadence`)
 
 Repository-disabled issue and merge-request scopes use a 24-hour in-memory
 background probe gate. Expiry admits one reserved background probe across all

--- a/context/retries-and-backoffs.md
+++ b/context/retries-and-backoffs.md
@@ -70,7 +70,9 @@ migrate ticker-driven sync or refresh loops into `backoff/v5`
 
 - Provider-index sync keeps at most one coalesced follow-up, atomically transfers
   its single-flight slot, and preserves nil-versus-empty scope; bursts neither
-  drop accepted work nor create an unbounded queue. (`internal/github/sync.go::runOnceWithSlot`)
+  drop accepted work nor create an unbounded queue. Scoped user bypasses stay
+  bound to stable repository identity when coalesced with full work.
+  (`internal/github/sync.go::runOnceWithSlot`)
 
 Repository-disabled issue and merge-request scopes use a 24-hour in-memory
 background probe gate. Expiry admits one reserved background probe across all

--- a/context/retries-and-backoffs.md
+++ b/context/retries-and-backoffs.md
@@ -74,6 +74,9 @@ migrate ticker-driven sync or refresh loops into `backoff/v5`
   bound to stable repository identity when coalesced with full work. Ad-hoc
   triggers return only after admission; provider execution stays asynchronous.
   (`internal/github/sync.go::triggerRunWithCadence`)
+- Public sync status stays running across retained follow-up handoffs and becomes
+  terminal only when the single-flight slot is released.
+  (`internal/github/sync.go::runOnceWithSlot`)
 
 Repository-disabled issue and merge-request scopes use a 24-hour in-memory
 background probe gate. Expiry admits one reserved background probe across all

--- a/context/retries-and-backoffs.md
+++ b/context/retries-and-backoffs.md
@@ -68,6 +68,10 @@ Steady background cadence is scheduling policy, not transient retry. Do not
 migrate ticker-driven sync or refresh loops into `backoff/v5`
 (`internal/github/sync.go::Syncer.Start`).
 
+- Provider-index sync keeps at most one coalesced follow-up, atomically transfers
+  its single-flight slot, and preserves nil-versus-empty scope; bursts neither
+  drop accepted work nor create an unbounded queue. (`internal/github/sync.go::runOnceWithSlot`)
+
 Repository-disabled issue and merge-request scopes use a 24-hour in-memory
 background probe gate. Expiry admits one reserved background probe across all
 lanes; any pre-provider exit abandons only the reservation, while completed provider

--- a/context/retries-and-backoffs.md
+++ b/context/retries-and-backoffs.md
@@ -74,8 +74,9 @@ migrate ticker-driven sync or refresh loops into `backoff/v5`
   bound to stable repository identity when coalesced with full work. Ad-hoc
   triggers return only after admission; provider execution stays asynchronous.
   (`internal/github/sync.go::triggerRunWithCadence`)
-- Public sync status stays running across retained follow-up handoffs and becomes
-  terminal only when the single-flight slot is released.
+- Public sync status stays running across retained follow-up handoffs; terminal
+  publication is ordered with slot release so later runs cannot be overwritten
+  by a stale idle snapshot.
   (`internal/github/sync.go::runOnceWithSlot`)
 
 Repository-disabled issue and merge-request scopes use a 24-hour in-memory

--- a/internal/github/feature_cooldown.go
+++ b/internal/github/feature_cooldown.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"slices"
 	"sync"
 	"time"
 
@@ -51,6 +52,7 @@ type repositoryFeatureCooldownBypassKey struct{}
 
 type repositoryFeatureCooldownBypass struct {
 	throughGeneration uint64
+	repos             []RepoRef
 }
 
 func withRepositoryFeatureCooldownBypass(
@@ -62,11 +64,28 @@ func withRepositoryFeatureCooldownBypass(
 	})
 }
 
+func withRepositoryFeatureCooldownBypassForRepos(
+	ctx context.Context,
+	throughGeneration uint64,
+	repos []RepoRef,
+) context.Context {
+	return context.WithValue(ctx, repositoryFeatureCooldownBypassKey{}, repositoryFeatureCooldownBypass{
+		throughGeneration: throughGeneration,
+		repos:             slices.Clone(repos),
+	})
+}
+
 func repositoryFeatureCooldownBypassFromContext(
 	ctx context.Context,
 ) (repositoryFeatureCooldownBypass, bool) {
 	bypass, ok := ctx.Value(repositoryFeatureCooldownBypassKey{}).(repositoryFeatureCooldownBypass)
 	return bypass, ok
+}
+
+func (b repositoryFeatureCooldownBypass) appliesTo(repo RepoRef) bool {
+	return b.repos == nil || slices.ContainsFunc(b.repos, func(candidate RepoRef) bool {
+		return sameRepoIntent(repo, candidate)
+	})
 }
 
 // repositoryFeatureKeys returns the cooldown keys for a repository. The
@@ -262,6 +281,7 @@ func (s *Syncer) beginRepositoryFeatureProbe(
 	feature string,
 ) (repositoryFeatureProbe, bool) {
 	bypass, bypassEnabled := repositoryFeatureCooldownBypassFromContext(ctx)
+	bypassEnabled = bypassEnabled && bypass.appliesTo(repo)
 	return s.featureCooldowns.beginProbe(
 		repo, feature, s.now().UTC(), bypass, bypassEnabled,
 	)
@@ -273,6 +293,7 @@ func (s *Syncer) beginRepositoryFeatureProbeWithRetry(
 	feature string,
 ) (repositoryFeatureProbe, bool, time.Time) {
 	bypass, bypassEnabled := repositoryFeatureCooldownBypassFromContext(ctx)
+	bypassEnabled = bypassEnabled && bypass.appliesTo(repo)
 	return s.featureCooldowns.beginProbeWithRetry(
 		repo, feature, s.now().UTC(), bypass, bypassEnabled,
 	)

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5914,6 +5914,7 @@ func (s *Syncer) runOnceWithSlot(
 		s.exclusiveRun = onlyRepos != nil
 		s.runMu.Unlock()
 	}
+	var terminalStatus *SyncStatus
 	defer func() {
 		s.runMu.Lock()
 		pending := s.pendingRun
@@ -5941,7 +5942,12 @@ func (s *Syncer) runOnceWithSlot(
 			)
 			if !launched {
 				s.releaseRunSlot()
+			} else {
+				return
 			}
+		}
+		if terminalStatus != nil {
+			s.publishStatus(terminalStatus)
 		}
 	}()
 
@@ -6133,11 +6139,11 @@ dispatch:
 			err = context.Canceled
 		}
 		slog.Info("sync canceled", "repos", total, "err", err)
-		s.publishStatus(&SyncStatus{
+		terminalStatus = &SyncStatus{
 			Running:   false,
 			LastRunAt: time.Now().UTC(),
 			LastError: err.Error(),
-		})
+		}
 		return
 	}
 
@@ -6170,14 +6176,14 @@ dispatch:
 		})
 	}
 
-	s.publishStatus(&SyncStatus{
+	terminalStatus = &SyncStatus{
 		Running:                 false,
 		LastRunAt:               time.Now().UTC(),
 		LastError:               lastErr,
 		LastErrorCode:           lastErrorCode,
 		LastErrorCeilingKey:     lastErrorCeilingKey,
 		LastErrorCeilingResetAt: lastErrorCeilingResetAt,
-	})
+	}
 }
 
 func (s *Syncer) releaseRunSlot() {

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -655,6 +655,13 @@ const (
 	displayNameFailureTTL = 15 * time.Minute
 )
 
+type pendingSyncRun struct {
+	bypassNextSyncAfter bool
+	full                bool
+	priorityRepos       []RepoRef
+	onlyRepos           []RepoRef
+}
+
 const syncProgressLogInterval = 100
 const largeRepoBulkGraphQLThreshold = syncProgressLogInterval
 const (
@@ -832,8 +839,8 @@ type Syncer struct {
 	parallelism              atomic.Int32
 	runMu                    sync.Mutex
 	running                  atomic.Bool
-	exclusiveRun             bool // guarded by runMu
-	scheduledFullPending     bool // guarded by runMu
+	exclusiveRun             bool            // guarded by runMu
+	pendingRun               *pendingSyncRun // guarded by runMu
 	providerWorkMu           sync.Mutex
 	providerWork             map[string]map[archive.WorkPriority]int
 	archiveProviderRequests  map[string]archiveProviderRequest
@@ -3702,8 +3709,9 @@ func (s *Syncer) fetcherFor(repo RepoRef) *GraphQLFetcher {
 // cadence gate, but still respect hard rate-limit pauses and the
 // syncer's lifecycle: Stop cancels the merged context so any
 // in-flight GitHub call unblocks, then waits for the goroutine to
-// exit. The caller's ctx is honored too, so per-request deadlines
-// still apply.
+// exit. The caller's ctx is honored by a run that starts immediately.
+// Once an accepted trigger is coalesced behind an active run, the follow-up
+// is owned by the syncer's lifecycle so caller completion cannot retract it.
 func (s *Syncer) TriggerRun(ctx context.Context) {
 	s.TriggerRunWithPriority(ctx, nil)
 }
@@ -5816,8 +5824,10 @@ func (s *Syncer) runOnce(
 	}
 	s.runMu.Lock()
 	if s.running.Load() {
-		if !bypassNextSyncAfter && onlyRepos == nil && s.exclusiveRun {
-			s.scheduledFullPending = true
+		if bypassNextSyncAfter || onlyRepos == nil && s.exclusiveRun {
+			s.coalescePendingRunLocked(
+				bypassNextSyncAfter, priorityRepos, onlyRepos,
+			)
 		}
 		s.runMu.Unlock()
 		return
@@ -5830,13 +5840,20 @@ func (s *Syncer) runOnce(
 		s.runMu.Lock()
 		s.running.Store(false)
 		s.exclusiveRun = false
-		retryScheduledFull := exclusive && s.scheduledFullPending
-		if retryScheduledFull {
-			s.scheduledFullPending = false
-		}
+		pending := s.pendingRun
+		s.pendingRun = nil
 		s.runMu.Unlock()
-		if retryScheduledFull {
-			s.triggerRunWithCadence(context.Background(), false, nil, nil)
+		if pending != nil {
+			only := pending.onlyRepos
+			if pending.full {
+				only = nil
+			}
+			s.triggerRunWithCadence(
+				context.Background(),
+				pending.bypassNextSyncAfter,
+				pending.priorityRepos,
+				only,
+			)
 		}
 	}()
 
@@ -6044,29 +6061,87 @@ dispatch:
 	})
 }
 
+// coalescePendingRunLocked records work accepted while another pass owns the
+// single-flight slot. A full pass subsumes scoped work; the scoped repositories
+// become priorities so the stronger request still reaches them first.
+func (s *Syncer) coalescePendingRunLocked(
+	bypassNextSyncAfter bool,
+	priorityRepos []RepoRef,
+	onlyRepos []RepoRef,
+) {
+	full := onlyRepos == nil
+	if s.pendingRun == nil {
+		s.pendingRun = &pendingSyncRun{
+			bypassNextSyncAfter: bypassNextSyncAfter,
+			full:                full,
+			priorityRepos:       appendUniqueRepoRefs(nil, priorityRepos),
+			onlyRepos:           appendUniqueRepoRefs(nil, onlyRepos),
+		}
+		return
+	}
+
+	pending := s.pendingRun
+	pending.bypassNextSyncAfter = pending.bypassNextSyncAfter || bypassNextSyncAfter
+	if full {
+		if !pending.full {
+			pending.priorityRepos = appendUniqueRepoRefs(
+				pending.priorityRepos, pending.onlyRepos,
+			)
+			pending.onlyRepos = nil
+			pending.full = true
+		}
+		pending.priorityRepos = appendUniqueRepoRefs(
+			pending.priorityRepos, priorityRepos,
+		)
+		return
+	}
+
+	if pending.full {
+		pending.priorityRepos = appendUniqueRepoRefs(
+			pending.priorityRepos, onlyRepos,
+		)
+	} else {
+		pending.onlyRepos = appendUniqueRepoRefs(pending.onlyRepos, onlyRepos)
+	}
+	pending.priorityRepos = appendUniqueRepoRefs(
+		pending.priorityRepos, priorityRepos,
+	)
+}
+
+func appendUniqueRepoRefs(dst []RepoRef, repos []RepoRef) []RepoRef {
+	for _, repo := range repos {
+		if slices.ContainsFunc(dst, func(existing RepoRef) bool {
+			return sameRepoIntent(existing, repo)
+		}) {
+			continue
+		}
+		dst = append(dst, repo)
+	}
+	return dst
+}
+
 func prioritizeRepos(repos, priorityRepos []RepoRef) []RepoRef {
 	if len(repos) == 0 || len(priorityRepos) == 0 {
 		return repos
 	}
 
-	priorityKeys := make(map[string]int, len(priorityRepos))
-	for i, repo := range priorityRepos {
-		key := repoPriorityKey(repo)
-		if key == "" {
-			continue
-		}
-		if _, exists := priorityKeys[key]; !exists {
-			priorityKeys[key] = i
+	priorityOrder := make(map[RepoRef]int, len(repos))
+	for _, repo := range repos {
+		for i, priority := range priorityRepos {
+			if sameRepoIntent(repo, priority) {
+				priorityOrder[repo] = i
+				break
+			}
 		}
 	}
-	if len(priorityKeys) == 0 {
+	if len(priorityOrder) == 0 {
 		return repos
 	}
 
 	out := slices.Clone(repos)
 	slices.SortStableFunc(out, func(a, b RepoRef) int {
-		ai, aOK := priorityKeys[repoPriorityKey(a)]
-		bi, bOK := priorityKeys[repoPriorityKey(b)]
+		ai, aOK := priorityOrder[a]
+		bi, bOK := priorityOrder[b]
 		switch {
 		case aOK && bOK:
 			return ai - bi
@@ -6159,20 +6234,31 @@ func excludeArchivedRepos(repos []RepoRef) []RepoRef {
 }
 
 func selectRepos(repos, selectedRepos []RepoRef) []RepoRef {
-	selectedKeys := make(map[string]struct{}, len(selectedRepos))
-	for _, repo := range selectedRepos {
-		if key := repoPriorityKey(repo); key != "" {
-			selectedKeys[key] = struct{}{}
-		}
-	}
-
-	out := make([]RepoRef, 0, len(selectedKeys))
+	out := make([]RepoRef, 0, len(selectedRepos))
 	for _, repo := range repos {
-		if _, ok := selectedKeys[repoPriorityKey(repo)]; ok {
+		if slices.ContainsFunc(selectedRepos, func(selected RepoRef) bool {
+			return sameRepoIntent(repo, selected)
+		}) {
 			out = append(out, repo)
 		}
 	}
 	return out
+}
+
+// sameRepoIntent matches stable provider identity whenever both refs have one.
+// Route fallback is reserved for refs that have not yet been provider-verified.
+func sameRepoIntent(a, b RepoRef) bool {
+	if repoPlatform(a) != repoPlatform(b) ||
+		!strings.EqualFold(repoHost(a), repoHost(b)) {
+		return false
+	}
+	aID := strings.TrimSpace(a.PlatformExternalID)
+	bID := strings.TrimSpace(b.PlatformExternalID)
+	if aID != "" && bID != "" {
+		return aID == bID
+	}
+	aRoute := repoPriorityKey(a)
+	return aRoute != "" && aRoute == repoPriorityKey(b)
 }
 
 func repoPriorityKey(repo RepoRef) string {

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -3745,13 +3745,25 @@ func (s *Syncer) triggerRunWithCadence(
 	priorityRepos []RepoRef,
 	onlyRepos []RepoRef,
 ) {
+	s.launchRunWithCadence(
+		ctx, bypassNextSyncAfter, priorityRepos, onlyRepos, false,
+	)
+}
+
+func (s *Syncer) launchRunWithCadence(
+	ctx context.Context,
+	bypassNextSyncAfter bool,
+	priorityRepos []RepoRef,
+	onlyRepos []RepoRef,
+	slotClaimed bool,
+) bool {
 	if !s.SyncEnabled() {
-		return
+		return false
 	}
 	s.lifecycleMu.Lock()
 	if s.stopped {
 		s.lifecycleMu.Unlock()
-		return
+		return false
 	}
 	merged, cancel := s.mergeWithRunCtx(ctx)
 	s.wg.Add(1)
@@ -3760,8 +3772,15 @@ func (s *Syncer) triggerRunWithCadence(
 	go func() {
 		defer s.wg.Done()
 		defer cancel()
-		s.runOnce(merged, bypassNextSyncAfter, priorityRepos, onlyRepos)
+		s.runOnceWithSlot(
+			merged,
+			bypassNextSyncAfter,
+			priorityRepos,
+			onlyRepos,
+			slotClaimed,
+		)
 	}()
+	return true
 }
 
 func repoPlatform(repo RepoRef) platform.Kind {
@@ -5819,41 +5838,65 @@ func (s *Syncer) runOnce(
 	priorityRepos []RepoRef,
 	onlyRepos []RepoRef,
 ) {
+	s.runOnceWithSlot(ctx, bypassNextSyncAfter, priorityRepos, onlyRepos, false)
+}
+
+func (s *Syncer) runOnceWithSlot(
+	ctx context.Context,
+	bypassNextSyncAfter bool,
+	priorityRepos []RepoRef,
+	onlyRepos []RepoRef,
+	slotClaimed bool,
+) {
 	if !s.SyncEnabled() {
-		return
-	}
-	s.runMu.Lock()
-	if s.running.Load() {
-		if bypassNextSyncAfter || onlyRepos == nil && s.exclusiveRun {
-			s.coalescePendingRunLocked(
-				bypassNextSyncAfter, priorityRepos, onlyRepos,
-			)
+		if slotClaimed {
+			s.releaseRunSlot()
 		}
-		s.runMu.Unlock()
 		return
 	}
-	s.running.Store(true)
-	exclusive := onlyRepos != nil
-	s.exclusiveRun = exclusive
-	s.runMu.Unlock()
+	if !slotClaimed {
+		s.runMu.Lock()
+		if s.running.Load() {
+			if bypassNextSyncAfter || onlyRepos == nil && s.exclusiveRun {
+				s.coalescePendingRunLocked(
+					bypassNextSyncAfter, priorityRepos, onlyRepos,
+				)
+			}
+			s.runMu.Unlock()
+			return
+		}
+		s.running.Store(true)
+		s.exclusiveRun = onlyRepos != nil
+		s.runMu.Unlock()
+	}
 	defer func() {
 		s.runMu.Lock()
-		s.running.Store(false)
-		s.exclusiveRun = false
 		pending := s.pendingRun
 		s.pendingRun = nil
+		if pending == nil {
+			s.running.Store(false)
+			s.exclusiveRun = false
+		} else {
+			// Keep ownership of the single-flight slot while the accepted
+			// follow-up is registered. New arrivals coalesce behind it.
+			s.exclusiveRun = !pending.full
+		}
 		s.runMu.Unlock()
 		if pending != nil {
 			only := pending.onlyRepos
 			if pending.full {
 				only = nil
 			}
-			s.triggerRunWithCadence(
+			launched := s.launchRunWithCadence(
 				context.Background(),
 				pending.bypassNextSyncAfter,
 				pending.priorityRepos,
 				only,
+				true,
 			)
+			if !launched {
+				s.releaseRunSlot()
+			}
 		}
 	}()
 
@@ -6061,6 +6104,14 @@ dispatch:
 	})
 }
 
+func (s *Syncer) releaseRunSlot() {
+	s.runMu.Lock()
+	s.running.Store(false)
+	s.exclusiveRun = false
+	s.pendingRun = nil
+	s.runMu.Unlock()
+}
+
 // coalescePendingRunLocked records work accepted while another pass owns the
 // single-flight slot. A full pass subsumes scoped work; the scoped repositories
 // become priorities so the stronger request still reaches them first.
@@ -6075,7 +6126,7 @@ func (s *Syncer) coalescePendingRunLocked(
 			bypassNextSyncAfter: bypassNextSyncAfter,
 			full:                full,
 			priorityRepos:       appendUniqueRepoRefs(nil, priorityRepos),
-			onlyRepos:           appendUniqueRepoRefs(nil, onlyRepos),
+			onlyRepos:           uniqueRepoRefsPreservingNil(onlyRepos),
 		}
 		return
 	}
@@ -6106,6 +6157,13 @@ func (s *Syncer) coalescePendingRunLocked(
 	pending.priorityRepos = appendUniqueRepoRefs(
 		pending.priorityRepos, priorityRepos,
 	)
+}
+
+func uniqueRepoRefsPreservingNil(repos []RepoRef) []RepoRef {
+	if repos == nil {
+		return nil
+	}
+	return appendUniqueRepoRefs(make([]RepoRef, 0, len(repos)), repos)
 }
 
 func appendUniqueRepoRefs(dst []RepoRef, repos []RepoRef) []RepoRef {

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -660,6 +660,7 @@ type pendingSyncRun struct {
 	full                bool
 	priorityRepos       []RepoRef
 	onlyRepos           []RepoRef
+	bypassRepos         []RepoRef
 }
 
 const syncProgressLogInterval = 100
@@ -3746,7 +3747,7 @@ func (s *Syncer) triggerRunWithCadence(
 	onlyRepos []RepoRef,
 ) {
 	s.launchRunWithCadence(
-		ctx, bypassNextSyncAfter, priorityRepos, onlyRepos, false,
+		ctx, bypassNextSyncAfter, priorityRepos, onlyRepos, nil, false,
 	)
 }
 
@@ -3755,6 +3756,7 @@ func (s *Syncer) launchRunWithCadence(
 	bypassNextSyncAfter bool,
 	priorityRepos []RepoRef,
 	onlyRepos []RepoRef,
+	bypassRepos []RepoRef,
 	slotClaimed bool,
 ) bool {
 	if !s.SyncEnabled() {
@@ -3777,6 +3779,7 @@ func (s *Syncer) launchRunWithCadence(
 			bypassNextSyncAfter,
 			priorityRepos,
 			onlyRepos,
+			bypassRepos,
 			slotClaimed,
 		)
 	}()
@@ -5838,7 +5841,7 @@ func (s *Syncer) runOnce(
 	priorityRepos []RepoRef,
 	onlyRepos []RepoRef,
 ) {
-	s.runOnceWithSlot(ctx, bypassNextSyncAfter, priorityRepos, onlyRepos, false)
+	s.runOnceWithSlot(ctx, bypassNextSyncAfter, priorityRepos, onlyRepos, nil, false)
 }
 
 func (s *Syncer) runOnceWithSlot(
@@ -5846,6 +5849,7 @@ func (s *Syncer) runOnceWithSlot(
 	bypassNextSyncAfter bool,
 	priorityRepos []RepoRef,
 	onlyRepos []RepoRef,
+	bypassRepos []RepoRef,
 	slotClaimed bool,
 ) {
 	if !s.SyncEnabled() {
@@ -5892,6 +5896,7 @@ func (s *Syncer) runOnceWithSlot(
 				pending.bypassNextSyncAfter,
 				pending.priorityRepos,
 				only,
+				pending.bypassRepos,
 				true,
 			)
 			if !launched {
@@ -5904,6 +5909,10 @@ func (s *Syncer) runOnceWithSlot(
 	if bypassNextSyncAfter {
 		ctx = withRepositoryFeatureCooldownBypass(
 			ctx, s.featureCooldowns.currentGeneration(),
+		)
+	} else if len(bypassRepos) > 0 {
+		ctx = withRepositoryFeatureCooldownBypassForRepos(
+			ctx, s.featureCooldowns.currentGeneration(), bypassRepos,
 		)
 	}
 
@@ -5926,7 +5935,16 @@ func (s *Syncer) runOnceWithSlot(
 	// out, so buckets holding only archived repositories keep an entry
 	// for the cadence advance below.
 	archivedEligibility := s.repoEligibility(repos, nextAfter)
-	repos = s.reconcileArchivedRepos(ctx, repos, archivedEligibility)
+	archivedBypassEligibility := s.repoEligibility(
+		selectRepos(repos, bypassRepos), nil,
+	)
+	repos = s.reconcileArchivedRepos(
+		ctx,
+		repos,
+		archivedEligibility,
+		bypassRepos,
+		archivedBypassEligibility,
+	)
 	repos = prioritizeRepos(repos, priorityRepos)
 
 	total := len(repos)
@@ -5958,7 +5976,12 @@ func (s *Syncer) runOnceWithSlot(
 		refreshed := s.refreshRateLimitSnapshots(rateLimitSnapshotCtx)
 		s.clearRecoveredRateLimitGates(refreshed, nextAfter, s.interval)
 	}
-	eligibleBuckets := s.repoEligibility(repos, nextAfter)
+	cadenceEligibleBuckets := s.repoEligibility(repos, nextAfter)
+	bypassEligibleBuckets := s.repoEligibility(
+		selectRepos(repos, bypassRepos), nil,
+	)
+	eligibleBuckets := maps.Clone(cadenceEligibleBuckets)
+	activeRepos := make([]RepoRef, 0, len(repos))
 
 	var (
 		completed               atomic.Int32
@@ -6000,12 +6023,20 @@ dispatch:
 			s.publishMonotonicProgress(state, done)
 			continue
 		}
-		if !eligibleBuckets[bucket] {
+		eligible := cadenceEligibleBuckets[bucket]
+		if !eligible && repoMatchesAnyIntent(r, bypassRepos) {
+			eligible = bypassEligibleBuckets[bucket]
+			if eligible {
+				eligibleBuckets[bucket] = true
+			}
+		}
+		if !eligible {
 			results[i].Error = "skipped: rate limit throttled"
 			done := completed.Add(1)
 			s.publishMonotonicProgress(state, done)
 			continue
 		}
+		activeRepos = append(activeRepos, r)
 		// Check ctx before entering the select. Go's select picks
 		// pseudo-randomly when both branches are ready, so a naked
 		// `select { case work <- r: case <-ctx.Done(): }` can still
@@ -6035,15 +6066,15 @@ dispatch:
 		// bucket rather than trusting only the workers' markers: the last
 		// repository on a credential can spend the headroom with no later
 		// repository left to observe it.
-		s.revokeExhaustedBuckets(eligibleBuckets, state, repos)
-		s.drainDetailQueue(ctx, eligibleBuckets, repos)
+		s.revokeExhaustedBuckets(eligibleBuckets, state, activeRepos)
+		s.drainDetailQueue(ctx, eligibleBuckets, activeRepos)
 	}
 
 	if !canceled.Load() && ctx.Err() == nil {
 		// The detail drain spends the same credentials, so re-check again
 		// before the comment drain rather than reusing a map the drain that
 		// just ran may have invalidated.
-		s.revokeExhaustedBuckets(eligibleBuckets, state, repos)
+		s.revokeExhaustedBuckets(eligibleBuckets, state, activeRepos)
 		s.drainPendingCommentSyncs(ctx, eligibleBuckets)
 	}
 
@@ -6074,6 +6105,11 @@ dispatch:
 		s.RefreshRateLimitSnapshots(rateLimitSnapshotCtx)
 	}
 	if onlyRepos == nil {
+		for bucket, eligible := range cadenceEligibleBuckets {
+			if eligible && !eligibleBuckets[bucket] {
+				cadenceEligibleBuckets[bucket] = false
+			}
+		}
 		// Archived-only buckets are absent from eligibleBuckets — their
 		// refs dropped out before it was computed — but an attempted
 		// archived refresh must advance the bucket's cadence gate too,
@@ -6081,7 +6117,7 @@ dispatch:
 		// throttle factor. The post-reconciliation value wins for
 		// buckets present in both maps.
 		advance := maps.Clone(archivedEligibility)
-		maps.Copy(advance, eligibleBuckets)
+		maps.Copy(advance, cadenceEligibleBuckets)
 		s.advanceNextSync(advance, s.nextSyncAfter, s.interval)
 	}
 
@@ -6121,18 +6157,25 @@ func (s *Syncer) coalescePendingRunLocked(
 	onlyRepos []RepoRef,
 ) {
 	full := onlyRepos == nil
+	bypassAll := bypassNextSyncAfter && full
+	var bypassRepos []RepoRef
+	if bypassNextSyncAfter && !full {
+		bypassRepos = onlyRepos
+	}
 	if s.pendingRun == nil {
 		s.pendingRun = &pendingSyncRun{
-			bypassNextSyncAfter: bypassNextSyncAfter,
+			bypassNextSyncAfter: bypassAll,
 			full:                full,
 			priorityRepos:       appendUniqueRepoRefs(nil, priorityRepos),
 			onlyRepos:           uniqueRepoRefsPreservingNil(onlyRepos),
+			bypassRepos:         appendUniqueRepoRefs(nil, bypassRepos),
 		}
 		return
 	}
 
 	pending := s.pendingRun
-	pending.bypassNextSyncAfter = pending.bypassNextSyncAfter || bypassNextSyncAfter
+	pending.bypassNextSyncAfter = pending.bypassNextSyncAfter || bypassAll
+	pending.bypassRepos = appendUniqueRepoRefs(pending.bypassRepos, bypassRepos)
 	if full {
 		if !pending.full {
 			pending.priorityRepos = appendUniqueRepoRefs(
@@ -6229,7 +6272,11 @@ func prioritizeRepos(repos, priorityRepos []RepoRef) []RepoRef {
 // before the pass refreshes rate-limit snapshots, so a gate that has
 // recovered upstream defers the refresh by at most one pass.
 func (s *Syncer) reconcileArchivedRepos(
-	ctx context.Context, repos []RepoRef, eligibility map[string]bool,
+	ctx context.Context,
+	repos []RepoRef,
+	eligibility map[string]bool,
+	bypassRepos []RepoRef,
+	bypassEligibility map[string]bool,
 ) []RepoRef {
 	live := make([]RepoRef, 0, len(repos))
 	skipped := make([]string, 0)
@@ -6243,7 +6290,11 @@ func (s *Syncer) reconcileArchivedRepos(
 			continue
 		}
 		bucket, err := s.bucketKeyForRepo(repo, false)
-		if err != nil || !eligibility[bucket] {
+		eligible := eligibility[bucket]
+		if !eligible && repoMatchesAnyIntent(repo, bypassRepos) {
+			eligible = bypassEligibility[bucket]
+		}
+		if err != nil || !eligible {
 			skipped = append(skipped, repo.Owner+"/"+repo.Name)
 			continue
 		}
@@ -6317,6 +6368,12 @@ func sameRepoIntent(a, b RepoRef) bool {
 	}
 	aRoute := repoPriorityKey(a)
 	return aRoute != "" && aRoute == repoPriorityKey(b)
+}
+
+func repoMatchesAnyIntent(repo RepoRef, intents []RepoRef) bool {
+	return slices.ContainsFunc(intents, func(intent RepoRef) bool {
+		return sameRepoIntent(repo, intent)
+	})
 }
 
 func repoPriorityKey(repo RepoRef) string {

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -878,9 +878,9 @@ type Syncer struct {
 	// rows with older timestamps than the feed's top cursor, which the
 	// feed's incremental poll would miss without a full reload nudge.
 	onNotificationSyncComplete func()
-	// statusMu serializes publishStatus so worker goroutines
-	// can't interleave updates and deliver out-of-order snapshots
-	// to SSE subscribers.
+	// statusMu serializes status publication and terminal run-slot release so
+	// worker goroutines and later runs cannot deliver out-of-order snapshots.
+	// When both locks are needed, statusMu must be acquired before runMu.
 	statusMu sync.Mutex
 
 	// failedRepos tracks repos whose last sync had a partial failure
@@ -1139,6 +1139,10 @@ func (s *Syncer) consumeRepoFailed(repo RepoRef) failScope {
 func (s *Syncer) publishStatus(status *SyncStatus) {
 	s.statusMu.Lock()
 	defer s.statusMu.Unlock()
+	s.publishStatusLocked(status)
+}
+
+func (s *Syncer) publishStatusLocked(status *SyncStatus) {
 	s.status.Store(status)
 	if s.onStatusChange != nil {
 		s.onStatusChange(status)
@@ -5916,6 +5920,10 @@ func (s *Syncer) runOnceWithSlot(
 	}
 	var terminalStatus *SyncStatus
 	defer func() {
+		// Serialize the terminal snapshot with slot release. A new run may
+		// claim runMu as soon as running becomes false, but its Running:true
+		// publication must follow this pass's terminal status.
+		s.statusMu.Lock()
 		s.runMu.Lock()
 		pending := s.pendingRun
 		s.pendingRun = nil
@@ -5928,26 +5936,27 @@ func (s *Syncer) runOnceWithSlot(
 			s.exclusiveRun = !pending.full
 		}
 		s.runMu.Unlock()
-		if pending != nil {
-			only := pending.onlyRepos
-			if pending.full {
-				only = nil
+		if pending == nil {
+			if terminalStatus != nil {
+				s.publishStatusLocked(terminalStatus)
 			}
-			launched := s.launchClaimedRun(
-				context.Background(),
-				pending.bypassNextSyncAfter,
-				pending.priorityRepos,
-				only,
-				pending.bypassRepos,
-			)
-			if !launched {
-				s.releaseRunSlot()
-			} else {
-				return
-			}
+			s.statusMu.Unlock()
+			return
 		}
-		if terminalStatus != nil {
-			s.publishStatus(terminalStatus)
+		s.statusMu.Unlock()
+		only := pending.onlyRepos
+		if pending.full {
+			only = nil
+		}
+		launched := s.launchClaimedRun(
+			context.Background(),
+			pending.bypassNextSyncAfter,
+			pending.priorityRepos,
+			only,
+			pending.bypassRepos,
+		)
+		if !launched {
+			s.releaseRunSlotWithStatus(terminalStatus)
 		}
 	}()
 
@@ -6192,6 +6201,15 @@ func (s *Syncer) releaseRunSlot() {
 	s.exclusiveRun = false
 	s.pendingRun = nil
 	s.runMu.Unlock()
+}
+
+func (s *Syncer) releaseRunSlotWithStatus(status *SyncStatus) {
+	s.statusMu.Lock()
+	defer s.statusMu.Unlock()
+	s.releaseRunSlot()
+	if status != nil {
+		s.publishStatusLocked(status)
+	}
 }
 
 // coalescePendingRunLocked records work accepted while another pass owns the

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -3713,8 +3713,9 @@ func (s *Syncer) fetcherFor(repo RepoRef) *GraphQLFetcher {
 // exit. The caller's ctx is honored by a run that starts immediately.
 // Once an accepted trigger is coalesced behind an active run, the follow-up
 // is owned by the syncer's lifecycle so caller completion cannot retract it.
-func (s *Syncer) TriggerRun(ctx context.Context) {
-	s.TriggerRunWithPriority(ctx, nil)
+// It returns true only after the request is retained as active or pending work.
+func (s *Syncer) TriggerRun(ctx context.Context) bool {
+	return s.TriggerRunWithPriority(ctx, nil)
 }
 
 // TriggerRunWithPriority kicks off a non-blocking ad-hoc sync and dispatches
@@ -3722,22 +3723,22 @@ func (s *Syncer) TriggerRun(ctx context.Context) {
 func (s *Syncer) TriggerRunWithPriority(
 	ctx context.Context,
 	priorityRepos []RepoRef,
-) {
-	s.triggerRun(ctx, slices.Clone(priorityRepos), nil)
+) bool {
+	return s.triggerRun(ctx, slices.Clone(priorityRepos), nil)
 }
 
 // TriggerRunForRepos kicks off a non-blocking ad-hoc sync restricted to the
 // matching configured repositories.
-func (s *Syncer) TriggerRunForRepos(ctx context.Context, repos []RepoRef) {
-	s.triggerRun(ctx, nil, slices.Clone(repos))
+func (s *Syncer) TriggerRunForRepos(ctx context.Context, repos []RepoRef) bool {
+	return s.triggerRun(ctx, nil, slices.Clone(repos))
 }
 
 func (s *Syncer) triggerRun(
 	ctx context.Context,
 	priorityRepos []RepoRef,
 	onlyRepos []RepoRef,
-) {
-	s.triggerRunWithCadence(ctx, true, priorityRepos, onlyRepos)
+) bool {
+	return s.triggerRunWithCadence(ctx, true, priorityRepos, onlyRepos)
 }
 
 func (s *Syncer) triggerRunWithCadence(
@@ -3745,19 +3746,71 @@ func (s *Syncer) triggerRunWithCadence(
 	bypassNextSyncAfter bool,
 	priorityRepos []RepoRef,
 	onlyRepos []RepoRef,
-) {
-	s.launchRunWithCadence(
-		ctx, bypassNextSyncAfter, priorityRepos, onlyRepos, nil, false,
+) bool {
+	if !s.SyncEnabled() {
+		return false
+	}
+
+	// Admission and lifecycle registration are one operation from the
+	// caller's perspective: a successful return means Stop cannot miss the
+	// work and an active run has already retained the request.
+	s.lifecycleMu.Lock()
+	if s.stopped {
+		s.lifecycleMu.Unlock()
+		return false
+	}
+	s.runMu.Lock()
+	if s.running.Load() {
+		accepted := bypassNextSyncAfter || onlyRepos == nil && s.exclusiveRun
+		if accepted {
+			s.coalescePendingRunLocked(
+				bypassNextSyncAfter, priorityRepos, onlyRepos,
+			)
+		}
+		s.runMu.Unlock()
+		s.lifecycleMu.Unlock()
+		return accepted
+	}
+	s.running.Store(true)
+	s.exclusiveRun = onlyRepos != nil
+	s.runMu.Unlock()
+
+	s.startClaimedRunLocked(
+		ctx, bypassNextSyncAfter, priorityRepos, onlyRepos, nil,
 	)
+	s.lifecycleMu.Unlock()
+	return true
 }
 
-func (s *Syncer) launchRunWithCadence(
+// startClaimedRunLocked registers and starts work whose single-flight slot is
+// already owned. The caller must hold lifecycleMu and must have checked stopped.
+func (s *Syncer) startClaimedRunLocked(
 	ctx context.Context,
 	bypassNextSyncAfter bool,
 	priorityRepos []RepoRef,
 	onlyRepos []RepoRef,
 	bypassRepos []RepoRef,
-	slotClaimed bool,
+) {
+	merged, cancel := s.mergeWithRunCtx(ctx)
+	s.wg.Go(func() {
+		defer cancel()
+		s.runOnceWithSlot(
+			merged,
+			bypassNextSyncAfter,
+			priorityRepos,
+			onlyRepos,
+			bypassRepos,
+			true,
+		)
+	})
+}
+
+func (s *Syncer) launchClaimedRun(
+	ctx context.Context,
+	bypassNextSyncAfter bool,
+	priorityRepos []RepoRef,
+	onlyRepos []RepoRef,
+	bypassRepos []RepoRef,
 ) bool {
 	if !s.SyncEnabled() {
 		return false
@@ -3767,22 +3820,10 @@ func (s *Syncer) launchRunWithCadence(
 		s.lifecycleMu.Unlock()
 		return false
 	}
-	merged, cancel := s.mergeWithRunCtx(ctx)
-	s.wg.Add(1)
+	s.startClaimedRunLocked(
+		ctx, bypassNextSyncAfter, priorityRepos, onlyRepos, bypassRepos,
+	)
 	s.lifecycleMu.Unlock()
-
-	go func() {
-		defer s.wg.Done()
-		defer cancel()
-		s.runOnceWithSlot(
-			merged,
-			bypassNextSyncAfter,
-			priorityRepos,
-			onlyRepos,
-			bypassRepos,
-			slotClaimed,
-		)
-	}()
 	return true
 }
 
@@ -5891,13 +5932,12 @@ func (s *Syncer) runOnceWithSlot(
 			if pending.full {
 				only = nil
 			}
-			launched := s.launchRunWithCadence(
+			launched := s.launchClaimedRun(
 				context.Background(),
 				pending.bypassNextSyncAfter,
 				pending.priorityRepos,
 				only,
 				pending.bypassRepos,
-				true,
 			)
 			if !launched {
 				s.releaseRunSlot()

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -14635,6 +14635,41 @@ func TestScopedRunDrainsDetailsOnlyForSelectedRepos(t *testing.T) {
 	assert.Equal(t, []string{"selected"}, detailRepos)
 }
 
+// If queued repo intents follow only a mutable route, a rename drops the
+// intended repository and route reuse can select an unrelated successor.
+func TestRepoIntentMatchingUsesStableProviderIdentity(t *testing.T) {
+	renamed := RepoRef{
+		Platform:           platform.KindGitHub,
+		Owner:              "new-owner",
+		Name:               "new-name",
+		PlatformHost:       "github.com",
+		PlatformExternalID: "stable-repo-id",
+	}
+	successor := RepoRef{
+		Platform:           platform.KindGitHub,
+		Owner:              "old-owner",
+		Name:               "old-name",
+		PlatformHost:       "github.com",
+		PlatformExternalID: "successor-repo-id",
+	}
+	requestedBeforeRename := RepoRef{
+		Platform:           platform.KindGitHub,
+		Owner:              "old-owner",
+		Name:               "old-name",
+		PlatformHost:       "github.com",
+		PlatformExternalID: "stable-repo-id",
+	}
+
+	assert.Equal(t,
+		[]RepoRef{renamed},
+		selectRepos([]RepoRef{successor, renamed}, []RepoRef{requestedBeforeRename}),
+	)
+	assert.Equal(t,
+		[]RepoRef{renamed, successor},
+		prioritizeRepos([]RepoRef{successor, renamed}, []RepoRef{requestedBeforeRename}),
+	)
+}
+
 func TestScopedRunDoesNotDelayNextFullRunOnSameHost(t *testing.T) {
 	ctx := t.Context()
 	d := openTestDB(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -14796,6 +14796,100 @@ func TestScheduledFullRunRetriesAfterOverlappingScopedRun(t *testing.T) {
 	}
 }
 
+// If a scoped refresh turns a queued cadence-respecting full pass into a
+// global bypass, the provider is called for unrelated repositories too.
+func TestQueuedScopedRefreshDoesNotBypassFullRunCadence(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	bucket := RateBucketKey("github", "github.com", "host")
+	database := openTestDB(t)
+	repos := []RepoRef{
+		{Owner: "owner", Name: "selected", PlatformHost: "github.com"},
+		{Owner: "owner", Name: "unrelated", PlatformHost: "github.com"},
+	}
+	disabledErr := platform.RepositoryFeatureDisabled(
+		platform.KindGitHub,
+		"github.com",
+		platform.RepositoryFeatureMergeRequests,
+		errors.New("repository pull requests disabled"),
+	)
+	firstSelectedEntered := make(chan struct{})
+	releaseFirstSelected := make(chan struct{})
+	completions := make(chan struct{}, 2)
+	var (
+		selectedCalls    atomic.Int32
+		unrelatedCalls   atomic.Int32
+		releaseFirstOnce sync.Once
+	)
+	mc := &mockClient{
+		listOpenPRsFn: func(ctx context.Context, _, repo string) ([]*gh.PullRequest, error) {
+			switch repo {
+			case "selected":
+				if selectedCalls.Add(1) == 1 {
+					close(firstSelectedEntered)
+					select {
+					case <-releaseFirstSelected:
+					case <-ctx.Done():
+						return nil, ctx.Err()
+					}
+					return nil, disabledErr
+				}
+			case "unrelated":
+				unrelatedCalls.Add(1)
+			}
+			return []*gh.PullRequest{}, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, database, nil, repos,
+		time.Hour,
+		map[string]*RateTracker{
+			bucket: NewRateTracker(database, "github.com", "host", "rest"),
+		},
+		nil,
+	)
+	syncer.SetParallelism(1)
+	syncer.nextSyncAfter[bucket] = time.Now().Add(time.Hour)
+	require.True(syncer.recordRepositoryFeatureDisabled(
+		repos[0], platform.RepositoryFeatureMergeRequests, disabledErr,
+	))
+	require.True(syncer.recordRepositoryFeatureDisabled(
+		repos[1], platform.RepositoryFeatureMergeRequests, disabledErr,
+	))
+	syncer.SetOnSyncCompleted(func([]RepoSyncResult) {
+		completions <- struct{}{}
+	})
+	t.Cleanup(func() {
+		releaseFirstOnce.Do(func() { close(releaseFirstSelected) })
+		syncer.Stop()
+	})
+
+	syncer.TriggerRunForRepos(ctx, repos[:1])
+	select {
+	case <-firstSelectedEntered:
+	case <-time.After(5 * time.Second):
+		require.FailNow("initial scoped refresh did not reach the provider")
+	}
+
+	// Retain a cadence-respecting full pass, then merge a user refresh for
+	// only the selected repository while the first pass still owns the slot.
+	syncer.RunOnce(ctx)
+	syncer.TriggerRunForRepos(ctx, repos[:1])
+	releaseFirstOnce.Do(func() { close(releaseFirstSelected) })
+
+	for range 2 {
+		select {
+		case <-completions:
+		case <-time.After(5 * time.Second):
+			require.FailNow("queued sync passes did not complete")
+		}
+	}
+	syncer.Stop()
+
+	require.Equal(int32(2), selectedCalls.Load())
+	require.Zero(unrelatedCalls.Load())
+}
+
 // If a queued pass loses the single-flight handoff to another run, the
 // accepted work is dropped and provider data can remain stale.
 func TestQueuedRunSurvivesSingleFlightHandoff(t *testing.T) {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -14796,6 +14796,35 @@ func TestScheduledFullRunRetriesAfterOverlappingScopedRun(t *testing.T) {
 	}
 }
 
+// If an asynchronous trigger returns before taking the admission lock, the
+// server can return 202 before the request is retained by the active run.
+func TestTriggerRunForReposReturnsOnlyAfterAdmission(t *testing.T) {
+	require := require.New(t)
+	repo := RepoRef{
+		Owner: "owner", Name: "selected", PlatformHost: "github.com",
+	}
+	syncer := NewSyncer(
+		nil, openTestDB(t), nil, []RepoRef{repo}, time.Hour, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+
+	// Model an active scoped pass with cadence-respecting full work
+	// already retained behind it.
+	syncer.runMu.Lock()
+	syncer.running.Store(true)
+	syncer.exclusiveRun = true
+	syncer.pendingRun = &pendingSyncRun{full: true}
+	syncer.runMu.Unlock()
+
+	accepted := syncer.TriggerRunForRepos(context.Background(), []RepoRef{repo})
+	require.True(accepted)
+
+	syncer.runMu.Lock()
+	bypassRepos := slices.Clone(syncer.pendingRun.bypassRepos)
+	syncer.runMu.Unlock()
+	require.Equal([]RepoRef{repo}, bypassRepos)
+}
+
 // If a scoped refresh turns a queued cadence-respecting full pass into a
 // global bypass, the provider is called for unrelated repositories too.
 func TestQueuedScopedRefreshDoesNotBypassFullRunCadence(t *testing.T) {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -14796,6 +14796,207 @@ func TestScheduledFullRunRetriesAfterOverlappingScopedRun(t *testing.T) {
 	}
 }
 
+// If a queued pass loses the single-flight handoff to another run, the
+// accepted work is dropped and provider data can remain stale.
+func TestQueuedRunSurvivesSingleFlightHandoff(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	repos := []RepoRef{{
+		Owner: "owner", Name: "repo", PlatformHost: "github.com",
+	}}
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	firstCompleted := make(chan struct{})
+	releaseFirstCompletion := make(chan struct{})
+	secondEntered := make(chan struct{})
+	releaseSecond := make(chan struct{})
+	thirdEntered := make(chan struct{})
+	var (
+		listCalls                  atomic.Int32
+		completionCalls            atomic.Int32
+		releaseFirstOnce           sync.Once
+		releaseFirstCompletionOnce sync.Once
+		releaseSecondOnce          sync.Once
+		unlockLifecycleOnce        sync.Once
+	)
+	mc := &mockClient{
+		listOpenPRsFn: func(ctx context.Context, _, _ string) ([]*gh.PullRequest, error) {
+			switch listCalls.Add(1) {
+			case 1:
+				close(firstEntered)
+				select {
+				case <-releaseFirst:
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			case 2:
+				close(secondEntered)
+				select {
+				case <-releaseSecond:
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			case 3:
+				close(thirdEntered)
+			}
+			return []*gh.PullRequest{}, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, openTestDB(t), nil, repos,
+		time.Hour, nil, nil,
+	)
+	syncer.SetParallelism(1)
+	syncer.SetOnSyncCompleted(func([]RepoSyncResult) {
+		if completionCalls.Add(1) != 1 {
+			return
+		}
+		close(firstCompleted)
+		select {
+		case <-releaseFirstCompletion:
+		case <-ctx.Done():
+		}
+	})
+	t.Cleanup(func() {
+		releaseFirstOnce.Do(func() { close(releaseFirst) })
+		releaseFirstCompletionOnce.Do(func() { close(releaseFirstCompletion) })
+		releaseSecondOnce.Do(func() { close(releaseSecond) })
+		syncer.Stop()
+	})
+
+	initialDone := make(chan struct{})
+	go func() {
+		defer close(initialDone)
+		syncer.runOnce(ctx, true, nil, repos)
+	}()
+	select {
+	case <-firstEntered:
+	case <-time.After(5 * time.Second):
+		require.FailNow("initial scoped run did not start within 5s")
+	}
+
+	// Queue a cadence-respecting full pass while the scoped pass owns the slot.
+	syncer.RunOnce(ctx)
+	releaseFirstOnce.Do(func() { close(releaseFirst) })
+	select {
+	case <-firstCompleted:
+	case <-time.After(5 * time.Second):
+		require.FailNow("initial scoped run did not reach completion within 5s")
+	}
+
+	competingDone := make(chan struct{})
+	// Once the first run drops the single-flight slot, hold its asynchronous
+	// replay registration long enough for the competing run to claim the slot.
+	syncer.lifecycleMu.Lock()
+	t.Cleanup(func() { unlockLifecycleOnce.Do(syncer.lifecycleMu.Unlock) })
+	releaseFirstCompletionOnce.Do(func() { close(releaseFirstCompletion) })
+	require.Eventually(func() bool {
+		syncer.runMu.Lock()
+		defer syncer.runMu.Unlock()
+		return !syncer.exclusiveRun
+	}, 5*time.Second, time.Millisecond, "initial run did not reach the handoff")
+	go func() {
+		defer close(competingDone)
+		// This user-triggered run can claim the slot during the old handoff gap.
+		syncer.runOnce(ctx, true, nil, nil)
+	}()
+	select {
+	case <-competingDone:
+		// The atomic handoff kept the slot, so this run coalesced behind it.
+	case <-secondEntered:
+		// The old handoff exposed the slot and this run claimed it.
+	case <-time.After(5 * time.Second):
+		require.FailNow("competing run did not reach the single-flight slot")
+	}
+	unlockLifecycleOnce.Do(syncer.lifecycleMu.Unlock)
+
+	select {
+	case <-secondEntered:
+	case <-time.After(5 * time.Second):
+		require.FailNow("second run did not start within 5s")
+	}
+	releaseSecondOnce.Do(func() { close(releaseSecond) })
+	select {
+	case <-thirdEntered:
+	case <-time.After(5 * time.Second):
+		require.FailNow("queued run was dropped during the single-flight handoff")
+	}
+	<-initialDone
+	<-competingDone
+	assert.Equal(t, int32(3), listCalls.Load())
+}
+
+// If an explicit empty scope is widened to a full pass while queued, every
+// configured provider repository is fetched unexpectedly.
+func TestQueuedEmptyRepoScopeRemainsEmpty(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	repos := []RepoRef{{
+		Owner: "owner", Name: "repo", PlatformHost: "github.com",
+	}}
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	completions := make(chan []RepoSyncResult, 2)
+	var (
+		listCalls        atomic.Int32
+		releaseFirstOnce sync.Once
+	)
+	mc := &mockClient{
+		listOpenPRsFn: func(ctx context.Context, _, _ string) ([]*gh.PullRequest, error) {
+			if listCalls.Add(1) == 1 {
+				close(firstEntered)
+				select {
+				case <-releaseFirst:
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			}
+			return []*gh.PullRequest{}, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, openTestDB(t), nil, repos,
+		time.Hour, nil, nil,
+	)
+	syncer.SetParallelism(1)
+	syncer.SetOnSyncCompleted(func(results []RepoSyncResult) {
+		completions <- slices.Clone(results)
+	})
+	t.Cleanup(func() {
+		releaseFirstOnce.Do(func() { close(releaseFirst) })
+		syncer.Stop()
+	})
+
+	initialDone := make(chan struct{})
+	go func() {
+		defer close(initialDone)
+		syncer.runOnce(ctx, true, nil, repos)
+	}()
+	select {
+	case <-firstEntered:
+	case <-time.After(5 * time.Second):
+		require.FailNow("initial scoped run did not start within 5s")
+	}
+
+	// An empty non-nil scope means there is intentionally no provider work.
+	syncer.runOnce(ctx, true, nil, []RepoRef{})
+	releaseFirstOnce.Do(func() { close(releaseFirst) })
+
+	var got [][]RepoSyncResult
+	for range 2 {
+		select {
+		case results := <-completions:
+			got = append(got, results)
+		case <-time.After(5 * time.Second):
+			require.FailNow("queued empty-scope run did not complete within 5s")
+		}
+	}
+	<-initialDone
+	require.Len(got[0], 1)
+	assert.Empty(t, got[1])
+	assert.Equal(t, int32(1), listCalls.Load())
+}
+
 func TestBudgetResetOnRateWindowReset(t *testing.T) {
 	assert := assert.New(t)
 	d := openTestDB(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -14919,6 +14919,100 @@ func TestQueuedScopedRefreshDoesNotBypassFullRunCadence(t *testing.T) {
 	require.Zero(unrelatedCalls.Load())
 }
 
+// If the run slot is released before its terminal status is ordered, a new
+// run can publish Running:true before the completed run overwrites it with
+// Running:false.
+func TestTerminalStatusPublicationKeepsRunSlotUntilOrdered(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	providerEntered := make(chan struct{})
+	releaseProvider := make(chan struct{})
+	firstCompleted := make(chan struct{})
+	var (
+		providerCalls   atomic.Int32
+		completionCalls atomic.Int32
+		releaseOnce     sync.Once
+	)
+	mock := &mockClient{
+		listOpenPRsFn: func(ctx context.Context, _, _ string) ([]*gh.PullRequest, error) {
+			if providerCalls.Add(1) == 1 {
+				close(providerEntered)
+				select {
+				case <-releaseProvider:
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			}
+			return []*gh.PullRequest{}, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mock}, openTestDB(t), nil,
+		[]RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		time.Hour, nil, nil,
+	)
+	syncer.SetOnSyncCompleted(func([]RepoSyncResult) {
+		if completionCalls.Add(1) == 1 {
+			close(firstCompleted)
+		}
+	})
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(releaseProvider) })
+		syncer.Stop()
+	})
+
+	initialDone := make(chan struct{})
+	go func() {
+		defer close(initialDone)
+		syncer.RunOnce(ctx)
+	}()
+	select {
+	case <-providerEntered:
+	case <-time.After(5 * time.Second):
+		require.FailNow("initial sync did not reach the provider")
+	}
+
+	// Widen the terminal-publication boundary without replacing it: the
+	// provider pass is real, and publishStatus still owns statusMu.
+	syncer.statusMu.Lock()
+	statusLocked := true
+	t.Cleanup(func() {
+		if statusLocked {
+			syncer.statusMu.Unlock()
+		}
+	})
+	releaseOnce.Do(func() { close(releaseProvider) })
+	select {
+	case <-firstCompleted:
+	case <-time.After(5 * time.Second):
+		require.FailNow("initial sync did not reach completion")
+	}
+	require.Never(
+		func() bool { return !syncer.running.Load() },
+		100*time.Millisecond,
+		time.Millisecond,
+		"run slot was released while terminal status publication was blocked",
+	)
+
+	require.True(syncer.TriggerRun(ctx))
+	syncer.statusMu.Unlock()
+	statusLocked = false
+	require.Eventually(
+		func() bool {
+			return completionCalls.Load() == 2 &&
+				providerCalls.Load() == 2 && !syncer.Status().Running
+		},
+		5*time.Second,
+		time.Millisecond,
+		"coalesced follow-up did not reach terminal status",
+	)
+	select {
+	case <-initialDone:
+	case <-time.After(5 * time.Second):
+		require.FailNow("initial sync did not finish its handoff")
+	}
+}
+
 // If a queued pass loses the single-flight handoff to another run, the
 // accepted work is dropped and provider data can remain stale.
 func TestQueuedRunSurvivesSingleFlightHandoff(t *testing.T) {

--- a/internal/github/syncertest/syncer_test.go
+++ b/internal/github/syncertest/syncer_test.go
@@ -803,6 +803,127 @@ func TestSyncerTriggerRunForReposSyncsOnlySelectedRepos(t *testing.T) {
 	assert.Equal([]string{"o/third"}, got)
 }
 
+// If an accepted trigger is dropped behind an in-flight provider snapshot,
+// data changed after that snapshot stays stale until an unrelated later run.
+func TestSyncerAcceptedTriggerQueuesBehindInFlightRun(t *testing.T) {
+	tests := []struct {
+		name    string
+		trigger func(*ghclient.Syncer, context.Context, []ghclient.RepoRef)
+	}{
+		{
+			name: "full",
+			trigger: func(syncer *ghclient.Syncer, ctx context.Context, _ []ghclient.RepoRef) {
+				syncer.TriggerRun(ctx)
+			},
+		},
+		{
+			name: "priority",
+			trigger: func(syncer *ghclient.Syncer, ctx context.Context, repos []ghclient.RepoRef) {
+				syncer.TriggerRunWithPriority(ctx, repos)
+			},
+		},
+		{
+			name: "scoped",
+			trigger: func(syncer *ghclient.Syncer, ctx context.Context, repos []ghclient.RepoRef) {
+				syncer.TriggerRunForRepos(ctx, repos)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			database := openTestDB(t)
+			ctx := t.Context()
+			repos := []ghclient.RepoRef{{
+				Owner:              "o",
+				Name:               "r",
+				PlatformHost:       "github.com",
+				PlatformExternalID: "repo-o-r",
+			}}
+			repoID, err := database.UpsertRepo(ctx, db.RepoIdentity{
+				Platform:       "github",
+				PlatformHost:   "github.com",
+				PlatformRepoID: "repo-o-r",
+				Owner:          "o",
+				Name:           "r",
+			})
+			require.NoError(err)
+
+			firstSnapshot := make(chan struct{})
+			releaseFirst := make(chan struct{})
+			var releaseOnce sync.Once
+			var listCalls atomic.Int32
+			var providerFresh atomic.Bool
+			mock := &mockClient{
+				listOpenPRsFn: func(
+					ctx context.Context, _, _ string,
+				) ([]*gh.PullRequest, error) {
+					if listCalls.Add(1) == 1 {
+						close(firstSnapshot)
+						select {
+						case <-releaseFirst:
+						case <-ctx.Done():
+							return nil, ctx.Err()
+						}
+					}
+					return []*gh.PullRequest{}, nil
+				},
+				getRepositoryFn: func(
+					_ context.Context, owner, repo string,
+				) (*gh.Repository, error) {
+					id := int64(1)
+					nodeID := "repo-o-r"
+					defaultBranch := "stale"
+					if providerFresh.Load() {
+						defaultBranch = "fresh"
+					}
+					return &gh.Repository{
+						ID:            &id,
+						NodeID:        &nodeID,
+						Name:          &repo,
+						Owner:         &gh.User{Login: &owner},
+						Archived:      new(bool),
+						DefaultBranch: &defaultBranch,
+					}, nil
+				},
+			}
+			syncer := ghclient.NewSyncer(
+				map[string]ghclient.Client{"github.com": mock},
+				database, nil, repos, time.Hour, nil, nil,
+			)
+			t.Cleanup(func() {
+				releaseOnce.Do(func() { close(releaseFirst) })
+				syncer.Stop()
+			})
+
+			syncer.TriggerRun(ctx)
+			select {
+			case <-firstSnapshot:
+			case <-time.After(5 * time.Second):
+				require.FailNow("initial sync did not reach the provider snapshot")
+			}
+
+			providerFresh.Store(true)
+			tt.trigger(syncer, ctx, repos)
+			releaseOnce.Do(func() { close(releaseFirst) })
+
+			require.Eventually(
+				func() bool { return listCalls.Load() == 2 },
+				5*time.Second,
+				10*time.Millisecond,
+				"accepted trigger did not run after the active sync",
+			)
+			syncer.Stop()
+
+			stored, err := database.GetRepoByID(ctx, repoID)
+			require.NoError(err)
+			require.NotNil(stored)
+			require.Equal("fresh", stored.DefaultBranch)
+		})
+	}
+}
+
 type blockingCtxMockClient struct {
 	mockClient
 	entered chan struct{}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -8202,6 +8202,20 @@ func TestAPITriggerSyncIgnoresRequestCancellation(t *testing.T) {
 	assert.Equal(t, "widget", repos[0].Name)
 }
 
+// If the route returns 202 after admission is refused, the client believes a
+// sync was retained even though no worker can execute it.
+func TestAPITriggerSyncRejectsAfterSyncerStops(t *testing.T) {
+	require := require.New(t)
+	database := dbtest.Open(t)
+	syncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
+	syncer.Stop()
+
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	rr := doJSON(t, srv, http.MethodPost, "/api/v1/sync", nil)
+	require.Equal(http.StatusServiceUnavailable, rr.Code, rr.Body.String())
+}
+
 func TestAPITriggerSyncOnlyRepoRestrictsRun(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/e2etest/sync_routes_test.go
+++ b/internal/server/e2etest/sync_routes_test.go
@@ -70,9 +70,9 @@ func TestSyncRoutesWithoutProviderSyncerE2E(t *testing.T) {
 	assert.Equal("syncer not configured", *trigger.ApplicationproblemJSONDefault.Detail)
 }
 
-// If the HTTP route drops a sync accepted during an active provider fetch,
-// users receive 202 while SQLite keeps the provider snapshot stale.
-func TestAcceptedFullSyncQueuesBehindInFlightProviderFetchE2E(t *testing.T) {
+// If an accepted queued sync reports completion before its provider pass,
+// clients stop waiting while SQLite still holds the earlier snapshot.
+func TestAcceptedFullSyncStaysRunningUntilQueuedProviderDataPersistsE2E(t *testing.T) {
 	require := require.New(t)
 
 	firstSnapshot := make(chan struct{})
@@ -80,6 +80,8 @@ func TestAcceptedFullSyncQueuesBehindInFlightProviderFetchE2E(t *testing.T) {
 	var releaseOnce sync.Once
 	var providerFresh atomic.Bool
 	var listCalls atomic.Int32
+	var statusMu sync.Mutex
+	var runningStates []bool
 	mock := &mockGH{
 		getRepositoryFn: func(
 			_ context.Context, owner, repo string,
@@ -134,6 +136,11 @@ func TestAcceptedFullSyncQueuesBehindInFlightProviderFetchE2E(t *testing.T) {
 		releaseOnce.Do(func() { close(releaseFirst) })
 		syncer.Stop()
 	})
+	syncer.SetOnStatusChange(func(status *ghclient.SyncStatus) {
+		statusMu.Lock()
+		runningStates = append(runningStates, status.Running)
+		statusMu.Unlock()
+	})
 
 	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{
 		HostCheckAllowLoopbackAnyPort: true,
@@ -172,10 +179,30 @@ func TestAcceptedFullSyncQueuesBehindInFlightProviderFetchE2E(t *testing.T) {
 		if listCalls.Load() != 2 {
 			return false
 		}
+		status, err := api.HTTP.GetSyncStatusWithResponse(t.Context())
+		if err != nil || status.StatusCode() != http.StatusOK ||
+			status.JSON200 == nil || status.JSON200.Running {
+			return false
+		}
 		repos, err := database.ListRepos(t.Context())
 		return err == nil && len(repos) == 1 && repos[0].DefaultBranch == "fresh"
 	}, 5*time.Second, 10*time.Millisecond,
 		"accepted full sync did not persist the fresh provider snapshot")
+
+	statusMu.Lock()
+	states := append([]bool(nil), runningStates...)
+	statusMu.Unlock()
+	require.NotEmpty(states)
+	terminalSeen := false
+	for _, running := range states {
+		if !running {
+			terminalSeen = true
+			continue
+		}
+		require.False(terminalSeen,
+			"sync status returned to running after reporting completion")
+	}
+	require.False(states[len(states)-1])
 }
 
 // If an HTTP-scoped refresh loses its repository binding while coalescing

--- a/internal/server/e2etest/sync_routes_test.go
+++ b/internal/server/e2etest/sync_routes_test.go
@@ -178,6 +178,168 @@ func TestAcceptedFullSyncQueuesBehindInFlightProviderFetchE2E(t *testing.T) {
 		"accepted full sync did not persist the fresh provider snapshot")
 }
 
+// If an HTTP-scoped refresh loses its repository binding while coalescing
+// with background work, unrelated repositories bypass their cadence gate.
+func TestQueuedScopedHTTPRefreshKeepsBypassRepositoryBoundE2E(t *testing.T) {
+	require := require.New(t)
+
+	selectedEntered := make(chan struct{})
+	releaseSelected := make(chan struct{})
+	completions := make(chan struct{}, 2)
+	var (
+		phase               atomic.Int32
+		selectedCalls       atomic.Int32
+		unrelatedCalls      atomic.Int32
+		releaseSelectedOnce sync.Once
+	)
+	mock := &mockGH{
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			id := int64(1)
+			if repo == "unrelated" {
+				id = 2
+			}
+			nodeID := "repo-acme-" + repo
+			defaultBranch := "seed"
+			if repo == "selected" {
+				switch phase.Load() {
+				case 1:
+					defaultBranch = "active"
+				case 2:
+					defaultBranch = "queued"
+				}
+			}
+			return &gh.Repository{
+				ID:            &id,
+				NodeID:        &nodeID,
+				Name:          &repo,
+				Owner:         &gh.User{Login: &owner},
+				Archived:      new(bool),
+				DefaultBranch: &defaultBranch,
+			}, nil
+		},
+		listOpenPullRequestsFn: func(
+			ctx context.Context, _, repo string,
+		) ([]*gh.PullRequest, error) {
+			switch repo {
+			case "selected":
+				if selectedCalls.Add(1) == 2 {
+					close(selectedEntered)
+					select {
+					case <-releaseSelected:
+					case <-ctx.Done():
+						return nil, ctx.Err()
+					}
+				}
+			case "unrelated":
+				unrelatedCalls.Add(1)
+			}
+			return []*gh.PullRequest{}, nil
+		},
+	}
+
+	database := dbtest.Open(t)
+	bucket := ghclient.RateBucketKey("github", "github.com", "host")
+	repos := []ghclient.RepoRef{
+		{
+			Platform:           platform.KindGitHub,
+			Owner:              "acme",
+			Name:               "selected",
+			PlatformHost:       "github.com",
+			PlatformExternalID: "repo-acme-selected",
+		},
+		{
+			Platform:           platform.KindGitHub,
+			Owner:              "acme",
+			Name:               "unrelated",
+			PlatformHost:       "github.com",
+			PlatformExternalID: "repo-acme-unrelated",
+		},
+	}
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database,
+		nil,
+		repos,
+		time.Hour,
+		map[string]*ghclient.RateTracker{
+			bucket: ghclient.NewRateTracker(database, "github.com", "host", "rest"),
+		},
+		nil,
+	)
+	syncer.SetParallelism(1)
+	t.Cleanup(func() {
+		releaseSelectedOnce.Do(func() { close(releaseSelected) })
+		syncer.Stop()
+	})
+
+	// A completed background pass seeds the shared host cadence window.
+	syncer.RunOnce(t.Context())
+	require.Equal(int32(1), selectedCalls.Load())
+	require.Equal(int32(1), unrelatedCalls.Load())
+	syncer.SetOnSyncCompleted(func([]ghclient.RepoSyncResult) {
+		completions <- struct{}{}
+	})
+
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{
+		HostCheckAllowLoopbackAnyPort: true,
+	})
+	forge := httptest.NewServer(srv)
+	t.Cleanup(forge.Close)
+	api, err := apiclient.NewWithHTTPClient(forge.URL, forge.Client())
+	require.NoError(err)
+	onlySelected := []string{"github|github.com/acme/selected"}
+	triggerSelected := func() {
+		t.Helper()
+		response, err := api.HTTP.TriggerSyncWithResponse(
+			t.Context(),
+			&generated.TriggerSyncParams{OnlyRepo: &onlySelected},
+			func(_ context.Context, req *http.Request) error {
+				req.Header.Set("Content-Type", "application/json")
+				return nil
+			},
+		)
+		require.NoError(err)
+		require.Equal(http.StatusAccepted, response.StatusCode(), string(response.Body))
+	}
+
+	phase.Store(1)
+	triggerSelected()
+	select {
+	case <-selectedEntered:
+	case <-time.After(5 * time.Second):
+		require.FailNow("HTTP-scoped refresh did not reach the provider")
+	}
+
+	// Queue normal background work, then merge another HTTP-scoped refresh
+	// while the first one still owns the single-flight slot.
+	syncer.RunOnce(t.Context())
+	triggerSelected()
+	phase.Store(2)
+	releaseSelectedOnce.Do(func() { close(releaseSelected) })
+
+	for range 2 {
+		select {
+		case <-completions:
+		case <-time.After(5 * time.Second):
+			require.FailNow("coalesced sync passes did not complete")
+		}
+	}
+
+	require.Equal(int32(3), selectedCalls.Load())
+	require.Equal(int32(1), unrelatedCalls.Load())
+	dbRepos, err := database.ListRepos(t.Context())
+	require.NoError(err)
+	require.Len(dbRepos, 2)
+	branches := make(map[string]string, len(dbRepos))
+	for _, repo := range dbRepos {
+		branches[repo.Name] = repo.DefaultBranch
+	}
+	require.Equal("queued", branches["selected"])
+	require.Equal("seed", branches["unrelated"])
+}
+
 func TestSyncListNotModifiedDoesNotChangeRateLimitBudgetE2E(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/e2etest/sync_routes_test.go
+++ b/internal/server/e2etest/sync_routes_test.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	gh "github.com/google/go-github/v89/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/apiclient"
@@ -66,6 +68,114 @@ func TestSyncRoutesWithoutProviderSyncerE2E(t *testing.T) {
 	assert.Equal(generated.ServiceUnavailable, trigger.ApplicationproblemJSONDefault.Code)
 	require.NotNil(trigger.ApplicationproblemJSONDefault.Detail)
 	assert.Equal("syncer not configured", *trigger.ApplicationproblemJSONDefault.Detail)
+}
+
+// If the HTTP route drops a sync accepted during an active provider fetch,
+// users receive 202 while SQLite keeps the provider snapshot stale.
+func TestAcceptedFullSyncQueuesBehindInFlightProviderFetchE2E(t *testing.T) {
+	require := require.New(t)
+
+	firstSnapshot := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var releaseOnce sync.Once
+	var providerFresh atomic.Bool
+	var listCalls atomic.Int32
+	mock := &mockGH{
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			id := int64(1)
+			nodeID := "repo-acme-widget"
+			defaultBranch := "stale"
+			if providerFresh.Load() {
+				defaultBranch = "fresh"
+			}
+			return &gh.Repository{
+				ID:            &id,
+				NodeID:        &nodeID,
+				Name:          &repo,
+				Owner:         &gh.User{Login: &owner},
+				Archived:      new(bool),
+				DefaultBranch: &defaultBranch,
+			}, nil
+		},
+		listOpenPullRequestsFn: func(
+			ctx context.Context, _, _ string,
+		) ([]*gh.PullRequest, error) {
+			if listCalls.Add(1) == 1 {
+				close(firstSnapshot)
+				select {
+				case <-releaseFirst:
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			}
+			return []*gh.PullRequest{}, nil
+		},
+	}
+
+	database := dbtest.Open(t)
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database,
+		nil,
+		[]ghclient.RepoRef{{
+			Platform:           platform.KindGitHub,
+			Owner:              "acme",
+			Name:               "widget",
+			PlatformHost:       "github.com",
+			PlatformExternalID: "repo-acme-widget",
+		}},
+		time.Minute,
+		nil,
+		nil,
+	)
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(releaseFirst) })
+		syncer.Stop()
+	})
+
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{
+		HostCheckAllowLoopbackAnyPort: true,
+	})
+	forge := httptest.NewServer(srv)
+	t.Cleanup(forge.Close)
+	api, err := apiclient.NewWithHTTPClient(forge.URL, forge.Client())
+	require.NoError(err)
+
+	triggerSync := func() {
+		t.Helper()
+		response, err := api.HTTP.TriggerSyncWithResponse(
+			t.Context(),
+			nil,
+			func(_ context.Context, req *http.Request) error {
+				req.Header.Set("Content-Type", "application/json")
+				return nil
+			},
+		)
+		require.NoError(err)
+		require.Equal(http.StatusAccepted, response.StatusCode(), string(response.Body))
+	}
+
+	triggerSync()
+	select {
+	case <-firstSnapshot:
+	case <-time.After(5 * time.Second):
+		require.FailNow("initial sync did not reach the provider snapshot")
+	}
+
+	providerFresh.Store(true)
+	triggerSync()
+	releaseOnce.Do(func() { close(releaseFirst) })
+
+	require.Eventually(func() bool {
+		if listCalls.Load() != 2 {
+			return false
+		}
+		repos, err := database.ListRepos(t.Context())
+		return err == nil && len(repos) == 1 && repos[0].DefaultBranch == "fresh"
+	}, 5*time.Second, 10*time.Millisecond,
+		"accepted full sync did not persist the fresh provider snapshot")
 }
 
 func TestSyncListNotModifiedDoesNotChangeRateLimitBudgetE2E(t *testing.T) {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -727,13 +727,17 @@ func (s *Server) triggerSync(
 		if err != nil {
 			return nil, httpapi.Validation("query.only_repo", err.Error())
 		}
-		s.syncer.TriggerRunForRepos(context.WithoutCancel(ctx), repos)
+		if !s.syncer.TriggerRunForRepos(context.WithoutCancel(ctx), repos) {
+			return nil, httpapi.ServiceUnavailable("syncer is stopping")
+		}
 		return &acceptedOutput{Status: http.StatusAccepted}, nil
 	}
-	s.syncer.TriggerRunWithPriority(
+	if !s.syncer.TriggerRunWithPriority(
 		context.WithoutCancel(ctx),
 		s.priorityReposFromFilter(input.PriorityRepos),
-	)
+	) {
+		return nil, httpapi.ServiceUnavailable("syncer is stopping")
+	}
 	if s.notificationsEnabled() {
 		s.runBackground(func(bgCtx context.Context) {
 			if err := s.syncer.RunNotificationSync(bgCtx); err != nil {


### PR DESCRIPTION
## What changed

- Retain full, priority, and repository-scoped sync requests made while another provider sync is running.
- Claim or update the single-flight slot before returning HTTP 202 while keeping provider execution asynchronous.
- Merge repeated requests into one bounded follow-up and keep status running until all retained work finishes.
- Preserve stable provider identity and limit scoped cadence and feature-cooldown bypasses to the requested repositories across GitHub, GitLab, Forgejo, and Gitea.

## Failure scenario

1. A sync starts and reads the provider's current data.
2. The provider receives new data before that sync finishes.
3. The user starts a full sync while the first sync still owns the work slot.
4. The old path either discarded that request or returned 202 before recording it as pending work.
5. The first sync could finish with its earlier snapshot and leave SQLite and the UI stale without a follow-up provider read.
6. After the request was retained, each pass still briefly published `running: false` before starting its queued follow-up, so status and SSE clients could stop waiting before fresh data reached SQLite.

Admission now happens before the response, handoffs retain the slot continuously, and terminal status is published only when no pending pass remains. Terminal publication is ordered with slot release so a later run cannot be overwritten by a stale idle snapshot. A stopped syncer rejects new requests instead of returning 202.
