### PR TITLE
fix: steady workspace activity ordering

### DIFF
--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -116,6 +116,9 @@ embedder protocol for arbitrary host state.
   affordance after its work resolves to a PR, while that PR receives the tmux recency
   candidate and uses it only when workspace recency is enabled
   (`internal/server/workspaceapi/subject_activity.go::Handler.WorkspaceSubjectSnapshot`).
+- Tmux recency publishes immediately, then at most once per rolling minute per workspace;
+  existing enrichment lazily publishes suppressed activity while live state stays
+  responsive. Nil resets the throttle; older samples never regress it (`internal/server/workspaceapi/workspace_enrichment.go::recordCachedWorkspaceTmux`).
 - Aggregate enrichment is fresh only after divergence and tmux both complete;
   partial results remain pending or stale
   (`internal/server/workspaceapi/workspace_enrichment.go::workspaceResponseFromEnrichmentCacheEntry`).

--- a/internal/server/workspaceapi/workspace_enrichment.go
+++ b/internal/server/workspaceapi/workspace_enrichment.go
@@ -13,6 +13,7 @@ const (
 	workspaceEnrichmentTTL            = 5 * time.Second
 	workspaceEnrichmentRefreshTimeout = 2 * time.Second
 	workspaceTmuxPruneInterval        = 5 * time.Second
+	workspaceTmuxRecencyMinInterval   = time.Minute
 	workspaceEnrichmentNotApplicable  = "not_applicable"
 	workspaceEnrichmentPending        = "pending"
 	workspaceEnrichmentFresh          = "fresh"
@@ -24,16 +25,19 @@ const (
 const EnrichmentTTL = workspaceEnrichmentTTL
 
 type workspaceEnrichmentCacheEntry struct {
-	response              workspaceResponse
-	hasDivergence         bool
-	hasTmux               bool
-	divergenceRefreshedAt time.Time
-	tmuxRefreshedAt       time.Time
-	lastAttemptAt         time.Time
-	divergenceError       string
-	tmuxError             string
-	divergenceAttemptAt   time.Time
-	tmuxAttemptAt         time.Time
+	response               workspaceResponse
+	hasDivergence          bool
+	hasTmux                bool
+	divergenceRefreshedAt  time.Time
+	tmuxRefreshedAt        time.Time
+	tmuxObservedOutputAt   time.Time
+	tmuxPublishedOutputAt  time.Time
+	tmuxRecencyPublishedAt time.Time
+	lastAttemptAt          time.Time
+	divergenceError        string
+	tmuxError              string
+	divergenceAttemptAt    time.Time
+	tmuxAttemptAt          time.Time
 }
 
 type workspaceEnrichmentKind uint8
@@ -144,6 +148,56 @@ func applyCachedWorkspaceTmux(
 	resp.TmuxWorking = cached.TmuxWorking
 	resp.TmuxActivitySource = cached.TmuxActivitySource
 	resp.TmuxLastOutputAt = cached.TmuxLastOutputAt
+}
+
+func recordCachedWorkspaceTmux(
+	entry *workspaceEnrichmentCacheEntry,
+	observed workspaceResponse,
+	now time.Time,
+) {
+	entry.response.TmuxPaneTitle = observed.TmuxPaneTitle
+	entry.response.TmuxWorking = observed.TmuxWorking
+	entry.response.TmuxActivitySource = observed.TmuxActivitySource
+
+	observedAt := parseWorkspaceTmuxOutputAt(observed.TmuxLastOutputAt)
+	if observedAt.IsZero() {
+		entry.response.TmuxLastOutputAt = nil
+		entry.tmuxObservedOutputAt = time.Time{}
+		entry.tmuxPublishedOutputAt = time.Time{}
+		entry.tmuxRecencyPublishedAt = time.Time{}
+		return
+	}
+	if !entry.tmuxObservedOutputAt.IsZero() &&
+		observedAt.Before(entry.tmuxObservedOutputAt) {
+		return
+	}
+	if observedAt.After(entry.tmuxObservedOutputAt) {
+		entry.tmuxObservedOutputAt = observedAt
+	}
+
+	now = now.UTC()
+	publish := entry.tmuxPublishedOutputAt.IsZero()
+	if !publish && entry.tmuxObservedOutputAt.After(entry.tmuxPublishedOutputAt) {
+		publish = entry.tmuxRecencyPublishedAt.IsZero() ||
+			!now.Before(entry.tmuxRecencyPublishedAt.Add(workspaceTmuxRecencyMinInterval))
+	}
+	if publish {
+		entry.tmuxPublishedOutputAt = entry.tmuxObservedOutputAt
+		entry.tmuxRecencyPublishedAt = now
+	}
+	formatted := entry.tmuxPublishedOutputAt.Format(time.RFC3339)
+	entry.response.TmuxLastOutputAt = &formatted
+}
+
+func parseWorkspaceTmuxOutputAt(value *string) time.Time {
+	if value == nil {
+		return time.Time{}
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, *value)
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed.UTC()
 }
 
 func applyWorkspaceEnrichmentCacheEntry(
@@ -431,7 +485,7 @@ func (s *Handler) recordWorkspaceEnrichmentResult(
 		}
 	}
 	if result.tmuxComplete {
-		applyCachedWorkspaceTmux(&entry.response, result.response)
+		recordCachedWorkspaceTmux(&entry, result.response, now)
 		entry.hasTmux = true
 		entry.tmuxRefreshedAt = now
 	}

--- a/internal/server/workspaceapi/workspace_enrichment.go
+++ b/internal/server/workspaceapi/workspace_enrichment.go
@@ -151,10 +151,10 @@ func applyCachedWorkspaceTmux(
 }
 
 func recordCachedWorkspaceTmux(
-	entry *workspaceEnrichmentCacheEntry,
+	entry workspaceEnrichmentCacheEntry,
 	observed workspaceResponse,
 	now time.Time,
-) {
+) workspaceEnrichmentCacheEntry {
 	entry.response.TmuxPaneTitle = observed.TmuxPaneTitle
 	entry.response.TmuxWorking = observed.TmuxWorking
 	entry.response.TmuxActivitySource = observed.TmuxActivitySource
@@ -165,11 +165,11 @@ func recordCachedWorkspaceTmux(
 		entry.tmuxObservedOutputAt = time.Time{}
 		entry.tmuxPublishedOutputAt = time.Time{}
 		entry.tmuxRecencyPublishedAt = time.Time{}
-		return
+		return entry
 	}
 	if !entry.tmuxObservedOutputAt.IsZero() &&
 		observedAt.Before(entry.tmuxObservedOutputAt) {
-		return
+		return entry
 	}
 	if observedAt.After(entry.tmuxObservedOutputAt) {
 		entry.tmuxObservedOutputAt = observedAt
@@ -187,6 +187,7 @@ func recordCachedWorkspaceTmux(
 	}
 	formatted := entry.tmuxPublishedOutputAt.Format(time.RFC3339)
 	entry.response.TmuxLastOutputAt = &formatted
+	return entry
 }
 
 func parseWorkspaceTmuxOutputAt(value *string) time.Time {
@@ -485,7 +486,7 @@ func (s *Handler) recordWorkspaceEnrichmentResult(
 		}
 	}
 	if result.tmuxComplete {
-		recordCachedWorkspaceTmux(&entry, result.response, now)
+		entry = recordCachedWorkspaceTmux(entry, result.response, now)
 		entry.hasTmux = true
 		entry.tmuxRefreshedAt = now
 	}

--- a/internal/server/workspaceapi/workspace_enrichment.go
+++ b/internal/server/workspaceapi/workspace_enrichment.go
@@ -167,10 +167,6 @@ func recordCachedWorkspaceTmux(
 		entry.tmuxRecencyPublishedAt = time.Time{}
 		return entry
 	}
-	if !entry.tmuxObservedOutputAt.IsZero() &&
-		observedAt.Before(entry.tmuxObservedOutputAt) {
-		return entry
-	}
 	if observedAt.After(entry.tmuxObservedOutputAt) {
 		entry.tmuxObservedOutputAt = observedAt
 	}

--- a/internal/server/workspaceapi/workspace_enrichment_test.go
+++ b/internal/server/workspaceapi/workspace_enrichment_test.go
@@ -635,6 +635,155 @@ func TestWorkspaceEnrichmentRefreshFailurePreservesLastKnownGood(t *testing.T) {
 	assert.Equal(lastGood.response.TmuxPaneTitle, synchronousEntry.response.TmuxPaneTitle)
 }
 
+func TestWorkspaceEnrichmentThrottlesPublishedTmuxRecency(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	srv := &Handler{
+		now:                            func() time.Time { return now },
+		workspaceEnrichmentCache:       make(map[string]workspaceEnrichmentCacheEntry),
+		workspaceEnrichmentGenerations: map[string]uint64{"ws-recency": 1},
+	}
+	record := func(activityAt time.Time, title string, working bool) workspaceEnrichmentCacheEntry {
+		formatted := activityAt.UTC().Format(time.RFC3339)
+		entry, recorded, _ := srv.recordWorkspaceEnrichmentResult(
+			"ws-recency",
+			1,
+			workspaceEnrichmentProbeResult{
+				response: workspaceResponse{
+					TmuxPaneTitle:      &title,
+					TmuxWorking:        working,
+					TmuxActivitySource: tmuxActivitySourceOutput,
+					TmuxLastOutputAt:   &formatted,
+				},
+				tmuxComplete: true,
+				kind:         workspaceEnrichmentTmux,
+			},
+		)
+		require.True(recorded)
+		return entry
+	}
+
+	firstActivityAt := now
+	entry := record(firstActivityAt, "first title", true)
+	require.NotNil(entry.response.TmuxLastOutputAt)
+	assert.Equal(firstActivityAt.Format(time.RFC3339), *entry.response.TmuxLastOutputAt)
+
+	now = now.Add(30 * time.Second)
+	suppressedActivityAt := now
+	entry = record(suppressedActivityAt, "updated title", false)
+	require.NotNil(entry.response.TmuxLastOutputAt)
+	assert.Equal(firstActivityAt.Format(time.RFC3339), *entry.response.TmuxLastOutputAt)
+	require.NotNil(entry.response.TmuxPaneTitle)
+	assert.Equal("updated title", *entry.response.TmuxPaneTitle)
+	assert.False(entry.response.TmuxWorking)
+
+	now = now.Add(20 * time.Second)
+	entry, recorded, _ := srv.recordWorkspaceEnrichmentResult(
+		"ws-recency", 1, workspaceEnrichmentProbeResult{
+			tmuxErr: errors.New("tmux probe failed"),
+			kind:    workspaceEnrichmentTmux,
+		},
+	)
+	require.True(recorded)
+	require.NotNil(entry.response.TmuxLastOutputAt)
+	assert.Equal(firstActivityAt.Format(time.RFC3339), *entry.response.TmuxLastOutputAt)
+
+	now = now.Add(10 * time.Second)
+	entry = record(suppressedActivityAt, "quiet title", false)
+	require.NotNil(entry.response.TmuxLastOutputAt)
+	assert.Equal(suppressedActivityAt.Format(time.RFC3339), *entry.response.TmuxLastOutputAt)
+
+	now = now.Add(time.Minute)
+	latestActivityAt := now
+	entry = record(latestActivityAt, "working again", true)
+	require.NotNil(entry.response.TmuxLastOutputAt)
+	assert.Equal(latestActivityAt.Format(time.RFC3339), *entry.response.TmuxLastOutputAt)
+}
+
+func TestWorkspaceEnrichmentDoesNotRegressPublishedTmuxRecency(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	now := time.Date(2026, 8, 20, 13, 0, 0, 0, time.UTC)
+	srv := &Handler{
+		now:                            func() time.Time { return now },
+		workspaceEnrichmentCache:       make(map[string]workspaceEnrichmentCacheEntry),
+		workspaceEnrichmentGenerations: map[string]uint64{"ws-regression": 1},
+	}
+	record := func(activityAt time.Time, title string) workspaceEnrichmentCacheEntry {
+		formatted := activityAt.UTC().Format(time.RFC3339)
+		entry, recorded, _ := srv.recordWorkspaceEnrichmentResult(
+			"ws-regression", 1, workspaceEnrichmentProbeResult{
+				response: workspaceResponse{
+					TmuxPaneTitle:      &title,
+					TmuxActivitySource: tmuxActivitySourceNone,
+					TmuxLastOutputAt:   &formatted,
+				},
+				tmuxComplete: true,
+				kind:         workspaceEnrichmentTmux,
+			},
+		)
+		require.True(recorded)
+		return entry
+	}
+
+	newerActivityAt := now
+	record(newerActivityAt, "newer session")
+	now = now.Add(time.Minute)
+	entry := record(newerActivityAt.Add(-time.Minute), "older remaining session")
+
+	require.NotNil(entry.response.TmuxLastOutputAt)
+	assert.Equal(newerActivityAt.Format(time.RFC3339), *entry.response.TmuxLastOutputAt)
+	require.NotNil(entry.response.TmuxPaneTitle)
+	assert.Equal("older remaining session", *entry.response.TmuxPaneTitle)
+}
+
+func TestWorkspaceEnrichmentAbsentTmuxRecencyClearsAndResetsThrottle(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	now := time.Date(2026, 8, 20, 14, 0, 0, 0, time.UTC)
+	srv := &Handler{
+		now:                            func() time.Time { return now },
+		workspaceEnrichmentCache:       make(map[string]workspaceEnrichmentCacheEntry),
+		workspaceEnrichmentGenerations: map[string]uint64{"ws-reset": 1},
+	}
+	initial := now
+	formatted := initial.Format(time.RFC3339)
+	_, recorded, _ := srv.recordWorkspaceEnrichmentResult(
+		"ws-reset", 1, workspaceEnrichmentProbeResult{
+			response:     workspaceResponse{TmuxLastOutputAt: &formatted},
+			tmuxComplete: true,
+			kind:         workspaceEnrichmentTmux,
+		},
+	)
+	require.True(recorded)
+
+	now = now.Add(10 * time.Second)
+	entry, recorded, _ := srv.recordWorkspaceEnrichmentResult(
+		"ws-reset", 1, workspaceEnrichmentProbeResult{
+			response:     workspaceResponse{TmuxActivitySource: tmuxActivitySourceNone},
+			tmuxComplete: true,
+			kind:         workspaceEnrichmentTmux,
+		},
+	)
+	require.True(recorded)
+	assert.Nil(entry.response.TmuxLastOutputAt)
+
+	now = now.Add(time.Second)
+	olderAfterReset := initial.Add(-time.Minute)
+	formatted = olderAfterReset.Format(time.RFC3339)
+	entry, recorded, _ = srv.recordWorkspaceEnrichmentResult(
+		"ws-reset", 1, workspaceEnrichmentProbeResult{
+			response:     workspaceResponse{TmuxLastOutputAt: &formatted},
+			tmuxComplete: true,
+			kind:         workspaceEnrichmentTmux,
+		},
+	)
+	require.True(recorded)
+	require.NotNil(entry.response.TmuxLastOutputAt)
+	assert.Equal(formatted, *entry.response.TmuxLastOutputAt)
+}
+
 func TestWorkspaceEnrichmentBroadcastsOnlyDurableChanges(t *testing.T) {
 	assert := assert.New(t)
 	srv := &Handler{

--- a/internal/server/workspaceapi/workspace_enrichment_test.go
+++ b/internal/server/workspaceapi/workspace_enrichment_test.go
@@ -690,7 +690,8 @@ func TestWorkspaceEnrichmentThrottlesPublishedTmuxRecency(t *testing.T) {
 	assert.Equal(firstActivityAt.Format(time.RFC3339), *entry.response.TmuxLastOutputAt)
 
 	now = now.Add(10 * time.Second)
-	entry = record(suppressedActivityAt, "quiet title", false)
+	olderRemainingSessionAt := firstActivityAt.Add(-time.Minute)
+	entry = record(olderRemainingSessionAt, "quiet title", false)
 	require.NotNil(entry.response.TmuxLastOutputAt)
 	assert.Equal(suppressedActivityAt.Format(time.RFC3339), *entry.response.TmuxLastOutputAt)
 


### PR DESCRIPTION
Continuous tmux output made active workspace rows reorder on every sampled activity timestamp.

- Publish the first activity immediately, then update ordering recency at most once per rolling minute.
- Keep working state and pane titles live, and lazily publish suppressed activity when the window elapses.
- Clear stale recency when activity disappears and prevent older samples from moving recency backward.

Workspace ordering and relative-time labels can lag live output by up to one minute. This is the deliberate tradeoff for a calmer list.
