### PR TITLE
fix: prevent workspace branch conflicts from blocking creation

### DIFF
--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -50,8 +50,10 @@ embedder protocol for arbitrary host state.
   derived from the number must exclude this type
   (`internal/db/queries.go::workspaceItemTypeKeysByNumber`). Requesting the same
   branch twice returns the existing workspace. Local branch and ref-namespace
-  conflicts use the first available `-N` variant as the persisted identity;
-  setup repeats allocation under the repository lock (`internal/workspace/manager.go::Manager.CreateAdHoc`).
+  conflicts use a four-character random hash suffix as the persisted identity;
+  database collisions retry with another suffix
+  (`internal/workspace/manager.go::Manager.persistAdHocWorkspace`). Setup never
+  rewrites that identity: a later Git ref collision fails explicitly.
   Once its branch is pushed the monitor links a PR into `associated_pr_number`
   (`internal/workspace/monitor.go::workspacePRMonitorEligible`); that number is
   the workspace's item identity for display, links, and search, so surfaces must
@@ -513,6 +515,8 @@ then to a detached checkout with no managed branch
 (`internal/workspace/manager.go::addFallbackWorktree`). kenn-forge owns the
 synthetic name and its numbered variants and may delete them during cleanup;
 any other pre-existing branch is user-owned and must keep pointing where it did.
+Ad-hoc workspaces instead reserve their final hashed branch identity before
+setup; a later external Git ref collision is an explicit setup error.
 
 ## Branch Upstream
 
@@ -521,8 +525,11 @@ single source of truth for every sync-derived workspace surface:
 `commits_ahead`/`commits_behind` in the list response, the sidebar
 ahead/behind arrows, push, pull, and unpushed-commit flags. All of them
 silently report nothing when the upstream is missing, so every path that
-creates a workspace-owned branch should configure it when repository identity
-is known. Upstream wiring requires a non-empty head-repository identity whose
+creates a PR-owned branch should configure it when repository identity is
+known. Issue, Kata, and ad-hoc workspaces create new untracked branches; a
+same-named remote ref is not authority to adopt an upstream
+(`internal/workspace/manager.go::configureFallbackBranchUpstream`). PR upstream
+wiring requires a non-empty head-repository identity whose
 provider, host, and full repository path match the base repository; matching
 commit SHAs are not identity evidence
 because forks preserve commit IDs. Unknown and fork heads stay untracked. The

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -49,8 +49,10 @@ embedder protocol for arbitrary host state.
   item key is `adhoc:<branch>` and `item_number` stays 0, so item-key fallbacks
   derived from the number must exclude this type
   (`internal/db/queries.go::workspaceItemTypeKeysByNumber`). Requesting the same
-  branch twice returns the existing workspace. Once its branch is pushed the
-  monitor links a PR into `associated_pr_number`
+  branch twice returns the existing workspace. Local branch and ref-namespace
+  conflicts use the first available `-N` variant as the persisted identity;
+  setup repeats allocation under the repository lock (`internal/workspace/manager.go::Manager.CreateAdHoc`).
+  Once its branch is pushed the monitor links a PR into `associated_pr_number`
   (`internal/workspace/monitor.go::workspacePRMonitorEligible`); that number is
   the workspace's item identity for display, links, and search, so surfaces must
   never gate PR affordances on `item_type == "pull_request"` alone.

--- a/internal/server/workspacetest/adhoc_workspace_test.go
+++ b/internal/server/workspacetest/adhoc_workspace_test.go
@@ -132,9 +132,7 @@ func TestCreateAdHocWorkspaceRejectsUntrackedRepo(t *testing.T) {
 	require.Equal(http.StatusNotFound, resp.StatusCode(), string(resp.Body))
 }
 
-// An existing local branch must surface the typed conflict envelope with a
-// suggested alternative so the caller can retry without guessing.
-func TestCreateAdHocWorkspaceExistingBranchReturnsTypedConflict(t *testing.T) {
+func TestCreateAdHocWorkspaceExistingBranchIsUniquified(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -148,17 +146,15 @@ func TestCreateAdHocWorkspaceExistingBranchReturnsTypedConflict(t *testing.T) {
 		generated.CreateRepoWorkspaceJSONRequestBody{Branch: &branch},
 	)
 	require.NoError(err)
-	require.Equal(http.StatusConflict, resp.StatusCode(), string(resp.Body))
+	require.Equal(http.StatusAccepted, resp.StatusCode(), string(resp.Body))
+	require.NotNil(resp.JSON202)
+	assert.Equal(branch+"-2", resp.JSON202.GitHeadRef)
 
-	problem := resp.ApplicationproblemJSONDefault
-	require.NotNil(problem)
-	require.NotNil(problem.Type)
-	assert.Equal("urn:kenn-forge:error:workspace-branch-conflict", *problem.Type)
-	assert.Equal(generated.BranchConflict, problem.Code)
-	require.NotNil(problem.Details)
-	details := *problem.Details
-	assert.Equal(branch, details["branch"])
-	assert.Equal(branch+"-2", details["suggestedBranch"])
+	ready := waitForWorkspaceReady(t, t.Context(), fixture.client, resp.JSON202.Id)
+	assert.Equal(branch+"-2", ready.GitHeadRef)
+	assert.Equal(branch+"-2", workspaceGitOutput(
+		t, ready.WorktreePath, "rev-parse", "--abbrev-ref", "HEAD",
+	))
 }
 
 func TestCreateAdHocWorkspaceReusesExistingBranchWhenAsked(t *testing.T) {
@@ -244,9 +240,9 @@ func TestCreateAdHocWorkspaceReuseStartsFromDivergedBranchTip(t *testing.T) {
 }
 
 // Renaming the branch from inside the worktree is a shell action kenn-forge does
-// not observe, so the workspace keeps its creation-time identity: the old name
-// still resolves to it, and the new name cannot be turned into a second
-// workspace while this worktree holds the branch.
+// not observe, so the workspace keeps its creation-time identity. The old name
+// still resolves to it, while a new workspace request for the renamed branch
+// receives a unique branch.
 func TestCreateAdHocWorkspaceAfterInWorktreeBranchRename(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -277,18 +273,12 @@ func TestCreateAdHocWorkspaceAfterInWorktreeBranchRename(t *testing.T) {
 	require.NotNil(again.JSON202)
 	assert.Equal(created.JSON202.Id, again.JSON202.Id)
 
-	// New name: the renamed branch exists locally, so this is the ordinary
-	// branch conflict with a suggested alternative, not a second worktree on the
-	// same branch.
-	conflict, err := fixture.client.HTTP.CreateRepoWorkspaceWithResponse(
+	unique, err := fixture.client.HTTP.CreateRepoWorkspaceWithResponse(
 		t.Context(), "gh", "acme", "widget",
 		generated.CreateRepoWorkspaceJSONRequestBody{Branch: &renamed},
 	)
 	require.NoError(err)
-	require.Equal(http.StatusConflict, conflict.StatusCode(), string(conflict.Body))
-	problem := conflict.ApplicationproblemJSONDefault
-	require.NotNil(problem)
-	assert.Equal(generated.BranchConflict, problem.Code)
-	require.NotNil(problem.Details)
-	assert.Equal(renamed+"-2", (*problem.Details)["suggestedBranch"])
+	require.Equal(http.StatusAccepted, unique.StatusCode(), string(unique.Body))
+	require.NotNil(unique.JSON202)
+	assert.Equal(renamed+"-2", unique.JSON202.GitHeadRef)
 }

--- a/internal/server/workspacetest/adhoc_workspace_test.go
+++ b/internal/server/workspacetest/adhoc_workspace_test.go
@@ -148,11 +148,11 @@ func TestCreateAdHocWorkspaceExistingBranchIsUniquified(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusAccepted, resp.StatusCode(), string(resp.Body))
 	require.NotNil(resp.JSON202)
-	assert.Equal(branch+"-2", resp.JSON202.GitHeadRef)
+	assert.Regexp(`^spike/rate-limits-[0-9a-f]{4}$`, resp.JSON202.GitHeadRef)
 
 	ready := waitForWorkspaceReady(t, t.Context(), fixture.client, resp.JSON202.Id)
-	assert.Equal(branch+"-2", ready.GitHeadRef)
-	assert.Equal(branch+"-2", workspaceGitOutput(
+	assert.Equal(resp.JSON202.GitHeadRef, ready.GitHeadRef)
+	assert.Equal(resp.JSON202.GitHeadRef, workspaceGitOutput(
 		t, ready.WorktreePath, "rev-parse", "--abbrev-ref", "HEAD",
 	))
 }
@@ -280,5 +280,8 @@ func TestCreateAdHocWorkspaceAfterInWorktreeBranchRename(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusAccepted, unique.StatusCode(), string(unique.Body))
 	require.NotNil(unique.JSON202)
-	assert.Equal(renamed+"-2", unique.JSON202.GitHeadRef)
+	assert.Regexp(
+		`^spike/rate-limits-v2-[0-9a-f]{4}$`,
+		unique.JSON202.GitHeadRef,
+	)
 }

--- a/internal/workspace/adhoc_test.go
+++ b/internal/workspace/adhoc_test.go
@@ -126,7 +126,7 @@ func TestCreateAdHocDistinctBranchesGetDistinctWorktrees(t *testing.T) {
 	assert.NotEqual(first.WorktreePath, second.WorktreePath)
 }
 
-func TestCreateAdHocExistingLocalBranchConflicts(t *testing.T) {
+func TestCreateAdHocExistingLocalBranchIsUniquified(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -144,11 +144,53 @@ func TestCreateAdHocExistingLocalBranchConflicts(t *testing.T) {
 		CreateAdHocOptions{BranchName: branch},
 	)
 
-	require.Nil(ws)
-	var conflict *WorkspaceBranchConflictError
-	require.ErrorAs(err, &conflict)
-	assert.Equal(branch, conflict.Branch)
-	assert.Equal(branch+"-2", conflict.SuggestedBranch)
+	require.NoError(err)
+	require.NotNil(ws)
+	assert.Equal(branch+"-2", ws.GitHeadRef)
+	assert.Equal(branch+"-2", ws.WorkspaceBranch)
+	assert.Equal(db.AdHocWorkspaceItemKey(branch+"-2"), ws.ItemKey)
+}
+
+func TestNextAvailableBranchNameAvoidsRefNamespaceConflicts(t *testing.T) {
+	tests := []struct {
+		name      string
+		existing  []string
+		requested string
+		want      string
+	}{
+		{
+			name:      "descendant",
+			existing:  []string{"docs/agent-context-routing"},
+			requested: "docs",
+			want:      "docs-2",
+		},
+		{
+			name:      "numbered descendant",
+			existing:  []string{"docs/agent-context-routing", "docs-2/claimed"},
+			requested: "docs",
+			want:      "docs-3",
+		},
+		{
+			name:      "ancestor",
+			existing:  []string{"docs"},
+			requested: "docs/agent-context-routing",
+			want:      "docs-2/agent-context-routing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			localRepo := setupLocalWorktreeBaseForWorkspaceGitTest(t, "feature/other")
+			for _, branch := range tt.existing {
+				runWorkspaceTestGit(t, localRepo, "branch", branch)
+			}
+
+			got, err := nextAvailableBranchName(t.Context(), localRepo, tt.requested)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestCreateAdHocReuseExistingLocalBranch(t *testing.T) {
@@ -216,6 +258,42 @@ func TestSetupAdHocWorkspaceBranchesFromOriginHead(t *testing.T) {
 		t, got.WorktreePath, "rev-parse", "HEAD",
 	)))
 	assert.Equal(originHead, worktreeHead)
+}
+
+func TestSetupAdHocWorkspaceUniquifiesBranchPrefixConflict(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	d := openTestDB(t)
+	localRepo, _, platformHost := setupHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/other",
+	)
+	runWorkspaceTestGit(t, localRepo, "branch", "docs/agent-context-routing")
+	seedRepo(t, d, platformHost, "acme", "widget")
+
+	tmuxScript, _ := writeRecorderScript(t)
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{tmuxScript})
+	mgr.SetWorktreeBasePathResolver(staticBaseResolver(localRepo))
+
+	ws, err := mgr.CreateAdHoc(
+		t.Context(), "github", platformHost, "acme", "widget",
+		CreateAdHocOptions{BranchName: "docs"},
+	)
+	require.NoError(err)
+	require.NoError(mgr.Setup(t.Context(), ws))
+
+	got, err := d.GetWorkspace(t.Context(), ws.ID)
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal("ready", got.Status)
+	assert.Equal("docs-2", got.GitHeadRef)
+	assert.Equal("docs-2", got.WorkspaceBranch)
+
+	head := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, got.WorktreePath, "rev-parse", "--abbrev-ref", "HEAD",
+	)))
+	assert.Equal("docs-2", head)
 }
 
 func TestAgentContextForAdHocWorkspace(t *testing.T) {

--- a/internal/workspace/adhoc_test.go
+++ b/internal/workspace/adhoc_test.go
@@ -160,21 +160,21 @@ func TestNextAvailableBranchNameAvoidsRefNamespaceConflicts(t *testing.T) {
 	}{
 		{
 			name:      "descendant",
-			existing:  []string{"docs/agent-context-routing"},
+			existing:  []string{"docs/guide-refresh"},
 			requested: "docs",
 			want:      "docs-2",
 		},
 		{
 			name:      "numbered descendant",
-			existing:  []string{"docs/agent-context-routing", "docs-2/claimed"},
+			existing:  []string{"docs/guide-refresh", "docs-2/claimed"},
 			requested: "docs",
 			want:      "docs-3",
 		},
 		{
 			name:      "ancestor",
 			existing:  []string{"docs"},
-			requested: "docs/agent-context-routing",
-			want:      "docs-2/agent-context-routing",
+			requested: "docs/guide-refresh",
+			want:      "docs-2/guide-refresh",
 		},
 	}
 
@@ -268,7 +268,7 @@ func TestSetupAdHocWorkspaceUniquifiesBranchPrefixConflict(t *testing.T) {
 	localRepo, _, platformHost := setupHTTPWorktreeBaseForWorkspaceGitTest(
 		t, "feature/other",
 	)
-	runWorkspaceTestGit(t, localRepo, "branch", "docs/agent-context-routing")
+	runWorkspaceTestGit(t, localRepo, "branch", "docs/guide-refresh")
 	seedRepo(t, d, platformHost, "acme", "widget")
 
 	tmuxScript, _ := writeRecorderScript(t)

--- a/internal/workspace/adhoc_test.go
+++ b/internal/workspace/adhoc_test.go
@@ -146,35 +146,42 @@ func TestCreateAdHocExistingLocalBranchIsUniquified(t *testing.T) {
 
 	require.NoError(err)
 	require.NotNil(ws)
-	assert.Equal(branch+"-2", ws.GitHeadRef)
-	assert.Equal(branch+"-2", ws.WorkspaceBranch)
-	assert.Equal(db.AdHocWorkspaceItemKey(branch+"-2"), ws.ItemKey)
+	assert.Regexp(`^spike/thing-[0-9a-f]{4}$`, ws.GitHeadRef)
+	assert.Equal(ws.GitHeadRef, ws.WorkspaceBranch)
+	assert.Equal(db.AdHocWorkspaceItemKey(ws.GitHeadRef), ws.ItemKey)
 }
 
-func TestNextAvailableBranchNameAvoidsRefNamespaceConflicts(t *testing.T) {
+func TestNextAvailableAdHocBranchNameAvoidsRefNamespaceConflicts(t *testing.T) {
+	const workspaceID = "0011223344556677"
+	firstHash := adHocBranchHash(workspaceID, 0)
+	secondHash := adHocBranchHash(workspaceID, 1)
 	tests := []struct {
 		name      string
 		existing  []string
 		requested string
 		want      string
+		wantNext  int
 	}{
 		{
 			name:      "descendant",
 			existing:  []string{"docs/guide-refresh"},
 			requested: "docs",
-			want:      "docs-2",
+			want:      "docs-" + firstHash,
+			wantNext:  1,
 		},
 		{
-			name:      "numbered descendant",
-			existing:  []string{"docs/guide-refresh", "docs-2/claimed"},
+			name:      "hash collision",
+			existing:  []string{"docs/guide-refresh", "docs-" + firstHash},
 			requested: "docs",
-			want:      "docs-3",
+			want:      "docs-" + secondHash,
+			wantNext:  2,
 		},
 		{
 			name:      "ancestor",
 			existing:  []string{"docs"},
 			requested: "docs/guide-refresh",
-			want:      "docs-2/guide-refresh",
+			want:      "docs-" + firstHash + "/guide-refresh",
+			wantNext:  1,
 		},
 	}
 
@@ -185,12 +192,76 @@ func TestNextAvailableBranchNameAvoidsRefNamespaceConflicts(t *testing.T) {
 				runWorkspaceTestGit(t, localRepo, "branch", branch)
 			}
 
-			got, err := nextAvailableBranchName(t.Context(), localRepo, tt.requested)
+			got, nextAttempt, err := nextAvailableAdHocBranchName(
+				t.Context(), localRepo, tt.requested, workspaceID, 0,
+			)
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantNext, nextAttempt)
 		})
 	}
+}
+
+func TestPersistAdHocWorkspaceRetriesReservedHashedBranch(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	const (
+		workspaceID = "0011223344556677"
+		requested   = "docs"
+	)
+	d := openTestDB(t)
+	seedRepo(t, d, "github.com", "acme", "widget")
+	localRepo := setupLocalWorktreeBaseForWorkspaceGitTest(t, "feature/other")
+	runWorkspaceTestGit(t, localRepo, "branch", "docs/guide-refresh")
+	mgr := NewManager(d, t.TempDir())
+
+	firstBranch, nextAttempt, err := nextAvailableAdHocBranchName(
+		t.Context(), localRepo, requested, workspaceID, 0,
+	)
+	require.NoError(err)
+	require.NoError(d.InsertWorkspace(t.Context(), &Workspace{
+		ID:              "reserved-workspace",
+		Platform:        "github",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        db.WorkspaceItemTypeAdHoc,
+		ItemKey:         db.AdHocWorkspaceItemKey(firstBranch),
+		GitHeadRef:      firstBranch,
+		WorkspaceBranch: firstBranch,
+		WorktreePath:    filepath.Join(t.TempDir(), "reserved-worktree"),
+		TmuxSession:     "forge-reserved-workspace",
+		TerminalBackend: "tmux",
+		Status:          "creating",
+	}))
+
+	ws := &Workspace{
+		ID:              workspaceID,
+		Platform:        "github",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        db.WorkspaceItemTypeAdHoc,
+		TmuxSession:     "forge-" + workspaceID,
+		TerminalBackend: "tmux",
+		Status:          "creating",
+	}
+	mgr.setAdHocWorkspaceIdentity(ws, firstBranch, firstBranch)
+
+	require.NoError(mgr.persistAdHocWorkspace(
+		t.Context(), ws, localRepo, requested, nextAttempt,
+	))
+	assert.NotEqual(firstBranch, ws.GitHeadRef)
+	assert.Regexp(`^docs-[0-9a-f]{4}$`, ws.GitHeadRef)
+	assert.Equal(ws.GitHeadRef, ws.WorkspaceBranch)
+	assert.Equal(db.AdHocWorkspaceItemKey(ws.GitHeadRef), ws.ItemKey)
+
+	stored, err := d.GetWorkspace(t.Context(), workspaceID)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal(ws.GitHeadRef, stored.GitHeadRef)
 }
 
 func TestCreateAdHocReuseExistingLocalBranch(t *testing.T) {
@@ -260,7 +331,45 @@ func TestSetupAdHocWorkspaceBranchesFromOriginHead(t *testing.T) {
 	assert.Equal(originHead, worktreeHead)
 }
 
-func TestSetupAdHocWorkspaceUniquifiesBranchPrefixConflict(t *testing.T) {
+func TestConfigureFallbackBranchUpstreamIgnoresAdHocWorkspace(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	const (
+		headBranch     = "spike/thing"
+		fallbackBranch = "kenn-forge/work-abcd"
+	)
+	localRepo := setupLocalWorktreeBaseForWorkspaceGitTest(t, "feature/other")
+	headSHA := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo, "rev-parse", "HEAD",
+	)))
+	runWorkspaceTestGit(
+		t, localRepo, "update-ref", "refs/remotes/origin/"+headBranch, headSHA,
+	)
+	runWorkspaceTestGit(t, localRepo, "branch", fallbackBranch, headSHA)
+	worktreePath := filepath.Join(t.TempDir(), "worktree")
+	runWorkspaceTestGit(
+		t, localRepo, "worktree", "add", worktreePath, fallbackBranch,
+	)
+
+	err := configureFallbackBranchUpstream(
+		t.Context(), localRepo,
+		&Workspace{
+			ItemType:     db.WorkspaceItemTypeAdHoc,
+			GitHeadRef:   headBranch,
+			WorktreePath: worktreePath,
+		},
+		fallbackBranch,
+	)
+	require.NoError(err)
+
+	_, err = gitConfigValue(
+		t.Context(), worktreePath, "branch."+fallbackBranch+".remote",
+	)
+	assert.Error(err)
+}
+
+func TestSetupAdHocWorkspaceUsesHashedBranchForPrefixConflict(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -287,13 +396,46 @@ func TestSetupAdHocWorkspaceUniquifiesBranchPrefixConflict(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(got)
 	assert.Equal("ready", got.Status)
-	assert.Equal("docs-2", got.GitHeadRef)
-	assert.Equal("docs-2", got.WorkspaceBranch)
+	assert.Regexp(`^docs-[0-9a-f]{4}$`, got.GitHeadRef)
+	assert.Equal(got.GitHeadRef, got.WorkspaceBranch)
+	assert.Equal(db.AdHocWorkspaceItemKey(got.GitHeadRef), got.ItemKey)
 
 	head := strings.TrimSpace(string(runWorkspaceTestGit(
 		t, got.WorktreePath, "rev-parse", "--abbrev-ref", "HEAD",
 	)))
-	assert.Equal("docs-2", head)
+	assert.Equal(got.GitHeadRef, head)
+}
+
+func TestSetupAdHocWorkspaceLateBranchConflictFailsWithoutChangingIdentity(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	d := openTestDB(t)
+	localRepo, _, platformHost := setupHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/other",
+	)
+	seedRepo(t, d, platformHost, "acme", "widget")
+
+	tmuxScript, _ := writeRecorderScript(t)
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{tmuxScript})
+	mgr.SetWorktreeBasePathResolver(staticBaseResolver(localRepo))
+
+	ws, err := mgr.CreateAdHoc(
+		t.Context(), "github", platformHost, "acme", "widget",
+		CreateAdHocOptions{BranchName: "docs"},
+	)
+	require.NoError(err)
+	runWorkspaceTestGit(t, localRepo, "branch", "docs/guide-refresh")
+
+	require.Error(mgr.Setup(t.Context(), ws))
+	got, err := d.GetWorkspace(t.Context(), ws.ID)
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal("error", got.Status)
+	assert.Equal("docs", got.GitHeadRef)
+	assert.Equal("docs", got.WorkspaceBranch)
+	assert.Equal(db.AdHocWorkspaceItemKey("docs"), got.ItemKey)
 }
 
 func TestAgentContextForAdHocWorkspace(t *testing.T) {

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -93,8 +93,7 @@ type CreateIssueOptions struct {
 //
 // Ad-hoc workspaces have no source item, so the branch is their only identity.
 // An empty BranchName generates one; a name that already exists locally is
-// reused when requested or automatically suffixed with the first available
-// numbered variant.
+// reused when requested or automatically suffixed with a short random hash.
 type CreateAdHocOptions struct {
 	BranchName          string
 	ReuseExistingBranch bool
@@ -742,11 +741,13 @@ func (m *Manager) CreateAdHoc(
 	if gitHeadRef == "" {
 		gitHeadRef = adHocWorkspaceBranch(id)
 	}
+	requestedBranch := gitHeadRef
 	if err := validateLocalBranchName(ctx, "", gitHeadRef); err != nil {
 		return nil, err
 	}
 
 	workspaceBranch := gitHeadRef
+	nextHashAttempt := 0
 	branchDir, ok, localBase, err := m.branchInspectionDir(
 		ctx, repo.Platform, platformHost, owner, name,
 		workspaceCloneRemoteURL(repo, platformHost, owner, name),
@@ -763,7 +764,12 @@ func (m *Manager) CreateAdHoc(
 			if !errors.As(err, &conflict) {
 				return nil, err
 			}
-			branch = conflict.SuggestedBranch
+			branch, nextHashAttempt, err = nextAvailableAdHocBranchName(
+				ctx, branchDir, requestedBranch, id, nextHashAttempt,
+			)
+			if err != nil {
+				return nil, err
+			}
 		}
 		workspaceBranch = branch
 	}
@@ -778,25 +784,60 @@ func (m *Manager) CreateAdHoc(
 		RepoOwner:       owner,
 		RepoName:        name,
 		ItemType:        db.WorkspaceItemTypeAdHoc,
-		ItemKey:         db.AdHocWorkspaceItemKey(gitHeadRef),
-		GitHeadRef:      gitHeadRef,
-		WorkspaceBranch: workspaceBranch,
-		WorktreePath: filepath.Join(
-			m.worktreeDir, repo.Platform, platformHost, owner, name,
-			adHocWorktreeDirName(gitHeadRef),
-		),
 		TmuxSession:     "forge-" + id,
 		TerminalBackend: m.PreferredTerminalBackend(),
 		Status:          "creating",
 	}
+	m.setAdHocWorkspaceIdentity(ws, gitHeadRef, workspaceBranch)
 
-	if err := m.db.InsertWorkspace(ctx, ws); err != nil {
-		if isUniqueConstraintError(err) {
-			return nil, fmt.Errorf("%w: %v", ErrWorkspaceDuplicate, err)
-		}
+	if err := m.persistAdHocWorkspace(
+		ctx, ws, branchDir, requestedBranch, nextHashAttempt,
+	); err != nil {
 		return nil, fmt.Errorf("insert workspace: %w", err)
 	}
 	return ws, nil
+}
+
+func (m *Manager) persistAdHocWorkspace(
+	ctx context.Context,
+	ws *Workspace,
+	branchDir, requestedBranch string,
+	nextHashAttempt int,
+) error {
+	for {
+		err := m.db.InsertWorkspace(ctx, ws)
+		if err == nil {
+			return nil
+		}
+		if !isUniqueConstraintError(err) {
+			return err
+		}
+		if nextHashAttempt == 0 {
+			return fmt.Errorf("%w: %v", ErrWorkspaceDuplicate, err)
+		}
+
+		branch, nextAttempt, nameErr := nextAvailableAdHocBranchName(
+			ctx, branchDir, requestedBranch, ws.ID, nextHashAttempt,
+		)
+		if nameErr != nil {
+			return nameErr
+		}
+		m.setAdHocWorkspaceIdentity(ws, branch, branch)
+		nextHashAttempt = nextAttempt
+	}
+}
+
+func (m *Manager) setAdHocWorkspaceIdentity(
+	ws *Workspace, identityBranch, managedBranch string,
+) {
+	ws.GitHeadRef = identityBranch
+	ws.WorkspaceBranch = managedBranch
+	ws.ItemKey = db.AdHocWorkspaceItemKey(identityBranch)
+	ws.WorktreePath = filepath.Join(
+		m.worktreeDir,
+		ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+		adHocWorktreeDirName(identityBranch),
+	)
 }
 
 // adHocWorkspaceBranch names a branch for work the user did not name. The
@@ -2383,9 +2424,12 @@ func (m *Manager) addIssueWorktree(
 		return "", nil
 	}
 	startRef := workspaceStartRef(ws)
-	return m.addFallbackWorktree(
+	if _, err := m.runOwnedGitWorktreeAddCreatingBranch(
 		ctx, cloneDir, ws, workspaceBranch, startRef,
-	)
+	); err != nil {
+		return "", err
+	}
+	return workspaceBranch, nil
 }
 
 func (m *Manager) addPreferredWorktree(
@@ -2652,7 +2696,7 @@ func configureFallbackBranchUpstream(
 	ws *Workspace,
 	fallbackBranch string,
 ) error {
-	if ws.MRHeadRepo != nil {
+	if ws.ItemType != db.WorkspaceItemTypePullRequest || ws.MRHeadRepo != nil {
 		return nil
 	}
 	trackingSHA, ok, err := gitRefSHA(
@@ -5582,18 +5626,60 @@ func nextAvailableBranchName(
 	)
 }
 
+func nextAvailableAdHocBranchName(
+	ctx context.Context,
+	dir, branch, workspaceID string,
+	startAttempt int,
+) (string, int, error) {
+	_, ancestorConflict, err := localBranchNameStatus(ctx, dir, branch)
+	if err != nil {
+		return "", startAttempt, err
+	}
+	for attempt := startAttempt; attempt < 1000; attempt++ {
+		suffix := adHocBranchHash(workspaceID, attempt)
+		for _, candidate := range suffixedBranchCandidates(
+			branch, suffix, ancestorConflict,
+		) {
+			available, err := localBranchNameAvailable(ctx, dir, candidate)
+			if err != nil {
+				return "", attempt, err
+			}
+			if available {
+				return candidate, attempt + 1, nil
+			}
+		}
+	}
+	return "", startAttempt, fmt.Errorf(
+		"could not find an available branch name derived from %q",
+		branch,
+	)
+}
+
+func adHocBranchHash(workspaceID string, attempt int) string {
+	sum := sha256.Sum256(fmt.Appendf(nil, "%s:%d", workspaceID, attempt))
+	return hex.EncodeToString(sum[:2])
+}
+
 func numberedBranchCandidates(
 	branch string, number int, escapeAncestors bool,
 ) []string {
+	return suffixedBranchCandidates(
+		branch, strconv.Itoa(number), escapeAncestors,
+	)
+}
+
+func suffixedBranchCandidates(
+	branch, suffix string, escapeAncestors bool,
+) []string {
 	parts := strings.Split(branch, "/")
 	candidates := make([]string, 0, len(parts))
-	candidates = append(candidates, fmt.Sprintf("%s-%d", branch, number))
+	candidates = append(candidates, branch+"-"+suffix)
 	if !escapeAncestors {
 		return candidates
 	}
 	for i := len(parts) - 2; i >= 0; i-- {
 		candidate := slices.Clone(parts)
-		candidate[i] = fmt.Sprintf("%s-%d", candidate[i], number)
+		candidate[i] += "-" + suffix
 		candidates = append(candidates, strings.Join(candidate, "/"))
 	}
 	return candidates

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -93,7 +93,8 @@ type CreateIssueOptions struct {
 //
 // Ad-hoc workspaces have no source item, so the branch is their only identity.
 // An empty BranchName generates one; a name that already exists locally is
-// either reused or reported as a conflict, matching the issue-workspace flow.
+// reused when requested or automatically suffixed with the first available
+// numbered variant.
 type CreateAdHocOptions struct {
 	BranchName          string
 	ReuseExistingBranch bool
@@ -758,9 +759,16 @@ func (m *Manager) CreateAdHoc(
 			ctx, branchDir, gitHeadRef, opts.ReuseExistingBranch, localBase,
 		)
 		if err != nil {
-			return nil, err
+			var conflict *WorkspaceBranchConflictError
+			if !errors.As(err, &conflict) {
+				return nil, err
+			}
+			branch = conflict.SuggestedBranch
 		}
 		workspaceBranch = branch
+	}
+	if workspaceBranch != "" {
+		gitHeadRef = workspaceBranch
 	}
 
 	ws := &Workspace{
@@ -920,7 +928,14 @@ func workspaceBranchForExistingLocalBranch(
 		return "", fmt.Errorf("inspect local branch: %w", err)
 	}
 	if !exists {
-		return branch, nil
+		available, err := localBranchNameAvailable(ctx, dir, branch)
+		if err != nil {
+			return "", fmt.Errorf("inspect local branch namespace: %w", err)
+		}
+		if available {
+			return branch, nil
+		}
+		return "", workspaceBranchConflict(ctx, dir, branch)
 	}
 	if reuse && !localBase {
 		return "", nil
@@ -2368,12 +2383,9 @@ func (m *Manager) addIssueWorktree(
 		return "", nil
 	}
 	startRef := workspaceStartRef(ws)
-	if _, err := m.runOwnedGitWorktreeAddCreatingBranch(
+	return m.addFallbackWorktree(
 		ctx, cloneDir, ws, workspaceBranch, startRef,
-	); err != nil {
-		return "", err
-	}
-	return workspaceBranch, nil
+	)
 }
 
 func (m *Manager) addPreferredWorktree(
@@ -5486,6 +5498,35 @@ func localBranchExists(
 	return false, err
 }
 
+func localBranchNameAvailable(
+	ctx context.Context, dir, branch string,
+) (bool, error) {
+	available, _, err := localBranchNameStatus(ctx, dir, branch)
+	return available, err
+}
+
+func localBranchNameStatus(
+	ctx context.Context, dir, branch string,
+) (available, ancestorConflict bool, err error) {
+	out, err := gitCombinedOutput(
+		ctx, dir, "for-each-ref", "--format=%(refname)", "refs/heads",
+	)
+	if err != nil {
+		return false, false, err
+	}
+	want := "refs/heads/" + branch
+	for ref := range strings.SplitSeq(out, "\n") {
+		ref = strings.TrimSpace(ref)
+		if strings.HasPrefix(want, ref+"/") {
+			return false, true, nil
+		}
+		if ref == want || strings.HasPrefix(ref, want+"/") {
+			return false, false, nil
+		}
+	}
+	return true, false, nil
+}
+
 func localBranchCheckedOut(
 	ctx context.Context, dir, branch string,
 ) (bool, error) {
@@ -5518,18 +5559,42 @@ func workspaceGitCommand(
 func nextAvailableBranchName(
 	ctx context.Context, dir, branch string,
 ) (string, error) {
+	_, ancestorConflict, err := localBranchNameStatus(ctx, dir, branch)
+	if err != nil {
+		return "", err
+	}
 	for i := 2; i < 1000; i++ {
-		candidate := fmt.Sprintf("%s-%d", branch, i)
-		exists, err := localBranchExists(ctx, dir, candidate)
-		if err != nil {
-			return "", err
-		}
-		if !exists {
-			return candidate, nil
+		for _, candidate := range numberedBranchCandidates(
+			branch, i, ancestorConflict,
+		) {
+			available, err := localBranchNameAvailable(ctx, dir, candidate)
+			if err != nil {
+				return "", err
+			}
+			if available {
+				return candidate, nil
+			}
 		}
 	}
 	return "", fmt.Errorf(
 		"could not find an available branch name derived from %q",
 		branch,
 	)
+}
+
+func numberedBranchCandidates(
+	branch string, number int, escapeAncestors bool,
+) []string {
+	parts := strings.Split(branch, "/")
+	candidates := make([]string, 0, len(parts))
+	candidates = append(candidates, fmt.Sprintf("%s-%d", branch, number))
+	if !escapeAncestors {
+		return candidates
+	}
+	for i := len(parts) - 2; i >= 0; i-- {
+		candidate := slices.Clone(parts)
+		candidate[i] = fmt.Sprintf("%s-%d", candidate[i], number)
+		candidates = append(candidates, strings.Join(candidate, "/"))
+	}
+	return candidates
 }


### PR DESCRIPTION
Creating an ad-hoc workspace no longer fails when its requested name already exists or conflicts with an existing Git ref prefix.

- Choose a namespace-safe branch with a four-character random suffix, persist it as the workspace identity, and retry if a pending workspace reserved the same suffix.
- Keep new ad-hoc, issue, and Kata branches untracked even when `origin` has a same-named branch.
- Preserve explicit existing-branch reuse. If a ref appears in the narrow gap after persistence, setup fails without rewriting the workspace identity.
