### PR TITLE
Keep Forge UI available when provider startup fails

### DIFF
--- a/cmd/kenn-forge/main.go
+++ b/cmd/kenn-forge/main.go
@@ -535,16 +535,23 @@ func run(opts serve.Options) error {
 		providerSources, err = registerProviderTokenSources(cfg, tokenSources)
 	} else {
 		providerSources, err = collectProviderTokenSources(ctx, cfg, tokenSources)
+		if err != nil {
+			slog.Warn(
+				"provider credentials unavailable; serving cached data without provider sync",
+				"err", err,
+			)
+			providerSources = nil
+		}
 	}
-	if err != nil {
+	if err != nil && opts.DisableSync {
 		return err
 	}
 	var identityResolver ghclient.IdentityResolver
-	if !opts.DisableSync {
+	if !opts.DisableSync && providerSources != nil {
 		identityResolver = ghclient.HTTPIdentityResolver{}
 	}
 
-	startup, err := buildProviderStartup(
+	startup, err := buildProviderStartupOrDegraded(
 		ctx, database, cfg, tokenSources, providerSources,
 		defaultProviderFactories(), identityResolver,
 	)

--- a/cmd/kenn-forge/provider_startup.go
+++ b/cmd/kenn-forge/provider_startup.go
@@ -292,6 +292,33 @@ func providerTokenSources(
 	return providerSources, nil
 }
 
+// buildProviderStartupOrDegraded keeps the local UI available when a remote
+// provider cannot be initialized. The database already contains the last
+// successful sync, and provider operations can report unavailable until the
+// daemon is restarted after the provider recovers.
+func buildProviderStartupOrDegraded(
+	ctx context.Context,
+	database *db.DB,
+	cfg *config.Config,
+	set *tokenauth.SourceSet,
+	providerSources map[string]tokenauth.Source,
+	factories map[string]providerFactory,
+	resolver github.IdentityResolver,
+) (providerStartup, error) {
+	startup, err := buildProviderStartup(
+		ctx, database, cfg, set, providerSources, factories, resolver,
+	)
+	if err == nil {
+		return startup, nil
+	}
+
+	slog.Warn(
+		"provider startup unavailable; serving cached data without provider sync",
+		"err", err,
+	)
+	return buildProviderStartup(ctx, database, cfg, set, nil, factories, nil)
+}
+
 func buildProviderStartup(
 	ctx context.Context,
 	database *db.DB,

--- a/cmd/kenn-forge/provider_startup_identity_test.go
+++ b/cmd/kenn-forge/provider_startup_identity_test.go
@@ -1231,6 +1231,37 @@ func TestBuildProviderStartupReportsSafeGitHubIdentityResolutionFailure(t *testi
 	assert.NotContains(t, err.Error(), "super-secret-token")
 }
 
+func TestBuildProviderStartupOrDegradedKeepsServerBootableWhenGitHubUnavailable(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	database := dbtest.Open(t)
+	t.Setenv("ORG_A_TOKEN", "org-a-token")
+	cfg := &config.Config{
+		SyncInterval: "5m",
+		Host:         "127.0.0.1",
+		Port:         8091,
+		BasePath:     "/",
+		Activity:     config.Activity{ViewMode: "flat", TimeRange: "7d"},
+		Repos:        []config.Repo{{Owner: "org-a", Name: "one"}},
+		GitHubOwnerTokens: []config.GitHubOwnerTokenConfig{{
+			Host: "github.com", Owner: "org-a", TokenEnv: "ORG_A_TOKEN",
+		}},
+	}
+	require.NoError(cfg.Validate())
+	set := tokenauth.NewSourceSet(tokenauth.Options{})
+	sources, err := collectProviderTokenSources(t.Context(), cfg, set)
+	require.NoError(err)
+
+	startup, err := buildProviderStartupOrDegraded(
+		t.Context(), database, cfg, set, sources, defaultProviderFactories(),
+		fakeGitHubIdentityResolver{err: map[string]error{
+			"ORG_A_TOKEN": errors.New("GitHub API unavailable: 503"),
+		}},
+	)
+	require.NoError(err)
+	assert.Empty(startup.registry.Providers())
+}
+
 // A repository PAT override picks the credential that signs that repository's
 // writes; it must not cost the owner its App installation. The installation
 // carries its own rate-limit budget, so it still leads reads, and it remains

--- a/context/server-runtime.md
+++ b/context/server-runtime.md
@@ -21,6 +21,9 @@ and the root event stream.
   files before marking completion and relocating the database; explicit config
   paths and `KENN_FORGE_HOME` never relocate config
   (`internal/config/legacy_migration.go::migrateLegacyConfig`).
+- Sync-enabled startup keeps the local UI available when provider credentials or
+  identity initialization is unavailable; it serves cached data without provider
+  sync until a later restart (`cmd/kenn-forge/main.go::run`).
 
 ## Startup Lock
 


### PR DESCRIPTION
## Summary

Forge is an offline snapshot of provider data. Before this change, a GitHub token or identity lookup failure during startup terminated the daemon. The daemon then entered a restart loop, so the local snapshot was unavailable whenever GitHub was unavailable.

Provider startup is now best-effort when sync is enabled:

```mermaid
flowchart LR
    A[GitHub unavailable] --> B[Provider bootstrap fails]
    B --> C[Serve cached SQLite snapshot]
    C -. restart after recovery .-> D[Provider sync resumes]
```

The UI stays available with the last successful snapshot. Provider-backed reads and writes remain unavailable until the provider can be initialized again. Explicit no-sync startup errors remain fatal.

## Verification

- Added a regression test for provider identity/API failure during startup.
- The full short Go suite, lint, and repository hooks pass on the branch.
- With GitHub identity requests returning 503, the daemon stayed running and the documented dashboard route returned HTTP 200.
