### PR TITLE
Make terminal font choices searchable and durable

### DIFF
--- a/context/embeds.md
+++ b/context/embeds.md
@@ -14,6 +14,10 @@ the single requested workspace surface. It does not run standalone startup work:
 settings hydration, sync polling, pull/issue preloads, event-stream connection,
 container/sidebar setup, or global keyboard shortcuts.
 
+- Workspace embeds hydrate terminal settings before mount and persist terminal-option
+  saves through the daemon settings API; embed mode must not leave an active Save control
+  as a silent no-op (`frontend/src/lib/components/settings/TerminalSettings.svelte::save`).
+
 Hosts communicate with embeds through the `window.__kenn_forge_*` bridge on that
 isolated browsing context. Because the bridge and browser history are
 document-global, callers that need more than one embed at a time should allocate

--- a/frontend/src/lib/components/settings/TerminalSettings.svelte
+++ b/frontend/src/lib/components/settings/TerminalSettings.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Checkbox } from "@kenn-io/kit-ui";
+  import { Checkbox, SearchInput } from "@kenn-io/kit-ui";
   import { Effect } from "effect";
   import Modal from "../shared/Modal.svelte";
   import { onDestroy, untrack } from "svelte";
@@ -15,7 +15,6 @@
     supportsLocalFonts,
     type LocalFontData as FontData,
   } from "../../browser/local-fonts.js";
-  import { isEmbedded } from "../../stores/embed-config.svelte.js";
   import {
     previewTerminalSettings,
     restoreTerminalSettingsPreview,
@@ -42,7 +41,6 @@
   }: Props = $props();
 
   const { settings: settingsStore } = getStores();
-  const embedded = isEmbedded();
   const runtime = getAppRuntime();
   let localFontExecution: AppExecution<void, unknown> | null = null;
 
@@ -86,6 +84,7 @@
     DEFAULT_TERMINAL_SETTINGS.retained_sessions,
   );
   let fontDialogOpen = $state(false);
+  let fontFilterDraft = $state("");
   let localFonts = $state<FontData[] | null>(null);
   let fontLoadError = $state<string | null>(null);
   let loadingFonts = $state(false);
@@ -201,6 +200,12 @@
         DEFAULT_TERMINAL_SETTINGS.retained_sessions
   );
   const canSave = $derived(!saving && isDirty);
+  const normalizedFontFilter = $derived(fontFilterDraft.trim().toLowerCase());
+  const filteredCommonMonospaceFonts = $derived(
+    normalizedFontFilter === ""
+      ? commonMonospaceFonts
+      : commonMonospaceFonts.filter((family) => family.toLowerCase().includes(normalizedFontFilter)),
+  );
   const localMonospaceFonts = $derived.by(() => {
     if (!localFonts) return [];
     const fonts: FontData[] = [];
@@ -213,6 +218,15 @@
       left.family.localeCompare(right.family),
     );
   });
+  const filteredLocalMonospaceFonts = $derived(
+    normalizedFontFilter === ""
+      ? localMonospaceFonts
+      : localMonospaceFonts.filter((font) =>
+          `${font.family} ${font.fullName} ${font.postscriptName} ${font.style}`
+            .toLowerCase()
+            .includes(normalizedFontFilter),
+        ),
+  );
   const supportsLocalFontPicker = $derived(
     supportsLocalFonts(),
   );
@@ -290,6 +304,7 @@
   }
 
   function openFontDialog(): void {
+    fontFilterDraft = "";
     fontDialogOpen = true;
     if (localFonts === null) {
       loadLocalFonts();
@@ -298,17 +313,22 @@
 
   function selectFontFamily(family: string): void {
     fontFamilyDraft = replacePreferredFontFamily(fontFamilyDraft, family);
+    closeFontDialog();
+  }
+
+  function closeFontDialog(): void {
+    fontFilterDraft = "";
     fontDialogOpen = false;
   }
 
   function closeFontDialogForEscape(event: KeyboardEvent): void {
     if (!fontDialogOpen || event.key !== "Escape" || event.defaultPrevented) return;
+    if (fontFilterDraft !== "" && event.target instanceof HTMLInputElement && event.target.type === "search") return;
     event.preventDefault();
-    fontDialogOpen = false;
+    closeFontDialog();
   }
 
   function save(): void {
-    if (embedded) return;
     if (!isDirty) return;
 
     saving = true;
@@ -506,24 +526,36 @@
   title="Choose monospace font"
   width={560}
   showClose
-  onClose={() => (fontDialogOpen = false)}
+  onClose={closeFontDialog}
 >
   <div class="font-dialog-content">
+      <SearchInput
+        bind:value={fontFilterDraft}
+        placeholder="Filter fonts..."
+        ariaLabel="Filter fonts"
+        size="sm"
+        block
+        autofocus
+      />
       <div class="font-section">
         <div class="font-section-title">Common fonts</div>
-        <div class="font-list">
-          {#each commonMonospaceFonts as family (family)}
-            <button
-              class="font-option"
-              type="button"
-              style:font-family={quoteFontFamily(family)}
-              onclick={() => selectFontFamily(family)}
-            >
-              <span>{family}</span>
-              <code>abc 123</code>
-            </button>
-          {/each}
-        </div>
+        {#if filteredCommonMonospaceFonts.length > 0}
+          <div class="font-list">
+            {#each filteredCommonMonospaceFonts as family (family)}
+              <button
+                class="font-option"
+                type="button"
+                style:font-family={quoteFontFamily(family)}
+                onclick={() => selectFontFamily(family)}
+              >
+                <span>{family}</span>
+                <code>abc 123</code>
+              </button>
+            {/each}
+          </div>
+        {:else}
+          <p class="font-state">No common fonts match.</p>
+        {/if}
       </div>
 
       <div class="font-section">
@@ -541,9 +573,9 @@
               Try again
             </button>
           {/if}
-        {:else if localMonospaceFonts.length > 0}
+        {:else if filteredLocalMonospaceFonts.length > 0}
           <div class="font-list local">
-            {#each localMonospaceFonts as font (font.family)}
+            {#each filteredLocalMonospaceFonts as font (font.family)}
               <button
                 class="font-option"
                 type="button"
@@ -555,11 +587,13 @@
               </button>
             {/each}
           </div>
-        {:else}
+        {:else if localMonospaceFonts.length === 0}
           <p class="font-state">
             No local monospace fonts were found. You can still type a font
             family manually.
           </p>
+        {:else}
+          <p class="font-state">No local fonts match.</p>
         {/if}
       </div>
   </div>

--- a/frontend/src/lib/components/settings/TerminalSettings.test.ts
+++ b/frontend/src/lib/components/settings/TerminalSettings.test.ts
@@ -4,31 +4,37 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import { makeAppRuntime, type OwnedAppRuntime } from "../../app/runtime.js";
 import type { StartupSnapshot } from "../../app/startup-workflow.js";
 
-const { mockGetTerminalSettings, mockSetTerminalSettings, mockTerminalStore, mockUpdateSettings, runtime } = vi.hoisted(
-  () => {
-    const defaultTerminal = {
-      font_family: "",
-      font_size: 14,
-      scrollback: 1000,
-      line_height: 1,
-      letter_spacing: 0,
-      cursor_blink: true,
-      font_ligatures: false,
-      hide_tmux_status: false,
-      retained_sessions: 10,
-    };
-    const store = { terminal: { ...defaultTerminal } };
-    return {
-      mockGetTerminalSettings: vi.fn(() => store.terminal),
-      mockSetTerminalSettings: vi.fn((terminal: typeof defaultTerminal) => {
-        store.terminal = terminal;
-      }),
-      mockTerminalStore: { defaultTerminal, store },
-      mockUpdateSettings: vi.fn(),
-      runtime: { current: undefined as unknown as OwnedAppRuntime },
-    };
-  },
-);
+const {
+  mockEmbedded,
+  mockGetTerminalSettings,
+  mockSetTerminalSettings,
+  mockTerminalStore,
+  mockUpdateSettings,
+  runtime,
+} = vi.hoisted(() => {
+  const defaultTerminal = {
+    font_family: "",
+    font_size: 14,
+    scrollback: 1000,
+    line_height: 1,
+    letter_spacing: 0,
+    cursor_blink: true,
+    font_ligatures: false,
+    hide_tmux_status: false,
+    retained_sessions: 10,
+  };
+  const store = { terminal: { ...defaultTerminal } };
+  return {
+    mockEmbedded: { value: false },
+    mockGetTerminalSettings: vi.fn(() => store.terminal),
+    mockSetTerminalSettings: vi.fn((terminal: typeof defaultTerminal) => {
+      store.terminal = terminal;
+    }),
+    mockTerminalStore: { defaultTerminal, store },
+    mockUpdateSettings: vi.fn(),
+    runtime: { current: undefined as unknown as OwnedAppRuntime },
+  };
+});
 
 vi.mock("../../context.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../context.js")>();
@@ -59,7 +65,7 @@ vi.mock("../../stores/embed-config.svelte.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../stores/embed-config.svelte.js")>();
   return {
     ...actual,
-    isEmbedded: () => false,
+    isEmbedded: () => mockEmbedded.value,
   };
 });
 
@@ -123,6 +129,7 @@ describe("TerminalSettings", () => {
       ...mockTerminalStore.defaultTerminal,
     };
     mockUpdateSettings.mockReset();
+    mockEmbedded.value = false;
   });
 
   beforeEach(() => {
@@ -678,7 +685,7 @@ describe("TerminalSettings", () => {
     });
   });
 
-  it("selects a common monospace font from the chooser", async () => {
+  it("filters fonts in the chooser", async () => {
     render(TerminalSettings, {
       props: {
         terminal: {
@@ -697,9 +704,85 @@ describe("TerminalSettings", () => {
     });
 
     await fireEvent.click(screen.getByRole("button", { name: "Choose" }));
-    await fireEvent.click(screen.getByRole("button", { name: /Fira Code/ }));
 
-    expect((screen.getByLabelText("Monospace font family") as HTMLInputElement).value).toBe('"Fira Code", monospace');
+    const filter = screen.getByRole("searchbox", { name: "Filter fonts" });
+    await fireEvent.input(filter, {
+      target: { value: "fira" },
+    });
+
+    expect(screen.getByRole("button", { name: /Fira Code/ })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /JetBrains Mono/ })).toBeNull();
+
+    await fireEvent.keyDown(filter, { key: "Escape" });
+
+    expect((filter as HTMLInputElement).value).toBe("");
+    expect(screen.getByRole("dialog", { name: "Choose monospace font" })).toBeTruthy();
+  });
+
+  it("persists a font selected from the chooser", async () => {
+    const selectedFontFamily = '"Fira Code", monospace';
+    mockUpdateSettings.mockResolvedValue({
+      terminal: {
+        ...mockTerminalStore.defaultTerminal,
+        font_family: selectedFontFamily,
+      },
+    });
+    const onUpdate = vi.fn();
+
+    render(TerminalSettings, {
+      props: {
+        terminal: { ...mockTerminalStore.defaultTerminal },
+        onUpdate,
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Choose" }));
+    await fireEvent.click(screen.getByRole("button", { name: /Fira Code/ }));
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockUpdateSettings).toHaveBeenCalledWith({
+        terminal: {
+          ...mockTerminalStore.defaultTerminal,
+          font_family: selectedFontFamily,
+        },
+      });
+      expect(onUpdate).toHaveBeenCalledWith({
+        ...mockTerminalStore.defaultTerminal,
+        font_family: selectedFontFamily,
+      });
+    });
+  });
+
+  it("persists a selected font from an embedded terminal", async () => {
+    mockEmbedded.value = true;
+    const selectedFontFamily = '"Fira Code", monospace';
+    mockUpdateSettings.mockResolvedValue({
+      terminal: {
+        ...mockTerminalStore.defaultTerminal,
+        font_family: selectedFontFamily,
+      },
+    });
+
+    render(TerminalSettings, {
+      props: {
+        terminal: { ...mockTerminalStore.defaultTerminal },
+        onUpdate: vi.fn(),
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Choose" }));
+    await fireEvent.click(screen.getByRole("button", { name: /Fira Code/ }));
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockUpdateSettings).toHaveBeenCalledWith({
+        terminal: {
+          ...mockTerminalStore.defaultTerminal,
+          font_family: selectedFontFamily,
+        },
+      });
+    });
   });
 
   it("replaces the preferred font while preserving fallbacks", async () => {

--- a/frontend/tests/e2e-full/00-settings-terminal-font.spec.ts
+++ b/frontend/tests/e2e-full/00-settings-terminal-font.spec.ts
@@ -97,8 +97,11 @@ test("settings saves and reloads workspace terminal options", async ({ page }) =
   await letterSpacing.fill("1");
   await retainedSessions.fill("7");
   await cursorBlink.uncheck();
-  await input.click();
-  await input.pressSequentially('"Iosevka Term", monospace');
+  await page.getByRole("button", { name: "Choose" }).click();
+  const fontDialog = page.getByRole("dialog", { name: "Choose monospace font" });
+  await fontDialog.getByRole("searchbox", { name: "Filter fonts" }).fill("Iosevka");
+  await fontDialog.getByRole("button", { name: /Iosevka Term/ }).click();
+  await expect(input).toHaveValue('"Iosevka Term", monospace');
   await expect(saveButton).toBeEnabled();
   const saveResponsePromise = page.waitForResponse(
     (response) => response.url().endsWith("/api/v1/settings") && response.request().method() === "PUT",


### PR DESCRIPTION
Font choices in embedded terminal options now use the daemon-backed settings save instead of stopping after the live preview.

- Adds an autofocus filter for common and local monospace fonts.
- Keeps selected terminal fonts after the browser surface reopens.
