### PR TITLE
test: enforce Testify helpers in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ migration-history-check:
 	go run ./tools/migrationhistorycheck
 
 guardrail-check: check-vite-plus-bin
-	$(MAKE) frontend-api-client-check font-size-token-check huma-route-check migration-history-check playwright-version-check script-tests docs-branding-check
+	$(MAKE) frontend-api-client-check font-size-token-check huma-route-check migration-history-check playwright-version-check script-tests testify-helper-check docs-branding-check
 
 
 # Regenerate the checked-in OpenAPI document and generated clients

--- a/cmd/kenn-forge/main_test.go
+++ b/cmd/kenn-forge/main_test.go
@@ -189,6 +189,8 @@ func TestRunMainShutdownStopsSignalsBeforeLongCleanup(t *testing.T) {
 }
 
 func TestRunMainShutdownBoundsMCPStoreCleanup(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	release := make(chan struct{})
@@ -212,17 +214,17 @@ func TestRunMainShutdownBoundsMCPStoreCleanup(t *testing.T) {
 		// The canceled parent context may also record a canceled database
 		// bound even though the database callback ran; only the MCP entry is
 		// required.
-		require.NotEmpty(t, errs)
-		assert.Equal(t, "close MCP temp store", errs[0].message)
-		require.ErrorIs(t, errs[0].err, context.Canceled)
+		require.NotEmpty(errs)
+		assert.Equal("close MCP temp store", errs[0].message)
+		require.ErrorIs(errs[0].err, context.Canceled)
 		for _, shutdownErr := range errs[1:] {
-			assert.Equal(t, "close database", shutdownErr.message)
-			require.ErrorIs(t, shutdownErr.err, context.Canceled)
+			assert.Equal("close database", shutdownErr.message)
+			require.ErrorIs(shutdownErr.err, context.Canceled)
 		}
 	case <-time.After(100 * time.Millisecond):
 		close(release)
 		<-done
-		require.Fail(t, "MCP temp-store cleanup ignored the shutdown context")
+		require.Fail("MCP temp-store cleanup ignored the shutdown context")
 	}
 
 	// Later cleanup must still run after the MCP cleanup budget expires:
@@ -230,7 +232,7 @@ func TestRunMainShutdownBoundsMCPStoreCleanup(t *testing.T) {
 	select {
 	case <-databaseClosed:
 	case <-time.After(100 * time.Millisecond):
-		require.Fail(t, "database cleanup did not run after MCP cleanup timed out")
+		require.Fail("database cleanup did not run after MCP cleanup timed out")
 	}
 	close(release)
 }
@@ -294,38 +296,40 @@ func TestBindDaemonListenersOwnsOptionalMCPPortAndClosesPrimaryOnFailure(t *test
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
 			var occupied net.Listener
 			if tt.occupiedMCP {
 				var err error
 				occupied, err = net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(explicitMCPPort)))
-				require.NoError(t, err)
+				require.NoError(err)
 				defer occupied.Close()
 			}
 			cfg := &config.Config{Host: "127.0.0.1", Port: primaryPort, MCP: tt.mcp}
 
 			primary, mcpListener, err := bindDaemonListeners(cfg)
 			if tt.wantErr != "" {
-				require.ErrorContains(t, err, tt.wantErr)
+				require.ErrorContains(err, tt.wantErr)
 				probe, listenErr := net.Listen("tcp", cfg.ListenAddr())
-				require.NoError(t, listenErr, "primary listener must close after MCP bind failure")
-				require.NoError(t, probe.Close())
+				require.NoError(listenErr, "primary listener must close after MCP bind failure")
+				require.NoError(probe.Close())
 				return
 			}
-			require.NoError(t, err)
+			require.NoError(err)
 			t.Cleanup(func() {
-				require.NoError(t, primary.Close())
+				require.NoError(primary.Close())
 				if mcpListener != nil {
-					require.NoError(t, mcpListener.Close())
+					require.NoError(mcpListener.Close())
 				}
 			})
 			if tt.wantMCPPort == 0 {
-				assert.Nil(t, mcpListener)
+				assert.Nil(mcpListener)
 				return
 			}
-			require.NotNil(t, mcpListener)
+			require.NotNil(mcpListener)
 			_, portText, splitErr := net.SplitHostPort(mcpListener.Addr().String())
-			require.NoError(t, splitErr)
-			assert.Equal(t, strconv.Itoa(tt.wantMCPPort), portText)
+			require.NoError(splitErr)
+			assert.Equal(strconv.Itoa(tt.wantMCPPort), portText)
 		})
 	}
 }

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -24,7 +24,8 @@ fixtures, or changing shell-script coverage.
   `t.Errorf`, `t.Fail`, or `t.FailNow`.
 - Import `github.com/stretchr/testify/assert` without an alias. When a test has
   more than three assertions, create `assert := assert.New(t)` and use the
-  helper methods thereafter.
+  helper methods thereafter. CI enforces this through `guardrail-check`
+  (`Makefile::guardrail-check`).
 - Prefer the generated Go API client for integration-style API tests.
 - Use established package fixtures instead of opening databases directly. Use
   `t.TempDir()` when a test needs filesystem isolation.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -58,21 +58,23 @@ func roundTripConfigString(t *testing.T, content string) (*Config, *Config) {
 }
 
 func TestMCPConfigDefaultsToBackendPortPlusOne(t *testing.T) {
+	assert := assert.New(t)
 	cfg, err := Load(writeConfig(t, "host = \"127.0.0.1\"\nport = 8091\n[mcp]\nenabled = true\n"))
 	require.NoError(t, err)
-	assert.Equal(t, 8092, cfg.MCPPort())
-	assert.Equal(t, "127.0.0.1:8092", cfg.MCPListenAddr())
-	assert.Equal(t, int64(128<<20), cfg.MCPDiffCacheBytes())
+	assert.Equal(8092, cfg.MCPPort())
+	assert.Equal("127.0.0.1:8092", cfg.MCPListenAddr())
+	assert.Equal(int64(128<<20), cfg.MCPDiffCacheBytes())
 }
 
 func TestMCPConfigRoundTrip(t *testing.T) {
+	require := require.New(t)
 	cfg, err := Load(writeConfig(t, ""))
-	require.NoError(t, err)
+	require.NoError(err)
 	cfg.MCP = MCP{Enabled: true, Port: 9192, DiffCacheMB: 256}
 	path := filepath.Join(t.TempDir(), "config.toml")
-	require.NoError(t, cfg.Save(path))
+	require.NoError(cfg.Save(path))
 	reloaded, err := Load(path)
-	require.NoError(t, err)
+	require.NoError(err)
 	assert.Equal(t, MCP{Enabled: true, Port: 9192, DiffCacheMB: 256}, reloaded.MCP)
 }
 

--- a/internal/mcpserver/difftmp_test.go
+++ b/internal/mcpserver/difftmp_test.go
@@ -36,79 +36,85 @@ func TestDiffFileStoreWriteAtomicallyReplacesExistingFile(t *testing.T) {
 }
 
 func TestDiffFileStoreFailedReplacementPreservesExistingEntries(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	store, err := newDiffFileStore(1024)
-	require.NoError(t, err)
+	require.NoError(err)
 	t.Cleanup(func() {
 		_ = os.Chmod(store.dir, 0o700)
-		require.NoError(t, store.Close())
+		require.NoError(store.Close())
 	})
 
 	existingPath, _, err := store.write("evidence.diff", []byte("old evidence\n"))
-	require.NoError(t, err)
+	require.NoError(err)
 	otherPath, _, err := store.write("other.diff", []byte("other evidence\n"))
-	require.NoError(t, err)
+	require.NoError(err)
 	sizeBefore := store.totalBytes
 
-	require.NoError(t, os.Chmod(store.dir, 0o500))
+	require.NoError(os.Chmod(store.dir, 0o500))
 	_, _, err = store.write("evidence.diff", []byte("replacement evidence\n"))
-	require.Error(t, err)
+	require.Error(err)
 
 	existing, err := os.ReadFile(existingPath)
-	require.NoError(t, err)
-	assert.Equal(t, "old evidence\n", string(existing))
+	require.NoError(err)
+	assert.Equal("old evidence\n", string(existing))
 	other, err := os.ReadFile(otherPath)
-	require.NoError(t, err)
-	assert.Equal(t, "other evidence\n", string(other))
-	assert.Equal(t, sizeBefore, store.totalBytes)
-	assert.Equal(t, 2, store.lru.Len())
+	require.NoError(err)
+	assert.Equal("other evidence\n", string(other))
+	assert.Equal(sizeBefore, store.totalBytes)
+	assert.Equal(2, store.lru.Len())
 
-	require.NoError(t, os.Chmod(store.dir, 0o700))
+	require.NoError(os.Chmod(store.dir, 0o700))
 	replaced, _, err := store.write("evidence.diff", []byte("new evidence\n"))
-	require.NoError(t, err)
-	assert.Equal(t, existingPath, replaced)
+	require.NoError(err)
+	assert.Equal(existingPath, replaced)
 }
 
 func TestDiffFileStoreReplacementAccountsForReplacedEntrySize(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	store, err := newDiffFileStore(64)
-	require.NoError(t, err)
+	require.NoError(err)
 	t.Cleanup(func() {
-		require.NoError(t, store.Close())
+		require.NoError(store.Close())
 	})
 
 	_, _, err = store.write("big.diff", make([]byte, 40))
-	require.NoError(t, err)
+	require.NoError(err)
 
 	// Replacing the only entry with a larger payload must reuse the replaced
 	// entry's budget instead of evicting it (or failing with no evictable
 	// files) while it is still published.
 	path, size, err := store.write("big.diff", make([]byte, 63))
-	require.NoError(t, err)
-	assert.Equal(t, int64(63), size)
-	assert.Equal(t, int64(63), store.totalBytes)
+	require.NoError(err)
+	assert.Equal(int64(63), size)
+	assert.Equal(int64(63), store.totalBytes)
 	data, err := os.ReadFile(path)
-	require.NoError(t, err)
-	assert.Len(t, data, 63)
+	require.NoError(err)
+	assert.Len(data, 63)
 }
 
 func TestDiffFileStoreReplacementEvictsOthersButNeverItself(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	store, err := newDiffFileStore(64)
-	require.NoError(t, err)
+	require.NoError(err)
 	t.Cleanup(func() {
-		require.NoError(t, store.Close())
+		require.NoError(store.Close())
 	})
 
 	bigPath, _, err := store.write("big.diff", make([]byte, 40))
-	require.NoError(t, err)
+	require.NoError(err)
 	smallPath, _, err := store.write("small.diff", make([]byte, 10))
-	require.NoError(t, err)
+	require.NoError(err)
 
 	replaced, _, err := store.write("big.diff", make([]byte, 60))
-	require.NoError(t, err)
-	assert.Equal(t, bigPath, replaced)
-	assert.Equal(t, int64(60), store.totalBytes)
+	require.NoError(err)
+	assert.Equal(bigPath, replaced)
+	assert.Equal(int64(60), store.totalBytes)
 	_, err = os.Stat(smallPath)
-	require.ErrorIs(t, err, os.ErrNotExist)
+	require.ErrorIs(err, os.ErrNotExist)
 	data, err := os.ReadFile(replaced)
-	require.NoError(t, err)
-	assert.Len(t, data, 60)
+	require.NoError(err)
+	assert.Len(data, 60)
 }

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -14,17 +14,19 @@ import (
 )
 
 func TestRegisteredToolsResourcesAndPromptsAreCurated(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	s := newMCPTestServer(t, &fakeBackend{})
 	cs := connectMCPTestSession(t, s)
 
 	tools, err := cs.ListTools(t.Context(), nil)
-	require.NoError(t, err)
+	require.NoError(err)
 	var toolNames []string
 	for _, tool := range tools.Tools {
 		toolNames = append(toolNames, tool.Name)
 	}
 	slices.Sort(toolNames)
-	assert.Equal(t, []string{
+	assert.Equal([]string{
 		"kenn_forge_find_review_candidates",
 		"kenn_forge_get_item_context",
 		"kenn_forge_get_item_diff",
@@ -40,45 +42,49 @@ func TestRegisteredToolsResourcesAndPromptsAreCurated(t *testing.T) {
 	}, toolNames)
 
 	resources, err := cs.ListResources(t.Context(), nil)
-	require.NoError(t, err)
-	require.Len(t, resources.Resources, 1)
-	assert.Equal(t, "kenn-forge://mcp/guidance", resources.Resources[0].URI)
+	require.NoError(err)
+	require.Len(resources.Resources, 1)
+	assert.Equal("kenn-forge://mcp/guidance", resources.Resources[0].URI)
 	read, err := cs.ReadResource(t.Context(), &mcp.ReadResourceParams{URI: "kenn-forge://mcp/guidance"})
-	require.NoError(t, err)
-	require.Len(t, read.Contents, 1)
-	assert.Contains(t, read.Contents[0].Text, "kenn_forge_find_review_candidates")
+	require.NoError(err)
+	require.Len(read.Contents, 1)
+	assert.Contains(read.Contents[0].Text, "kenn_forge_find_review_candidates")
 
 	prompts, err := cs.ListPrompts(t.Context(), nil)
-	require.NoError(t, err)
-	require.Len(t, prompts.Prompts, 1)
+	require.NoError(err)
+	require.Len(prompts.Prompts, 1)
 	prompt, err := cs.GetPrompt(t.Context(), &mcp.GetPromptParams{Name: "kenn-forge-review-candidates"})
-	require.NoError(t, err)
-	require.Len(t, prompt.Messages, 1)
+	require.NoError(err)
+	require.Len(prompt.Messages, 1)
 	content, ok := prompt.Messages[0].Content.(*mcp.TextContent)
-	require.True(t, ok)
-	assert.Contains(t, content.Text, "kenn_forge_get_item_diff")
-	assert.Contains(t, content.Text, "expected_status")
+	require.True(ok)
+	assert.Contains(content.Text, "kenn_forge_get_item_diff")
+	assert.Contains(content.Text, "expected_status")
 }
 
 func TestServerUses20260728ProtocolCapabilities(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	s := newMCPTestServer(t, &fakeBackend{})
 
 	initialized := connectMCPTestSession(t, s).InitializeResult()
 
-	require.NotNil(t, initialized)
-	assert.Equal(t, "2026-07-28", initialized.ProtocolVersion)
+	require.NotNil(initialized)
+	assert.Equal("2026-07-28", initialized.ProtocolVersion)
 	//nolint:staticcheck // Verify the 2026-07-28 server does not advertise deprecated logging.
-	assert.Nil(t, initialized.Capabilities.Logging)
-	require.NotNil(t, initialized.Capabilities.Tools)
-	assert.False(t, initialized.Capabilities.Tools.ListChanged)
-	require.NotNil(t, initialized.Capabilities.Prompts)
-	assert.False(t, initialized.Capabilities.Prompts.ListChanged)
-	require.NotNil(t, initialized.Capabilities.Resources)
-	assert.False(t, initialized.Capabilities.Resources.ListChanged)
-	assert.False(t, initialized.Capabilities.Resources.Subscribe)
+	assert.Nil(initialized.Capabilities.Logging)
+	require.NotNil(initialized.Capabilities.Tools)
+	assert.False(initialized.Capabilities.Tools.ListChanged)
+	require.NotNil(initialized.Capabilities.Prompts)
+	assert.False(initialized.Capabilities.Prompts.ListChanged)
+	require.NotNil(initialized.Capabilities.Resources)
+	assert.False(initialized.Capabilities.Resources.ListChanged)
+	assert.False(initialized.Capabilities.Resources.Subscribe)
 }
 
 func TestToolErrorsPreserveStructuredEvidenceThroughClientSession(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	backend := &fakeBackend{listRepositoriesFn: func(context.Context) ([]RepositorySummary, error) {
 		return nil, &Error{
 			Kind: "agent_handoff_failed", Code: "runtime_launch_failed",
@@ -94,9 +100,9 @@ func TestToolErrorsPreserveStructuredEvidenceThroughClientSession(t *testing.T) 
 		t.Context(), &mcp.CallToolParams{Name: "kenn_forge_list_repos"},
 	)
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	assert.True(t, result.IsError)
+	require.NoError(err)
+	require.NotNil(result)
+	assert.True(result.IsError)
 	type evidence struct {
 		Kind      string         `json:"kind"`
 		Code      string         `json:"code"`
@@ -106,31 +112,33 @@ func TestToolErrorsPreserveStructuredEvidenceThroughClientSession(t *testing.T) 
 		Details   map[string]any `json:"details"`
 	}
 	metadata, found := result.Meta[toolErrorMetaKey]
-	require.True(t, found)
+	require.True(found)
 	data, err := json.Marshal(metadata)
-	require.NoError(t, err)
+	require.NoError(err)
 	var got evidence
-	require.NoError(t, json.Unmarshal(data, &got))
-	assert.Equal(t, "agent_handoff_failed", got.Kind)
-	assert.Equal(t, "runtime_launch_failed", got.Code)
-	assert.Equal(t, "agent launch outcome is unknown", got.Message)
-	assert.False(t, got.Retryable)
-	assert.True(t, got.Ambiguous)
-	assert.Equal(t, "ws-1", got.Details["workspace_id"])
-	assert.Equal(t, "runtime-1", got.Details["runtime_session_key"])
-	assert.Equal(t, "message_delivered", got.Details["failed_stage"])
+	require.NoError(json.Unmarshal(data, &got))
+	assert.Equal("agent_handoff_failed", got.Kind)
+	assert.Equal("runtime_launch_failed", got.Code)
+	assert.Equal("agent launch outcome is unknown", got.Message)
+	assert.False(got.Retryable)
+	assert.True(got.Ambiguous)
+	assert.Equal("ws-1", got.Details["workspace_id"])
+	assert.Equal("runtime-1", got.Details["runtime_session_key"])
+	assert.Equal("message_delivered", got.Details["failed_stage"])
 
-	require.Len(t, result.Content, 1)
+	require.Len(result.Content, 1)
 	text, ok := result.Content[0].(*mcp.TextContent)
-	require.True(t, ok)
+	require.True(ok)
 	var payload struct {
 		Error evidence `json:"error"`
 	}
-	require.NoError(t, json.Unmarshal([]byte(text.Text), &payload))
-	assert.Equal(t, got, payload.Error)
+	require.NoError(json.Unmarshal([]byte(text.Text), &payload))
+	assert.Equal(got, payload.Error)
 }
 
 func TestSpawnToolFailurePreservesPartialHandoffEvidenceThroughClientSession(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	backend := successfulSpawnBackend("ws-1", "runtime-1", "coding-1")
 	backend.launchWorkspaceRuntimeFn = func(context.Context, string, string) (RuntimeSession, error) {
 		return RuntimeSession{}, &Error{
@@ -159,27 +167,27 @@ func TestSpawnToolFailurePreservesPartialHandoffEvidenceThroughClientSession(t *
 		},
 	)
 
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	assert.True(t, result.IsError)
+	require.NoError(err)
+	require.NotNil(result)
+	assert.True(result.IsError)
 
 	metadata, found := result.Meta[toolErrorMetaKey]
-	require.True(t, found)
+	require.True(found)
 	raw, err := json.Marshal(metadata)
-	require.NoError(t, err)
+	require.NoError(err)
 	var evidence toolErrorEvidence
-	require.NoError(t, json.Unmarshal(raw, &evidence))
-	assert.Equal(t, "unavailable", evidence.Kind)
-	assert.Equal(t, "runtimeLaunchFailed", evidence.Code)
-	assert.Equal(t, "runtime_launched", evidence.Details["failed_stage"])
-	assert.Equal(t, "workspace_ready", evidence.Details["last_completed_stage"])
-	assert.Equal(t, "ws-1", evidence.Details["workspace_id"])
-	assert.Equal(t, "ready", evidence.Details["workspace_status"])
+	require.NoError(json.Unmarshal(raw, &evidence))
+	assert.Equal("unavailable", evidence.Kind)
+	assert.Equal("runtimeLaunchFailed", evidence.Code)
+	assert.Equal("runtime_launched", evidence.Details["failed_stage"])
+	assert.Equal("workspace_ready", evidence.Details["last_completed_stage"])
+	assert.Equal("ws-1", evidence.Details["workspace_id"])
+	assert.Equal("ready", evidence.Details["workspace_status"])
 
 	// The partial handoff output survives alongside the structured error so
 	// clients can locate the workspace that was already created.
 	structured, err := json.Marshal(result.StructuredContent)
-	require.NoError(t, err)
+	require.NoError(err)
 	var partial struct {
 		Stage     string `json:"stage"`
 		Workspace struct {
@@ -187,10 +195,10 @@ func TestSpawnToolFailurePreservesPartialHandoffEvidenceThroughClientSession(t *
 			Status string `json:"status"`
 		} `json:"workspace"`
 	}
-	require.NoError(t, json.Unmarshal(structured, &partial))
-	assert.Equal(t, "workspace_ready", partial.Stage)
-	assert.Equal(t, "ws-1", partial.Workspace.ID)
-	assert.Equal(t, "ready", partial.Workspace.Status)
+	require.NoError(json.Unmarshal(structured, &partial))
+	assert.Equal("workspace_ready", partial.Stage)
+	assert.Equal("ws-1", partial.Workspace.ID)
+	assert.Equal("ready", partial.Workspace.Status)
 }
 
 func TestHTTPHandlerServesOnlyStatelessMCPPath(t *testing.T) {

--- a/internal/mcpserver/tools_agent_spawn_test.go
+++ b/internal/mcpserver/tools_agent_spawn_test.go
@@ -13,11 +13,13 @@ import (
 )
 
 func TestSpawnWorkspaceWithAgentCallsDirectServicesAndUsesAuthoritativeEvidence(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	backend := successfulSpawnBackend("ws-new", "runtime-new", "coding-new")
 	workspaceReads := 0
 	backend.createPullWorkspaceFn = func(_ context.Context, item ItemIdentity, suppress bool) (Workspace, error) {
-		assert.Equal(t, testItemIdentity("pr", 42), item)
-		assert.True(t, suppress)
+		assert.Equal(testItemIdentity("pr", 42), item)
+		assert.True(suppress)
 		return Workspace{ID: "ws-new", Status: "creating", Created: true}, nil
 	}
 	backend.getWorkspaceFn = func(context.Context, string) (Workspace, error) {
@@ -29,7 +31,7 @@ func TestSpawnWorkspaceWithAgentCallsDirectServicesAndUsesAuthoritativeEvidence(
 		return Workspace{ID: "ws-new", Status: status}, nil
 	}
 	backend.submitInitialMessageFn = func(_ context.Context, req InitialMessageRequest) (InitialMessageStatus, error) {
-		assert.Equal(t, InitialMessageRequest{
+		assert.Equal(InitialMessageRequest{
 			WorkspaceID: "ws-new", RuntimeSessionKey: "runtime-new",
 			Agent: "codex", SessionID: "coding-new",
 			Message: "review this\nthen implement",
@@ -48,16 +50,16 @@ func TestSpawnWorkspaceWithAgentCallsDirectServicesAndUsesAuthoritativeEvidence(
 		AgentTarget: "codex", InitialMessage: "review this\r\nthen implement", Timeout: "2s",
 	})
 
-	require.NoError(t, err)
-	assert.Equal(t, "message_delivered", out.Stage)
-	assert.Equal(t, "delivered", out.InitialMessage.State)
-	assert.Equal(t, "ws-new", out.Workspace.ID)
-	assert.False(t, out.Workspace.Reused)
-	assert.Equal(t, "runtime-new", out.Runtime.SessionKey)
-	assert.Equal(t, "coding-new", out.CodingSession.SessionID)
+	require.NoError(err)
+	assert.Equal("message_delivered", out.Stage)
+	assert.Equal("delivered", out.InitialMessage.State)
+	assert.Equal("ws-new", out.Workspace.ID)
+	assert.False(out.Workspace.Reused)
+	assert.Equal("runtime-new", out.Runtime.SessionKey)
+	assert.Equal("coding-new", out.CodingSession.SessionID)
 	raw, err := json.Marshal(out)
-	require.NoError(t, err)
-	assert.NotContains(t, string(raw), `"message_delivered":`)
+	require.NoError(err)
+	assert.NotContains(string(raw), `"message_delivered":`)
 }
 
 func TestSpawnWorkspaceWithAgentReusesWorkspaceAndLaunchesFreshRuntime(t *testing.T) {
@@ -81,6 +83,7 @@ func TestSpawnWorkspaceWithAgentReusesWorkspaceAndLaunchesFreshRuntime(t *testin
 }
 
 func TestSpawnWorkspaceWithAgentReusesPRWorkspaceCreatedConcurrently(t *testing.T) {
+	assert := assert.New(t)
 	backend := successfulSpawnBackend("ws-raced", "runtime-raced", "coding-raced")
 	pullReads := 0
 	backend.getPullFn = func(context.Context, ItemIdentity) (PullDetail, error) {
@@ -102,12 +105,13 @@ func TestSpawnWorkspaceWithAgentReusesPRWorkspaceCreatedConcurrently(t *testing.
 	out, err := s.spawnWorkspaceWithAgent(t.Context(), prSpawnInput("start"))
 
 	require.NoError(t, err)
-	assert.True(t, out.Workspace.Reused)
-	assert.Equal(t, "ws-raced", out.Workspace.ID)
-	assert.Equal(t, 2, pullReads)
+	assert.True(out.Workspace.Reused)
+	assert.Equal("ws-raced", out.Workspace.ID)
+	assert.Equal(2, pullReads)
 }
 
 func TestSpawnWorkspaceWithAgentTimeoutReturnsStageWithoutDeliveryClaim(t *testing.T) {
+	assert := assert.New(t)
 	backend := successfulSpawnBackend("ws-timeout", "runtime", "coding")
 	backend.createPullWorkspaceFn = func(context.Context, ItemIdentity, bool) (Workspace, error) {
 		return Workspace{ID: "ws-timeout", Status: "creating", Created: true}, nil
@@ -124,11 +128,11 @@ func TestSpawnWorkspaceWithAgentTimeoutReturnsStageWithoutDeliveryClaim(t *testi
 
 	var backendErr *Error
 	require.ErrorAs(t, err, &backendErr)
-	assert.Equal(t, "agent_handoff_timeout", backendErr.Kind)
-	assert.Equal(t, "workspace_created", backendErr.Details["last_completed_stage"])
-	assert.Equal(t, "workspace_ready", backendErr.Details["failed_stage"])
-	assert.Equal(t, "ws-timeout", backendErr.Details["workspace_id"])
-	assert.NotContains(t, backendErr.Details, "message_delivered")
+	assert.Equal("agent_handoff_timeout", backendErr.Kind)
+	assert.Equal("workspace_created", backendErr.Details["last_completed_stage"])
+	assert.Equal("workspace_ready", backendErr.Details["failed_stage"])
+	assert.Equal("ws-timeout", backendErr.Details["workspace_id"])
+	assert.NotContains(backendErr.Details, "message_delivered")
 }
 
 func TestSpawnWorkspaceWithAgentReportsWorkspaceError(t *testing.T) {
@@ -201,6 +205,7 @@ func TestSpawnWorkspaceWithAgentCreatesIssueAndAdHocWorkspaces(t *testing.T) {
 }
 
 func TestSpawnWorkspaceWithAgentRetriesMultilineMessageUntilInputModeIsReady(t *testing.T) {
+	assert := assert.New(t)
 	backend := successfulSpawnBackend("ws-paste", "runtime-paste", "coding-paste")
 	messagePosts := 0
 	backend.submitInitialMessageFn = func(context.Context, InitialMessageRequest) (InitialMessageStatus, error) {
@@ -218,12 +223,13 @@ func TestSpawnWorkspaceWithAgentRetriesMultilineMessageUntilInputModeIsReady(t *
 	out, err := s.spawnWorkspaceWithAgent(t.Context(), prSpawnInput("first\nsecond"))
 
 	require.NoError(t, err)
-	assert.Equal(t, "message_delivered", out.Stage)
-	assert.Equal(t, "delivered", out.InitialMessage.State)
-	assert.Equal(t, 3, messagePosts)
+	assert.Equal("message_delivered", out.Stage)
+	assert.Equal("delivered", out.InitialMessage.State)
+	assert.Equal(3, messagePosts)
 }
 
 func TestSpawnWorkspaceWithAgentRecoversAmbiguousMessageFromSameBackend(t *testing.T) {
+	assert := assert.New(t)
 	backend := successfulSpawnBackend("ws-recovery", "runtime-recovery", "coding-recovery")
 	messagePosts := 0
 	statusReads := 0
@@ -243,13 +249,14 @@ func TestSpawnWorkspaceWithAgentRecoversAmbiguousMessageFromSameBackend(t *testi
 	out, err := s.spawnWorkspaceWithAgent(t.Context(), prSpawnInput("start"))
 
 	require.NoError(t, err)
-	assert.Equal(t, "message_delivered", out.Stage)
-	assert.Equal(t, "delivered", out.InitialMessage.State)
-	assert.Equal(t, 1, messagePosts)
-	assert.Equal(t, 1, statusReads)
+	assert.Equal("message_delivered", out.Stage)
+	assert.Equal("delivered", out.InitialMessage.State)
+	assert.Equal(1, messagePosts)
+	assert.Equal(1, statusReads)
 }
 
 func TestSpawnWorkspaceWithAgentTreatsPendingMessageStateAsAmbiguous(t *testing.T) {
+	assert := assert.New(t)
 	backend := successfulSpawnBackend("ws-pending", "runtime-pending", "coding-pending")
 	backend.submitInitialMessageFn = func(context.Context, InitialMessageRequest) (InitialMessageStatus, error) {
 		return InitialMessageStatus{State: "pending", MessageBytes: 5}, nil
@@ -260,12 +267,13 @@ func TestSpawnWorkspaceWithAgentTreatsPendingMessageStateAsAmbiguous(t *testing.
 
 	var backendErr *Error
 	require.ErrorAs(t, err, &backendErr)
-	assert.True(t, backendErr.Ambiguous)
-	assert.Equal(t, "pending", backendErr.Details["initial_message_state"])
-	assert.NotContains(t, backendErr.Details, "message_delivered")
+	assert.True(backendErr.Ambiguous)
+	assert.Equal("pending", backendErr.Details["initial_message_state"])
+	assert.NotContains(backendErr.Details, "message_delivered")
 }
 
 func TestSpawnWorkspaceWithAgentKeepsUncertainRecoveryAmbiguous(t *testing.T) {
+	assert := assert.New(t)
 	backend := successfulSpawnBackend("ws-recovery", "runtime-recovery", "coding-recovery")
 	backend.submitInitialMessageFn = func(context.Context, InitialMessageRequest) (InitialMessageStatus, error) {
 		return InitialMessageStatus{}, &Error{Kind: "internal_error", Message: "result unknown", Ambiguous: true}
@@ -279,13 +287,14 @@ func TestSpawnWorkspaceWithAgentKeepsUncertainRecoveryAmbiguous(t *testing.T) {
 
 	var backendErr *Error
 	require.ErrorAs(t, err, &backendErr)
-	assert.True(t, backendErr.Ambiguous)
-	assert.Equal(t, "uncertain", backendErr.Details["initial_message_state"])
-	assert.Equal(t, "message_delivered", backendErr.Details["failed_stage"])
-	assert.NotContains(t, backendErr.Details, "message_delivered")
+	assert.True(backendErr.Ambiguous)
+	assert.Equal("uncertain", backendErr.Details["initial_message_state"])
+	assert.Equal("message_delivered", backendErr.Details["failed_stage"])
+	assert.NotContains(backendErr.Details, "message_delivered")
 }
 
 func TestSpawnWorkspaceWithAgentReportsRuntimeExitBeforeHookSession(t *testing.T) {
+	assert := assert.New(t)
 	backend := successfulSpawnBackend("ws-exit", "runtime-exit", "coding")
 	backend.listWorkspaceAgentSessionsFn = func(context.Context, string) ([]WorkspaceAgentSession, error) {
 		return nil, nil
@@ -304,9 +313,9 @@ func TestSpawnWorkspaceWithAgentReportsRuntimeExitBeforeHookSession(t *testing.T
 
 	var backendErr *Error
 	require.ErrorAs(t, err, &backendErr)
-	assert.Equal(t, "coding_session_observed", backendErr.Details["failed_stage"])
-	assert.Contains(t, backendErr.Message, "runtime exited")
-	assert.Equal(t, 0, messagePosts)
+	assert.Equal("coding_session_observed", backendErr.Details["failed_stage"])
+	assert.Contains(backendErr.Message, "runtime exited")
+	assert.Equal(0, messagePosts)
 }
 
 func TestSpawnWorkspaceWithAgentRejectsInvalidInputBeforeBackendCalls(t *testing.T) {

--- a/internal/mcpserver/tools_agent_test.go
+++ b/internal/mcpserver/tools_agent_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestListAgentTargetsFiltersSupportedHookAgentsWithoutCommands(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	backend := &fakeBackend{listLaunchTargetsFn: func(context.Context) ([]LaunchTarget, error) {
 		return []LaunchTarget{
 			{Key: "gemini", Label: "Gemini", Kind: "agent", Source: "builtin", Available: true},
@@ -24,17 +26,19 @@ func TestListAgentTargetsFiltersSupportedHookAgentsWithoutCommands(t *testing.T)
 
 	out, err := s.listAgentTargets(t.Context(), listAgentTargetsInput{})
 
-	require.NoError(t, err)
-	require.Len(t, out.Targets, 2)
-	assert.Equal(t, "codex", out.Targets[0].Key)
-	assert.False(t, out.Targets[0].Available)
-	assert.Equal(t, "gemini", out.Targets[1].Key)
+	require.NoError(err)
+	require.Len(out.Targets, 2)
+	assert.Equal("codex", out.Targets[0].Key)
+	assert.False(out.Targets[0].Available)
+	assert.Equal("gemini", out.Targets[1].Key)
 	raw, err := json.Marshal(out)
-	require.NoError(t, err)
-	assert.NotContains(t, string(raw), "command")
+	require.NoError(err)
+	assert.NotContains(string(raw), "command")
 }
 
 func TestListWorkspaceAgentSessionsMapsLiveProjectionDeterministically(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	deliveredAt := time.Date(2026, 8, 7, 14, 59, 1, 0, time.UTC)
 	var workspaceID string
 	backend := &fakeBackend{listWorkspaceAgentSessionsFn: func(
@@ -63,12 +67,12 @@ func TestListWorkspaceAgentSessionsMapsLiveProjectionDeterministically(t *testin
 		t.Context(), listWorkspaceAgentSessionsInput{WorkspaceID: "ws-1"},
 	)
 
-	require.NoError(t, err)
-	assert.Equal(t, "ws-1", workspaceID)
-	require.Len(t, out.Sessions, 2)
-	assert.Equal(t, "claude", out.Sessions[0].Agent)
-	require.NotNil(t, out.Sessions[0].InitialMessage)
-	assert.Equal(t, "delivered", out.Sessions[0].InitialMessage.State)
-	assert.Equal(t, "2026-08-07T14:59:01Z", out.Sessions[0].InitialMessage.DeliveredAt)
-	assert.Equal(t, "codex", out.Sessions[1].Agent)
+	require.NoError(err)
+	assert.Equal("ws-1", workspaceID)
+	require.Len(out.Sessions, 2)
+	assert.Equal("claude", out.Sessions[0].Agent)
+	require.NotNil(out.Sessions[0].InitialMessage)
+	assert.Equal("delivered", out.Sessions[0].InitialMessage.State)
+	assert.Equal("2026-08-07T14:59:01Z", out.Sessions[0].InitialMessage.DeliveredAt)
+	assert.Equal("codex", out.Sessions[1].Agent)
 }

--- a/internal/mcpserver/tools_candidates_test.go
+++ b/internal/mcpserver/tools_candidates_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestFindReviewCandidatesGroupsActivityAndEnrichesItems(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	var activityQuery ActivityQuery
 	backend := &fakeBackend{
 		listActivityFn: func(_ context.Context, query ActivityQuery) (ActivityPage, error) {
@@ -37,7 +39,7 @@ func TestFindReviewCandidatesGroupsActivityAndEnrichesItems(t *testing.T) {
 			}}, nil
 		},
 		listPullsFn: func(_ context.Context, query ItemListQuery) ([]Pull, error) {
-			assert.Equal(t, ItemListQuery{Repository: testRepository(), State: "all", Limit: 200}, query)
+			assert.Equal(ItemListQuery{Repository: testRepository(), State: "all", Limit: 200}, query)
 			return []Pull{{
 				Number: 42, Title: "Retry budget", State: "open", Author: "alice",
 				Repository: testRepository(), Workspace: &WorkspaceRef{ID: "ws-pr", Status: "ready"},
@@ -45,7 +47,7 @@ func TestFindReviewCandidatesGroupsActivityAndEnrichesItems(t *testing.T) {
 			}}, nil
 		},
 		listIssuesFn: func(_ context.Context, query ItemListQuery) ([]Issue, error) {
-			assert.Equal(t, ItemListQuery{Repository: testRepository(), State: "all", Limit: 200}, query)
+			assert.Equal(ItemListQuery{Repository: testRepository(), State: "all", Limit: 200}, query)
 			return []Issue{{
 				Number: 7, Title: "Retry docs", State: "open", Author: "dave",
 				WorkflowStatus: "waiting", Repository: testRepository(),
@@ -55,7 +57,7 @@ func TestFindReviewCandidatesGroupsActivityAndEnrichesItems(t *testing.T) {
 			return WorkflowPage{}, nil
 		},
 		getPullStackFn: func(_ context.Context, item ItemIdentity) (Stack, error) {
-			assert.Equal(t, testItemIdentity("pr", 42), item)
+			assert.Equal(testItemIdentity("pr", 42), item)
 			return Stack{Position: 2, Size: 4, Health: "blocked"}, nil
 		},
 	}
@@ -65,25 +67,27 @@ func TestFindReviewCandidatesGroupsActivityAndEnrichesItems(t *testing.T) {
 		Since: "2026-07-01T00:00:00Z", ActivityTypes: []string{"comment"},
 	})
 
-	require.NoError(t, err)
-	assert.Equal(t, []string{"comment"}, activityQuery.ActivityTypes)
-	require.Len(t, out.Candidates, 2)
+	require.NoError(err)
+	assert.Equal([]string{"comment"}, activityQuery.ActivityTypes)
+	require.Len(out.Candidates, 2)
 	issue := out.Candidates[0]
-	assert.Equal(t, 7, issue.Item.Number)
-	assert.Equal(t, "waiting", issue.Workflow.Status)
-	assert.Equal(t, []string{"carol commented"}, issue.Activity.Reasons)
+	assert.Equal(7, issue.Item.Number)
+	assert.Equal("waiting", issue.Workflow.Status)
+	assert.Equal([]string{"carol commented"}, issue.Activity.Reasons)
 	pr := out.Candidates[1]
-	assert.Equal(t, 2, pr.Activity.EventCount)
-	assert.Equal(t, []string{"bob", "alice"}, pr.Activity.Actors)
-	assert.True(t, pr.Workspace.Exists)
-	assert.True(t, pr.Stack.Present)
-	assert.True(t, pr.Cache.DetailLoaded)
+	assert.Equal(2, pr.Activity.EventCount)
+	assert.Equal([]string{"bob", "alice"}, pr.Activity.Actors)
+	assert.True(pr.Workspace.Exists)
+	assert.True(pr.Stack.Present)
+	assert.True(pr.Cache.DetailLoaded)
 	raw, err := json.Marshal(out)
-	require.NoError(t, err)
-	assert.NotContains(t, string(raw), "EventCount")
+	require.NoError(err)
+	assert.NotContains(string(raw), "EventCount")
 }
 
 func TestFindReviewCandidatesUsesWorkflowMetadataAndFiltersBeforeStackLookup(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	stackCalls := 0
 	backend := candidateBackendForPull(42)
 	backend.listWorkflowStatesFn = func(_ context.Context, query WorkflowQuery) (WorkflowPage, error) {
@@ -104,20 +108,22 @@ func TestFindReviewCandidatesUsesWorkflowMetadataAndFiltersBeforeStackLookup(t *
 	excluded, err := s.findReviewCandidates(t.Context(), findCandidatesInput{
 		ExcludeWorkflowStates: []string{"reviewing"},
 	})
-	require.NoError(t, err)
-	assert.Empty(t, excluded.Candidates)
-	assert.Equal(t, 0, stackCalls)
+	require.NoError(err)
+	assert.Empty(excluded.Candidates)
+	assert.Equal(0, stackCalls)
 
 	included, err := s.findReviewCandidates(t.Context(), findCandidatesInput{
 		WorkflowStates: []string{"reviewing"},
 	})
-	require.NoError(t, err)
-	require.Len(t, included.Candidates, 1)
-	assert.Equal(t, "2026-07-01T14:10:00Z", included.Candidates[0].Workflow.UpdatedAt)
-	assert.Equal(t, 1, stackCalls)
+	require.NoError(err)
+	require.Len(included.Candidates, 1)
+	assert.Equal("2026-07-01T14:10:00Z", included.Candidates[0].Workflow.UpdatedAt)
+	assert.Equal(1, stackCalls)
 }
 
 func TestFindReviewCandidatesDefaultsTo25AndCapsAt100(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	backend := &fakeBackend{
 		listActivityFn: func(context.Context, ActivityQuery) (ActivityPage, error) {
 			items := make([]ActivityItem, 102)
@@ -142,16 +148,16 @@ func TestFindReviewCandidatesDefaultsTo25AndCapsAt100(t *testing.T) {
 	s := newMCPTestServer(t, backend)
 
 	defaultOut, err := s.findReviewCandidates(t.Context(), findCandidatesInput{ItemTypes: []string{"issue"}})
-	require.NoError(t, err)
-	assert.Len(t, defaultOut.Candidates, 25)
-	assert.True(t, defaultOut.Capped)
+	require.NoError(err)
+	assert.Len(defaultOut.Candidates, 25)
+	assert.True(defaultOut.Capped)
 
 	maxOut, err := s.findReviewCandidates(t.Context(), findCandidatesInput{
 		ItemTypes: []string{"issue"}, Limit: 500,
 	})
-	require.NoError(t, err)
-	assert.Len(t, maxOut.Candidates, 100)
-	assert.True(t, maxOut.Capped)
+	require.NoError(err)
+	assert.Len(maxOut.Candidates, 100)
+	assert.True(maxOut.Capped)
 }
 
 func TestFindReviewCandidatesPropagatesStackFailure(t *testing.T) {

--- a/internal/mcpserver/tools_diff_test.go
+++ b/internal/mcpserver/tools_diff_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestGetItemDiffSummaryUsesBackendWithoutReturningPatches(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	var got ItemIdentity
 	var includePatches bool
 	backend := &fakeBackend{getPullDiffFn: func(_ context.Context, item ItemIdentity, patches bool) (Diff, error) {
@@ -35,23 +37,25 @@ func TestGetItemDiffSummaryUsesBackendWithoutReturningPatches(t *testing.T) {
 		Item: itemRefInput{Type: "pr", Provider: "github", PlatformRepoID: "repo-acme-widget", Owner: "acme", Name: "widget", Number: 42},
 	})
 
-	require.NoError(t, err)
-	assert.Equal(t, ItemIdentity{Type: "pr", Provider: "github", PlatformRepoID: "repo-acme-widget", Owner: "acme", Name: "widget", Number: 42}, got)
-	assert.False(t, includePatches)
-	assert.True(t, out.Stale)
-	assert.Equal(t, 8, out.TotalAdditions)
-	assert.Equal(t, 3, out.TotalDeletions)
-	assert.True(t, out.Files[1].IsBinary)
+	require.NoError(err)
+	assert.Equal(ItemIdentity{Type: "pr", Provider: "github", PlatformRepoID: "repo-acme-widget", Owner: "acme", Name: "widget", Number: 42}, got)
+	assert.False(includePatches)
+	assert.True(out.Stale)
+	assert.Equal(8, out.TotalAdditions)
+	assert.Equal(3, out.TotalDeletions)
+	assert.True(out.Files[1].IsBinary)
 	raw, err := json.Marshal(out)
-	require.NoError(t, err)
-	assert.NotContains(t, string(raw), "must not leak")
-	assert.NotContains(t, string(raw), `"diff_file"`)
+	require.NoError(err)
+	assert.NotContains(string(raw), "must not leak")
+	assert.NotContains(string(raw), `"diff_file"`)
 }
 
 func TestGetItemDiffEmitWritesOneBackendSnapshotAndOverwrites(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	calls := 0
 	backend := &fakeBackend{getPullDiffFn: func(_ context.Context, _ ItemIdentity, patches bool) (Diff, error) {
-		assert.True(t, patches)
+		assert.True(patches)
 		calls++
 		if calls == 1 {
 			return Diff{Stale: true, Files: []DiffFile{
@@ -80,22 +84,22 @@ func TestGetItemDiffEmitWritesOneBackendSnapshotAndOverwrites(t *testing.T) {
 	}
 
 	first, err := s.getItemDiff(t.Context(), input)
-	require.NoError(t, err)
-	require.NotNil(t, first.DiffFile)
+	require.NoError(err)
+	require.NotNil(first.DiffFile)
 	firstData, err := os.ReadFile(first.DiffFile.Path)
-	require.NoError(t, err)
-	assert.Equal(t, 2, strings.Count(string(firstData), "diff --git "))
+	require.NoError(err)
+	assert.Equal(2, strings.Count(string(firstData), "diff --git "))
 	info, err := os.Stat(first.DiffFile.Path)
-	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	require.NoError(err)
+	assert.Equal(os.FileMode(0o600), info.Mode().Perm())
 
 	second, err := s.getItemDiff(t.Context(), input)
-	require.NoError(t, err)
-	require.NotNil(t, second.DiffFile)
-	assert.Equal(t, first.DiffFile.Path, second.DiffFile.Path)
+	require.NoError(err)
+	require.NotNil(second.DiffFile)
+	assert.Equal(first.DiffFile.Path, second.DiffFile.Path)
 	secondData, err := os.ReadFile(second.DiffFile.Path)
-	require.NoError(t, err)
-	assert.Equal(t, "diff --git a/src/new.go b/src/new.go\nnew file mode 100644\n", string(secondData))
+	require.NoError(err)
+	assert.Equal("diff --git a/src/new.go b/src/new.go\nnew file mode 100644\n", string(secondData))
 }
 
 func TestGetItemDiffClassifiesUnavailableIdentityAndLocalFailures(t *testing.T) {
@@ -136,6 +140,8 @@ func TestGetItemDiffClassifiesUnavailableIdentityAndLocalFailures(t *testing.T) 
 }
 
 func TestGetItemDiffEmitSynthesizesEvidenceForFilesWithoutTextPatches(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	backend := &fakeBackend{getPullDiffFn: func(context.Context, ItemIdentity, bool) (Diff, error) {
 		return Diff{Files: []DiffFile{
 			{Path: "assets/logo.png", Status: "modified", IsBinary: true},
@@ -156,20 +162,20 @@ func TestGetItemDiffEmitSynthesizesEvidenceForFilesWithoutTextPatches(t *testing
 		EmitDiffFile: true,
 	})
 
-	require.NoError(t, err)
-	require.NotNil(t, out.DiffFile)
+	require.NoError(err)
+	require.NotNil(out.DiffFile)
 	data, err := os.ReadFile(out.DiffFile.Path)
-	require.NoError(t, err)
+	require.NoError(err)
 	patch := string(data)
-	assert.Contains(t, patch, "diff --git a/assets/logo.png b/assets/logo.png\n")
-	assert.Contains(t, patch, "Binary files a/assets/logo.png and b/assets/logo.png differ\n")
-	assert.Contains(t, patch, "diff --git a/src/old.go b/src/new.go\n")
-	assert.Contains(t, patch, "rename from src/old.go\nrename to src/new.go\n")
-	assert.Contains(t, patch, "diff --git a/scripts/run.sh b/scripts/run.sh\n")
-	assert.Contains(t, patch, "diff --git a/docs/empty.md b/docs/empty.md\n--- /dev/null\n+++ b/docs/empty.md\n")
-	assert.Contains(t, patch, "diff --git a/legacy/empty.cfg b/legacy/empty.cfg\n--- a/legacy/empty.cfg\n+++ /dev/null\n")
-	assert.Contains(t, patch, "rename from assets/original.png\nrename to assets/moved.png\nBinary files a/assets/original.png and b/assets/moved.png differ\n")
-	assert.Contains(t, patch, "copy from assets/original.png\ncopy to assets/copy.png\nBinary files a/assets/original.png and b/assets/copy.png differ\n")
+	assert.Contains(patch, "diff --git a/assets/logo.png b/assets/logo.png\n")
+	assert.Contains(patch, "Binary files a/assets/logo.png and b/assets/logo.png differ\n")
+	assert.Contains(patch, "diff --git a/src/old.go b/src/new.go\n")
+	assert.Contains(patch, "rename from src/old.go\nrename to src/new.go\n")
+	assert.Contains(patch, "diff --git a/scripts/run.sh b/scripts/run.sh\n")
+	assert.Contains(patch, "diff --git a/docs/empty.md b/docs/empty.md\n--- /dev/null\n+++ b/docs/empty.md\n")
+	assert.Contains(patch, "diff --git a/legacy/empty.cfg b/legacy/empty.cfg\n--- a/legacy/empty.cfg\n+++ /dev/null\n")
+	assert.Contains(patch, "rename from assets/original.png\nrename to assets/moved.png\nBinary files a/assets/original.png and b/assets/moved.png differ\n")
+	assert.Contains(patch, "copy from assets/original.png\ncopy to assets/copy.png\nBinary files a/assets/original.png and b/assets/copy.png differ\n")
 }
 
 func TestGetItemDiffRejectsOversizedTempFile(t *testing.T) {
@@ -210,6 +216,7 @@ func TestGetItemDiffRejectsFileLargerThanConfiguredCache(t *testing.T) {
 }
 
 func TestDiffFileNameCanonicalizesAndSeparatesIdentities(t *testing.T) {
+	assert := assert.New(t)
 	omittedHost := diffFileName(itemRefInput{
 		Type: "pr", Provider: "gh", PlatformRepoID: "repo-acme-widget",
 		Owner: "Acme", Name: "Widget", Number: 7,
@@ -237,36 +244,38 @@ func TestDiffFileNameCanonicalizesAndSeparatesIdentities(t *testing.T) {
 		Type: "pr", Provider: "gitea", PlatformRepoID: "gitea-widget", PlatformHost: "git.example.test",
 		Owner: "team", Name: "widget", Number: 7,
 	})
-	assert.Equal(t, omittedHost, explicitHost)
-	assert.NotEqual(t, omittedHost, collisionCandidate)
-	assert.NotEqual(t, forgejoUpper, forgejoLower)
-	assert.NotEqual(t, giteaUpper, giteaLower)
-	assert.NotContains(t, omittedHost, "/")
-	assert.LessOrEqual(t, len(omittedHost), maxMCPDiffFileNameBytes)
-	assert.True(t, strings.HasSuffix(omittedHost, ".diff"))
+	assert.Equal(omittedHost, explicitHost)
+	assert.NotEqual(omittedHost, collisionCandidate)
+	assert.NotEqual(forgejoUpper, forgejoLower)
+	assert.NotEqual(giteaUpper, giteaLower)
+	assert.NotContains(omittedHost, "/")
+	assert.LessOrEqual(len(omittedHost), maxMCPDiffFileNameBytes)
+	assert.True(strings.HasSuffix(omittedHost, ".diff"))
 }
 
 func TestDiffFileStoreEvictsLeastRecentlyRequestedFiles(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	store, err := newDiffFileStore(8)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(store.Close()) })
 
 	firstPath, _, err := store.write("first.diff", []byte("1111"))
-	require.NoError(t, err)
+	require.NoError(err)
 	secondPath, _, err := store.write("second.diff", []byte("2222"))
-	require.NoError(t, err)
+	require.NoError(err)
 	refreshedPath, _, err := store.write("first.diff", []byte("1111"))
-	require.NoError(t, err)
-	assert.Equal(t, firstPath, refreshedPath)
+	require.NoError(err)
+	assert.Equal(firstPath, refreshedPath)
 	thirdPath, _, err := store.write("third.diff", []byte("3333"))
-	require.NoError(t, err)
+	require.NoError(err)
 
 	_, err = os.Stat(firstPath)
-	require.NoError(t, err)
+	require.NoError(err)
 	_, err = os.Stat(secondPath)
-	assert.True(t, os.IsNotExist(err), "expected least recently requested diff to be evicted, got %v", err)
+	assert.True(os.IsNotExist(err), "expected least recently requested diff to be evicted, got %v", err)
 	_, err = os.Stat(thirdPath)
-	require.NoError(t, err)
+	require.NoError(err)
 }
 
 func TestDiffFileStoreRejectsFileLargerThanCache(t *testing.T) {
@@ -281,11 +290,12 @@ func TestDiffFileStoreRejectsFileLargerThanCache(t *testing.T) {
 }
 
 func TestDiffFileStoreCloseRemovesDirectory(t *testing.T) {
+	require := require.New(t)
 	store, err := newDiffFileStore(64)
-	require.NoError(t, err)
+	require.NoError(err)
 	path, _, err := store.write("one.diff", []byte("diff --git a/a b/a\n"))
-	require.NoError(t, err)
-	require.NoError(t, store.Close())
+	require.NoError(err)
+	require.NoError(store.Close())
 	_, err = os.Stat(filepath.Dir(path))
 	assert.True(t, os.IsNotExist(err), "expected temp dir to be removed, got %v", err)
 }

--- a/internal/mcpserver/tools_items_test.go
+++ b/internal/mcpserver/tools_items_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestGetItemContextPullLimitsEventsAndMapsBackendDetail(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	var got ItemIdentity
 	backend := &fakeBackend{
 		getPullFn: func(_ context.Context, item ItemIdentity) (PullDetail, error) {
@@ -60,20 +62,22 @@ func TestGetItemContextPullLimitsEventsAndMapsBackendDetail(t *testing.T) {
 
 	out, err := s.getItemContext(t.Context(), getItemContextInput{Item: inputItem, EventLimit: 2})
 
-	require.NoError(t, err)
-	assert.Equal(t, itemIdentity(inputItem), got)
-	assert.Equal(t, "full body", out.Body)
-	assert.Equal(t, "mcp", out.Workflow.UpdatedSource)
-	require.Len(t, out.Events, 2)
-	assert.Equal(t, "newest", out.Events[0].Author)
-	assert.Len(t, out.Events[0].BodyPreview, 500)
-	require.NotNil(t, out.Workspace)
-	assert.True(t, out.Stack.Present)
-	require.Len(t, out.Checks, 1)
-	assert.True(t, out.Cache.DetailLoaded)
+	require.NoError(err)
+	assert.Equal(itemIdentity(inputItem), got)
+	assert.Equal("full body", out.Body)
+	assert.Equal("mcp", out.Workflow.UpdatedSource)
+	require.Len(out.Events, 2)
+	assert.Equal("newest", out.Events[0].Author)
+	assert.Len(out.Events[0].BodyPreview, 500)
+	require.NotNil(out.Workspace)
+	assert.True(out.Stack.Present)
+	require.Len(out.Checks, 1)
+	assert.True(out.Cache.DetailLoaded)
 }
 
 func TestGetItemContextIssueCanOmitEvents(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	backend := &fakeBackend{getIssueFn: func(context.Context, ItemIdentity) (IssueDetail, error) {
 		return IssueDetail{
 			Issue: &Issue{
@@ -95,16 +99,18 @@ func TestGetItemContextIssueCanOmitEvents(t *testing.T) {
 		IncludeEvents: &includeEvents,
 	})
 
-	require.NoError(t, err)
-	assert.Equal(t, "full issue body", out.Body)
-	assert.Equal(t, "waiting", out.Workflow.Status)
-	assert.Empty(t, out.Events)
+	require.NoError(err)
+	assert.Equal("full issue body", out.Body)
+	assert.Equal("waiting", out.Workflow.Status)
+	assert.Empty(out.Events)
 	raw, err := json.Marshal(out)
-	require.NoError(t, err)
-	assert.NotContains(t, string(raw), `"events"`)
+	require.NoError(err)
+	assert.NotContains(string(raw), `"events"`)
 }
 
 func TestListItemsByWorkflowStateForwardsTypedQuery(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	var got WorkflowQuery
 	backend := &fakeBackend{listWorkflowStatesFn: func(_ context.Context, query WorkflowQuery) (WorkflowPage, error) {
 		got = query
@@ -134,8 +140,8 @@ func TestListItemsByWorkflowStateForwardsTypedQuery(t *testing.T) {
 		IncludeClosed: true, Limit: 10, Cursor: "cursor",
 	})
 
-	require.NoError(t, err)
-	assert.Equal(t, WorkflowQuery{
+	require.NoError(err)
+	assert.Equal(WorkflowQuery{
 		Repository: RepositoryIdentity{
 			Provider: "gitlab", PlatformRepoID: "gitlab-project", PlatformHost: "git.example.test",
 			RepoPath: "group/sub/project", Owner: "group/sub", Name: "project",
@@ -143,9 +149,9 @@ func TestListItemsByWorkflowStateForwardsTypedQuery(t *testing.T) {
 		ItemTypes: []string{"pr", "issue"}, States: []string{"reviewing", "waiting"},
 		IncludeClosed: true, Limit: 10, Cursor: "cursor",
 	}, got)
-	require.Len(t, out.Items, 1)
-	assert.Equal(t, "next", out.NextCursor)
-	assert.Equal(t, "group/sub/project", out.Items[0].Item.RepoPath)
+	require.Len(out.Items, 1)
+	assert.Equal("next", out.NextCursor)
+	assert.Equal("group/sub/project", out.Items[0].Item.RepoPath)
 }
 
 func TestListItemsByWorkflowStatePropagatesBackendError(t *testing.T) {

--- a/internal/mcpserver/tools_read_test.go
+++ b/internal/mcpserver/tools_read_test.go
@@ -57,6 +57,8 @@ func TestRepoFilterInputRepositoryIdentity(t *testing.T) {
 }
 
 func TestListReposUsesBackendSummaries(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	backend := &fakeBackend{listRepositoriesFn: func(context.Context) ([]RepositorySummary, error) {
 		return []RepositorySummary{
 			{Repository: testRepository(), OpenPRCount: 3, OpenIssueCount: 2, LastSyncCompletedAt: "2026-07-01T10:00:00Z"},
@@ -67,15 +69,17 @@ func TestListReposUsesBackendSummaries(t *testing.T) {
 
 	out, err := s.listRepos(t.Context(), listReposInput{Limit: 1})
 
-	require.NoError(t, err)
-	require.Len(t, out.Repos, 1)
-	assert.Equal(t, "repo-acme-widget", out.Repos[0].PlatformRepoID)
-	assert.Equal(t, "acme/widget", out.Repos[0].RepoPath)
-	assert.Equal(t, 3, out.Repos[0].OpenPRCount)
-	assert.Equal(t, 2, out.Repos[0].OpenIssueCount)
+	require.NoError(err)
+	require.Len(out.Repos, 1)
+	assert.Equal("repo-acme-widget", out.Repos[0].PlatformRepoID)
+	assert.Equal("acme/widget", out.Repos[0].RepoPath)
+	assert.Equal(3, out.Repos[0].OpenPRCount)
+	assert.Equal(2, out.Repos[0].OpenIssueCount)
 }
 
 func TestSearchItemsForwardsTypedQueriesAndOrdersResults(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	var pullQuery, issueQuery ItemListQuery
 	backend := &fakeBackend{
 		listPullsFn: func(_ context.Context, query ItemListQuery) ([]Pull, error) {
@@ -103,26 +107,28 @@ func TestSearchItemsForwardsTypedQueriesAndOrdersResults(t *testing.T) {
 		Query: "retry", Repo: repoFilterInput{Provider: "github", PlatformRepoID: "repo-acme-widget", Owner: "acme", Name: "widget"},
 	})
 
-	require.NoError(t, err)
-	assert.Equal(t, ItemListQuery{
+	require.NoError(err)
+	assert.Equal(ItemListQuery{
 		Repository: testRepository(), State: "open", Text: "retry", Limit: 26,
 	}, pullQuery)
-	assert.Equal(t, pullQuery, issueQuery)
-	require.Len(t, out.Results, 2)
-	assert.Equal(t, "issue", out.Results[0].Item.Type)
-	assert.Equal(t, "new", out.Results[0].WorkflowStatus)
-	assert.Equal(t, "reviewing", out.Results[1].WorkflowStatus)
+	assert.Equal(pullQuery, issueQuery)
+	require.Len(out.Results, 2)
+	assert.Equal("issue", out.Results[0].Item.Type)
+	assert.Equal("new", out.Results[0].WorkflowStatus)
+	assert.Equal("reviewing", out.Results[1].WorkflowStatus)
 	raw, err := json.Marshal(out)
-	require.NoError(t, err)
-	assert.NotContains(t, string(raw), "must not be returned")
+	require.NoError(err)
+	assert.NotContains(string(raw), "must not be returned")
 }
 
 func TestSearchItemsPagesMergedPullsAndReportsCaps(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	var offsets []int
 	backend := &fakeBackend{listPullsFn: func(_ context.Context, query ItemListQuery) ([]Pull, error) {
 		offsets = append(offsets, query.Offset)
-		assert.Equal(t, "all", query.State)
-		assert.Equal(t, 2, query.Limit)
+		assert.Equal("all", query.State)
+		assert.Equal(2, query.Limit)
 		if query.Offset == 0 {
 			return []Pull{
 				{Number: 1, State: "open", Repository: testRepository()},
@@ -140,14 +146,16 @@ func TestSearchItemsPagesMergedPullsAndReportsCaps(t *testing.T) {
 		Query: "change", State: "merged", ItemTypes: []string{"pr"}, Limit: 1,
 	})
 
-	require.NoError(t, err)
-	assert.Equal(t, []int{0, 2}, offsets)
-	require.Len(t, out.Results, 1)
-	assert.Equal(t, 3, out.Results[0].Item.Number)
-	assert.True(t, out.Capped)
+	require.NoError(err)
+	assert.Equal([]int{0, 2}, offsets)
+	require.Len(out.Results, 1)
+	assert.Equal(3, out.Results[0].Item.Number)
+	assert.True(out.Capped)
 }
 
 func TestListActivityForwardsTypedFiltersAndAppliesOutputLimit(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	var got ActivityQuery
 	backend := &fakeBackend{listActivityFn: func(_ context.Context, query ActivityQuery) (ActivityPage, error) {
 		got = query
@@ -170,12 +178,12 @@ func TestListActivityForwardsTypedFiltersAndAppliesOutputLimit(t *testing.T) {
 		Types: []string{"comment", "commit"}, Search: "retry", Limit: 1, After: "cursor-1",
 	})
 
-	require.NoError(t, err)
-	assert.Equal(t, ActivityQuery{
+	require.NoError(err)
+	assert.Equal(ActivityQuery{
 		Since: "2026-07-01T00:00:00Z", Repository: testRepository(),
 		ActivityTypes: []string{"comment", "commit"}, Search: "retry", After: "cursor-1",
 	}, got)
-	require.Len(t, out.Items, 1)
-	assert.True(t, out.Capped)
-	assert.Equal(t, "please retry", out.Items[0].BodyPreview)
+	require.Len(out.Items, 1)
+	assert.True(out.Capped)
+	assert.Equal("please retry", out.Items[0].BodyPreview)
 }

--- a/internal/mcpserver/tools_stack_test.go
+++ b/internal/mcpserver/tools_stack_test.go
@@ -43,6 +43,8 @@ func TestGetStackContextPropagatesMissingPull(t *testing.T) {
 }
 
 func TestGetStackContextSortsMembersAndJoinsPagedWorkflowState(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	var cursors []string
 	backend := &fakeBackend{
 		getPullStackFn: func(context.Context, ItemIdentity) (Stack, error) {
@@ -54,10 +56,10 @@ func TestGetStackContextSortsMembersAndJoinsPagedWorkflowState(t *testing.T) {
 		},
 		listWorkflowStatesFn: func(_ context.Context, query WorkflowQuery) (WorkflowPage, error) {
 			cursors = append(cursors, query.Cursor)
-			assert.Equal(t, testRepository(), query.Repository)
-			assert.Equal(t, []string{"pr"}, query.ItemTypes)
-			assert.True(t, query.IncludeClosed)
-			assert.Equal(t, 200, query.Limit)
+			assert.Equal(testRepository(), query.Repository)
+			assert.Equal([]string{"pr"}, query.ItemTypes)
+			assert.True(query.IncludeClosed)
+			assert.Equal(200, query.Limit)
 			if query.Cursor == "" {
 				return WorkflowPage{
 					Items:      []WorkflowItem{{Identity: testItemIdentity("pr", 41), Workflow: WorkflowState{Status: "waiting"}}},
@@ -79,12 +81,12 @@ func TestGetStackContextSortsMembersAndJoinsPagedWorkflowState(t *testing.T) {
 		},
 	})
 
-	require.NoError(t, err)
-	assert.Equal(t, []string{"", "next"}, cursors)
-	require.Len(t, out.Members, 3)
-	assert.Equal(t, 41, out.Members[0].Number)
-	assert.Equal(t, "waiting", out.Members[0].WorkflowStatus)
-	assert.True(t, out.Members[1].IsRequested)
-	assert.True(t, out.Members[1].IsDraft)
-	assert.Equal(t, "reviewing", out.Members[1].WorkflowStatus)
+	require.NoError(err)
+	assert.Equal([]string{"", "next"}, cursors)
+	require.Len(out.Members, 3)
+	assert.Equal(41, out.Members[0].Number)
+	assert.Equal("waiting", out.Members[0].WorkflowStatus)
+	assert.True(out.Members[1].IsRequested)
+	assert.True(out.Members[1].IsDraft)
+	assert.Equal("reviewing", out.Members[1].WorkflowStatus)
 }

--- a/internal/mcpserver/tools_workflow_test.go
+++ b/internal/mcpserver/tools_workflow_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestSetItemWorkflowStateForwardsTypedMutation(t *testing.T) {
+	assert := assert.New(t)
 	var gotItem ItemIdentity
 	var gotUpdate WorkflowUpdate
 	backend := &fakeBackend{setWorkflowStateFn: func(
@@ -36,17 +37,18 @@ func TestSetItemWorkflowStateForwardsTypedMutation(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	assert.Equal(t, testItemIdentity("pr", 42), gotItem)
-	assert.Equal(t, WorkflowUpdate{
+	assert.Equal(testItemIdentity("pr", 42), gotItem)
+	assert.Equal(WorkflowUpdate{
 		Status: "reviewing", ExpectedStatus: "new", Source: "mcp",
 		Actor: "agent", Reason: "checking docs",
 	}, gotUpdate)
-	assert.Equal(t, "new", out.PreviousStatus)
-	assert.Equal(t, "reviewing", out.Status)
-	assert.Equal(t, "agent", out.UpdatedActor)
+	assert.Equal("new", out.PreviousStatus)
+	assert.Equal("reviewing", out.Status)
+	assert.Equal("agent", out.UpdatedActor)
 }
 
 func TestSetItemWorkflowStateForwardsForce(t *testing.T) {
+	assert := assert.New(t)
 	var got WorkflowUpdate
 	backend := &fakeBackend{setWorkflowStateFn: func(
 		_ context.Context, _ ItemIdentity, update WorkflowUpdate,
@@ -62,9 +64,9 @@ func TestSetItemWorkflowStateForwardsForce(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	assert.True(t, got.Force)
-	assert.Empty(t, got.ExpectedStatus)
-	assert.Equal(t, "waiting", out.Status)
+	assert.True(got.Force)
+	assert.Empty(got.ExpectedStatus)
+	assert.Equal("waiting", out.Status)
 }
 
 func TestSetItemWorkflowStateRequiresOneMutationGuard(t *testing.T) {

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -2145,19 +2145,20 @@ func TestRestartRequiredForAuthFleetSessionsAndSSHPeers(t *testing.T) {
 }
 
 func TestRestartRequiredForMCPConfig(t *testing.T) {
+	assert := assert.New(t)
 	base := &config.Config{MCP: config.MCP{Enabled: true, Port: 8092, DiffCacheMB: 128}}
 	snap := snapshotStartupConfig(base)
 
-	assert.False(t, snap.restartRequiredFor(&config.Config{
+	assert.False(snap.restartRequiredFor(&config.Config{
 		MCP: config.MCP{Enabled: true, Port: 8092, DiffCacheMB: 128},
 	}))
-	assert.True(t, snap.restartRequiredFor(&config.Config{
+	assert.True(snap.restartRequiredFor(&config.Config{
 		MCP: config.MCP{Enabled: false, Port: 8092, DiffCacheMB: 128},
 	}))
-	assert.True(t, snap.restartRequiredFor(&config.Config{
+	assert.True(snap.restartRequiredFor(&config.Config{
 		MCP: config.MCP{Enabled: true, Port: 9192, DiffCacheMB: 128},
 	}))
-	assert.True(t, snap.restartRequiredFor(&config.Config{
+	assert.True(snap.restartRequiredFor(&config.Config{
 		MCP: config.MCP{Enabled: true, Port: 8092, DiffCacheMB: 256},
 	}))
 }

--- a/internal/server/mcp_backend_test.go
+++ b/internal/server/mcp_backend_test.go
@@ -30,14 +30,16 @@ func TestDaemonPingPublishesMCPURL(t *testing.T) {
 }
 
 func TestMCPBackendAppliesActivityItemTypesBeforeSafetyWindow(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	srv, database := setupTestServer(t)
 	ctx := t.Context()
 	pullID := seedPR(t, database, "acme", "widget", 42)
 	repo, err := database.GetRepoByIdentity(ctx, verifiedGitHubRepoIdentity("github.com", "acme", "widget"))
-	require.NoError(t, err)
-	require.NotNil(t, repo)
+	require.NoError(err)
+	require.NotNil(repo)
 	base := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Second)
-	require.NoError(t, database.UpsertMREvents(ctx, []db.MREvent{{
+	require.NoError(database.UpsertMREvents(ctx, []db.MREvent{{
 		MergeRequestID: pullID, EventType: "issue_comment", Author: "reviewer",
 		Body: "review this", CreatedAt: base, DedupeKey: "mcp-item-filter-comment",
 	}}))
@@ -51,27 +53,29 @@ func TestMCPBackendAppliesActivityItemTypesBeforeSafetyWindow(t *testing.T) {
 			Subject: "repository activity", CreatedAt: at, UpdatedAt: at,
 		}
 	}
-	require.NoError(t, database.UpsertBranchCommits(ctx, commits))
+	require.NoError(database.UpsertBranchCommits(ctx, commits))
 
 	page, err := srv.MCPBackend().ListActivity(ctx, mcpserver.ActivityQuery{
 		Since: base.Add(-time.Minute).Format(time.RFC3339), ItemTypes: []string{"pr"},
 	})
 
-	require.NoError(t, err)
-	require.NotEmpty(t, page.Items)
+	require.NoError(err)
+	require.NotEmpty(page.Items)
 	for _, item := range page.Items {
-		assert.Equal(t, "pr", item.ItemType)
-		assert.Equal(t, repo.PlatformRepoID, item.Repository.PlatformRepoID)
+		assert.Equal("pr", item.ItemType)
+		assert.Equal(repo.PlatformRepoID, item.Repository.PlatformRepoID)
 	}
-	assert.False(t, page.Capped)
+	assert.False(page.Capped)
 }
 
 func TestMCPBackendTranslatesInactivePasteModeToRetryableError(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	ctx := t.Context()
 	database := dbtest.Open(t)
 	worktree := t.TempDir()
 	workspaceID := "ws-mcp-initial-message"
-	require.NoError(t, database.InsertWorkspace(ctx, &db.Workspace{
+	require.NoError(database.InsertWorkspace(ctx, &db.Workspace{
 		ID: workspaceID, Platform: "github", PlatformHost: "github.com",
 		RepoOwner: "acme", RepoName: "widgets",
 		ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 42,
@@ -92,9 +96,9 @@ func TestMCPBackendTranslatesInactivePasteModeToRetryableError(t *testing.T) {
 	})
 	t.Cleanup(runtime.Shutdown)
 	session, err := runtime.Launch(ctx, workspaceID, worktree, "codex")
-	require.NoError(t, err)
+	require.NoError(err)
 	activity := agentactivity.NewStore(t.TempDir())
-	require.NoError(t, activity.HandleEvent("codex", agentactivity.HookEvent{
+	require.NoError(activity.HandleEvent("codex", agentactivity.HookEvent{
 		SessionID: "coding-session", CWD: worktree,
 		HookEventName: "UserPromptSubmit",
 	}, session.Key))
@@ -109,19 +113,21 @@ func TestMCPBackendTranslatesInactivePasteModeToRetryableError(t *testing.T) {
 	})
 
 	var backendErr *mcpserver.Error
-	require.ErrorAs(t, err, &backendErr)
-	assert.Equal(t, mcpserver.ErrorCodeInitialMessageInputModeNotReady, backendErr.Code)
-	assert.Equal(t, "unavailable", backendErr.Kind)
-	assert.True(t, backendErr.Retryable)
-	assert.False(t, backendErr.Ambiguous)
+	require.ErrorAs(err, &backendErr)
+	assert.Equal(mcpserver.ErrorCodeInitialMessageInputModeNotReady, backendErr.Code)
+	assert.Equal("unavailable", backendErr.Kind)
+	assert.True(backendErr.Retryable)
+	assert.False(backendErr.Ambiguous)
 }
 
 func TestMCPPullWorkspaceDuplicateUsesStableConflictCode(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	_, database, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
 	ctx := t.Context()
 	repo, err := database.GetRepoByIdentity(ctx, verifiedGitHubRepoIdentity("github.com", "acme", "widget"))
-	require.NoError(t, err)
-	require.NotNil(t, repo)
+	require.NoError(err)
+	require.NotNil(repo)
 	item := mcpserver.ItemIdentity{
 		Type: "pr", Provider: "github", PlatformHost: "github.com",
 		PlatformRepoID: repo.PlatformRepoID,
@@ -129,13 +135,13 @@ func TestMCPPullWorkspaceDuplicateUsesStableConflictCode(t *testing.T) {
 	}
 
 	_, err = srv.MCPBackend().CreatePullWorkspace(ctx, item, true)
-	require.NoError(t, err)
+	require.NoError(err)
 	_, err = srv.MCPBackend().CreatePullWorkspace(ctx, item, true)
 
 	var backendErr *mcpserver.Error
-	require.ErrorAs(t, err, &backendErr)
-	assert.Equal(t, "conflict", backendErr.Kind)
-	assert.Equal(t, mcpserver.ErrorCodeWorkspaceAlreadyExists, backendErr.Code)
+	require.ErrorAs(err, &backendErr)
+	assert.Equal("conflict", backendErr.Kind)
+	assert.Equal(mcpserver.ErrorCodeWorkspaceAlreadyExists, backendErr.Code)
 }
 
 func TestMCPBackendRejectsMismatchedStableRepositoryID(t *testing.T) {
@@ -155,21 +161,23 @@ func TestMCPBackendRejectsMismatchedStableRepositoryID(t *testing.T) {
 }
 
 func TestMCPBackendReadFailsClosedWhenRouteReassignedMidRead(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	srv, database := setupTestServer(t)
 	ctx := t.Context()
 	seedPR(t, database, "acme", "widget", 42)
 	repo, err := database.GetRepoByIdentity(ctx, verifiedGitHubRepoIdentity("github.com", "acme", "widget"))
-	require.NoError(t, err)
-	require.NotNil(t, repo)
+	require.NoError(err)
+	require.NotNil(repo)
 	backend, ok := srv.MCPBackend().(mcpBackend)
-	require.True(t, ok)
+	require.True(ok)
 
 	resolved, err := backend.resolveRepositoryFence(ctx, mcpserver.RepositoryIdentity{
 		Provider: "github", PlatformHost: "github.com",
 		PlatformRepoID: repo.PlatformRepoID,
 		Owner:          "acme", Name: "widget",
 	})
-	require.NoError(t, err)
+	require.NoError(err)
 
 	// Reassign route ownership between stable-identity validation and the
 	// route-addressed read, the window the fence exists to police.
@@ -178,26 +186,28 @@ func TestMCPBackendReadFailsClosedWhenRouteReassignedMidRead(t *testing.T) {
 		PlatformRepoID: "replacement-repository",
 		Owner:          "acme", Name: "widget", RepoPath: "acme/widget",
 	}, time.Now().UTC())
-	require.NoError(t, err)
-	require.True(t, accepted)
+	require.NoError(err)
+	require.True(accepted)
 
 	err = backend.confirmRepositoryRoute(ctx, resolved)
 
 	var backendErr *mcpserver.Error
-	require.ErrorAs(t, err, &backendErr)
-	assert.Equal(t, "not_found", backendErr.Kind)
-	assert.Equal(t, string(httpapi.CodeRepoNotFound), backendErr.Code)
+	require.ErrorAs(err, &backendErr)
+	assert.Equal("not_found", backendErr.Kind)
+	assert.Equal(string(httpapi.CodeRepoNotFound), backendErr.Code)
 }
 
 func TestMCPBackendWorkflowDoesNotExposeOrMutateRemovedUpstreamItems(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	srv, database := setupTestServer(t)
 	ctx := t.Context()
 	seedPR(t, database, "acme", "widget", 1)
 	seedPR(t, database, "acme", "widget", 2)
 	seedIssue(t, database, "acme", "widget", 3, "open")
 	repo, err := database.GetRepoByIdentity(ctx, verifiedGitHubRepoIdentity("github.com", "acme", "widget"))
-	require.NoError(t, err)
-	require.NotNil(t, repo)
+	require.NoError(err)
+	require.NotNil(repo)
 	markArchiveItemRemovedUpstreamForServerTest(
 		t, database, repo.ID, db.ArchiveItemTypeMergeRequest, 1,
 	)
@@ -215,10 +225,10 @@ func TestMCPBackendWorkflowDoesNotExposeOrMutateRemovedUpstreamItems(t *testing.
 		Repository: repository, IncludeClosed: true,
 	})
 
-	require.NoError(t, err)
-	require.Len(t, page.Items, 1)
-	assert.Equal(t, 2, page.Items[0].Identity.Number)
-	assert.Equal(t, repo.PlatformRepoID, page.Items[0].Identity.PlatformRepoID)
+	require.NoError(err)
+	require.Len(page.Items, 1)
+	assert.Equal(2, page.Items[0].Identity.Number)
+	assert.Equal(repo.PlatformRepoID, page.Items[0].Identity.PlatformRepoID)
 
 	_, err = backend.SetWorkflowState(ctx, mcpserver.ItemIdentity{
 		Type: "pr", Provider: "github", PlatformHost: "github.com",
@@ -228,12 +238,12 @@ func TestMCPBackendWorkflowDoesNotExposeOrMutateRemovedUpstreamItems(t *testing.
 		Status: "reviewing", ExpectedStatus: "new", Source: "mcp",
 	})
 	var backendErr *mcpserver.Error
-	require.ErrorAs(t, err, &backendErr)
-	assert.Equal(t, "not_found", backendErr.Kind)
-	assert.Equal(t, string(httpapi.CodePullNotFound), backendErr.Code)
+	require.ErrorAs(err, &backendErr)
+	assert.Equal("not_found", backendErr.Kind)
+	assert.Equal(string(httpapi.CodePullNotFound), backendErr.Code)
 
 	stored, err := database.GetItemWorkflowState(ctx, repo.ID, db.ItemTypePR, 1)
-	require.NoError(t, err)
-	require.NotNil(t, stored)
-	assert.Equal(t, "new", stored.Status)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal("new", stored.Status)
 }

--- a/internal/server/workspaceapi/initial_message_test.go
+++ b/internal/server/workspaceapi/initial_message_test.go
@@ -89,6 +89,8 @@ func TestInitialMessageSubmitFailureReleasesPreWriteAttempt(t *testing.T) {
 }
 
 func TestInitialMessageInactivePasteModeReturnsRetryableServiceSignal(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	handler := New(Deps{Now: func() time.Time {
 		return time.Date(2026, 8, 18, 17, 0, 0, 0, time.UTC)
 	}})
@@ -96,16 +98,16 @@ func TestInitialMessageInactivePasteModeReturnsRetryableServiceSignal(t *testing
 		Agent: "codex", SessionID: "coding-session", Message: "first\nsecond",
 	}
 	_, reserved := handler.reserveInitialMessageAttempt("ws-1", "runtime-1", proposed)
-	require.True(t, reserved)
+	require.True(reserved)
 
 	result, err := handler.handleInitialMessageSubmitError(
 		"ws-1", "runtime-1", proposed, localruntime.ErrBracketedPasteInactive,
 	)
 
-	require.ErrorIs(t, err, ErrInitialMessageInputModeNotReady)
-	assert.Empty(t, result.State)
+	require.ErrorIs(err, ErrInitialMessageInputModeNotReady)
+	assert.Empty(result.State)
 	_, found := handler.initialMessageAttempt("ws-1", "runtime-1")
-	assert.False(t, found)
+	assert.False(found)
 }
 
 func TestSubmitInitialMessageServiceReturnsDeliveredStateAndRoutesShareAttempt(t *testing.T) {

--- a/internal/server/workspaceapi/services_test.go
+++ b/internal/server/workspaceapi/services_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestCreatePullWorkspaceServiceSuppressesAutoAssign(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	database := dbtest.Open(t)
 	ctx := t.Context()
 	repoIdentity := db.RepoIdentity{
@@ -24,7 +26,7 @@ func TestCreatePullWorkspaceServiceSuppressesAutoAssign(t *testing.T) {
 		PlatformRepoID: "repo-acme-widget", Owner: "acme", Name: "widget",
 	}
 	repoID, err := database.UpsertRepo(ctx, repoIdentity)
-	require.NoError(t, err)
+	require.NoError(err)
 	now := time.Now().UTC().Truncate(time.Second)
 	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
 		RepoID: repoID, PlatformID: 7000, Number: 7,
@@ -33,10 +35,10 @@ func TestCreatePullWorkspaceServiceSuppressesAutoAssign(t *testing.T) {
 		HeadBranch: "feature", BaseBranch: "main",
 		CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
 	})
-	require.NoError(t, err)
+	require.NoError(err)
 	provider := &autoAssignProvider{pull: platform.MergeRequest{}}
 	registry, err := platform.NewRegistry(provider)
-	require.NoError(t, err)
+	require.NoError(err)
 	syncer := ghclient.NewSyncerWithRegistry(registry, database, nil, nil, time.Hour, nil, nil)
 	t.Cleanup(syncer.Stop)
 	handler := New(Deps{
@@ -49,7 +51,7 @@ func TestCreatePullWorkspaceServiceSuppressesAutoAssign(t *testing.T) {
 	t.Cleanup(func() {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		require.NoError(t, handler.Shutdown(shutdownCtx))
+		require.NoError(handler.Shutdown(shutdownCtx))
 	})
 
 	result, err := handler.CreatePullWorkspace(ctx, CreatePullWorkspaceRequest{
@@ -57,18 +59,20 @@ func TestCreatePullWorkspaceServiceSuppressesAutoAssign(t *testing.T) {
 		Owner: "acme", Name: "widget", Number: 7, SuppressAutoAssign: true,
 	})
 
-	require.NoError(t, err)
-	assert.NotEmpty(t, result.Workspace.ID)
-	assert.True(t, result.Workspace.Created)
-	assert.Empty(t, provider.pullAssigned)
+	require.NoError(err)
+	assert.NotEmpty(result.Workspace.ID)
+	assert.True(result.Workspace.Created)
+	assert.Empty(provider.pullAssigned)
 }
 
 func TestLaunchWorkspaceRuntimeServiceReturnsSession(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	database := dbtest.Open(t)
 	ctx := t.Context()
 	worktree := t.TempDir()
 	workspaceID := "ws-runtime-service"
-	require.NoError(t, database.InsertWorkspace(ctx, &db.Workspace{
+	require.NoError(database.InsertWorkspace(ctx, &db.Workspace{
 		ID: workspaceID, Platform: "github", PlatformHost: "github.com",
 		RepoOwner: "acme", RepoName: "widget", ItemType: db.WorkspaceItemTypeAdHoc,
 		ItemKey: db.AdHocWorkspaceItemKey("work/service"), GitHeadRef: "work/service",
@@ -94,12 +98,12 @@ func TestLaunchWorkspaceRuntimeServiceReturnsSession(t *testing.T) {
 		ctx, workspaceID, string(localruntime.LaunchTargetPlainShell),
 	)
 
-	require.NoError(t, err)
-	assert.NotEmpty(t, session.Key)
-	assert.Equal(t, workspaceID, session.WorkspaceID)
-	assert.Equal(t, string(localruntime.LaunchTargetPlainShell), session.TargetKey)
+	require.NoError(err)
+	assert.NotEmpty(session.Key)
+	assert.Equal(workspaceID, session.WorkspaceID)
+	assert.Equal(string(localruntime.LaunchTargetPlainShell), session.TargetKey)
 	stored, err := workspaceManager.RuntimeSessionsForWorkspace(ctx, workspaceID)
-	require.NoError(t, err)
-	require.Len(t, stored, 1)
-	assert.Equal(t, session.Key, stored[0].SessionKey)
+	require.NoError(err)
+	require.Len(stored, 1)
+	assert.Equal(session.Key, stored[0].SessionKey)
 }

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -2307,6 +2307,7 @@ func TestManagerSubmitInitialMessageClassifiesMissingSessionAsNotWritten(t *test
 }
 
 func TestManagerSubmitInitialMessageHonorsContextWithoutHoldingSessionLock(t *testing.T) {
+	require := require.New(t)
 	writeStarted := make(chan struct{})
 	writeRelease := make(chan struct{})
 	writeFinished := make(chan struct{})
@@ -2341,19 +2342,19 @@ func TestManagerSubmitInitialMessageHonorsContextWithoutHoldingSessionLock(t *te
 	select {
 	case <-snapshotDone:
 	case <-time.After(time.Second):
-		require.FailNow(t, "session lock remained held during terminal write")
+		require.FailNow("session lock remained held during terminal write")
 	}
 	select {
 	case err := <-result:
-		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.ErrorIs(err, context.DeadlineExceeded)
 	case <-time.After(time.Second):
-		require.FailNow(t, "initial message write ignored context deadline")
+		require.FailNow("initial message write ignored context deadline")
 	}
 	close(writeRelease)
 	select {
 	case <-writeFinished:
 	case <-time.After(time.Second):
-		require.FailNow(t, "blocked test write did not finish")
+		require.FailNow("blocked test write did not finish")
 	}
 }
 


### PR DESCRIPTION
Testify helper violations could merge because the checker ran only in optional local hooks.

- Convert the 85 existing violations to local `assert` and `require` helpers without changing test behavior.
- Add `testify-helper-check` to the existing CI guardrail target so future violations fail before merge.
- Record the CI enforcement point in the shared testing context.
