### PR TITLE
fix: open failed workspaces for deletion recovery

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -136,9 +136,9 @@ Interactive surfaces must agree on which item is selected.
 - Pull and issue detail actions route `deleting`/`deletion_failed` workspaces to
   Workspaces recovery; inline hosts must not reopen their terminals
   (`frontend/src/lib/components/detail/PullDetail.svelte::workspaceActionButton`).
-- A `deletion_failed` workspace exposes the same confirmed force-delete recovery
-  on local and fleet rows; fleet requests forward `force=true` to the owning host
-  (`frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte::confirmDeleteWorkspaceFromList`).
+- A `deletion_failed` workspace remains selectable so terminal recovery and the same confirmed force-delete action stay reachable on local and fleet rows; fleet requests
+  forward `force=true` to the owning host (`frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte::openWorkspace`,
+  `frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte::confirmDeleteWorkspaceFromList`).
 - A terminal view whose loaded workspace is `deleting` or `deletion_failed`
   blocks its normal runtime and workspace actions. It renders deletion progress
   or confirmed force-delete recovery instead, retaining the exact workspace and

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -821,7 +821,7 @@
   }
 
   function openWorkspace(ws: Workspace): void {
-    if (ws.status === "deleting" || ws.status === "deletion_failed") return;
+    if (ws.status === "deleting") return;
     const doneVersion = doneStateVersion(ws);
     if (doneVersion !== null) {
       acknowledgedDoneStates = {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -1103,7 +1103,7 @@ describe("WorkspaceListSidebar", () => {
             provider: "github",
             platformHost: "github.com",
             owner: "kenn-io",
-            name: "kenn-platform",
+            name: "project-platform",
             number: 2,
             title: "Hosted code fetch and caching strategy",
           }),
@@ -1133,7 +1133,7 @@ describe("WorkspaceListSidebar", () => {
     expect(screen.getByText("Migrate native HTTP surface to Huma v2")).toBeTruthy();
 
     await fireEvent.input(filter, {
-      target: { value: "kenn-platform" },
+      target: { value: "project-platform" },
     });
     expect(container.querySelectorAll(".ws-row")).toHaveLength(1);
     expect(screen.getByText("Hosted code fetch and caching strategy")).toBeTruthy();
@@ -1785,7 +1785,7 @@ describe("WorkspaceListSidebar", () => {
     expect((await screen.findByLabelText(label)).classList.contains(className)).toBe(true);
   });
 
-  it("keeps failed deletion visible with retry and confirmed force-delete recovery", async () => {
+  it("opens a failed issue workspace for retry and confirmed force-delete recovery", async () => {
     mockGet.mockResolvedValue({
       data: {
         workspaces: [
@@ -1796,6 +1796,7 @@ describe("WorkspaceListSidebar", () => {
             owner: "kenn-io",
             name: "kenn-forge",
             number: 9,
+            itemType: "issue",
             status: "deletion_failed",
             errorMessage: "workspace has uncommitted changes: notes.txt",
           }),
@@ -1816,7 +1817,7 @@ describe("WorkspaceListSidebar", () => {
       "workspace has uncommitted changes: notes.txt",
     );
     await fireEvent.click(container.querySelector(".ws-row")!);
-    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith("/terminal/ws-delete-failed");
 
     await fireEvent.contextMenu(container.querySelector(".ws-row")!);
     expect((screen.getByRole("menuitem", { name: "Retry deletion..." }) as HTMLButtonElement).disabled).toBe(false);

--- a/frontend/tests/e2e-full/detail-action-buttons.spec.ts
+++ b/frontend/tests/e2e-full/detail-action-buttons.spec.ts
@@ -389,7 +389,7 @@ test.describe("detail action buttons", () => {
     }
   });
 
-  test("a merge cleanup failure remains visible and supports force-delete recovery", async ({ page }) => {
+  test("a merge cleanup failure opens and supports force-delete recovery", async ({ page }) => {
     test.skip(
       !hasCommand("git") || !hasCommand("tmux", ["-V"]),
       "git and tmux are required for the real workspace flow",
@@ -449,6 +449,12 @@ test.describe("detail action buttons", () => {
       const failedWorkspaceRow = page.locator(".ws-row").filter({
         has: page.locator(".workspace-lifecycle-state--deletion_failed"),
       });
+      await failedWorkspaceRow.click();
+      await expect(page).toHaveURL(new RegExp(`/terminal/${createdWorkspace.id}$`));
+      await expect(page.getByRole("img", { name: "Workspace deletion failed" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Force delete workspace" })).toBeVisible();
+
+      await page.goto(`${server.info.base_url}/workspaces`);
       await failedWorkspaceRow.click({ button: "right" });
       await page.getByRole("menuitem", { name: "Force delete workspace..." }).click();
 


### PR DESCRIPTION
A workspace whose automatic cleanup fails after merge now remains clickable in the Workspaces list. Opening it shows the saved deletion error and the existing force-delete recovery action.

The row handler previously blocked both `deleting` and `deletion_failed`. It now blocks only deletions still in progress, so failed issue and pull request workspaces retain their recovery path.
