### PR TITLE
feat: make MCP connectivity discoverable from the CLI

### DIFF
--- a/cmd/kenn-forge/cli.go
+++ b/cmd/kenn-forge/cli.go
@@ -64,6 +64,7 @@ func newRootCommand(opts cliOptions) *cobra.Command {
 		newArchiveCommand(opts.Stdout, time.Now),
 		newAgentHookCommand(opts.Stdin, opts.Stdout),
 		newDaemonCommand(opts.DaemonRunner),
+		newMCPCommand(opts.Stdout, loadMCPQuickstart),
 		newPtyOwnerCommand(),
 		serve.NewCommand(opts.RunServer),
 	)

--- a/cmd/kenn-forge/daemon_client.go
+++ b/cmd/kenn-forge/daemon_client.go
@@ -11,8 +11,9 @@ import (
 )
 
 type daemonHTTPClient struct {
-	BaseURL string
-	Client  *http.Client
+	BaseURL   string
+	Client    *http.Client
+	TokenPath string
 }
 
 func discoverDaemonHTTP(configPath string, timeout time.Duration) (daemonHTTPClient, error) {
@@ -45,8 +46,9 @@ func discoverDaemonHTTP(configPath string, timeout time.Duration) (daemonHTTPCli
 		base: http.DefaultTransport,
 	}
 	return daemonHTTPClient{
-		BaseURL: baseURL,
-		Client:  &http.Client{Timeout: timeout, Transport: transport},
+		BaseURL:   baseURL,
+		Client:    &http.Client{Timeout: timeout, Transport: transport},
+		TokenPath: status.Metadata.TokenPath,
 	}, nil
 }
 

--- a/cmd/kenn-forge/main_test.go
+++ b/cmd/kenn-forge/main_test.go
@@ -1117,12 +1117,11 @@ func TestRootHelpListsEveryPublicCommandWithoutStartingServer(t *testing.T) {
 
 	for _, name := range []string{
 		"activity", "agent-hook", "api", "archive", "config", "docs",
-		"daemon", "issues", "pulls", "quickstart", "rate-limits", "repo-summaries",
+		"daemon", "issues", "mcp", "pulls", "quickstart", "rate-limits", "repo-summaries",
 		"repos", "serve", "stacks", "sync", "version", "workspaces",
 	} {
 		assert.Contains(stdout.String(), name)
 	}
-	assert.NotContains(stdout.String(), "mcp")
 	assert.NotContains(stdout.String(), "pty-owner")
 	assert.NotContains(stdout.String(), "completion")
 	assert.False(started)
@@ -1163,6 +1162,7 @@ func TestRootNestedHelpExposesCommandFlags(t *testing.T) {
 		{name: "daemon status", args: []string{"daemon", "status", "--help"}, want: []string{"--config", "--json"}},
 		{name: "daemon stop", args: []string{"daemon", "stop", "--help"}, want: []string{"--config"}},
 		{name: "daemon restart", args: []string{"daemon", "restart", "--help"}, want: []string{"--config"}},
+		{name: "mcp quickstart", args: []string{"mcp", "quickstart", "--help"}, want: []string{"--config", "--json", "--timeout"}},
 		{name: "serve", args: []string{"serve", "--help"}, want: []string{"--config", "--pprof-addr"}},
 		{name: "api", args: []string{"api", "--help"}, want: []string{"list", "--config", "-d", "-i", "--timeout"}},
 	}

--- a/cmd/kenn-forge/mcp_cli.go
+++ b/cmd/kenn-forge/mcp_cli.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	shellquote "github.com/kballard/go-shellquote"
 	"github.com/spf13/cobra"
 	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/runtimelock"
@@ -105,7 +106,7 @@ func loadMCPQuickstart(
 	}
 	if _, err := os.Stat(runtimelock.LockPath(cfg.DataDir)); err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return stoppedMCPQuickstart(cfg.MCP.Enabled), nil
+			return stoppedMCPQuickstart(cfg.MCP.Enabled, configPath), nil
 		}
 		return mcpQuickstartInfo{}, fmt.Errorf("mcp quickstart: inspect daemon lock: %w", err)
 	}
@@ -114,7 +115,7 @@ func loadMCPQuickstart(
 		return mcpQuickstartInfo{}, fmt.Errorf("mcp quickstart: read daemon status: %w", err)
 	}
 	if !status.Running {
-		return stoppedMCPQuickstart(cfg.MCP.Enabled), nil
+		return stoppedMCPQuickstart(cfg.MCP.Enabled, configPath), nil
 	}
 	if status.Metadata == nil {
 		return mcpQuickstartInfo{}, fmt.Errorf(
@@ -162,18 +163,26 @@ func loadMCPQuickstart(
 	return daemonMCPQuickstart(*settings.MCP, daemon.TokenPath), nil
 }
 
-func stoppedMCPQuickstart(enabled bool) mcpQuickstartInfo {
+func stoppedMCPQuickstart(enabled bool, configPath string) mcpQuickstartInfo {
+	startArgs := []string{"kenn-forge", "daemon", "start"}
+	if configPath != config.DefaultConfigPath() {
+		startArgs = append(startArgs, "--config", configPath)
+	}
+	startStep := fmt.Sprintf(
+		"Start the Forge daemon with `%s`.",
+		shellquote.Join(startArgs...),
+	)
 	info := mcpQuickstartInfo{
 		Enabled:        enabled,
 		Transport:      "streamable-http",
 		Authentication: mcpAuthenticationInfo{},
 	}
 	if enabled {
-		info.NextSteps = []string{"Start the Forge daemon with `kenn-forge daemon start`."}
+		info.NextSteps = []string{startStep}
 	} else {
 		info.NextSteps = []string{
 			"Enable the MCP companion in Forge Settings or set `[mcp].enabled = true`.",
-			"Start the Forge daemon with `kenn-forge daemon start`.",
+			startStep,
 		}
 	}
 	return info

--- a/cmd/kenn-forge/mcp_cli.go
+++ b/cmd/kenn-forge/mcp_cli.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/forge/internal/config"
+	"go.kenn.io/forge/internal/runtimelock"
+)
+
+const mcpTokenEnvironment = "KENN_FORGE_API_TOKEN"
+
+type mcpQuickstartLoader func(context.Context, string, time.Duration) (mcpQuickstartInfo, error)
+
+type mcpQuickstartInfo struct {
+	Enabled         bool                    `json:"enabled"`
+	Active          bool                    `json:"active"`
+	RestartRequired bool                    `json:"restart_required"`
+	Transport       string                  `json:"transport"`
+	Endpoint        string                  `json:"endpoint,omitempty"`
+	Authentication  mcpAuthenticationInfo   `json:"authentication"`
+	ClientConfig    *mcpClientConfiguration `json:"client_config,omitempty"`
+	NextSteps       []string                `json:"next_steps,omitempty"`
+}
+
+type mcpAuthenticationInfo struct {
+	Required         bool   `json:"required"`
+	TokenEnvironment string `json:"token_environment,omitempty"`
+	TokenPath        string `json:"token_path,omitempty"`
+}
+
+type mcpClientConfiguration struct {
+	MCPServers map[string]mcpClientServer `json:"mcpServers"`
+}
+
+type mcpClientServer struct {
+	Type    string            `json:"type"`
+	URL     string            `json:"url"`
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
+type mcpSettingsEnvelope struct {
+	MCP *mcpSettingsInfo `json:"mcp"`
+}
+
+type mcpSettingsInfo struct {
+	Enabled            bool   `json:"enabled"`
+	RestartRequired    bool   `json:"restart_required"`
+	ActiveURL          string `json:"active_url"`
+	ActiveRequiresAuth bool   `json:"active_requires_auth"`
+}
+
+func newMCPCommand(stdout io.Writer, load mcpQuickstartLoader) *cobra.Command {
+	var configPath string
+	var asJSON bool
+	var timeout time.Duration
+	cmd := &cobra.Command{
+		Use:   "mcp",
+		Short: "Discover and configure the MCP companion",
+		Args:  cobra.NoArgs,
+	}
+	quickstart := &cobra.Command{
+		Use:   "quickstart",
+		Short: "Print MCP connectivity and client configuration",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			info, err := load(cmd.Context(), configPath, timeout)
+			if err != nil {
+				return err
+			}
+			if asJSON {
+				encoder := json.NewEncoder(stdout)
+				encoder.SetIndent("", "  ")
+				return encoder.Encode(info)
+			}
+			return writeMCPQuickstart(stdout, info)
+		},
+	}
+	quickstart.Flags().StringVar(
+		&configPath, "config", config.DefaultConfigPath(), "path to config file",
+	)
+	quickstart.Flags().BoolVar(&asJSON, "json", false, "render output as JSON")
+	quickstart.Flags().DurationVar(&timeout, "timeout", 5*time.Second, "daemon request timeout")
+	cmd.AddCommand(quickstart)
+	return cmd
+}
+
+func loadMCPQuickstart(
+	ctx context.Context,
+	configPath string,
+	timeout time.Duration,
+) (mcpQuickstartInfo, error) {
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return mcpQuickstartInfo{}, fmt.Errorf("mcp quickstart: load config: %w", err)
+	}
+	if _, err := os.Stat(runtimelock.LockPath(cfg.DataDir)); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return stoppedMCPQuickstart(cfg.MCP.Enabled), nil
+		}
+		return mcpQuickstartInfo{}, fmt.Errorf("mcp quickstart: inspect daemon lock: %w", err)
+	}
+	status, err := runtimelock.Read(cfg.DataDir)
+	if err != nil {
+		return mcpQuickstartInfo{}, fmt.Errorf("mcp quickstart: read daemon status: %w", err)
+	}
+	if !status.Running {
+		return stoppedMCPQuickstart(cfg.MCP.Enabled), nil
+	}
+	if status.Metadata == nil {
+		return mcpQuickstartInfo{}, fmt.Errorf(
+			"mcp quickstart: daemon metadata unavailable: %s",
+			status.MetadataUnavailable,
+		)
+	}
+
+	daemon, err := discoverDaemonHTTP(configPath, timeout)
+	if err != nil {
+		return mcpQuickstartInfo{}, fmt.Errorf("mcp quickstart: discover daemon: %w", err)
+	}
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		strings.TrimRight(daemon.BaseURL, "/")+"/api/v1/settings",
+		nil,
+	)
+	if err != nil {
+		return mcpQuickstartInfo{}, fmt.Errorf("mcp quickstart: build settings request: %w", err)
+	}
+	request.Header.Set("Accept", "application/json")
+	response, err := daemon.Client.Do(request)
+	if err != nil {
+		return mcpQuickstartInfo{}, fmt.Errorf("mcp quickstart: read settings: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return mcpQuickstartInfo{}, fmt.Errorf(
+			"mcp quickstart: read settings: daemon returned %s",
+			response.Status,
+		)
+	}
+	var settings mcpSettingsEnvelope
+	decoder := json.NewDecoder(response.Body)
+	if err := decoder.Decode(&settings); err != nil {
+		return mcpQuickstartInfo{}, fmt.Errorf("mcp quickstart: decode settings: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return mcpQuickstartInfo{}, fmt.Errorf("mcp quickstart: decode settings: trailing JSON data")
+	}
+	if settings.MCP == nil {
+		return mcpQuickstartInfo{}, fmt.Errorf("mcp quickstart: daemon did not publish MCP settings")
+	}
+	return daemonMCPQuickstart(*settings.MCP, daemon.TokenPath), nil
+}
+
+func stoppedMCPQuickstart(enabled bool) mcpQuickstartInfo {
+	info := mcpQuickstartInfo{
+		Enabled:        enabled,
+		Transport:      "streamable-http",
+		Authentication: mcpAuthenticationInfo{},
+	}
+	if enabled {
+		info.NextSteps = []string{"Start the Forge daemon with `kenn-forge daemon start`."}
+	} else {
+		info.NextSteps = []string{
+			"Enable the MCP companion in Forge Settings or set `[mcp].enabled = true`.",
+			"Start the Forge daemon with `kenn-forge daemon start`.",
+		}
+	}
+	return info
+}
+
+func daemonMCPQuickstart(
+	settings mcpSettingsInfo,
+	tokenPath string,
+) mcpQuickstartInfo {
+	info := mcpQuickstartInfo{
+		Enabled:         settings.Enabled,
+		Active:          settings.ActiveURL != "",
+		RestartRequired: settings.RestartRequired,
+		Transport:       "streamable-http",
+		Endpoint:        settings.ActiveURL,
+		Authentication: mcpAuthenticationInfo{
+			Required: settings.ActiveRequiresAuth,
+		},
+	}
+	if settings.ActiveRequiresAuth {
+		info.Authentication.TokenEnvironment = mcpTokenEnvironment
+		info.Authentication.TokenPath = tokenPath
+	}
+	if info.Active {
+		server := mcpClientServer{Type: "http", URL: info.Endpoint}
+		if settings.ActiveRequiresAuth {
+			server.Headers = map[string]string{
+				"Authorization": "Bearer ${" + mcpTokenEnvironment + "}",
+			}
+		}
+		info.ClientConfig = &mcpClientConfiguration{
+			MCPServers: map[string]mcpClientServer{"kenn-forge": server},
+		}
+	}
+	switch {
+	case !settings.Enabled && info.Active:
+		info.NextSteps = []string{"The MCP companion remains active until the Forge daemon restarts."}
+	case settings.Enabled && !info.Active:
+		info.NextSteps = []string{"Restart the Forge daemon to start the MCP companion."}
+	case settings.RestartRequired:
+		info.NextSteps = []string{"Restart the Forge daemon to apply the saved MCP settings."}
+	case !settings.Enabled:
+		info.NextSteps = []string{
+			"Enable the MCP companion in Forge Settings, then restart the Forge daemon.",
+		}
+	}
+	return info
+}
+
+func writeMCPQuickstart(stdout io.Writer, info mcpQuickstartInfo) error {
+	if _, err := fmt.Fprintln(stdout, "OK mcp quickstart"); err != nil {
+		return err
+	}
+	status := "inactive"
+	if info.Active {
+		status = "active"
+	}
+	if _, err := fmt.Fprintf(stdout, "status: %s\n", status); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(stdout, "enabled: %t\n", info.Enabled); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(stdout, "transport: %s\n", info.Transport); err != nil {
+		return err
+	}
+	if info.Endpoint != "" {
+		if _, err := fmt.Fprintf(stdout, "endpoint: %s\n", info.Endpoint); err != nil {
+			return err
+		}
+	}
+	if info.Authentication.Required {
+		if _, err := fmt.Fprintf(
+			stdout,
+			"authentication: bearer token via %s\ntoken_path: %s\n",
+			info.Authentication.TokenEnvironment,
+			info.Authentication.TokenPath,
+		); err != nil {
+			return err
+		}
+	} else if info.Active {
+		if _, err := fmt.Fprintln(stdout, "authentication: not required"); err != nil {
+			return err
+		}
+	}
+	if info.RestartRequired {
+		if _, err := fmt.Fprintln(stdout, "restart_required: true"); err != nil {
+			return err
+		}
+	}
+	if info.ClientConfig != nil {
+		if _, err := fmt.Fprintln(stdout, "client_config:"); err != nil {
+			return err
+		}
+		encoder := json.NewEncoder(stdout)
+		encoder.SetIndent("  ", "  ")
+		if err := encoder.Encode(info.ClientConfig); err != nil {
+			return err
+		}
+	}
+	if len(info.NextSteps) > 0 {
+		if _, err := fmt.Fprintln(stdout, "next:"); err != nil {
+			return err
+		}
+		for _, step := range info.NextSteps {
+			if _, err := fmt.Fprintf(stdout, "- %s\n", step); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/kenn-forge/mcp_cli_test.go
+++ b/cmd/kenn-forge/mcp_cli_test.go
@@ -65,7 +65,8 @@ func TestMCPQuickstartCommandPrintsStructuredConnector(t *testing.T) {
 func TestLoadMCPQuickstartExplainsStoppedDaemonWithoutCreatingRuntimeState(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
-	root := t.TempDir()
+	root := filepath.Join(t.TempDir(), "custom config")
+	require.NoError(os.Mkdir(root, 0o700))
 	dataDir := filepath.Join(root, "data")
 	configPath := filepath.Join(root, "config.toml")
 	require.NoError(os.WriteFile(configPath, fmt.Appendf(nil, `
@@ -82,7 +83,10 @@ enabled = true
 
 	assert.True(info.Enabled)
 	assert.False(info.Active)
-	assert.Contains(info.NextSteps, "Start the Forge daemon with `kenn-forge daemon start`.")
+	assert.Contains(
+		info.NextSteps,
+		"Start the Forge daemon with `kenn-forge daemon start --config '"+configPath+"'`.",
+	)
 	_, err = os.Stat(runtimelock.LockPath(dataDir))
 	assert.ErrorIs(err, os.ErrNotExist)
 }

--- a/cmd/kenn-forge/mcp_cli_test.go
+++ b/cmd/kenn-forge/mcp_cli_test.go
@@ -68,14 +68,14 @@ func TestLoadMCPQuickstartExplainsStoppedDaemonWithoutCreatingRuntimeState(t *te
 	root := t.TempDir()
 	dataDir := filepath.Join(root, "data")
 	configPath := filepath.Join(root, "config.toml")
-	require.NoError(os.WriteFile(configPath, []byte(fmt.Sprintf(`
+	require.NoError(os.WriteFile(configPath, fmt.Appendf(nil, `
 host = "127.0.0.1"
 port = 8091
 data_dir = %q
 
 [mcp]
 enabled = true
-`, dataDir)), 0o600))
+`, dataDir), 0o600))
 
 	info, err := loadMCPQuickstart(t.Context(), configPath, time.Second)
 	require.NoError(err)

--- a/cmd/kenn-forge/mcp_cli_test.go
+++ b/cmd/kenn-forge/mcp_cli_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/runtimelock"
+)
+
+func TestMCPQuickstartCommandPrintsAgentConnector(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	info := daemonMCPQuickstart(mcpSettingsInfo{
+		Enabled:            true,
+		ActiveURL:          "http://127.0.0.1:8092/mcp",
+		ActiveRequiresAuth: true,
+	}, "/tmp/forge/auth_token")
+	var output bytes.Buffer
+	cmd := newMCPCommand(&output, func(_ context.Context, _ string, _ time.Duration) (mcpQuickstartInfo, error) {
+		return info, nil
+	})
+	cmd.SetArgs([]string{"quickstart"})
+
+	require.NoError(cmd.Execute())
+
+	text := output.String()
+	assert.Contains(text, "OK mcp quickstart")
+	assert.Contains(text, "endpoint: http://127.0.0.1:8092/mcp")
+	assert.Contains(text, "token_path: /tmp/forge/auth_token")
+	assert.Contains(text, `"Authorization": "Bearer ${KENN_FORGE_API_TOKEN}"`)
+}
+
+func TestMCPQuickstartCommandPrintsStructuredConnector(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	info := daemonMCPQuickstart(mcpSettingsInfo{
+		Enabled:   true,
+		ActiveURL: "http://127.0.0.1:8092/mcp",
+	}, "")
+	var output bytes.Buffer
+	cmd := newMCPCommand(&output, func(_ context.Context, _ string, _ time.Duration) (mcpQuickstartInfo, error) {
+		return info, nil
+	})
+	cmd.SetArgs([]string{"quickstart", "--json"})
+
+	require.NoError(cmd.Execute())
+
+	var got mcpQuickstartInfo
+	require.NoError(json.Unmarshal(output.Bytes(), &got))
+	assert.True(got.Active)
+	assert.Equal("http://127.0.0.1:8092/mcp", got.Endpoint)
+	require.NotNil(got.ClientConfig)
+	assert.Equal("http", got.ClientConfig.MCPServers["kenn-forge"].Type)
+	assert.Empty(got.ClientConfig.MCPServers["kenn-forge"].Headers)
+}
+
+func TestLoadMCPQuickstartExplainsStoppedDaemonWithoutCreatingRuntimeState(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	root := t.TempDir()
+	dataDir := filepath.Join(root, "data")
+	configPath := filepath.Join(root, "config.toml")
+	require.NoError(os.WriteFile(configPath, []byte(fmt.Sprintf(`
+host = "127.0.0.1"
+port = 8091
+data_dir = %q
+
+[mcp]
+enabled = true
+`, dataDir)), 0o600))
+
+	info, err := loadMCPQuickstart(t.Context(), configPath, time.Second)
+	require.NoError(err)
+
+	assert.True(info.Enabled)
+	assert.False(info.Active)
+	assert.Contains(info.NextSteps, "Start the Forge daemon with `kenn-forge daemon start`.")
+	_, err = os.Stat(runtimelock.LockPath(dataDir))
+	assert.ErrorIs(err, os.ErrNotExist)
+}

--- a/cmd/kenn-forge/mcp_lifecycle_e2e_test.go
+++ b/cmd/kenn-forge/mcp_lifecycle_e2e_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"net"
 	"os"
 	"path/filepath"
@@ -86,6 +87,21 @@ func TestDaemonServesMCPEndpointThroughLifecycleE2E(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(result)
 	assert.False(result.IsError)
+
+	quickstart := procutil.Command(
+		bin, "mcp", "quickstart", "--config", cfgPath, "--json",
+	)
+	quickstartOutput, err := quickstart.Output()
+	require.NoError(err)
+	var connection mcpQuickstartInfo
+	require.NoError(json.Unmarshal(quickstartOutput, &connection))
+	assert.True(connection.Active)
+	assert.Equal("http://"+mcpAddr+"/mcp", connection.Endpoint)
+	require.NotNil(connection.ClientConfig)
+	assert.Equal(
+		connection.Endpoint,
+		connection.ClientConfig.MCPServers["kenn-forge"].URL,
+	)
 	require.NoError(session.Close())
 
 	require.NoError(serve.Process.Signal(syscall.SIGTERM))

--- a/context/mcp-server.md
+++ b/context/mcp-server.md
@@ -12,6 +12,9 @@
   hot-restarts the companion: report restart drift, keep showing an endpoint
   that remains active until restart, and provide only token-file guidance rather
   than returning the daemon bearer (`internal/server/settings_handlers.go::Server.buildLocalSettingsResponse`).
+- `kenn-forge mcp quickstart` is the canonical agent discovery path for the
+  active connector and saved restart drift; expose token paths and environment
+  placeholders there, never bearer contents (`cmd/kenn-forge/mcp_cli.go::newMCPCommand`).
 - MCP serves only `/mcp` over stateless Streamable HTTP. Authentication follows
   `[api].require_auth`; direct loopback peer, exact loopback authority, absent
   forwarding headers, and optional same-origin HTTP Origin are required

--- a/internal/cli/ctl/ctl.go
+++ b/internal/cli/ctl/ctl.go
@@ -336,6 +336,7 @@ func newQuickstartCommand(cfg *viper.Viper, stdout io.Writer) *cobra.Command {
 					{"command": "kenn-forge api GET /version", "does": "Show server version"},
 					{"command": "kenn-forge api GET /sync/status", "does": "Inspect sync state"},
 					{"command": "kenn-forge api POST /sync", "does": "Trigger a sync"},
+					{"command": "kenn-forge mcp quickstart", "does": "Print MCP connectivity and client configuration"},
 				},
 				"notes": []string{
 					"PATH values without /api/v1 are automatically scoped to /api/v1.",

--- a/internal/cli/ctl/ctl_test.go
+++ b/internal/cli/ctl/ctl_test.go
@@ -93,6 +93,7 @@ func TestQuickstartFormatsStructuredOutput(t *testing.T) {
 	assert.Equal("http://forge.test/api/v1", payload["api_base_url"])
 	assert.Contains(jsonOut.String(), "kenn-forge api GET /pulls")
 	assert.Contains(jsonOut.String(), "kenn-forge api GET /version")
+	assert.Contains(jsonOut.String(), "kenn-forge mcp quickstart")
 
 	var yamlOut bytes.Buffer
 	cmd = newCommand(commandDeps{


### PR DESCRIPTION
Agents can now run `kenn-forge mcp quickstart` to discover Forge's active Streamable HTTP endpoint and copy a connector entry. Structured JSON also reports saved and active state, restart guidance, and token-file or environment placeholders without exposing bearer token contents.
