### PR TITLE
perf: remove repository tests from Git hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,13 +304,6 @@ test: ensure-embed-dir ensure-tmp-dir
 test-short: ensure-embed-dir ensure-tmp-dir
 	$(GOTESTSUM)=tmp/test-short-output.json -- $(GO_TEST_P_FLAG) ./... -short -shuffle=on
 
-# Pre-commit lane for test-short. Deliberately no -shuffle=on: shuffle is not a
-# cacheable go-test flag, so it forces a full re-run of every package on every
-# commit. Unshuffled runs let unchanged packages hit the Go test result cache;
-# CI and make test/test-short keep shuffled ordering to catch test coupling.
-test-short-precommit: ensure-embed-dir ensure-tmp-dir
-	$(GOTESTSUM)=tmp/test-short-precommit-output.json -- $(GO_TEST_P_FLAG) ./... -short
-
 # Run integration tests that execute real git commands (excluded from test-short)
 test-integration: ensure-embed-dir ensure-tmp-dir
 	$(GOTESTSUM)=tmp/test-integration-output.json -- $(GO_TEST_P_FLAG) -tags integration ./... -run '^TestIntegration' -shuffle=on

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -10,7 +10,7 @@ fixtures, or changing shell-script coverage.
   Go caches; `GO_TEST_P=` intentionally restores native package concurrency.
   (`scripts/run-hook-go.sh`, `prek.toml`)
 - Reduce scanner pressure at source, not by redirecting `GOTMPDIR`.
-- Repository-wide Go tests run at pre-push, not pre-commit. Any future fast hook
+- Repository-wide Go tests do not run from Git hooks. Any future fast hook
   lane must select a small set of packages rather than require per-test opt-outs.
 - `-short` must skip tests that build and launch real kenn-forge daemons or run
   load-sensitive sync E2Es; those flows belong in full Go lanes (`cmd/kenn-forge/lock_e2e_test.go::buildForgeWithLDFlags`, `internal/server/e2etest/sync_cooldown_test.go::TestTriggerSyncE2EPrioritizesNonDefaultHostFilter`).

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -8,7 +8,10 @@ fixtures, or changing shell-script coverage.
   `-count=N` only when `N > 1` for repeated runs.
 - Routine local Go lanes and hooks bound package/processor concurrency and share
   Go caches; `GO_TEST_P=` intentionally restores native package concurrency.
-  Reduce scanner pressure at source, not by redirecting `GOTMPDIR`. (`Makefile:50`, `scripts/run-hook-go.sh:12`, `prek.toml:53`)
+  (`scripts/run-hook-go.sh`, `prek.toml`)
+- Reduce scanner pressure at source, not by redirecting `GOTMPDIR`.
+- Repository-wide Go tests run at pre-push, not pre-commit. Any future fast hook
+  lane must select a small set of packages rather than require per-test opt-outs.
 - `-short` must skip tests that build and launch real kenn-forge daemons or run
   load-sensitive sync E2Es; those flows belong in full Go lanes (`cmd/kenn-forge/lock_e2e_test.go::buildForgeWithLDFlags`, `internal/server/e2etest/sync_cooldown_test.go::TestTriggerSyncE2EPrioritizesNonDefaultHostFilter`).
 - Race tests must synchronize at the narrow boundary under test; do not put a short

--- a/prek.toml
+++ b/prek.toml
@@ -50,9 +50,6 @@ hooks = [
   { id = "font-size-token-check", name = "enforce font-size design tokens", language = "system", entry = "make font-size-token-check", files = "^(scripts/check-font-size-tokens\\.(ts|test\\.ts)|frontend/src/.*\\.(svelte|css|ts))$", pass_filenames = false, priority = 10 },
   { id = "script-tests", name = "script regression tests", language = "system", entry = "make script-tests", files = "^(scripts/.*\\.(mjs|ts|sh|py)|frontend/scripts/.*\\.ts|docs/screenshots/.*\\.(md|ts)|package\\.json|bun\\.lock)$", pass_filenames = false, priority = 10 },
   { id = "playwright-version-check", name = "browser CI image matches pinned toolchain", language = "system", entry = "make playwright-version-check", files = "^(scripts/check-playwright-version\\.mjs|\\.github/docker/playwright/Dockerfile|\\.github/workflows/ci\\.yml|package\\.json|frontend/package\\.json|packages/github-app-ui/package\\.json)$", pass_filenames = false, priority = 10 },
-  { id = "go-test", name = "go test (repository-wide)", language = "system", entry = "./scripts/run-hook-go.sh make test", stages = [
-    "pre-push",
-  ], always_run = true, pass_filenames = false, priority = 21 },
   { id = "testify-helper-check", name = "testify helper check", language = "system", entry = "./scripts/run-hook-go.sh make testify-helper-check", files = "^(go\\.mod|go\\.sum|.*\\.go)$", pass_filenames = false, priority = 21 },
   { id = "huma-route-check", name = "prevent non-Huma Go routes", language = "system", entry = "./scripts/run-hook-go.sh make huma-route-check", files = "^(tools/nohttpmux/.*\\.go|cmd/.*\\.go|internal/.*\\.go|kenn-forge\\.go)$", pass_filenames = false, priority = 22 },
   { id = "migration-history-check", name = "enforce immutable history and one migration per PR", language = "system", entry = "./scripts/run-hook-go.sh make migration-history-check", files = "^internal/db/migrations/.*$", pass_filenames = false, priority = 23 },

--- a/prek.toml
+++ b/prek.toml
@@ -50,7 +50,9 @@ hooks = [
   { id = "font-size-token-check", name = "enforce font-size design tokens", language = "system", entry = "make font-size-token-check", files = "^(scripts/check-font-size-tokens\\.(ts|test\\.ts)|frontend/src/.*\\.(svelte|css|ts))$", pass_filenames = false, priority = 10 },
   { id = "script-tests", name = "script regression tests", language = "system", entry = "make script-tests", files = "^(scripts/.*\\.(mjs|ts|sh|py)|frontend/scripts/.*\\.ts|docs/screenshots/.*\\.(md|ts)|package\\.json|bun\\.lock)$", pass_filenames = false, priority = 10 },
   { id = "playwright-version-check", name = "browser CI image matches pinned toolchain", language = "system", entry = "make playwright-version-check", files = "^(scripts/check-playwright-version\\.mjs|\\.github/docker/playwright/Dockerfile|\\.github/workflows/ci\\.yml|package\\.json|frontend/package\\.json|packages/github-app-ui/package\\.json)$", pass_filenames = false, priority = 10 },
-  { id = "go-test-short", name = "go test (short)", language = "system", entry = "./scripts/run-hook-go.sh make test-short-precommit", files = "^(go\\.mod|go\\.sum|.*\\.go)$", pass_filenames = false, priority = 20 },
+  { id = "go-test", name = "go test (repository-wide)", language = "system", entry = "./scripts/run-hook-go.sh make test", stages = [
+    "pre-push",
+  ], always_run = true, pass_filenames = false, priority = 21 },
   { id = "testify-helper-check", name = "testify helper check", language = "system", entry = "./scripts/run-hook-go.sh make testify-helper-check", files = "^(go\\.mod|go\\.sum|.*\\.go)$", pass_filenames = false, priority = 21 },
   { id = "huma-route-check", name = "prevent non-Huma Go routes", language = "system", entry = "./scripts/run-hook-go.sh make huma-route-check", files = "^(tools/nohttpmux/.*\\.go|cmd/.*\\.go|internal/.*\\.go|kenn-forge\\.go)$", pass_filenames = false, priority = 22 },
   { id = "migration-history-check", name = "enforce immutable history and one migration per PR", language = "system", entry = "./scripts/run-hook-go.sh make migration-history-check", files = "^internal/db/migrations/.*$", pass_filenames = false, priority = 23 },


### PR DESCRIPTION
Repository-wide Go tests no longer run during commits or pushes. The previous hook invoked `go test -short ./...` for any Go change, which still discovered more than 6,500 tests and made routine Git operations wait several minutes.

- Keep Git hooks focused on formatting, lint, and static guards.
- Remove the hook-specific unshuffled test target.
- Require any future fast hook lane to select a small package set, so missing per-test opt-outs cannot make every Git operation slower.

The existing `make test` and `make test-short` targets remain available for explicit runs.
