### PR TITLE
Keep Forge available when a provider is unreachable at startup

### DIFF
--- a/cmd/kenn-forge/main.go
+++ b/cmd/kenn-forge/main.go
@@ -534,7 +534,7 @@ func run(opts serve.Options) error {
 	if opts.DisableSync {
 		providerSources, err = registerProviderTokenSources(cfg, tokenSources)
 	} else {
-		providerSources, err = collectProviderTokenSources(ctx, cfg, tokenSources)
+		providerSources, err = collectProviderTokenSourcesDegraded(ctx, cfg, tokenSources)
 		if err != nil {
 			slog.Warn(
 				"provider credentials unavailable; serving cached data without provider sync",

--- a/cmd/kenn-forge/main.go
+++ b/cmd/kenn-forge/main.go
@@ -535,16 +535,23 @@ func run(opts serve.Options) error {
 		providerSources, err = registerProviderTokenSources(cfg, tokenSources)
 	} else {
 		providerSources, err = collectProviderTokenSources(ctx, cfg, tokenSources)
+		if err != nil {
+			slog.Warn(
+				"provider credentials unavailable; serving cached data without provider sync",
+				"err", err,
+			)
+			providerSources = nil
+		}
 	}
-	if err != nil {
+	if err != nil && opts.DisableSync {
 		return err
 	}
 	var identityResolver ghclient.IdentityResolver
-	if !opts.DisableSync {
+	if !opts.DisableSync && providerSources != nil {
 		identityResolver = ghclient.HTTPIdentityResolver{}
 	}
 
-	startup, err := buildProviderStartup(
+	startup, err := buildProviderStartupOrDegraded(
 		ctx, database, cfg, tokenSources, providerSources,
 		defaultProviderFactories(), identityResolver,
 	)

--- a/cmd/kenn-forge/main.go
+++ b/cmd/kenn-forge/main.go
@@ -551,9 +551,9 @@ func run(opts serve.Options) error {
 		identityResolver = ghclient.HTTPIdentityResolver{}
 	}
 
-	startup, err := buildProviderStartupOrDegraded(
+	startup, err := buildProviderStartupForServe(
 		ctx, database, cfg, tokenSources, providerSources,
-		defaultProviderFactories(), identityResolver,
+		defaultProviderFactories(), identityResolver, opts.DisableSync,
 	)
 	if err != nil {
 		if ctx.Err() != nil && errors.Is(err, context.Canceled) {

--- a/cmd/kenn-forge/main_test.go
+++ b/cmd/kenn-forge/main_test.go
@@ -603,6 +603,38 @@ func TestBuildProviderStartupKeepsForgeProviderHostsDistinct(t *testing.T) {
 	assert.NotNil(giteaReader)
 }
 
+func TestBuildProviderStartupOrDegradedKeepsHealthyProviderWhenFactoryFails(t *testing.T) {
+	require := require.New(t)
+
+	set := tokenauth.NewSourceSet(tokenauth.Options{})
+	startup, err := buildProviderStartupOrDegraded(
+		t.Context(), dbtest.Open(t), &config.Config{}, set,
+		map[string]tokenauth.Source{
+			providerHostKey(string(platform.KindForgejo), "forge.example.com"): mainTestTokenSource(
+				t, string(platform.KindForgejo), "forge.example.com", "FORGEJO_TEST_TOKEN", "forgejo-token",
+			),
+			providerHostKey(string(platform.KindGitea), "gitea.example.com"): mainTestTokenSource(
+				t, string(platform.KindGitea), "gitea.example.com", "GITEA_TEST_TOKEN", "gitea-token",
+			),
+		},
+		map[string]providerFactory{
+			string(platform.KindForgejo): func(providerFactoryInput) (providerFactoryOutput, error) {
+				return providerFactoryOutput{}, errors.New("provider API unavailable")
+			},
+			string(platform.KindGitea): func(input providerFactoryInput) (providerFactoryOutput, error) {
+				return providerFactoryOutput{provider: mainTestRepositoryReader{
+					kind: platform.KindGitea,
+					host: input.host,
+				}}, nil
+			},
+		},
+		nil,
+	)
+	require.NoError(err)
+	_, err = startup.registry.Provider(platform.KindGitea, "gitea.example.com")
+	require.NoError(err)
+}
+
 func TestBuildProviderStartupUsesRegisteredFactoryForFutureProvider(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/cmd/kenn-forge/main_test.go
+++ b/cmd/kenn-forge/main_test.go
@@ -635,6 +635,27 @@ func TestBuildProviderStartupOrDegradedKeepsHealthyProviderWhenFactoryFails(t *t
 	require.NoError(err)
 }
 
+func TestBuildProviderStartupForServeReturnsFactoryErrorWhenSyncDisabled(t *testing.T) {
+	require := require.New(t)
+
+	set := tokenauth.NewSourceSet(tokenauth.Options{})
+	_, err := buildProviderStartupForServe(
+		t.Context(), dbtest.Open(t), &config.Config{}, set,
+		map[string]tokenauth.Source{
+			providerHostKey(string(platform.KindForgejo), "forge.example.com"): mainTestTokenSource(
+				t, string(platform.KindForgejo), "forge.example.com", "FORGEJO_TEST_TOKEN", "forgejo-token",
+			),
+		},
+		map[string]providerFactory{
+			string(platform.KindForgejo): func(providerFactoryInput) (providerFactoryOutput, error) {
+				return providerFactoryOutput{}, errors.New("provider API unavailable")
+			},
+		},
+		nil, true,
+	)
+	require.ErrorContains(err, "create Forgejo client for forge.example.com: provider API unavailable")
+}
+
 func TestBuildProviderStartupUsesRegisteredFactoryForFutureProvider(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/cmd/kenn-forge/provider_startup.go
+++ b/cmd/kenn-forge/provider_startup.go
@@ -292,6 +292,33 @@ func providerTokenSources(
 	return providerSources, nil
 }
 
+// buildProviderStartupOrDegraded keeps the local UI available when a remote
+// provider cannot be initialized. The database already contains the last
+// successful sync, and provider operations can report unavailable until the
+// daemon is restarted after the provider recovers.
+func buildProviderStartupOrDegraded(
+	ctx context.Context,
+	database *db.DB,
+	cfg *config.Config,
+	set *tokenauth.SourceSet,
+	providerSources map[string]tokenauth.Source,
+	factories map[string]providerFactory,
+	resolver github.IdentityResolver,
+) (providerStartup, error) {
+	startup, err := buildProviderStartup(
+		ctx, database, cfg, set, providerSources, factories, resolver,
+	)
+	if err == nil {
+		return startup, nil
+	}
+
+	slog.Warn(
+		"provider startup unavailable; serving cached data without provider sync",
+		"err", err,
+	)
+	return buildProviderStartup(ctx, database, cfg, set, nil, factories, nil)
+}
+
 func buildProviderStartup(
 	ctx context.Context,
 	database *db.DB,

--- a/cmd/kenn-forge/provider_startup.go
+++ b/cmd/kenn-forge/provider_startup.go
@@ -238,14 +238,26 @@ func collectProviderTokenSources(
 	cfg *config.Config,
 	set *tokenauth.SourceSet,
 ) (map[string]tokenauth.Source, error) {
-	return providerTokenSources(ctx, cfg, set, true)
+	return providerTokenSources(ctx, cfg, set, true, false)
+}
+
+// collectProviderTokenSourcesDegraded resolves provider tokens like
+// collectProviderTokenSources, but a host whose credentials fail is excluded
+// with a warning instead of failing startup, so one provider outage cannot
+// stop sync for healthy hosts. Config-consistency errors still fail.
+func collectProviderTokenSourcesDegraded(
+	ctx context.Context,
+	cfg *config.Config,
+	set *tokenauth.SourceSet,
+) (map[string]tokenauth.Source, error) {
+	return providerTokenSources(ctx, cfg, set, true, true)
 }
 
 func registerProviderTokenSources(
 	cfg *config.Config,
 	set *tokenauth.SourceSet,
 ) (map[string]tokenauth.Source, error) {
-	return providerTokenSources(context.Background(), cfg, set, false)
+	return providerTokenSources(context.Background(), cfg, set, false, false)
 }
 
 func providerTokenSources(
@@ -253,14 +265,19 @@ func providerTokenSources(
 	cfg *config.Config,
 	set *tokenauth.SourceSet,
 	resolve bool,
+	degradeFailedHosts bool,
 ) (map[string]tokenauth.Source, error) {
 	if err := cfg.ValidateRepoTokenSourceConsistency(); err != nil {
 		return nil, err
 	}
 	providerSources := make(map[string]tokenauth.Source, len(cfg.Repos)+len(cfg.Platforms)+1)
+	failedHosts := make(map[string]struct{})
 	for _, plan := range cfg.ProviderTokenSources() {
 		desc := plan.Descriptor
 		key := providerHostKey(desc.Key.Platform, desc.Key.Host)
+		if _, failed := failedHosts[key]; failed {
+			continue
+		}
 		_, seen := providerSources[key]
 		src := set.Upsert(desc)
 		if resolve {
@@ -270,6 +287,20 @@ func providerTokenSources(
 			}
 			if _, err := src.Token(tokenCtx); err != nil {
 				if !plan.Required && errors.Is(err, tokenauth.ErrMissingToken) {
+					continue
+				}
+				if degradeFailedHosts {
+					// Any credential failure excludes the whole host: syncing
+					// with a partial credential chain could select the wrong
+					// route for repositories whose token did not resolve.
+					failedHosts[key] = struct{}{}
+					delete(providerSources, key)
+					slog.Warn(
+						"provider host credentials unavailable; serving cached data for it without sync",
+						"platform", desc.Key.Platform,
+						"host", desc.Key.Host,
+						"err", err,
+					)
 					continue
 				}
 				label := fmt.Sprintf("%s host %s", desc.Key.Platform, desc.Key.Host)
@@ -292,10 +323,24 @@ func providerTokenSources(
 	return providerSources, nil
 }
 
+// providerHostStartupError marks a startup failure attributable to one
+// provider host so degraded startup can drop that host and keep the rest.
+type providerHostStartupError struct {
+	platformName string
+	host         string
+	err          error
+}
+
+func (e *providerHostStartupError) Error() string { return e.err.Error() }
+
+func (e *providerHostStartupError) Unwrap() error { return e.err }
+
 // buildProviderStartupOrDegraded keeps the local UI available when a remote
-// provider cannot be initialized. The database already contains the last
-// successful sync, and provider operations can report unavailable until the
-// daemon is restarted after the provider recovers.
+// provider cannot be initialized. Failures attributable to one provider host
+// drop only that host, so healthy hosts keep syncing; anything else falls
+// back to an empty provider registry. The database already contains the last
+// successful sync, and dropped hosts serve cached data until the daemon is
+// restarted after the provider recovers.
 func buildProviderStartupOrDegraded(
 	ctx context.Context,
 	database *db.DB,
@@ -305,18 +350,40 @@ func buildProviderStartupOrDegraded(
 	factories map[string]providerFactory,
 	resolver github.IdentityResolver,
 ) (providerStartup, error) {
-	startup, err := buildProviderStartup(
-		ctx, database, cfg, set, providerSources, factories, resolver,
-	)
-	if err == nil {
-		return startup, nil
+	sources := providerSources
+	for {
+		startup, err := buildProviderStartup(
+			ctx, database, cfg, set, sources, factories, resolver,
+		)
+		if err == nil {
+			return startup, nil
+		}
+		var hostErr *providerHostStartupError
+		if errors.As(err, &hostErr) {
+			key := providerHostKey(hostErr.platformName, hostErr.host)
+			if _, ok := sources[key]; ok {
+				slog.Warn(
+					"provider host startup unavailable; serving cached data for it without sync",
+					"platform", hostErr.platformName,
+					"host", hostErr.host,
+					"err", hostErr.err,
+				)
+				next := make(map[string]tokenauth.Source, len(sources)-1)
+				for k, v := range sources {
+					if k != key {
+						next[k] = v
+					}
+				}
+				sources = next
+				continue
+			}
+		}
+		slog.Warn(
+			"provider startup unavailable; serving cached data without provider sync",
+			"err", err,
+		)
+		return buildProviderStartup(ctx, database, cfg, set, nil, factories, nil)
 	}
-
-	slog.Warn(
-		"provider startup unavailable; serving cached data without provider sync",
-		"err", err,
-	)
-	return buildProviderStartup(ctx, database, cfg, set, nil, factories, nil)
 }
 
 func buildProviderStartup(
@@ -349,7 +416,8 @@ func buildProviderStartup(
 	}
 	if resolver != nil {
 		if err := buildGitHubIdentityRuntimes(
-			ctx, database, cfg, set, resolver, budgetPerHour, &startup,
+			ctx, database, cfg, set, resolver, budgetPerHour,
+			providerSources, &startup,
 		); err != nil {
 			return providerStartup{}, err
 		}
@@ -488,12 +556,24 @@ func buildGitHubIdentityRuntimes(
 	set *tokenauth.SourceSet,
 	resolver github.IdentityResolver,
 	budgetPerHour int,
+	providerSources map[string]tokenauth.Source,
 	startup *providerStartup,
 ) error {
 	if cfg == nil || set == nil || resolver == nil {
 		return nil
 	}
-	plans := githubCredentialPlans(cfg)
+	// Hosts absent from providerSources were excluded (credentials failed or
+	// nothing resolved); their identity runtimes and routes stay absent too.
+	allPlans := githubCredentialPlans(cfg)
+	plans := allPlans[:0:0]
+	for _, plan := range allPlans {
+		key := providerHostKey(
+			plan.Descriptor.Key.Platform, plan.Descriptor.Key.Host,
+		)
+		if _, ok := providerSources[key]; ok {
+			plans = append(plans, plan)
+		}
+	}
 	requiredHosts := make(map[string]struct{}, len(plans))
 	for _, plan := range plans {
 		if plan.Required {
@@ -530,10 +610,14 @@ func buildGitHubIdentityRuntimes(
 				)
 				continue
 			} else {
-				return fmt.Errorf(
-					"resolve GitHub identity for %s via %s: %w",
-					desc.Key.Scope, desc.SafeString(), err,
-				)
+				return &providerHostStartupError{
+					platformName: desc.Key.Platform,
+					host:         desc.Key.Host,
+					err: fmt.Errorf(
+						"resolve GitHub identity for %s via %s: %w",
+						desc.Key.Scope, desc.SafeString(), err,
+					),
+				}
 			}
 		}
 		readIdentity := writeIdentity

--- a/cmd/kenn-forge/provider_startup.go
+++ b/cmd/kenn-forge/provider_startup.go
@@ -335,6 +335,26 @@ func (e *providerHostStartupError) Error() string { return e.err.Error() }
 
 func (e *providerHostStartupError) Unwrap() error { return e.err }
 
+func buildProviderStartupForServe(
+	ctx context.Context,
+	database *db.DB,
+	cfg *config.Config,
+	set *tokenauth.SourceSet,
+	providerSources map[string]tokenauth.Source,
+	factories map[string]providerFactory,
+	resolver github.IdentityResolver,
+	disableSync bool,
+) (providerStartup, error) {
+	if disableSync {
+		return buildProviderStartup(
+			ctx, database, cfg, set, providerSources, factories, resolver,
+		)
+	}
+	return buildProviderStartupOrDegraded(
+		ctx, database, cfg, set, providerSources, factories, resolver,
+	)
+}
+
 // buildProviderStartupOrDegraded keeps the local UI available when a remote
 // provider cannot be initialized. Failures attributable to one provider host
 // drop only that host, so healthy hosts keep syncing; anything else falls

--- a/cmd/kenn-forge/provider_startup.go
+++ b/cmd/kenn-forge/provider_startup.go
@@ -456,9 +456,13 @@ func buildProviderStartup(
 			quotaRegistry: startup.quotaRegistry,
 		})
 		if err != nil {
-			return providerStartup{}, fmt.Errorf(
-				"create %s client for %s: %w", platformLabel(platformName), host, err,
-			)
+			return providerStartup{}, &providerHostStartupError{
+				platformName: platformName,
+				host:         host,
+				err: fmt.Errorf(
+					"create %s client for %s: %w", platformLabel(platformName), host, err,
+				),
+			}
 		}
 		if built.githubClient != nil {
 			if routed := startup.githubClients[host]; routed != nil {

--- a/cmd/kenn-forge/provider_startup_identity_test.go
+++ b/cmd/kenn-forge/provider_startup_identity_test.go
@@ -1262,6 +1262,125 @@ func TestBuildProviderStartupOrDegradedKeepsServerBootableWhenGitHubUnavailable(
 	assert.Empty(startup.registry.Providers())
 }
 
+func TestCollectProviderTokenSourcesDegradedExcludesFailedHost(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	t.Setenv("FORGE_PAT", "forge-token")
+	cfg := &config.Config{
+		SyncInterval: "5m", Host: "127.0.0.1", Port: 8091, BasePath: "/",
+		Activity: config.Activity{ViewMode: "flat", TimeRange: "7d"},
+		Platforms: []config.PlatformConfig{{
+			Type: "forgejo", Host: "code.example.com", TokenEnv: "FORGE_PAT",
+		}},
+		Repos: []config.Repo{
+			{Owner: "org-a", Name: "one"},
+			{Platform: "forgejo", PlatformHost: "code.example.com", Owner: "group", Name: "two"},
+		},
+		GitHubOwnerTokens: []config.GitHubOwnerTokenConfig{{
+			Host: "github.com", Owner: "org-a", TokenEnv: "UNSET_ORG_A_PAT",
+		}},
+	}
+	require.NoError(cfg.Validate())
+
+	sources, err := collectProviderTokenSourcesDegraded(
+		t.Context(), cfg, tokenauth.NewSourceSet(tokenauth.Options{}),
+	)
+	require.NoError(err,
+		"a failing host must degrade instead of failing startup")
+	assert.Contains(sources, providerHostKey("forgejo", "code.example.com"))
+	assert.NotContains(sources, providerHostKey("github", "github.com"))
+}
+
+func TestBuildProviderStartupOrDegradedKeepsHealthyProvidersWhenGitHubFails(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	database := dbtest.Open(t)
+	t.Setenv("ORG_A_TOKEN", "org-a-token")
+	t.Setenv("GITLAB_PAT", "gitlab-token")
+	cfg := &config.Config{
+		SyncInterval: "5m", Host: "127.0.0.1", Port: 8091, BasePath: "/",
+		Activity: config.Activity{ViewMode: "flat", TimeRange: "7d"},
+		Platforms: []config.PlatformConfig{{
+			Type: "gitlab", Host: "gitlab.example.com", TokenEnv: "GITLAB_PAT",
+		}},
+		Repos: []config.Repo{
+			{Owner: "org-a", Name: "one"},
+			{Platform: "gitlab", PlatformHost: "gitlab.example.com", Owner: "group", Name: "two"},
+		},
+		GitHubOwnerTokens: []config.GitHubOwnerTokenConfig{{
+			Host: "github.com", Owner: "org-a", TokenEnv: "ORG_A_TOKEN",
+		}},
+	}
+	require.NoError(cfg.Validate())
+	set := tokenauth.NewSourceSet(tokenauth.Options{})
+	sources, err := collectProviderTokenSourcesDegraded(t.Context(), cfg, set)
+	require.NoError(err)
+
+	startup, err := buildProviderStartupOrDegraded(
+		t.Context(), database, cfg, set, sources, defaultProviderFactories(),
+		fakeGitHubIdentityResolver{err: map[string]error{
+			"ORG_A_TOKEN": errors.New("GitHub API unavailable: 503"),
+		}},
+	)
+	require.NoError(err)
+	require.Len(startup.registry.Providers(), 1,
+		"the healthy GitLab host must keep syncing")
+	assert.Empty(startup.githubClients)
+	assert.NotContains(startup.cloneSources, tokenauth.Key{
+		Platform: "github", Host: "github.com",
+	})
+	assert.Contains(startup.cloneSources, tokenauth.Key{
+		Platform: "gitlab", Host: "gitlab.example.com",
+	})
+}
+
+func TestBuildProviderStartupOrDegradedIsolatesFailingGitHubHost(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	database := dbtest.Open(t)
+	t.Setenv("ORG_A_TOKEN", "org-a-token")
+	t.Setenv("GHE_PAT", "ghe-token")
+	cfg := &config.Config{
+		SyncInterval: "5m", Host: "127.0.0.1", Port: 8091, BasePath: "/",
+		Activity: config.Activity{ViewMode: "flat", TimeRange: "7d"},
+		Platforms: []config.PlatformConfig{{
+			Type: "github", Host: "ghe.example.com", TokenEnv: "GHE_PAT",
+		}},
+		Repos: []config.Repo{
+			{Owner: "org-a", Name: "one"},
+			{PlatformHost: "ghe.example.com", Owner: "org-b", Name: "two"},
+		},
+		GitHubOwnerTokens: []config.GitHubOwnerTokenConfig{{
+			Host: "github.com", Owner: "org-a", TokenEnv: "ORG_A_TOKEN",
+		}},
+	}
+	require.NoError(cfg.Validate())
+	set := tokenauth.NewSourceSet(tokenauth.Options{})
+	sources, err := collectProviderTokenSourcesDegraded(t.Context(), cfg, set)
+	require.NoError(err)
+
+	startup, err := buildProviderStartupOrDegraded(
+		t.Context(), database, cfg, set, sources, defaultProviderFactories(),
+		fakeGitHubIdentityResolver{
+			byEnv: map[string]github.GitHubIdentity{
+				"GHE_PAT": {Key: github.IdentityKey{
+					Host: "ghe.example.com", Principal: "user:octo",
+				}},
+			},
+			err: map[string]error{
+				"ORG_A_TOKEN": errors.New("GitHub API unavailable: 503"),
+			},
+		},
+	)
+	require.NoError(err)
+	assert.NotContains(startup.cloneSources, tokenauth.Key{
+		Platform: "github", Host: "github.com",
+	}, "the unavailable GitHub host must degrade to cached data")
+	assert.Contains(startup.cloneSources, tokenauth.Key{
+		Platform: "github", Host: "ghe.example.com",
+	}, "the healthy GitHub host must keep syncing")
+}
+
 // A repository PAT override picks the credential that signs that repository's
 // writes; it must not cost the owner its App installation. The installation
 // carries its own rate-limit budget, so it still leads reads, and it remains

--- a/cmd/kenn-forge/provider_startup_identity_test.go
+++ b/cmd/kenn-forge/provider_startup_identity_test.go
@@ -1231,6 +1231,37 @@ func TestBuildProviderStartupReportsSafeGitHubIdentityResolutionFailure(t *testi
 	assert.NotContains(t, err.Error(), "super-secret-token")
 }
 
+func TestBuildProviderStartupOrDegradedKeepsServerBootableWhenGitHubUnavailable(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	database := dbtest.Open(t)
+	t.Setenv("ORG_A_TOKEN", "org-a-token")
+	cfg := &config.Config{
+		SyncInterval: "5m",
+		Host:         "127.0.0.1",
+		Port:         8091,
+		BasePath:     "/",
+		Activity:     config.Activity{ViewMode: "flat", TimeRange: "7d"},
+		Repos:        []config.Repo{{Owner: "org-a", Name: "one"}},
+		GitHubOwnerTokens: []config.GitHubOwnerTokenConfig{{
+			Host: "github.com", Owner: "org-a", TokenEnv: "ORG_A_TOKEN",
+		}},
+	}
+	require.NoError(cfg.Validate())
+	set := tokenauth.NewSourceSet(tokenauth.Options{})
+	sources, err := collectProviderTokenSources(t.Context(), cfg, set)
+	require.NoError(err)
+
+	startup, err := buildProviderStartupOrDegraded(
+		t.Context(), database, cfg, set, sources, defaultProviderFactories(),
+		fakeGitHubIdentityResolver{err: map[string]error{
+			"ORG_A_TOKEN": errors.New("GitHub API unavailable: 503"),
+		}},
+	)
+	require.NoError(err)
+	assert.Empty(startup.registry.Providers())
+}
+
 // A repository PAT override picks the credential that signs that repository's
 // writes; it must not cost the owner its App installation. The installation
 // carries its own rate-limit budget, so it still leads reads, and it remains

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -120,6 +120,9 @@ GitHub may additionally define exact-repository and owner authorization routes.
 - Reload credential probes cover only provider hosts registered at startup, so
   a degraded host cannot block unrelated config changes
   (`internal/server/config_reload.go::Server.validateReloadProviderTokenSources`).
+- Reloads retain boot-tracked exact and glob matches for degraded hosts; new
+  unavailable hosts remain untracked until restart
+  (`internal/server/config_reload.go::Server.resolveReposForReload`).
 - Disabled startup registers credential descriptors without resolving them, so
   provider tokens stay lazy (`cmd/kenn-forge/provider_startup.go::registerProviderTokenSources`).
 - Refresh access uses the gated registry; only explicit foreground provider

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -117,6 +117,9 @@ GitHub may additionally define exact-repository and owner authorization routes.
 
 - Self-hosted hosts are hostnames with optional ports, not URL paths.
 - A missing token should fail only the provider host that needs it.
+- Reload credential probes cover only provider hosts registered at startup, so
+  a degraded host cannot block unrelated config changes
+  (`internal/server/config_reload.go::Server.validateReloadProviderTokenSources`).
 - Disabled startup registers credential descriptors without resolving them, so
   provider tokens stay lazy (`cmd/kenn-forge/provider_startup.go::registerProviderTokenSources`).
 - Refresh access uses the gated registry; only explicit foreground provider

--- a/context/server-runtime.md
+++ b/context/server-runtime.md
@@ -22,8 +22,10 @@ and the root event stream.
   paths and `KENN_FORGE_HOME` never relocate config
   (`internal/config/legacy_migration.go::migrateLegacyConfig`).
 - Sync-enabled startup keeps the local UI available when provider credentials or
-  identity initialization is unavailable; it serves cached data without provider
-  sync until a later restart (`cmd/kenn-forge/main.go::run`).
+  identity initialization is unavailable. Failures attributable to one provider
+  host drop only that host while healthy hosts keep syncing; unattributable
+  failures degrade to no provider sync. Dropped hosts serve cached data until a
+  later restart (`cmd/kenn-forge/provider_startup.go::buildProviderStartupOrDegraded`).
 
 ## Startup Lock
 

--- a/context/server-runtime.md
+++ b/context/server-runtime.md
@@ -21,6 +21,9 @@ and the root event stream.
   files before marking completion and relocating the database; explicit config
   paths and `KENN_FORGE_HOME` never relocate config
   (`internal/config/legacy_migration.go::migrateLegacyConfig`).
+- Sync-enabled startup keeps the local UI available when provider credentials or
+  identity initialization is unavailable; it serves cached data without provider
+  sync until a later restart (`cmd/kenn-forge/main.go::run`).
 
 ## Startup Lock
 

--- a/internal/server/config_reload.go
+++ b/internal/server/config_reload.go
@@ -709,6 +709,11 @@ func (s *Server) resolveReposForReload(
 		host := raw.PlatformHostOrDefault()
 		kind := platform.Kind(raw.PlatformOrDefault())
 		if _, err := s.syncer.RepositoryReader(kind, host); err != nil {
+			for _, repo := range ghclient.FallbackConfiguredRepoRefs(previous, raw) {
+				if slices.Contains(previous, repo) {
+					set.Add(repo, false)
+				}
+			}
 			skipped = append(skipped, fmt.Sprintf(
 				"%s/%s@%s/%s",
 				string(kind), host, raw.Owner, raw.Name,

--- a/internal/server/config_reload.go
+++ b/internal/server/config_reload.go
@@ -625,6 +625,17 @@ func (s *Server) validateReloadProviderTokenSources(
 			continue
 		}
 		desc := plan.Descriptor
+		if s.syncer != nil {
+			registry := s.syncer.Registry()
+			if registry == nil {
+				continue
+			}
+			if _, err := registry.Provider(
+				platform.Kind(desc.Key.Platform), desc.Key.Host,
+			); err != nil {
+				continue
+			}
+		}
 		if _, ok := s.tokenSources.Get(desc.Key); !ok {
 			continue
 		}

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -899,7 +899,9 @@ token_env = "KENN_FORGE_MISSING_REPO_TOKEN"
 	assert.Equal("KENN_FORGE_REPO_TOKEN", currentTokenEnv)
 }
 
-func TestConfigReload_IgnoresCredentialsForProviderMissingAtStartup(t *testing.T) {
+func TestConfigReload_PreservesCachedReposForProviderMissingAtStartup(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	t.Setenv("KENN_FORGE_GITHUB_TOKEN", "github-token")
 	t.Setenv("KENN_FORGE_FAILED_GITLAB_TOKEN", "")
 	const failedProvider = `
@@ -913,9 +915,15 @@ platform = "gitlab"
 platform_host = "gitlab.example.com"
 owner = "acme"
 name = "backend"
+
+[[repos]]
+platform = "gitlab"
+platform_host = "gitlab.example.com"
+owner = "acme"
+name = "service-*"
 `
 
-	srv, _, cfgPath := setupTestServerWithConfigContent(
+	srv, database, cfgPath := setupTestServerWithConfigContent(
 		t, validReloadConfig+failedProvider, &mockGH{},
 	)
 	set := tokenauth.NewSourceSet(tokenauth.Options{})
@@ -923,10 +931,37 @@ name = "backend"
 		set.Upsert(plan.Descriptor)
 	}
 	srv.tokenSources = set
+	startupFallbacks := []ghclient.RepoRef{
+		{
+			Platform: platform.KindGitLab, PlatformHost: "gitlab.example.com",
+			Owner: "acme", Name: "backend", RepoPath: "acme/backend",
+			PlatformExternalID: "gid://gitlab/Project/42",
+			ConfiguredRepoPath: "acme/backend",
+		},
+		{
+			Platform: platform.KindGitLab, PlatformHost: "gitlab.example.com",
+			Owner: "acme", Name: "service-api", RepoPath: "acme/service-api",
+		},
+	}
+	srv.syncer.SetRepos(append(srv.syncer.TrackedRepos(), startupFallbacks...))
+	for i, repo := range startupFallbacks {
+		seedVerifiedRepo(t, database, db.RepoIdentity{
+			Platform: string(repo.Platform), PlatformHost: repo.PlatformHost,
+			PlatformRepoID: fmt.Sprintf("gid://gitlab/Project/%d", 42+i),
+			Owner:          repo.Owner, Name: repo.Name, RepoPath: repo.RepoPath,
+		})
+	}
+	assert.ElementsMatch([]string{"backend", "service-api"}, listRepoNames(t, srv))
 
 	writeConfigToml(t, cfgPath, validReloadConfigChangedActivity+failedProvider)
 	event := srv.applyConfigChange(t.Context())
-	require.True(t, event.Valid, "unrelated reload failed: %s", event.Error)
+	require.True(event.Valid, "unrelated reload failed: %s", event.Error)
+	assert.True(event.RestartRequired)
+	tracked := srv.syncer.TrackedRepos()
+	for _, repo := range startupFallbacks {
+		assert.Contains(tracked, repo)
+	}
+	assert.ElementsMatch([]string{"backend", "service-api"}, listRepoNames(t, srv))
 }
 
 func TestValidateReloadCloneTokenSourcesUsesRepoDescriptorForProviderHost(t *testing.T) {

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -899,6 +899,36 @@ token_env = "KENN_FORGE_MISSING_REPO_TOKEN"
 	assert.Equal("KENN_FORGE_REPO_TOKEN", currentTokenEnv)
 }
 
+func TestConfigReload_IgnoresCredentialsForProviderMissingAtStartup(t *testing.T) {
+	t.Setenv("KENN_FORGE_GITHUB_TOKEN", "github-token")
+	t.Setenv("KENN_FORGE_FAILED_GITLAB_TOKEN", "")
+	const failedProvider = `
+[[platforms]]
+type = "gitlab"
+host = "gitlab.example.com"
+token_env = "KENN_FORGE_FAILED_GITLAB_TOKEN"
+
+[[repos]]
+platform = "gitlab"
+platform_host = "gitlab.example.com"
+owner = "acme"
+name = "backend"
+`
+
+	srv, _, cfgPath := setupTestServerWithConfigContent(
+		t, validReloadConfig+failedProvider, &mockGH{},
+	)
+	set := tokenauth.NewSourceSet(tokenauth.Options{})
+	for _, plan := range srv.cfg.ProviderTokenSources() {
+		set.Upsert(plan.Descriptor)
+	}
+	srv.tokenSources = set
+
+	writeConfigToml(t, cfgPath, validReloadConfigChangedActivity+failedProvider)
+	event := srv.applyConfigChange(t.Context())
+	require.True(t, event.Valid, "unrelated reload failed: %s", event.Error)
+}
+
 func TestValidateReloadCloneTokenSourcesUsesRepoDescriptorForProviderHost(t *testing.T) {
 	cfgPath := filepath.Join(t.TempDir(), "config.toml")
 	writeConfigToml(t, cfgPath, `


### PR DESCRIPTION
Restarts the approach from #928: provider startup is best-effort, and the UI keeps serving the local SQLite snapshot when a provider cannot be reached.

- A GitHub token or identity bootstrap failure no longer terminates the daemon; the affected host serves cached data without provider sync until a restart after the provider recovers.
- Failures are isolated per provider host: one host's credential or identity failure drops only that host, and healthy GitHub, GitLab, Forgejo, and Gitea hosts keep syncing (the review finding on #928).
- Failures not attributable to one host fall back to serving cached data with no provider sync.
- Degraded hosts get no provider clients, so provider reads and writes for them fail closed rather than running on unverified state.

Replaces #932, whose in-process recovery machinery grew well beyond the original goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)