### PR TITLE
feat: launch Pi in workspace sessions

### DIFF
--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -270,8 +270,8 @@ where needed.
 
 ## Agent Launch Context
 
-Agent launch selects Codex and Claude families by case-folded target-name prefix.
-Codex receives generated workspace context followed by root `AGENTS.md` verbatim
+Agent launch selects Codex, Pi, and Claude families by case-folded target-name prefix.
+Codex and Pi receive generated workspace context followed by root `AGENTS.md` verbatim
 in `AGENTS.override.md`; only a non-symlink regular file up to 1 MiB is appended,
 otherwise the override is context-only (`internal/workspace/agent_context.go::readRepositoryAgentInstructions`).
 Claude receives context-only `CLAUDE.local.md` because its local file is additive

--- a/internal/workspace/agent_context.go
+++ b/internal/workspace/agent_context.go
@@ -297,7 +297,8 @@ func (m *Manager) RenderAgentContextForWorktree(
 func agentContextRelPath(targetKey string) string {
 	targetKey = strings.TrimSpace(targetKey)
 	switch {
-	case hasCaseFoldedPrefix(targetKey, "codex"):
+	case hasCaseFoldedPrefix(targetKey, "codex"),
+		hasCaseFoldedPrefix(targetKey, "pi"):
 		return "AGENTS.override.md"
 	case hasCaseFoldedPrefix(targetKey, "claude"):
 		return "CLAUDE.local.md"

--- a/internal/workspace/agent_context_test.go
+++ b/internal/workspace/agent_context_test.go
@@ -258,10 +258,14 @@ func TestAgentContextRelPathMatchesCaseFoldedAgentFamilyPrefixes(t *testing.T) {
 		{name: "codex builtin", targetKey: "codex", want: "AGENTS.override.md"},
 		{name: "codex configured suffix", targetKey: "Codex yolo", want: "AGENTS.override.md"},
 		{name: "codex surrounding whitespace", targetKey: "  CODEX proxy  ", want: "AGENTS.override.md"},
+		{name: "pi builtin", targetKey: "pi", want: "AGENTS.override.md"},
+		{name: "pi configured suffix", targetKey: "Pi-reviewer", want: "AGENTS.override.md"},
+		{name: "pi surrounding whitespace", targetKey: "  PI custom  ", want: "AGENTS.override.md"},
 		{name: "claude builtin", targetKey: "claude", want: "CLAUDE.local.md"},
 		{name: "claude configured suffix", targetKey: "Claude reviewer", want: "CLAUDE.local.md"},
 		{name: "unrelated agent", targetKey: "opencode"},
-		{name: "prefix must begin name", targetKey: "my-codex"},
+		{name: "codex prefix must begin name", targetKey: "my-codex"},
+		{name: "pi prefix must begin name", targetKey: "my-pi"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/workspace/localruntime/targets.go
+++ b/internal/workspace/localruntime/targets.go
@@ -20,6 +20,10 @@ var builtinAgents = []LaunchTarget{
 		Source: "builtin", Command: []string{"claude"},
 	},
 	{
+		Key: "pi", Label: "Pi", Kind: LaunchTargetAgent,
+		Source: "builtin", Command: []string{"pi"},
+	},
+	{
 		Key: "gemini", Label: "Gemini", Kind: LaunchTargetAgent,
 		Source: "builtin", Command: []string{"gemini"},
 	},

--- a/internal/workspace/localruntime/targets_test.go
+++ b/internal/workspace/localruntime/targets_test.go
@@ -106,15 +106,37 @@ func TestResolveLaunchTargetsConfigKeyCoexistsWithBuiltin(
 	assert.True(findTarget(t, targets, "codex").Available)
 }
 
+func TestResolveLaunchTargetsIncludesPiBuiltin(t *testing.T) {
+	targets := ResolveLaunchTargets(
+		nil,
+		[]string{"tmux"},
+		fakeLookPath(map[string]string{
+			"pi":   "/usr/bin/pi",
+			"tmux": "/usr/bin/tmux",
+		}),
+	)
+
+	pi := findTarget(t, targets, "pi")
+	assert := assert.New(t)
+	assert.Equal("Pi", pi.Label)
+	assert.Equal(LaunchTargetAgent, pi.Kind)
+	assert.Equal("builtin", pi.Source)
+	assert.Equal([]string{"pi"}, pi.Command)
+	assert.True(pi.Available)
+}
+
 func TestResolveLaunchTargetsUndetectedBuiltinUnavailable(
 	t *testing.T,
 ) {
 	targets := ResolveLaunchTargets(nil, []string{"tmux"}, fakeLookPath(nil))
 
 	codex := findTarget(t, targets, "codex")
+	pi := findTarget(t, targets, "pi")
 	assert := assert.New(t)
 	assert.False(codex.Available)
 	assert.Contains(codex.DisabledReason, "not found")
+	assert.False(pi.Available)
+	assert.Contains(pi.DisabledReason, "pi not found")
 }
 
 func TestResolveLaunchTargetsIncludesSystemTargets(t *testing.T) {


### PR DESCRIPTION
Pi can now be selected anywhere kenn-forge offers workspace launch targets. Forge detects `pi` through the shared built-in agent flow, so existing configuration overrides and unavailable-target behavior continue to apply.

Pi-family targets also receive generated pull request or issue context through `AGENTS.override.md`, including configured names such as `pi-reviewer`.

Closes #921
