### PR TITLE
fix: align force-push timeline timestamps

### DIFF
--- a/frontend/src/lib/components/detail/EventTimeline.svelte
+++ b/frontend/src/lib/components/detail/EventTimeline.svelte
@@ -2435,7 +2435,7 @@
     transition: opacity 0.15s;
   }
 
-  .event-timeline :global(.kit-comment-card:not(.event-card--commit) .kit-card__meta) {
+  .event-timeline :global(.kit-comment-card:not(.event-card--commit):has(.kit-card__actions) .kit-card__meta) {
     order: 2;
     margin-left: 0;
   }

--- a/frontend/src/lib/components/detail/EventTimeline.timestamp-layout.browser.svelte.ts
+++ b/frontend/src/lib/components/detail/EventTimeline.timestamp-layout.browser.svelte.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { cleanup, render } from "vitest-browser-svelte";
+import { Effect } from "effect";
+
+import "../../../app.css";
+import type { PREvent } from "../../api/types.js";
+import { makeAppRuntime, type OwnedAppRuntime } from "../../app/runtime.js";
+import EventTimelineTestHarness from "./EventTimelineTestHarness.svelte";
+
+const forcePushEvent = {
+  ID: 1,
+  MergeRequestID: 42,
+  PlatformID: null,
+  EventType: "force_push",
+  Author: "alice",
+  Body: "",
+  Summary: "7b48e66 -> 94aa952",
+  MetadataJSON: JSON.stringify({
+    before_sha: "7b48e66000000000000000000000000000000000",
+    after_sha: "94aa952000000000000000000000000000000000",
+  }),
+  DedupeKey: "force-push-1",
+  CreatedAt: "2026-08-20T12:00:00Z",
+  ThreadID: null,
+  Resolvable: false,
+  Resolved: false,
+} as PREvent;
+
+let runtime: OwnedAppRuntime | null = null;
+
+afterEach(async () => {
+  cleanup();
+  if (runtime) await Effect.runPromise(runtime.disposeEffect);
+  runtime = null;
+});
+
+describe("EventTimeline timestamp layout", () => {
+  it("keeps a force-push timestamp in the card's trailing metadata slot", () => {
+    runtime = makeAppRuntime();
+    const wrapper = document.createElement("div");
+    wrapper.style.width = "760px";
+    document.body.appendChild(wrapper);
+
+    render(EventTimelineTestHarness, {
+      target: wrapper,
+      props: {
+        runtime,
+        timelineProps: { events: [forcePushEvent] },
+      },
+    });
+
+    const card = wrapper.querySelector<HTMLElement>(".kit-comment-card.event-card--compact");
+    const timestamp = card?.querySelector<HTMLElement>(".kit-card__meta");
+    expect(card).not.toBeNull();
+    expect(timestamp).not.toBeNull();
+
+    const cardRect = card!.getBoundingClientRect();
+    const timestampRect = timestamp!.getBoundingClientRect();
+    expect(cardRect.right - timestampRect.right).toBeLessThanOrEqual(24);
+
+    wrapper.remove();
+  });
+});


### PR DESCRIPTION
Force-push activity placed its relative timestamp beside the actor instead of at the card's trailing edge. `EventTimeline` removed the shared card's automatic metadata margin even when the card had no action slot.

Limit that override to cards that render actions. Header-only system events now keep the shared `CommentCard` timestamp layout, while ordinary comments retain action-before-time ordering.

A Chromium regression mounts the real timeline at 760px and checks that the timestamp remains inside the card's trailing padding. The 80-test timeline component suite and frontend checks pass. The corrected rendering was reviewed locally.
