### PR TITLE
Single-flight GitHub App token mints with failure cooldown

### DIFF
--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -122,7 +122,7 @@ func (s staticTokenSource) Token(context.Context) (string, error) {
 	return string(s), nil
 }
 
-func (s staticTokenSource) Invalidate() {}
+func (s staticTokenSource) Invalidate(string) {}
 
 func (s staticTokenSource) Descriptor() tokenauth.Descriptor {
 	return tokenauth.Descriptor{Key: tokenauth.Key{Platform: "github", Host: "github.com"}}

--- a/cmd/kenn-forge/provider_startup.go
+++ b/cmd/kenn-forge/provider_startup.go
@@ -85,7 +85,7 @@ func (s missingRouteTokenSource) Token(context.Context) (string, error) {
 	}
 }
 
-func (missingRouteTokenSource) Invalidate() {}
+func (missingRouteTokenSource) Invalidate(string) {}
 
 func (missingRouteTokenSource) Descriptor() tokenauth.Descriptor {
 	return tokenauth.Descriptor{}

--- a/context/retries-and-backoffs.md
+++ b/context/retries-and-backoffs.md
@@ -137,12 +137,12 @@ Reach for a shared slot whenever multiple in-process call sites
 hit the same upstream resource. Prefer dedup over retry — it removes
 the cause, retry just absorbs the effect.
 
-GitHub App token mints share one in-flight result per credential. Caller-context failures are not
-cached or returned to waiters, which retry with their own context. Headerless failures cool down
-for five seconds; server-directed retry deadlines stop at one hour. Invalidation (stale 401
-retries, credential updates) never evicts an in-flight mint — it has handed out no token yet, and
-evicting it lets concurrent stale invalidations defeat single-flight
-(`internal/tokenauth/source.go::githubAppTokenStore.resolve`).
+GitHub App token mints share one in-flight result per credential. Only errors matching the minting
+caller's context failure bypass caching and waiters; internal timeouts cool down normally. Headerless
+failures cool down for five seconds; server-directed retry deadlines stop at one hour.
+(`internal/tokenauth/source.go::githubAppTokenStore.resolve`)
+Invalidation preserves in-flight mints and active failure cooldowns across stale 401 retries.
+(`internal/tokenauth/source.go::githubAppTokenStore.invalidate`)
 
 Roborev configured-repository discovery retains successful inventory and
 definitive hook results for the process lifetime; only transient failures retry

--- a/context/retries-and-backoffs.md
+++ b/context/retries-and-backoffs.md
@@ -137,6 +137,13 @@ Reach for a shared slot whenever multiple in-process call sites
 hit the same upstream resource. Prefer dedup over retry — it removes
 the cause, retry just absorbs the effect.
 
+GitHub App token mints share one in-flight result per credential. Caller-context failures are not
+cached or returned to waiters, which retry with their own context. Headerless failures cool down
+for five seconds; server-directed retry deadlines stop at one hour. Invalidation (stale 401
+retries, credential updates) never evicts an in-flight mint — it has handed out no token yet, and
+evicting it lets concurrent stale invalidations defeat single-flight
+(`internal/tokenauth/source.go::githubAppTokenStore.resolve`).
+
 Roborev configured-repository discovery retains successful inventory and
 definitive hook results for the process lifetime; only transient failures retry
 after cooldown. Shared refresh work is lifecycle-bound and independently

--- a/context/retries-and-backoffs.md
+++ b/context/retries-and-backoffs.md
@@ -141,8 +141,9 @@ GitHub App token mints share one in-flight result per credential. Only errors ma
 caller's context failure bypass caching and waiters; internal timeouts cool down normally. Headerless
 failures cool down for five seconds; server-directed retry deadlines stop at one hour.
 (`internal/tokenauth/source.go::githubAppTokenStore.resolve`)
-Invalidation preserves in-flight mints and active failure cooldowns across stale 401 retries.
-(`internal/tokenauth/source.go::githubAppTokenStore.invalidate`)
+Unauthorized retries evict only the exact rejected token; in-flight mints, active failure cooldowns,
+and newer completed tokens survive stale responses.
+(`internal/tokenauth/source.go::githubAppTokenStore.invalidateToken`)
 
 Roborev configured-repository discovery retains successful inventory and
 definitive hook results for the process lifetime; only transient failures retry

--- a/internal/gitclone/auth_test.go
+++ b/internal/gitclone/auth_test.go
@@ -23,7 +23,10 @@ func (s *mutableTestTokenSource) Token(context.Context) (string, error) {
 	return s.token, nil
 }
 
-func (s *mutableTestTokenSource) Invalidate() {
+func (s *mutableTestTokenSource) Invalidate(rejectedToken string) {
+	if s.token != rejectedToken {
+		return
+	}
 	s.invalidated++
 	s.token = "second-token"
 }
@@ -473,7 +476,7 @@ func (s *failingTokenSource) Token(context.Context) (string, error) {
 	return "", tokenauth.ErrMissingToken
 }
 
-func (s *failingTokenSource) Invalidate() {}
+func (s *failingTokenSource) Invalidate(string) {}
 
 func (s *failingTokenSource) Descriptor() tokenauth.Descriptor {
 	return tokenauth.Descriptor{Key: tokenauth.Key{Platform: "test", Host: "github.com"}}

--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -815,18 +815,18 @@ func (m *Manager) gitNetworked(
 	cleanupBeforeAuthRetry func() error,
 	args ...string,
 ) ([]byte, error) {
-	out, stderr, err := m.runGitAuthed(ctx, source, host, dir, args...)
+	out, stderr, rejectedToken, err := m.runGitAuthed(ctx, source, host, dir, args...)
 	if err == nil {
 		return out, nil
 	}
 	wrapped := wrapGitError(err, stderr)
-	if isAuthGitError(wrapped) && invalidateTokenSource(source) {
+	if isAuthGitError(wrapped) && invalidateTokenSource(source, rejectedToken) {
 		if cleanupBeforeAuthRetry != nil {
 			if err := cleanupBeforeAuthRetry(); err != nil {
 				return nil, err
 			}
 		}
-		out, stderr, err = m.runGitAuthed(ctx, source, host, dir, args...)
+		out, stderr, _, err = m.runGitAuthed(ctx, source, host, dir, args...)
 		if err == nil {
 			return out, nil
 		}
@@ -839,12 +839,13 @@ func (m *Manager) gitNetworked(
 // command. Networked git has no stdin, so it takes no input.
 func (m *Manager) runGitAuthed(
 	ctx context.Context, source tokenauth.Source, host, dir string, args ...string,
-) ([]byte, []byte, error) {
-	runner, err := m.gitRunnerAuthed(ctx, source, host)
+) ([]byte, []byte, string, error) {
+	runner, token, err := m.gitRunnerAuthed(ctx, source, host)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
-	return runGitCommand(ctx, runner, dir, nil, args...)
+	out, stderr, err := runGitCommand(ctx, runner, dir, nil, args...)
+	return out, stderr, token, err
 }
 
 // runGitCommand runs git in dir with the given runner, bounded by the shared
@@ -926,11 +927,11 @@ func gitExitCode(err error) (int, bool) {
 	return 0, false
 }
 
-func invalidateTokenSource(source tokenauth.Source) bool {
+func invalidateTokenSource(source tokenauth.Source, rejectedToken string) bool {
 	if source == nil {
 		return false
 	}
-	source.Invalidate()
+	source.Invalidate(rejectedToken)
 	return true
 }
 
@@ -961,20 +962,20 @@ func (m *Manager) fallbackSource(host string) tokenauth.Source {
 // networked operations. With no source configured it returns the plain runner.
 func (m *Manager) gitRunnerAuthed(
 	ctx context.Context, source tokenauth.Source, host string,
-) (gitcmd.Runner, error) {
+) (gitcmd.Runner, string, error) {
 	runner := newGitRunner()
 	if source == nil {
-		return runner, nil
+		return runner, "", nil
 	}
 	token, err := source.Token(ctx)
 	if err != nil {
-		return runner, fmt.Errorf("resolve git token for host %s: %w", host, err)
+		return runner, "", fmt.Errorf("resolve git token for host %s: %w", host, err)
 	}
 	if token != "" {
 		// GitHub's smart HTTP endpoint expects Basic auth credentials.
 		runner = runner.WithBasicAuth("x-access-token", token)
 	}
-	return runner, nil
+	return runner, token, nil
 }
 
 // isNotFoundError checks if git stderr indicates a missing object or ref.

--- a/internal/github/identity.go
+++ b/internal/github/identity.go
@@ -120,10 +120,12 @@ func (s *identityBoundSource) Token(ctx context.Context) (string, error) {
 	return token, nil
 }
 
-func (s *identityBoundSource) Invalidate() {
-	s.source.Invalidate()
+func (s *identityBoundSource) Invalidate(rejectedToken string) {
+	s.source.Invalidate(rejectedToken)
 	s.mu.Lock()
-	s.acceptedToken = ""
+	if s.acceptedToken == rejectedToken {
+		s.acceptedToken = ""
+	}
 	s.mu.Unlock()
 }
 
@@ -137,7 +139,7 @@ type staticTokenSource struct {
 }
 
 func (s staticTokenSource) Token(context.Context) (string, error) { return s.token, nil }
-func (s staticTokenSource) Invalidate()                           {}
+func (s staticTokenSource) Invalidate(string)                     {}
 func (s staticTokenSource) Descriptor() tokenauth.Descriptor      { return s.desc }
 
 type authenticatedUserLookup func(
@@ -162,10 +164,12 @@ func (s *identityRecordingSource) Token(ctx context.Context) (string, error) {
 	return token, nil
 }
 
-func (s *identityRecordingSource) Invalidate() {
-	s.source.Invalidate()
+func (s *identityRecordingSource) Invalidate(rejectedToken string) {
+	s.source.Invalidate(rejectedToken)
 	s.mu.Lock()
-	s.token = ""
+	if s.token == rejectedToken {
+		s.token = ""
+	}
 	s.mu.Unlock()
 }
 

--- a/internal/github/identity_test.go
+++ b/internal/github/identity_test.go
@@ -133,7 +133,7 @@ func TestIdentityBoundSourceRejectsCrossUserRotation(t *testing.T) {
 	_, err := bound.Token(tokenauth.WithMutationAuth(t.Context()))
 	require.NoError(err)
 	source.token = "different-user-token"
-	bound.Invalidate()
+	bound.Invalidate("same-user-token")
 	_, err = bound.Token(tokenauth.WithMutationAuth(t.Context()))
 	assert.ErrorIs(t, err, ErrIdentityChanged)
 }
@@ -147,7 +147,7 @@ func (f identityResolverFunc) ResolvePAT(ctx context.Context, host string, sourc
 type mutableIdentityTestSource struct{ token string }
 
 func (s *mutableIdentityTestSource) Token(context.Context) (string, error) { return s.token, nil }
-func (s *mutableIdentityTestSource) Invalidate()                           {}
+func (s *mutableIdentityTestSource) Invalidate(string)                     {}
 func (s *mutableIdentityTestSource) Descriptor() tokenauth.Descriptor {
 	return tokenauth.Descriptor{Key: tokenauth.Key{Platform: "github", Host: "github.com"}}
 }

--- a/internal/github/runtime_auth_test.go
+++ b/internal/github/runtime_auth_test.go
@@ -30,11 +30,14 @@ func (s *mutableRuntimeAuthTokenSource) Token(context.Context) (string, error) {
 	return s.token, nil
 }
 
-func (s *mutableRuntimeAuthTokenSource) Invalidate() {
+func (s *mutableRuntimeAuthTokenSource) Invalidate(rejectedToken string) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.token != rejectedToken {
+		return
+	}
 	s.token = "second-token"
 	s.invalidates++
-	s.mu.Unlock()
 }
 
 func (s *mutableRuntimeAuthTokenSource) Descriptor() tokenauth.Descriptor {

--- a/internal/github/syncertest/gitealike_report_test.go
+++ b/internal/github/syncertest/gitealike_report_test.go
@@ -24,7 +24,7 @@ type staticGiteaLikeToken struct {
 
 func (s staticGiteaLikeToken) Token(context.Context) (string, error) { return "token", nil }
 
-func (s staticGiteaLikeToken) Invalidate() {}
+func (s staticGiteaLikeToken) Invalidate(string) {}
 
 func (s staticGiteaLikeToken) Descriptor() tokenauth.Descriptor {
 	return tokenauth.Descriptor{

--- a/internal/github/syncertest/gitlab_sync_test.go
+++ b/internal/github/syncertest/gitlab_sync_test.go
@@ -22,7 +22,7 @@ type staticGitLabToken string
 
 func (s staticGitLabToken) Token(context.Context) (string, error) { return string(s), nil }
 
-func (s staticGitLabToken) Invalidate() {}
+func (s staticGitLabToken) Invalidate(string) {}
 
 func (s staticGitLabToken) Descriptor() tokenauth.Descriptor {
 	return tokenauth.Descriptor{Key: tokenauth.Key{Platform: "gitlab", Host: "gitlab.example.com"}}

--- a/internal/github/token_source_test.go
+++ b/internal/github/token_source_test.go
@@ -16,7 +16,7 @@ func (s staticTestTokenSource) Token(context.Context) (string, error) {
 	return string(s), nil
 }
 
-func (s staticTestTokenSource) Invalidate() {}
+func (s staticTestTokenSource) Invalidate(string) {}
 
 func (s staticTestTokenSource) Descriptor() tokenauth.Descriptor {
 	return tokenauth.Descriptor{Key: tokenauth.Key{Platform: "test", Host: "test"}}

--- a/internal/githubapp/client.go
+++ b/internal/githubapp/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -212,6 +213,7 @@ func (c *Client) CoreRateLimit(ctx context.Context, token string) (*RateLimit, e
 // StatusError is a non-2xx API response.
 type StatusError struct {
 	StatusCode int
+	Header     http.Header
 	Body       string
 }
 
@@ -221,6 +223,32 @@ func (e *StatusError) Error() string {
 		msg = msg[:200] + "..."
 	}
 	return fmt.Sprintf("github api status %d: %s", e.StatusCode, msg)
+}
+
+// RetryDeadline returns the server-provided time when a rate-limited request
+// may be retried. Retry-After takes precedence over the primary rate-limit
+// reset header when both are present.
+func (e *StatusError) RetryDeadline(now time.Time) time.Time {
+	if e == nil {
+		return time.Time{}
+	}
+	if value := strings.TrimSpace(e.Header.Get("Retry-After")); value != "" {
+		if seconds, err := strconv.ParseInt(value, 10, 64); err == nil {
+			return now.Add(time.Duration(seconds) * time.Second)
+		}
+		if at, err := http.ParseTime(value); err == nil {
+			return at
+		}
+	}
+	rateExhausted := strings.TrimSpace(e.Header.Get("X-RateLimit-Remaining")) == "0"
+	reset := strings.TrimSpace(e.Header.Get("X-RateLimit-Reset"))
+	if (e.StatusCode == http.StatusTooManyRequests || rateExhausted) &&
+		reset != "" {
+		if epoch, err := strconv.ParseInt(reset, 10, 64); err == nil {
+			return time.Unix(epoch, 0).UTC()
+		}
+	}
+	return time.Time{}
 }
 
 // IsStatus reports whether err is a StatusError with the given code.
@@ -265,7 +293,11 @@ func (c *Client) do(
 		return fmt.Errorf("reading response body: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return &StatusError{StatusCode: resp.StatusCode, Body: string(data)}
+		return &StatusError{
+			StatusCode: resp.StatusCode,
+			Header:     resp.Header.Clone(),
+			Body:       string(data),
+		}
 	}
 	if out == nil {
 		return nil

--- a/internal/githubapp/client_test.go
+++ b/internal/githubapp/client_test.go
@@ -2,6 +2,7 @@ package githubapp
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -136,5 +137,40 @@ func TestAPIBaseForHost(t *testing.T) {
 	}
 	for _, tt := range tests {
 		assert.Equal(t, tt.want, APIBaseForHost(tt.host), "host %q", tt.host)
+	}
+}
+
+func TestStatusErrorRetryDeadline(t *testing.T) {
+	now := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	rateResetHeader := make(http.Header)
+	rateResetHeader.Set("X-RateLimit-Reset", fmt.Sprint(now.Add(10*time.Minute).Unix()))
+	rateResetHeader.Set("X-RateLimit-Remaining", "0")
+	unrelatedResetHeader := make(http.Header)
+	unrelatedResetHeader.Set("X-RateLimit-Reset", fmt.Sprint(now.Add(10*time.Minute).Unix()))
+	unrelatedResetHeader.Set("X-RateLimit-Remaining", "4999")
+	for _, tt := range []struct {
+		name   string
+		header http.Header
+		want   time.Time
+	}{
+		{
+			name:   "retry after seconds",
+			header: http.Header{"Retry-After": {"90"}},
+			want:   now.Add(90 * time.Second),
+		},
+		{
+			name:   "rate limit reset",
+			header: rateResetHeader,
+			want:   now.Add(10 * time.Minute),
+		},
+		{
+			name:   "unrelated forbidden response",
+			header: unrelatedResetHeader,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &StatusError{StatusCode: http.StatusForbidden, Header: tt.header}
+			assert.Equal(t, tt.want, err.RetryDeadline(now))
+		})
 	}
 }

--- a/internal/platform/forgejo/token_source_test.go
+++ b/internal/platform/forgejo/token_source_test.go
@@ -16,7 +16,7 @@ func (s staticTestTokenSource) Token(context.Context) (string, error) {
 	return string(s), nil
 }
 
-func (s staticTestTokenSource) Invalidate() {}
+func (s staticTestTokenSource) Invalidate(string) {}
 
 func (s staticTestTokenSource) Descriptor() tokenauth.Descriptor {
 	return tokenauth.Descriptor{Key: tokenauth.Key{Platform: "test", Host: "test"}}

--- a/internal/platform/gitea/token_source_test.go
+++ b/internal/platform/gitea/token_source_test.go
@@ -16,7 +16,7 @@ func (s staticTestTokenSource) Token(context.Context) (string, error) {
 	return string(s), nil
 }
 
-func (s staticTestTokenSource) Invalidate() {}
+func (s staticTestTokenSource) Invalidate(string) {}
 
 func (s staticTestTokenSource) Descriptor() tokenauth.Descriptor {
 	return tokenauth.Descriptor{Key: tokenauth.Key{Platform: "test", Host: "test"}}

--- a/internal/platform/gitlab/token_source_test.go
+++ b/internal/platform/gitlab/token_source_test.go
@@ -16,7 +16,7 @@ func (s staticTestTokenSource) Token(context.Context) (string, error) {
 	return string(s), nil
 }
 
-func (s staticTestTokenSource) Invalidate() {}
+func (s staticTestTokenSource) Invalidate(string) {}
 
 func (s staticTestTokenSource) Descriptor() tokenauth.Descriptor {
 	return tokenauth.Descriptor{Key: tokenauth.Key{Platform: "test", Host: "test"}}
@@ -35,7 +35,7 @@ func (s *mutableTestTokenSource) Token(context.Context) (string, error) {
 	return s.token, nil
 }
 
-func (s *mutableTestTokenSource) Invalidate() {
+func (s *mutableTestTokenSource) Invalidate(string) {
 	s.invalidated++
 }
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -18360,13 +18360,18 @@ func TestAPIPublishReviewDraftReconcilesAfterTransientThreadIngestFailure(t *tes
 		UpdatedAt: now,
 	}}
 	var reviewThreadCalls atomic.Int32
+	reviewThreadRefreshStarted := make(chan struct{}, 1)
 	provider.reviewThreadsFn = func(
 		context.Context,
 		platform.RepoRef,
 		int,
 	) ([]platform.MergeRequestReviewThread, error) {
-		if reviewThreadCalls.Add(1) == 1 {
+		call := reviewThreadCalls.Add(1)
+		if call == 1 {
 			return nil, errors.New("transient review thread refresh failure")
+		}
+		if call == 2 {
+			reviewThreadRefreshStarted <- struct{}{}
 		}
 		return provider.reviewThreads, nil
 	}
@@ -18403,6 +18408,14 @@ func TestAPIPublishReviewDraftReconcilesAfterTransientThreadIngestFailure(t *tes
 
 	detailPath := "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7"
 	require.Eventually(func() bool {
+		select {
+		case <-reviewThreadRefreshStarted:
+			return true
+		default:
+			return false
+		}
+	}, 10*time.Second, 10*time.Millisecond, "background refresh did not reach the provider")
+	require.Eventually(func() bool {
 		detailRR := doJSON(t, srv, http.MethodGet, detailPath, nil)
 		if detailRR.Code != http.StatusOK {
 			return false
@@ -18415,7 +18428,7 @@ func TestAPIPublishReviewDraftReconcilesAfterTransientThreadIngestFailure(t *tes
 			detail.Events[0].EventType == "review_comment" &&
 			detail.Events[0].Body == "hidden provider comment" &&
 			detail.Events[0].MetadataJSON == hiddenMetadata
-	}, time.Second, 10*time.Millisecond)
+	}, 10*time.Second, 10*time.Millisecond)
 
 	threads, err := database.ListMRReviewThreads(ctx, mr.ID)
 	require.NoError(err)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -22102,7 +22102,9 @@ func (s *countingTokenFileSource) Token(ctx context.Context) (string, error) {
 	return s.inner.Token(ctx)
 }
 
-func (s *countingTokenFileSource) Invalidate() { s.inner.Invalidate() }
+func (s *countingTokenFileSource) Invalidate(rejectedToken string) {
+	s.inner.Invalidate(rejectedToken)
+}
 
 func (s *countingTokenFileSource) Descriptor() tokenauth.Descriptor {
 	return s.inner.Descriptor()

--- a/internal/server/e2etest/gitlab_mutations_test.go
+++ b/internal/server/e2etest/gitlab_mutations_test.go
@@ -28,7 +28,7 @@ const gitlabMutationThreadID = "abc123def456789012345678901234567890abcd"
 type staticGitLabTokenSource string
 
 func (s staticGitLabTokenSource) Token(context.Context) (string, error) { return string(s), nil }
-func (s staticGitLabTokenSource) Invalidate()                           {}
+func (s staticGitLabTokenSource) Invalidate(string)                     {}
 func (s staticGitLabTokenSource) Descriptor() tokenauth.Descriptor {
 	return tokenauth.Descriptor{Key: tokenauth.Key{Platform: "gitlab", Host: "gitlab.com"}}
 }

--- a/internal/server/e2etest/labels_provider_test.go
+++ b/internal/server/e2etest/labels_provider_test.go
@@ -30,7 +30,7 @@ import (
 type staticTokenSource string
 
 func (s staticTokenSource) Token(context.Context) (string, error) { return string(s), nil }
-func (s staticTokenSource) Invalidate()                           {}
+func (s staticTokenSource) Invalidate(string)                     {}
 func (s staticTokenSource) Descriptor() tokenauth.Descriptor {
 	return tokenauth.Descriptor{}
 }

--- a/internal/server/token_source_test.go
+++ b/internal/server/token_source_test.go
@@ -16,7 +16,7 @@ func (s staticTestTokenSource) Token(context.Context) (string, error) {
 	return string(s), nil
 }
 
-func (s staticTestTokenSource) Invalidate() {}
+func (s staticTestTokenSource) Invalidate(string) {}
 
 func (s staticTestTokenSource) Descriptor() tokenauth.Descriptor {
 	return tokenauth.Descriptor{Key: tokenauth.Key{Platform: "test", Host: "test"}}

--- a/internal/tokenauth/github_app_test.go
+++ b/internal/tokenauth/github_app_test.go
@@ -251,50 +251,52 @@ func TestGitHubAppFailedMintIsSingleFlight(t *testing.T) {
 }
 
 func TestGitHubAppInvalidateDoesNotEvictInFlightMint(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	var mints atomic.Int64
-	entered := make(chan struct{})
-	release := make(chan struct{})
-	src := NewManagedSource(githubAppDescriptor(42), Options{
-		GitHubApp: func(context.Context, Candidate) (string, time.Time, error) {
-			if mints.Add(1) == 1 {
-				close(entered)
-				<-release
-			}
-			return "ghs_fresh", time.Now().Add(time.Hour), nil
-		},
+	synctest.Test(t, func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+		var mints atomic.Int64
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		src := NewManagedSource(githubAppDescriptor(42), Options{
+			GitHubApp: func(context.Context, Candidate) (string, time.Time, error) {
+				if mints.Add(1) == 1 {
+					close(entered)
+					<-release
+				}
+				return "ghs_fresh", time.Now().Add(time.Hour), nil
+			},
+		})
+
+		type result struct {
+			token string
+			err   error
+		}
+		winner := make(chan result, 1)
+		go func() {
+			token, err := src.Token(context.Background())
+			winner <- result{token: token, err: err}
+		}()
+		<-entered
+		// A stale 401 for the previous token arrives while the replacement
+		// mint is already in flight.
+		src.Invalidate("ghs_stale")
+
+		joiner := make(chan result, 1)
+		go func() {
+			token, err := src.Token(context.Background())
+			joiner <- result{token: token, err: err}
+		}()
+		synctest.Wait()
+		assert.Equal(int64(1), mints.Load(),
+			"stale invalidation must not evict the in-flight mint into a parallel mint")
+		close(release)
+		for _, ch := range []chan result{winner, joiner} {
+			got := <-ch
+			require.NoError(got.err)
+			assert.Equal("ghs_fresh", got.token)
+		}
+		assert.Equal(int64(1), mints.Load())
 	})
-
-	type result struct {
-		token string
-		err   error
-	}
-	winner := make(chan result, 1)
-	go func() {
-		token, err := src.Token(context.Background())
-		winner <- result{token: token, err: err}
-	}()
-	<-entered
-	// A stale 401 for the previous token arrives while the replacement
-	// mint is already in flight.
-	src.Invalidate("ghs_stale")
-
-	joiner := make(chan result, 1)
-	go func() {
-		token, err := src.Token(context.Background())
-		joiner <- result{token: token, err: err}
-	}()
-	time.Sleep(50 * time.Millisecond) // let the joiner reach the store
-	assert.Equal(int64(1), mints.Load(),
-		"stale invalidation must not evict the in-flight mint into a parallel mint")
-	close(release)
-	for _, ch := range []chan result{winner, joiner} {
-		got := <-ch
-		require.NoError(got.err)
-		assert.Equal("ghs_fresh", got.token)
-	}
-	assert.Equal(int64(1), mints.Load())
 }
 
 func TestGitHubAppStaleUnauthorizedDoesNotEvictReplacementToken(t *testing.T) {

--- a/internal/tokenauth/github_app_test.go
+++ b/internal/tokenauth/github_app_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -53,7 +55,7 @@ func TestGitHubAppTokenMintAndCache(t *testing.T) {
 	assert.Equal(int64(1), mints.Load())
 
 	// Invalidate (e.g. a 401 retry in AuthTransport) forces a re-mint.
-	src.Invalidate()
+	src.Invalidate("ghs_minted")
 	_, err = src.Token(context.Background())
 	require.NoError(err)
 	assert.Equal(int64(2), mints.Load())
@@ -272,7 +274,7 @@ func TestGitHubAppInvalidateDoesNotEvictInFlightMint(t *testing.T) {
 	<-entered
 	// A stale 401 for the previous token arrives while the replacement
 	// mint is already in flight.
-	src.Invalidate()
+	src.Invalidate("ghs_stale")
 
 	joiner := make(chan result, 1)
 	go func() {
@@ -289,6 +291,76 @@ func TestGitHubAppInvalidateDoesNotEvictInFlightMint(t *testing.T) {
 		assert.Equal("ghs_fresh", got.token)
 	}
 	assert.Equal(int64(1), mints.Load())
+}
+
+func TestGitHubAppStaleUnauthorizedDoesNotEvictReplacementToken(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	var mints atomic.Int64
+	src := NewManagedSource(githubAppDescriptor(42), Options{
+		GitHubApp: func(context.Context, Candidate) (string, time.Time, error) {
+			mint := mints.Add(1)
+			return fmt.Sprintf("token-%d", mint), time.Now().Add(time.Hour), nil
+		},
+	})
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var authMu sync.Mutex
+	authByPath := make(map[string][]string)
+	transport := AuthTransport{
+		Source: src,
+		Base: RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			authMu.Lock()
+			authByPath[req.URL.Path] = append(
+				authByPath[req.URL.Path], req.Header.Get("Authorization"),
+			)
+			attempt := len(authByPath[req.URL.Path])
+			authMu.Unlock()
+
+			status := http.StatusOK
+			if attempt == 1 {
+				status = http.StatusUnauthorized
+				if req.URL.Path == "/first" {
+					close(firstEntered)
+					<-releaseFirst
+				}
+			}
+			return &http.Response{
+				StatusCode: status,
+				Body:       http.NoBody,
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}),
+		SetHeader:           BearerAuthHeader,
+		RetryOnUnauthorized: true,
+	}
+
+	firstReq, err := http.NewRequestWithContext(
+		t.Context(), http.MethodGet, "https://api.example.test/first", nil,
+	)
+	require.NoError(err)
+	firstResult := make(chan error, 1)
+	go func() {
+		_, err := transport.RoundTrip(firstReq)
+		firstResult <- err
+	}()
+	<-firstEntered
+
+	secondReq, err := http.NewRequestWithContext(
+		t.Context(), http.MethodGet, "https://api.example.test/second", nil,
+	)
+	require.NoError(err)
+	_, secondErr := transport.RoundTrip(secondReq)
+	close(releaseFirst)
+	firstErr := <-firstResult
+	require.NoError(secondErr)
+	require.NoError(firstErr)
+
+	assert.Equal([]string{"Bearer token-1", "Bearer token-2"}, authByPath["/second"])
+	assert.Equal([]string{"Bearer token-1", "Bearer token-2"}, authByPath["/first"])
+	assert.Equal(int64(2), mints.Load(),
+		"a stale 401 must not evict the replacement token")
 }
 
 func TestGitHubAppMintCancellationIsNotPublishedToWaiters(t *testing.T) {
@@ -466,7 +538,7 @@ func TestGitHubAppInvalidatePreservesFailedMintCooldown(t *testing.T) {
 
 	_, err := src.Token(context.Background())
 	require.ErrorContains(t, err, "upstream unavailable")
-	src.Invalidate()
+	src.Invalidate("ghs_stale")
 	_, err = src.Token(context.Background())
 	require.ErrorContains(t, err, "upstream unavailable")
 	assert.Equal(t, int64(1), mints.Load(),

--- a/internal/tokenauth/github_app_test.go
+++ b/internal/tokenauth/github_app_test.go
@@ -206,6 +206,236 @@ func TestGitHubAppMintFailureSurfacesError(t *testing.T) {
 	require.ErrorContains(t, err, "github_app:77@github.com")
 }
 
+func TestGitHubAppFailedMintIsSingleFlight(t *testing.T) {
+	var mints atomic.Int64
+	firstEntered := make(chan struct{})
+	secondEntered := make(chan struct{})
+	release := make(chan struct{})
+	src := NewManagedSource(githubAppDescriptor(42), Options{
+		GitHubApp: func(context.Context, Candidate) (string, time.Time, error) {
+			switch mints.Add(1) {
+			case 1:
+				close(firstEntered)
+			case 2:
+				close(secondEntered)
+			}
+			<-release
+			return "", time.Time{}, errors.New("rate limited")
+		},
+	})
+
+	results := make(chan error, 2)
+	for range 2 {
+		go func() {
+			_, err := src.Token(context.Background())
+			results <- err
+		}()
+	}
+	<-firstEntered
+	select {
+	case <-secondEntered:
+		assert.Fail(t, "parallel callers minted the same App token independently")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(release)
+	for range 2 {
+		require.ErrorContains(t, <-results, "rate limited")
+	}
+	assert.Equal(t, int64(1), mints.Load())
+}
+
+func TestGitHubAppInvalidateDoesNotEvictInFlightMint(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var mints atomic.Int64
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	src := NewManagedSource(githubAppDescriptor(42), Options{
+		GitHubApp: func(context.Context, Candidate) (string, time.Time, error) {
+			if mints.Add(1) == 1 {
+				close(entered)
+				<-release
+			}
+			return "ghs_fresh", time.Now().Add(time.Hour), nil
+		},
+	})
+
+	type result struct {
+		token string
+		err   error
+	}
+	winner := make(chan result, 1)
+	go func() {
+		token, err := src.Token(context.Background())
+		winner <- result{token: token, err: err}
+	}()
+	<-entered
+	// A stale 401 for the previous token arrives while the replacement
+	// mint is already in flight.
+	src.Invalidate()
+
+	joiner := make(chan result, 1)
+	go func() {
+		token, err := src.Token(context.Background())
+		joiner <- result{token: token, err: err}
+	}()
+	time.Sleep(50 * time.Millisecond) // let the joiner reach the store
+	assert.Equal(int64(1), mints.Load(),
+		"stale invalidation must not evict the in-flight mint into a parallel mint")
+	close(release)
+	for _, ch := range []chan result{winner, joiner} {
+		got := <-ch
+		require.NoError(got.err)
+		assert.Equal("ghs_fresh", got.token)
+	}
+	assert.Equal(int64(1), mints.Load())
+}
+
+func TestGitHubAppMintCancellationIsNotPublishedToWaiters(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	var mints atomic.Int64
+	winnerEntered := make(chan struct{})
+	src := NewManagedSource(githubAppDescriptor(42), Options{
+		GitHubApp: func(ctx context.Context, _ Candidate) (string, time.Time, error) {
+			if mints.Add(1) == 1 {
+				close(winnerEntered)
+				<-ctx.Done()
+				return "", time.Time{}, ctx.Err()
+			}
+			return "ghs_recovered", time.Now().Add(time.Hour), nil
+		},
+	})
+
+	winnerCtx, cancel := context.WithCancel(context.Background())
+	winnerErr := make(chan error, 1)
+	go func() {
+		_, err := src.Token(winnerCtx)
+		winnerErr <- err
+	}()
+	<-winnerEntered
+	type result struct {
+		token string
+		err   error
+	}
+	waiterResult := make(chan result, 1)
+	go func() {
+		token, err := src.Token(context.Background())
+		waiterResult <- result{token: token, err: err}
+	}()
+	time.Sleep(50 * time.Millisecond) // let the waiter park on the in-flight mint
+	cancel()
+
+	require.ErrorIs(<-winnerErr, context.Canceled)
+	waiter := <-waiterResult
+	require.NoError(waiter.err)
+	assert.Equal("ghs_recovered", waiter.token)
+	assert.Equal(int64(2), mints.Load(),
+		"waiter must re-mint with its own context after the winner cancels")
+}
+
+func TestGitHubAppMintCallerDeadlineFailureIsNotCached(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	var mints atomic.Int64
+	src := NewManagedSource(githubAppDescriptor(42), Options{
+		GitHubApp: func(ctx context.Context, _ Candidate) (string, time.Time, error) {
+			if mints.Add(1) == 1 {
+				<-ctx.Done()
+				return "", time.Time{}, ctx.Err()
+			}
+			return "ghs_recovered", time.Now().Add(time.Hour), nil
+		},
+	})
+
+	deadlineCtx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	_, err := src.Token(deadlineCtx)
+	require.ErrorIs(err, context.DeadlineExceeded)
+
+	token, err := src.Token(context.Background())
+	require.NoError(err)
+	assert.Equal("ghs_recovered", token)
+	assert.Equal(int64(2), mints.Load(),
+		"caller-caused deadline failure must not enter the retry window")
+}
+
+type retryDeadlineTestError struct {
+	at time.Time
+}
+
+func (e retryDeadlineTestError) Error() string { return "rate limited" }
+
+func (e retryDeadlineTestError) RetryDeadline(time.Time) time.Time { return e.at }
+
+func TestGitHubAppFailedMintCachesBoundedRetryDeadline(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	now := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	tooLate := now.Add(24 * time.Hour)
+	assert.Equal(now.Add(githubAppMintRetryMax),
+		githubAppMintRetryDeadline(retryDeadlineTestError{at: tooLate}, now))
+	assert.Equal(now.Add(githubAppMintRetryDefault),
+		githubAppMintRetryDeadline(retryDeadlineTestError{at: now}, now))
+	assert.True(githubAppMintRetryDeadline(context.Canceled, now).IsZero())
+
+	var mints atomic.Int64
+	store := newGitHubAppTokenStore()
+	store.now = func() time.Time { return now }
+	src := newManagedSource(githubAppDescriptor(42), Options{
+		GitHubApp: func(context.Context, Candidate) (string, time.Time, error) {
+			if mints.Add(1) == 1 {
+				return "", time.Time{}, retryDeadlineTestError{at: now.Add(time.Minute)}
+			}
+			return "ghs_recovered", now.Add(time.Hour), nil
+		},
+	}, store)
+
+	_, err := src.Token(context.Background())
+	require.ErrorContains(err, "rate limited")
+	_, err = src.Token(context.Background())
+	require.ErrorContains(err, "rate limited")
+	assert.Equal(int64(1), mints.Load(), "retry window must suppress another mint")
+
+	now = now.Add(time.Minute)
+	token, err := src.Token(context.Background())
+	require.NoError(err)
+	assert.Equal("ghs_recovered", token)
+	assert.Equal(int64(2), mints.Load())
+}
+
+func TestGitHubAppHeaderlessMintFailureCooldownIsSharedAcrossRoutes(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	now := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
+	var mints atomic.Int64
+	set := NewSourceSet(Options{
+		GitHubApp: func(context.Context, Candidate) (string, time.Time, error) {
+			if mints.Add(1) == 1 {
+				return "", time.Time{}, errors.New("upstream unavailable")
+			}
+			return "ghs_recovered", now.Add(time.Hour), nil
+		},
+	})
+	set.appTokens.now = func() time.Time { return now }
+	first := githubAppDescriptor(42)
+	first.Key.Scope = "repo:kenn-io/one"
+	second := githubAppDescriptor(42)
+	second.Key.Scope = "repo:kenn-io/two"
+
+	_, err := set.Upsert(first).Token(context.Background())
+	require.ErrorContains(err, "upstream unavailable")
+	_, err = set.Upsert(second).Token(context.Background())
+	require.ErrorContains(err, "upstream unavailable")
+	assert.Equal(int64(1), mints.Load(), "shared routes must retain the failure cooldown")
+
+	now = now.Add(githubAppMintRetryDefault)
+	token, err := set.Upsert(second).Token(context.Background())
+	require.NoError(err)
+	assert.Equal("ghs_recovered", token)
+	assert.Equal(int64(2), mints.Load())
+}
+
 func TestMutationAuthSkipsGitHubAppCandidate(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/tokenauth/github_app_test.go
+++ b/internal/tokenauth/github_app_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -209,41 +210,44 @@ func TestGitHubAppMintFailureSurfacesError(t *testing.T) {
 }
 
 func TestGitHubAppFailedMintIsSingleFlight(t *testing.T) {
-	var mints atomic.Int64
-	firstEntered := make(chan struct{})
-	secondEntered := make(chan struct{})
-	release := make(chan struct{})
-	src := NewManagedSource(githubAppDescriptor(42), Options{
-		GitHubApp: func(context.Context, Candidate) (string, time.Time, error) {
-			switch mints.Add(1) {
-			case 1:
-				close(firstEntered)
-			case 2:
-				close(secondEntered)
-			}
-			<-release
-			return "", time.Time{}, errors.New("rate limited")
-		},
-	})
+	synctest.Test(t, func(t *testing.T) {
+		var mints atomic.Int64
+		firstEntered := make(chan struct{})
+		secondEntered := make(chan struct{})
+		release := make(chan struct{})
+		src := NewManagedSource(githubAppDescriptor(42), Options{
+			GitHubApp: func(context.Context, Candidate) (string, time.Time, error) {
+				switch mints.Add(1) {
+				case 1:
+					close(firstEntered)
+				case 2:
+					close(secondEntered)
+				}
+				<-release
+				return "", time.Time{}, errors.New("rate limited")
+			},
+		})
 
-	results := make(chan error, 2)
-	for range 2 {
-		go func() {
-			_, err := src.Token(context.Background())
-			results <- err
-		}()
-	}
-	<-firstEntered
-	select {
-	case <-secondEntered:
-		assert.Fail(t, "parallel callers minted the same App token independently")
-	case <-time.After(100 * time.Millisecond):
-	}
-	close(release)
-	for range 2 {
-		require.ErrorContains(t, <-results, "rate limited")
-	}
-	assert.Equal(t, int64(1), mints.Load())
+		results := make(chan error, 2)
+		for range 2 {
+			go func() {
+				_, err := src.Token(context.Background())
+				results <- err
+			}()
+		}
+		<-firstEntered
+		synctest.Wait()
+		select {
+		case <-secondEntered:
+			assert.Fail(t, "parallel callers minted the same App token independently")
+		default:
+		}
+		close(release)
+		for range 2 {
+			require.ErrorContains(t, <-results, "rate limited")
+		}
+		assert.Equal(t, int64(1), mints.Load())
+	})
 }
 
 func TestGitHubAppInvalidateDoesNotEvictInFlightMint(t *testing.T) {
@@ -364,46 +368,48 @@ func TestGitHubAppStaleUnauthorizedDoesNotEvictReplacementToken(t *testing.T) {
 }
 
 func TestGitHubAppMintCancellationIsNotPublishedToWaiters(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-	var mints atomic.Int64
-	winnerEntered := make(chan struct{})
-	src := NewManagedSource(githubAppDescriptor(42), Options{
-		GitHubApp: func(ctx context.Context, _ Candidate) (string, time.Time, error) {
-			if mints.Add(1) == 1 {
-				close(winnerEntered)
-				<-ctx.Done()
-				return "", time.Time{}, ctx.Err()
-			}
-			return "ghs_recovered", time.Now().Add(time.Hour), nil
-		},
+	synctest.Test(t, func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		var mints atomic.Int64
+		winnerEntered := make(chan struct{})
+		src := NewManagedSource(githubAppDescriptor(42), Options{
+			GitHubApp: func(ctx context.Context, _ Candidate) (string, time.Time, error) {
+				if mints.Add(1) == 1 {
+					close(winnerEntered)
+					<-ctx.Done()
+					return "", time.Time{}, ctx.Err()
+				}
+				return "ghs_recovered", time.Now().Add(time.Hour), nil
+			},
+		})
+
+		winnerCtx, cancel := context.WithCancel(context.Background())
+		winnerErr := make(chan error, 1)
+		go func() {
+			_, err := src.Token(winnerCtx)
+			winnerErr <- err
+		}()
+		<-winnerEntered
+		type result struct {
+			token string
+			err   error
+		}
+		waiterResult := make(chan result, 1)
+		go func() {
+			token, err := src.Token(context.Background())
+			waiterResult <- result{token: token, err: err}
+		}()
+		synctest.Wait()
+		cancel()
+
+		require.ErrorIs(<-winnerErr, context.Canceled)
+		waiter := <-waiterResult
+		require.NoError(waiter.err)
+		assert.Equal("ghs_recovered", waiter.token)
+		assert.Equal(int64(2), mints.Load(),
+			"waiter must re-mint with its own context after the winner cancels")
 	})
-
-	winnerCtx, cancel := context.WithCancel(context.Background())
-	winnerErr := make(chan error, 1)
-	go func() {
-		_, err := src.Token(winnerCtx)
-		winnerErr <- err
-	}()
-	<-winnerEntered
-	type result struct {
-		token string
-		err   error
-	}
-	waiterResult := make(chan result, 1)
-	go func() {
-		token, err := src.Token(context.Background())
-		waiterResult <- result{token: token, err: err}
-	}()
-	time.Sleep(50 * time.Millisecond) // let the waiter park on the in-flight mint
-	cancel()
-
-	require.ErrorIs(<-winnerErr, context.Canceled)
-	waiter := <-waiterResult
-	require.NoError(waiter.err)
-	assert.Equal("ghs_recovered", waiter.token)
-	assert.Equal(int64(2), mints.Load(),
-		"waiter must re-mint with its own context after the winner cancels")
 }
 
 func TestGitHubAppMintCallerDeadlineFailureIsNotCached(t *testing.T) {

--- a/internal/tokenauth/github_app_test.go
+++ b/internal/tokenauth/github_app_test.go
@@ -360,6 +360,25 @@ func TestGitHubAppMintCallerDeadlineFailureIsNotCached(t *testing.T) {
 		"caller-caused deadline failure must not enter the retry window")
 }
 
+func TestGitHubAppMintInternalDeadlineFailureIsCached(t *testing.T) {
+	var mints atomic.Int64
+	src := NewManagedSource(githubAppDescriptor(42), Options{
+		GitHubApp: func(context.Context, Candidate) (string, time.Time, error) {
+			if mints.Add(1) == 1 {
+				return "", time.Time{}, fmt.Errorf("mint client timeout: %w", context.DeadlineExceeded)
+			}
+			return "ghs_recovered", time.Now().Add(time.Hour), nil
+		},
+	})
+
+	for range 2 {
+		_, err := src.Token(context.Background())
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	}
+	assert.Equal(t, int64(1), mints.Load(),
+		"an internal client deadline must enter the retry window")
+}
+
 type retryDeadlineTestError struct {
 	at time.Time
 }
@@ -374,10 +393,10 @@ func TestGitHubAppFailedMintCachesBoundedRetryDeadline(t *testing.T) {
 	now := time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC)
 	tooLate := now.Add(24 * time.Hour)
 	assert.Equal(now.Add(githubAppMintRetryMax),
-		githubAppMintRetryDeadline(retryDeadlineTestError{at: tooLate}, now))
+		githubAppMintRetryDeadline(retryDeadlineTestError{at: tooLate}, nil, now))
 	assert.Equal(now.Add(githubAppMintRetryDefault),
-		githubAppMintRetryDeadline(retryDeadlineTestError{at: now}, now))
-	assert.True(githubAppMintRetryDeadline(context.Canceled, now).IsZero())
+		githubAppMintRetryDeadline(retryDeadlineTestError{at: now}, nil, now))
+	assert.True(githubAppMintRetryDeadline(context.Canceled, context.Canceled, now).IsZero())
 
 	var mints atomic.Int64
 	store := newGitHubAppTokenStore()
@@ -434,6 +453,24 @@ func TestGitHubAppHeaderlessMintFailureCooldownIsSharedAcrossRoutes(t *testing.T
 	require.NoError(err)
 	assert.Equal("ghs_recovered", token)
 	assert.Equal(int64(2), mints.Load())
+}
+
+func TestGitHubAppInvalidatePreservesFailedMintCooldown(t *testing.T) {
+	var mints atomic.Int64
+	src := NewManagedSource(githubAppDescriptor(42), Options{
+		GitHubApp: func(context.Context, Candidate) (string, time.Time, error) {
+			mints.Add(1)
+			return "", time.Time{}, errors.New("upstream unavailable")
+		},
+	})
+
+	_, err := src.Token(context.Background())
+	require.ErrorContains(t, err, "upstream unavailable")
+	src.Invalidate()
+	_, err = src.Token(context.Background())
+	require.ErrorContains(t, err, "upstream unavailable")
+	assert.Equal(t, int64(1), mints.Load(),
+		"stale invalidation must preserve an active failure cooldown")
 }
 
 func TestMutationAuthSkipsGitHubAppCandidate(t *testing.T) {

--- a/internal/tokenauth/source.go
+++ b/internal/tokenauth/source.go
@@ -42,8 +42,12 @@ type ManagedSource struct {
 }
 
 type githubAppTokenCache struct {
-	token string
-	exp   time.Time
+	token       string
+	exp         time.Time
+	err         error
+	retryAt     time.Time
+	mintDone    chan struct{}
+	invalidated bool
 }
 
 // githubAppTokenStore is shared by every managed source in one SourceSet.
@@ -51,31 +55,111 @@ type githubAppTokenCache struct {
 // minted for their common App installation without weakening route selection.
 type githubAppTokenStore struct {
 	mu     sync.Mutex
-	tokens map[Candidate]githubAppTokenCache
+	tokens map[Candidate]*githubAppTokenCache
+	now    func() time.Time
 }
 
 func newGitHubAppTokenStore() *githubAppTokenStore {
-	return &githubAppTokenStore{tokens: make(map[Candidate]githubAppTokenCache)}
+	return &githubAppTokenStore{
+		tokens: make(map[Candidate]*githubAppTokenCache),
+		now:    time.Now,
+	}
 }
 
-func (s *githubAppTokenStore) get(candidate Candidate) githubAppTokenCache {
-	if s == nil {
-		return githubAppTokenCache{}
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.tokens[canonicalCandidate(candidate)]
+const (
+	githubAppMintRetryDefault = 5 * time.Second
+	githubAppMintRetryMax     = time.Hour
+)
+
+type retryDeadlineError interface {
+	RetryDeadline(time.Time) time.Time
 }
 
-func (s *githubAppTokenStore) put(
-	candidate Candidate, cached githubAppTokenCache,
-) {
-	if s == nil {
-		return
+func githubAppMintRetryDeadline(err error, now time.Time) time.Time {
+	if err == nil || errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) {
+		return time.Time{}
 	}
-	s.mu.Lock()
-	s.tokens[canonicalCandidate(candidate)] = cached
-	s.mu.Unlock()
+	var retryErr retryDeadlineError
+	if !errors.As(err, &retryErr) {
+		return now.Add(githubAppMintRetryDefault)
+	}
+	retryAt := retryErr.RetryDeadline(now)
+	if !retryAt.After(now) {
+		return now.Add(githubAppMintRetryDefault)
+	}
+	maxRetryAt := now.Add(githubAppMintRetryMax)
+	if retryAt.After(maxRetryAt) {
+		return maxRetryAt
+	}
+	return retryAt
+}
+
+func (s *githubAppTokenStore) resolve(
+	ctx context.Context,
+	candidate Candidate,
+	minter GitHubAppMinter,
+) (string, time.Time, error) {
+	key := canonicalCandidate(candidate)
+	for {
+		now := s.now()
+		s.mu.Lock()
+		cached := s.tokens[key]
+		if cached != nil && cached.err != nil && now.Before(cached.retryAt) {
+			err := cached.err
+			s.mu.Unlock()
+			return "", time.Time{}, err
+		}
+		if cached != nil && cached.token != "" &&
+			now.Add(githubAppTokenRefreshSkew).Before(cached.exp) {
+			token, exp := cached.token, cached.exp
+			s.mu.Unlock()
+			return token, exp, nil
+		}
+		if cached != nil && cached.mintDone != nil {
+			done := cached.mintDone
+			s.mu.Unlock()
+			select {
+			case <-ctx.Done():
+				return "", time.Time{}, ctx.Err()
+			case <-done:
+				s.mu.Lock()
+				if cached.invalidated {
+					s.mu.Unlock()
+					continue
+				}
+				token, exp, err := cached.token, cached.exp, cached.err
+				s.mu.Unlock()
+				return token, exp, err
+			}
+		}
+
+		cached = &githubAppTokenCache{mintDone: make(chan struct{})}
+		s.tokens[key] = cached
+		s.mu.Unlock()
+
+		token, exp, err := minter(ctx, candidate)
+		now = s.now()
+		s.mu.Lock()
+		cached.token = token
+		cached.exp = exp
+		cached.err = err
+		cached.retryAt = githubAppMintRetryDeadline(err, now)
+		if err != nil && cached.retryAt.IsZero() {
+			// Cancellation and deadline failures come from the winning
+			// caller's context, not from GitHub: mark the entry so
+			// waiters loop and re-mint with their own live contexts
+			// instead of inheriting the error.
+			cached.invalidated = true
+		}
+		close(cached.mintDone)
+		cached.mintDone = nil
+		if s.tokens[key] == cached && cached.invalidated {
+			delete(s.tokens, key)
+		}
+		s.mu.Unlock()
+		return token, exp, err
+	}
 }
 
 func (s *githubAppTokenStore) invalidate(candidates []Candidate) {
@@ -84,9 +168,24 @@ func (s *githubAppTokenStore) invalidate(candidates []Candidate) {
 	}
 	s.mu.Lock()
 	for _, candidate := range candidates {
-		if candidate.Kind == SourceKindGitHubApp {
-			delete(s.tokens, canonicalCandidate(candidate))
+		if candidate.Kind != SourceKindGitHubApp {
+			continue
 		}
+		key := canonicalCandidate(candidate)
+		cached := s.tokens[key]
+		if cached == nil {
+			continue
+		}
+		// An in-flight mint has never handed a token to anyone, so an
+		// invalidation arriving now is about an older, completed token
+		// (a stale 401 retry). Evicting the mint would let concurrent
+		// stale invalidations trigger parallel mints and discard the
+		// fresh result.
+		if cached.mintDone != nil {
+			continue
+		}
+		cached.invalidated = true
+		delete(s.tokens, key)
 	}
 	s.mu.Unlock()
 }
@@ -231,7 +330,6 @@ func (s *ManagedSource) githubAppToken(
 			return "", false, nil
 		}
 	}
-	cacheKey := canonicalCandidate(candidate)
 	s.mu.Lock()
 	minter := s.options.GitHubApp
 	store := s.appTokens
@@ -239,11 +337,7 @@ func (s *ManagedSource) githubAppToken(
 	if minter == nil {
 		return "", false, nil
 	}
-	cached := store.get(cacheKey)
-	if cached.token != "" && time.Until(cached.exp) > githubAppTokenRefreshSkew {
-		return cached.token, true, nil
-	}
-	token, exp, err := minter(ctx, candidate)
+	token, _, err := store.resolve(ctx, candidate, minter)
 	if err != nil {
 		// Surface mint failures instead of silently degrading to the
 		// PAT chain: the app exists precisely because the PAT budget
@@ -255,7 +349,6 @@ func (s *ManagedSource) githubAppToken(
 	if token == "" {
 		return "", true, nil
 	}
-	store.put(cacheKey, githubAppTokenCache{token: token, exp: exp})
 	return token, true, nil
 }
 

--- a/internal/tokenauth/source.go
+++ b/internal/tokenauth/source.go
@@ -28,7 +28,8 @@ type Options struct {
 
 type Source interface {
 	Token(context.Context) (string, error)
-	Invalidate()
+	// Invalidate evicts only cache state that produced rejectedToken.
+	Invalidate(rejectedToken string)
 	Descriptor() Descriptor
 }
 
@@ -161,7 +162,7 @@ func (s *githubAppTokenStore) resolve(
 	}
 }
 
-func (s *githubAppTokenStore) invalidate(candidates []Candidate) {
+func (s *githubAppTokenStore) evictCompleted(candidates []Candidate) {
 	if s == nil {
 		return
 	}
@@ -176,13 +177,33 @@ func (s *githubAppTokenStore) invalidate(candidates []Candidate) {
 		if cached == nil {
 			continue
 		}
-		// An in-flight mint or active failure cooldown has not handed a
-		// token to anyone, so an invalidation arriving now is about an
-		// older, completed token (a stale 401 retry). Evicting either
-		// entry would let stale invalidations defeat single-flight or
-		// failure backoff.
+		// Other routes may share the same canonical candidate. Preserve
+		// in-flight mints and active failure cooldowns because neither
+		// contains a completed token from the replaced descriptor.
 		if cached.mintDone != nil ||
 			cached.err != nil && now.Before(cached.retryAt) {
+			continue
+		}
+		cached.invalidated = true
+		delete(s.tokens, key)
+	}
+	s.mu.Unlock()
+}
+
+func (s *githubAppTokenStore) invalidateToken(
+	candidates []Candidate, rejectedToken string,
+) {
+	if s == nil || rejectedToken == "" {
+		return
+	}
+	s.mu.Lock()
+	for _, candidate := range candidates {
+		if candidate.Kind != SourceKindGitHubApp {
+			continue
+		}
+		key := canonicalCandidate(candidate)
+		cached := s.tokens[key]
+		if cached == nil || cached.token != rejectedToken {
 			continue
 		}
 		cached.invalidated = true
@@ -215,16 +236,18 @@ func (s *ManagedSource) Update(desc Descriptor) {
 	if !s.desc.EqualSource(desc) {
 		s.ghToken = ""
 		s.ghCached = false
-		s.appTokens.invalidate(s.desc.Candidates)
+		s.appTokens.evictCompleted(s.desc.Candidates)
 	}
 	s.desc = cloneDescriptor(desc)
 }
 
-func (s *ManagedSource) Invalidate() {
+func (s *ManagedSource) Invalidate(rejectedToken string) {
 	s.mu.Lock()
-	s.ghToken = ""
-	s.ghCached = false
-	s.appTokens.invalidate(s.desc.Candidates)
+	if s.ghToken == rejectedToken {
+		s.ghToken = ""
+		s.ghCached = false
+	}
+	s.appTokens.invalidateToken(s.desc.Candidates, rejectedToken)
 	s.mu.Unlock()
 }
 

--- a/internal/tokenauth/source.go
+++ b/internal/tokenauth/source.go
@@ -75,9 +75,8 @@ type retryDeadlineError interface {
 	RetryDeadline(time.Time) time.Time
 }
 
-func githubAppMintRetryDeadline(err error, now time.Time) time.Time {
-	if err == nil || errors.Is(err, context.Canceled) ||
-		errors.Is(err, context.DeadlineExceeded) {
+func githubAppMintRetryDeadline(err, callerErr error, now time.Time) time.Time {
+	if err == nil || (callerErr != nil && errors.Is(err, callerErr)) {
 		return time.Time{}
 	}
 	var retryErr retryDeadlineError
@@ -144,7 +143,7 @@ func (s *githubAppTokenStore) resolve(
 		cached.token = token
 		cached.exp = exp
 		cached.err = err
-		cached.retryAt = githubAppMintRetryDeadline(err, now)
+		cached.retryAt = githubAppMintRetryDeadline(err, ctx.Err(), now)
 		if err != nil && cached.retryAt.IsZero() {
 			// Cancellation and deadline failures come from the winning
 			// caller's context, not from GitHub: mark the entry so
@@ -167,6 +166,7 @@ func (s *githubAppTokenStore) invalidate(candidates []Candidate) {
 		return
 	}
 	s.mu.Lock()
+	now := s.now()
 	for _, candidate := range candidates {
 		if candidate.Kind != SourceKindGitHubApp {
 			continue
@@ -176,12 +176,13 @@ func (s *githubAppTokenStore) invalidate(candidates []Candidate) {
 		if cached == nil {
 			continue
 		}
-		// An in-flight mint has never handed a token to anyone, so an
-		// invalidation arriving now is about an older, completed token
-		// (a stale 401 retry). Evicting the mint would let concurrent
-		// stale invalidations trigger parallel mints and discard the
-		// fresh result.
-		if cached.mintDone != nil {
+		// An in-flight mint or active failure cooldown has not handed a
+		// token to anyone, so an invalidation arriving now is about an
+		// older, completed token (a stale 401 retry). Evicting either
+		// entry would let stale invalidations defeat single-flight or
+		// failure backoff.
+		if cached.mintDone != nil ||
+			cached.err != nil && now.Before(cached.retryAt) {
 			continue
 		}
 		cached.invalidated = true

--- a/internal/tokenauth/source_test.go
+++ b/internal/tokenauth/source_test.go
@@ -82,7 +82,7 @@ func TestManagedSourceGitHubCLIInvalidatesCache(t *testing.T) {
 	require.NoError(err)
 	second, err := src.Token(context.Background())
 	require.NoError(err)
-	src.Invalidate()
+	src.Invalidate("first")
 	third, err := src.Token(context.Background())
 	require.NoError(err)
 

--- a/internal/tokenauth/transport.go
+++ b/internal/tokenauth/transport.go
@@ -42,7 +42,7 @@ func (t AuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if base == nil {
 		base = http.DefaultTransport
 	}
-	first, err := t.authorizedRequest(req)
+	first, firstToken, err := t.authorizedRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -59,20 +59,20 @@ func (t AuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	_, _ = io.Copy(io.Discard, resp.Body)
 	_ = resp.Body.Close()
-	t.Source.Invalidate()
-	second, err := t.authorizedRequest(retry)
+	t.Source.Invalidate(firstToken)
+	second, _, err := t.authorizedRequest(retry)
 	if err != nil {
 		return nil, err
 	}
 	return base.RoundTrip(second)
 }
 
-func (t AuthTransport) authorizedRequest(req *http.Request) (*http.Request, error) {
+func (t AuthTransport) authorizedRequest(req *http.Request) (*http.Request, string, error) {
 	if err := t.validateOrigin(req); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if t.Source == nil {
-		return nil, fmt.Errorf("%w: nil token source", ErrMissingToken)
+		return nil, "", fmt.Errorf("%w: nil token source", ErrMissingToken)
 	}
 	ctx := req.Context()
 	if t.GitHubOwner != nil {
@@ -80,14 +80,14 @@ func (t AuthTransport) authorizedRequest(req *http.Request) (*http.Request, erro
 	}
 	token, err := t.Source.Token(ctx)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	clone := req.Clone(req.Context())
 	if req.Body != nil && req.Body != http.NoBody {
 		clone.Body = req.Body
 	}
 	t.SetHeader(clone, token)
-	return clone, nil
+	return clone, token, nil
 }
 
 func (t AuthTransport) validateOrigin(req *http.Request) error {

--- a/internal/tokenauth/transport_test.go
+++ b/internal/tokenauth/transport_test.go
@@ -13,8 +13,9 @@ import (
 )
 
 type sequenceSource struct {
-	tokens      []string
-	invalidated int
+	tokens            []string
+	invalidated       int
+	invalidatedTokens []string
 }
 
 func (s *sequenceSource) Token(context.Context) (string, error) {
@@ -25,7 +26,10 @@ func (s *sequenceSource) Token(context.Context) (string, error) {
 	return token, nil
 }
 
-func (s *sequenceSource) Invalidate() { s.invalidated++ }
+func (s *sequenceSource) Invalidate(token string) {
+	s.invalidated++
+	s.invalidatedTokens = append(s.invalidatedTokens, token)
+}
 
 func (s *sequenceSource) Descriptor() Descriptor {
 	return Descriptor{Key: Key{Platform: "github", Host: "github.com"}}
@@ -97,6 +101,7 @@ func TestRetryOnUnauthorizedInvalidatesAndRetriesOnce(t *testing.T) {
 
 	assert.Equal(http.StatusOK, resp.StatusCode)
 	assert.Equal(1, src.invalidated)
+	assert.Equal([]string{"old"}, src.invalidatedTokens)
 	assert.Equal([]string{"Bearer old", "Bearer new"}, auth)
 }
 


### PR DESCRIPTION
Extracted from the degraded-startup work on #932, where it was developed and review-hardened; it stands on its own.

- Concurrent routes sharing one GitHub App installation now share one in-flight token mint per canonical credential instead of minting duplicates.
- Mint failures cool down for five seconds, or until the server-directed Retry-After / rate-limit reset (capped at one hour) now carried on `githubapp.StatusError`.
- Failures caused by the minting caller's own canceled or deadline-expired context are neither cached nor handed to waiting routes; waiters re-mint with their own contexts.
- Invalidation (stale 401 retries, credential updates) never evicts an in-flight mint, so concurrent stale invalidations cannot trigger parallel mints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)