### PR TITLE
feat: support multiline review comments

### DIFF
--- a/context/inline-review-comments.md
+++ b/context/inline-review-comments.md
@@ -18,6 +18,9 @@ published review-thread ingestion, or review controls in shared diff UI.
   arbitrary range diffs remain disabled until their coordinate mapping is
   explicitly supported
   (`internal/server/pullapi/diff_review_handlers.go::dbReviewLineRange`).
+- Line-number click, drag, and Shift selection only change the active review
+  range. The gutter utility opens the composer for that range
+  (`frontend/src/lib/components/diff/DiffFile.svelte::handlePierreGutterUtility`).
 - Public routes use provider-aware pull paths and internal draft/thread IDs.
   Provider review, thread, and comment IDs remain persistence metadata unless a
   concrete public API need is introduced

--- a/context/inline-review-comments.md
+++ b/context/inline-review-comments.md
@@ -18,7 +18,7 @@ published review-thread ingestion, or review controls in shared diff UI.
   arbitrary range diffs remain disabled until their coordinate mapping is
   explicitly supported
   (`internal/server/pullapi/diff_review_handlers.go::dbReviewLineRange`).
-- Line-number click, drag, and Shift selection only change the active review
+- Line-number pointer and keyboard selection only change the active review
   range. The gutter utility opens the composer for that range
   (`frontend/src/lib/components/diff/DiffFile.svelte::handlePierreGutterUtility`).
 - Public routes use provider-aware pull paths and internal draft/thread IDs.

--- a/docs/reports/2026-08-19-multiline-review-comments.md
+++ b/docs/reports/2026-08-19-multiline-review-comments.md
@@ -1,0 +1,97 @@
+# Multiline review comments research
+
+## Recommendation
+
+Implement issue [#936](https://github.com/kenn-io/forge/issues/936) in Forge's diff UI using the line-selection and gutter-utility APIs already present in the pinned `@pierre/diffs` 1.3.5. No Pierre upgrade, fork, or upstream change is required for the first implementation.
+
+The intended interaction should be:
+
+1. Drag across line numbers, or click a line number and Shift-click another, to select a range.
+2. Use the gutter `+` action to open the inline composer for that selection.
+3. Limit the range to one file, one diff side, and one hunk. If the provider does not advertise native multiline ranges, retain single-line commenting.
+
+This matches Pierre's own DiffsHub integration: it enables line selection and the gutter utility, uses selection completion separately from comment creation, and receives the selected range through `onGutterUtilityClick` ([source](https://github.com/pierrecomputer/pierre/blob/59ec35ffac97abccef4c69f8d58d3747cbfbc6cb/apps/diffshub/components/DiffsHubViewer.tsx#L427-L455)).
+
+## Why this is mostly a Forge frontend change
+
+Forge already carries multiline ranges through the GitHub review path:
+
+- `DiffFile.svelte` converts a Pierre `SelectedLineRange` into `start_side`, `start_line`, `side`, and `line`, and downgrades invalid selections to one line. Its checks already require provider support, the same side, and the same hunk ([source](https://github.com/kenn-io/forge/blob/4976043d38a485f0b61704d0e945c43c670d6c52/frontend/src/lib/components/diff/DiffFile.svelte#L339-L412)).
+- GitHub advertises `NativeMultilineRanges: true` ([source](https://github.com/kenn-io/forge/blob/4976043d38a485f0b61704d0e945c43c670d6c52/internal/github/sync.go#L2003-L2032)).
+- GitHub publishing maps the stored start fields to `DraftReviewComment.StartSide` and `StartLine` ([source](https://github.com/kenn-io/forge/blob/4976043d38a485f0b61704d0e945c43c670d6c52/internal/github/sync.go#L3350-L3439)). GitHub's review endpoint accepts `comments[].line`, `side`, `start_line`, and `start_side` for multiline comments ([official API](https://docs.github.com/en/rest/pulls/reviews#create-a-review-for-a-pull-request)).
+- The API validates that start fields are paired, positive, ordered, and allowed by the provider capability ([source](https://github.com/kenn-io/forge/blob/4976043d38a485f0b61704d0e945c43c670d6c52/internal/server/pullapi/diff_review_handlers.go#L1090-L1121), [capability check](https://github.com/kenn-io/forge/blob/4976043d38a485f0b61704d0e945c43c670d6c52/internal/server/pullapi/diff_review_handlers.go#L551-L570)). The database query layer also persists `start_side` and `start_line` ([source](https://github.com/kenn-io/forge/blob/4976043d38a485f0b61704d0e945c43c670d6c52/internal/db/queries_review.go#L121-L139)).
+- Existing frontend tests exercise capability-gated Shift selection, same-hunk enforcement, and saved range rendering ([source](https://github.com/kenn-io/forge/blob/4976043d38a485f0b61704d0e945c43c670d6c52/frontend/src/lib/components/diff/DiffFile.test.ts#L732-L755), [same-hunk case](https://github.com/kenn-io/forge/blob/4976043d38a485f0b61704d0e945c43c670d6c52/frontend/src/lib/components/diff/DiffFile.test.ts#L930-L1002)).
+
+The missing piece is the normal user interaction. `PierreFileDiff.svelte` currently passes `enableLineSelection: false` and disables Pierre's line hover treatment ([source](https://github.com/kenn-io/forge/blob/4976043d38a485f0b61704d0e945c43c670d6c52/frontend/src/lib/components/diff/PierreFileDiff.svelte#L192-L200)). It then walks Pierre's shadow DOM and injects a custom `+` button for every rendered line ([source](https://github.com/kenn-io/forge/blob/4976043d38a485f0b61704d0e945c43c670d6c52/frontend/src/lib/components/diff/PierreFileDiff.svelte#L1265-L1391)). That implementation supports a range only through the non-obvious sequence "click `+`, then Shift-click another `+`"; it does not expose Pierre's drag selection.
+
+## What Pierre 1.3.5 already provides
+
+Forge pins `@pierre/diffs` 1.3.5 ([source](https://github.com/kenn-io/forge/blob/4976043d38a485f0b61704d0e945c43c670d6c52/frontend/package.json#L28-L35)), corresponding to Pierre tag `diffs-v1.3.5` at commit [`59ec35f`](https://github.com/pierrecomputer/pierre/tree/59ec35ffac97abccef4c69f8d58d3747cbfbc6cb).
+
+That exact release provides:
+
+- `enableLineSelection`, with click, drag, and Shift-extension on line numbers ([official example](https://github.com/pierrecomputer/pierre/blob/59ec35ffac97abccef4c69f8d58d3747cbfbc6cb/apps/docs/app/%28diffs%29/_examples/LineSelection/LineSelection.tsx#L38-L50)).
+- A `SelectedLineRange` containing start/end line numbers and sides ([source](https://github.com/pierrecomputer/pierre/blob/59ec35ffac97abccef4c69f8d58d3747cbfbc6cb/packages/diffs/src/types.ts#L521-L529)).
+- Selection lifecycle callbacks, controlled selection, and `FileDiff.setSelectedLines` ([callbacks](https://github.com/pierrecomputer/pierre/blob/59ec35ffac97abccef4c69f8d58d3747cbfbc6cb/packages/diffs/src/managers/InteractionManager.ts#L217-L239), [example](https://github.com/pierrecomputer/pierre/blob/59ec35ffac97abccef4c69f8d58d3747cbfbc6cb/apps/docs/app/%28diffs%29/_examples/LineSelection/LineSelection.tsx#L164-L179)).
+- `enableGutterUtility` and `onGutterUtilityClick(range)`, which are the supported equivalents of Forge's injected buttons ([source](https://github.com/pierrecomputer/pierre/blob/59ec35ffac97abccef4c69f8d58d3747cbfbc6cb/packages/diffs/src/managers/InteractionManager.ts#L217-L239)).
+- Upstream browser coverage for drag selection ([source](https://github.com/pierrecomputer/pierre/blob/59ec35ffac97abccef4c69f8d58d3747cbfbc6cb/packages/diffs/test/e2e/line-select.pw.ts#L32-L56)).
+
+Pierre's line selection starts only from the line-number column ([source](https://github.com/pierrecomputer/pierre/blob/59ec35ffac97abccef4c69f8d58d3747cbfbc6cb/packages/diffs/src/managers/InteractionManager.ts#L807-L816)), so enabling it does not restore row-wide content clicks. That distinction matters because Forge previously disabled row-wide selection after diff-content clicks unexpectedly opened the composer ([Forge change](https://github.com/kenn-io/forge/commit/ceed3408208fcd5ab39ab7730b1af9446ebb3a0b)).
+
+## Proposed implementation seams
+
+Keep provider rules and range normalization in `DiffFile.svelte`; keep Pierre-specific interaction wiring in `PierreFileDiff.svelte`.
+
+In `PierreFileDiff.svelte`:
+
+- Pass the component's `enableLineSelection` prop through to Pierre instead of hardcoding `false`.
+- Enable Pierre's gutter utility whenever inline review comments are enabled.
+- Expose selection-end and gutter-utility callbacks to the parent. Selection-end updates the visible selection; gutter activation opens the composer for the normalized range.
+- Remove `applyLineCommentButtons` and its custom shadow-DOM button, pointer snapshot, and Shift-range helpers once equivalent behavior is covered through Pierre's callbacks.
+
+In `DiffFile.svelte`:
+
+- Split the current `handlePierreSelection` responsibility into "normalize/store selection" and "open composer." This avoids creating or moving the composer repeatedly while a pointer drag is in progress.
+- Continue to use `normalizedSelection` as the authority for capability, side, and hunk constraints.
+- Keep the current `diffHeadSHA` requirement so a draft remains bound to the reviewed head.
+- On cancellation, clear both the composer and Pierre selection, matching the current single-line behavior.
+
+This change should not require a new API type, database migration, generated client update, or GitHub backend change.
+
+## Alternatives considered
+
+### Extend the injected `+` buttons
+
+Forge could add pointer-drag handling around the existing custom buttons. This is the smallest conceptual change, but it would duplicate interaction logic Pierre already owns and deepen the dependency on undocumented shadow-DOM structure. It also leaves the range gesture difficult to discover. Not recommended.
+
+### Enable native selection but retain the injected buttons
+
+This is a reasonable temporary rollout if replacing the gutter utility exposes a Pierre defect. It delivers drag selection with less UI churn, but leaves two interaction systems coordinating selection state and retains the most brittle code. Use only as a fallback, not the target design.
+
+### Upgrade, patch, or fork Pierre first
+
+The pinned release already exposes the required APIs and Pierre uses them in its own review UI, so an upstream prerequisite is not supported by the current evidence. Open an upstream issue only for a reproduced 1.3.5 defect, especially around Forge's virtualized diffs, slotted annotations, or context expansion. Any such report should include a minimal Pierre reproduction rather than Forge's shadow-DOM integration.
+
+## Verification plan
+
+Add focused coverage for the user-visible interaction, not for Pierre's library internals:
+
+- Unified and split views: forward and backward drag on line numbers, followed by the gutter `+`, opens one composer spanning the expected lines.
+- Shift-click extends an existing selection and the gutter action uses the full range.
+- Cross-side and cross-hunk attempts normalize to one valid line; providers without `native_multiline_ranges` continue to create single-line drafts.
+- A saved range renders across all selected lines; cancel clears the transient selection; editing and submitting preserve `start_side` and `start_line`.
+- Selection still works after context expansion and while files enter and leave the virtualized viewport, with existing inline annotations present.
+- Keyboard activation of the gutter action remains available. Touch behavior should be verified on an actual touch-capable browser before claiming support; Pierre uses pointer events, but this research did not test Forge on touch hardware.
+
+The highest-risk area is not GitHub serialization. It is keeping Pierre's internal selection, Forge's controlled selection, annotation insertion, and virtualized rerenders synchronized. A browser-level test should cover that combined path after the component tests pass.
+
+## Other providers
+
+Treat other providers as follow-up work rather than part of issue #936's GitHub request.
+
+- GitLab's discussions API supports `position[line_range]`, including start and end positions ([official API](https://docs.gitlab.com/api/discussions/#parameters-for-multiline-comments)). Forge already builds a `LineRangeOptions`, but currently advertises `NativeMultilineRanges: false` ([source](https://github.com/kenn-io/forge/blob/4976043d38a485f0b61704d0e945c43c670d6c52/internal/platform/gitlab/client.go#L244-L267), [range mapping](https://github.com/kenn-io/forge/blob/4976043d38a485f0b61704d0e945c43c670d6c52/internal/platform/gitlab/diff_review.go#L187-L204)). GitLab requires endpoint `line_code` values, so the capability should remain false until those are populated and tested.
+- Forgejo's API model exposes `extra_lines_count` for review comments ([official OpenAPI](https://codeberg.org/swagger.v1.json)), while Forge currently advertises multiline ranges as false ([source](https://github.com/kenn-io/forge/blob/4976043d38a485f0b61704d0e945c43c670d6c52/internal/platform/forgejo/client.go#L139-L154)). Its semantics and supported server versions need a separate provider test before enabling the capability.
+
+## Decision summary
+
+The backend and provider model are already ready for GitHub multiline review ranges. Implement the feature by adopting Pierre 1.3.5's supported line-selection and gutter-utility APIs, with Forge retaining ownership of provider capability checks and valid range normalization. Do not make Pierre upstream work a prerequisite; use it only for defects reproduced during the integration.

--- a/frontend/src/lib/components/diff/DiffFile.svelte
+++ b/frontend/src/lib/components/diff/DiffFile.svelte
@@ -118,6 +118,7 @@
 
   let selectedRange = $state<SelectedLineRange | null>(null);
   let composerRange = $state<DiffReviewLineRange | null>(null);
+  let suppressNextPierreSelection = false;
   const selectableLineRefs = $derived.by(() => ({
     left: selectableLines("left"),
     right: selectableLines("right"),
@@ -398,6 +399,10 @@
   }
 
   function handlePierreSelection(selection: SelectedLineRange | null): void {
+    if (suppressNextPierreSelection) {
+      suppressNextPierreSelection = false;
+      return;
+    }
     if (!selection) {
       closeComposer();
       return;
@@ -405,6 +410,23 @@
     const normalized = normalizedSelection(selection);
     if (!normalized) {
       closeComposer();
+      return;
+    }
+    if (composerRange && rangeKey(composerRange) !== rangeKey(normalized.range)) {
+      composerRange = null;
+    }
+    selectedRange = normalized.selected;
+  }
+
+  function handlePierreGutterUtility(selection: SelectedLineRange): void {
+    const normalized = normalizedSelection(selection);
+    if (!normalized) {
+      closeComposer();
+      return;
+    }
+    if (composerRange && rangeKey(composerRange) === rangeKey(normalized.range)) {
+      closeComposer();
+      suppressNextPierreSelection = true;
       return;
     }
     selectedRange = normalized.selected;
@@ -630,6 +652,7 @@
               selectedRanges={draftSelectedRanges}
               enableLineSelection={reviewEnabled && !!diffHeadSHA}
               onLineSelected={handlePierreSelection}
+              onGutterUtilityClick={handlePierreGutterUtility}
               renderAnnotation={renderUnknownAnnotation}
               {virtualizer}
             />

--- a/frontend/src/lib/components/diff/DiffFile.test.ts
+++ b/frontend/src/lib/components/diff/DiffFile.test.ts
@@ -716,7 +716,9 @@ describe("DiffFile", () => {
   async function keyboardActivateLineCommentButton(line: number, side: "left" | "right"): Promise<void> {
     const button = await findLineCommentButton(line, side);
     button.focus();
+    expect(await fireEvent.keyDown(button, { key: "Enter", code: "Enter" })).toBe(true);
     await fireEvent.click(button, { detail: 0 });
+    await fireEvent.keyUp(button, { key: "Enter", code: "Enter" });
   }
 
   async function findLineCommentButton(line: number, side: "left" | "right"): Promise<HTMLButtonElement> {
@@ -931,6 +933,26 @@ describe("DiffFile", () => {
 
     expect(screen.queryByPlaceholderText("Leave a comment")).toBeNull();
     expect(selectedPierreLines()).toHaveLength(0);
+  });
+
+  it("opens an inline composer without preceding pointer interaction", async () => {
+    renderDiffFile(makeFile(), {
+      reviewEnabled: true,
+      diffHeadSHA: "diff-head",
+    });
+
+    const lineNumber = await findPierreLineNumber(2, "right");
+    expect(lineNumber.tabIndex).toBe(0);
+    lineNumber.focus();
+    await fireEvent.keyDown(lineNumber, { key: "Enter", code: "Enter" });
+    await fireEvent.keyUp(lineNumber, { key: "Enter", code: "Enter" });
+
+    await findLineCommentButton(2, "right");
+    expect(screen.queryByPlaceholderText("Leave a comment")).toBeNull();
+
+    await keyboardActivateLineCommentButton(2, "right");
+
+    expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy();
   });
 
   it("toggles an active multiline composer from keyboard line comment button activation", async () => {

--- a/frontend/src/lib/components/diff/DiffFile.test.ts
+++ b/frontend/src/lib/components/diff/DiffFile.test.ts
@@ -752,6 +752,34 @@ describe("DiffFile", () => {
     });
   }
 
+  async function findPierreLineKeyboardTarget(line: number, side: "left" | "right"): Promise<HTMLElement> {
+    const lineNumber = await findPierreLineNumber(line, side);
+    const target = lineNumber.querySelector<HTMLElement>("[data-line-number-content]");
+    expect(target).toBeTruthy();
+    return target!;
+  }
+
+  async function keyboardSelectPierreLine(
+    line: number,
+    side: "left" | "right",
+    options: { shiftKey?: boolean } = {},
+  ): Promise<void> {
+    const target = await findPierreLineKeyboardTarget(line, side);
+    target.focus();
+    expect(
+      await fireEvent.keyDown(target, {
+        key: "Enter",
+        code: "Enter",
+        shiftKey: options.shiftKey,
+      }),
+    ).toBe(false);
+    await fireEvent.keyUp(target, {
+      key: "Enter",
+      code: "Enter",
+      shiftKey: options.shiftKey,
+    });
+  }
+
   function selectedPierreLines(): NodeListOf<Element> | undefined {
     return document.querySelector(".pierre-diff")?.shadowRoot?.querySelectorAll("[data-selected-line]");
   }
@@ -935,24 +963,31 @@ describe("DiffFile", () => {
     expect(selectedPierreLines()).toHaveLength(0);
   });
 
-  it("opens an inline composer without preceding pointer interaction", async () => {
+  it("opens a multiline inline composer without pointer interaction", async () => {
     renderDiffFile(makeFile(), {
       reviewEnabled: true,
       diffHeadSHA: "diff-head",
+      nativeMultilineRanges: true,
     });
 
-    const lineNumber = await findPierreLineNumber(2, "right");
-    expect(lineNumber.tabIndex).toBe(0);
-    lineNumber.focus();
-    await fireEvent.keyDown(lineNumber, { key: "Enter", code: "Enter" });
-    await fireEvent.keyUp(lineNumber, { key: "Enter", code: "Enter" });
+    const lineNumber = await findPierreLineNumber(1, "right");
+    const lineNumberTarget = await findPierreLineKeyboardTarget(1, "right");
+    expect(lineNumber.tabIndex).toBe(-1);
+    expect(lineNumber.getAttribute("role")).toBeNull();
+    expect(lineNumberTarget.tabIndex).toBe(0);
+    expect(lineNumberTarget.getAttribute("role")).toBe("button");
+
+    await keyboardSelectPierreLine(1, "right");
+    await keyboardSelectPierreLine(2, "right", { shiftKey: true });
 
     await findLineCommentButton(2, "right");
     expect(screen.queryByPlaceholderText("Leave a comment")).toBeNull();
+    expect(selectedPierreLines()?.length).toBeGreaterThanOrEqual(2);
 
     await keyboardActivateLineCommentButton(2, "right");
 
     expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy();
+    expect(selectedPierreLines()?.length).toBeGreaterThanOrEqual(2);
   });
 
   it("toggles an active multiline composer from keyboard line comment button activation", async () => {

--- a/frontend/src/lib/components/diff/DiffFile.test.ts
+++ b/frontend/src/lib/components/diff/DiffFile.test.ts
@@ -665,7 +665,19 @@ describe("DiffFile", () => {
     side: "left" | "right",
     options: { shiftKey?: boolean } = {},
   ): Promise<void> {
-    await clickLineCommentButton(line, side, options);
+    const lineNumber = await findPierreLineNumber(line, side);
+    await fireEvent.pointerDown(lineNumber, {
+      button: 0,
+      pointerId: 1,
+      pointerType: "mouse",
+      shiftKey: options.shiftKey,
+    });
+    await fireEvent.pointerUp(lineNumber, {
+      button: 0,
+      pointerId: 1,
+      pointerType: "mouse",
+      shiftKey: options.shiftKey,
+    });
   }
 
   async function clickLineCommentButton(
@@ -673,40 +685,66 @@ describe("DiffFile", () => {
     side: "left" | "right",
     options: { shiftKey?: boolean } = {},
   ): Promise<void> {
-    const button = await findLineCommentButton(line, side);
-    button.dispatchEvent(
-      new MouseEvent("pointerdown", {
-        bubbles: true,
-        button: 0,
-        shiftKey: options.shiftKey,
-      }),
-    );
-    await fireEvent.mouseDown(button, {
+    let button = findGutterUtilityButton();
+    const utilityLine = button?.closest<HTMLElement>("[data-column-number]");
+    if (
+      !utilityLine ||
+      utilityLine.getAttribute("data-column-number") !== String(line) ||
+      !utilityLine.hasAttribute(side === "left" ? "data-diff-old-line" : "data-diff-new-line")
+    ) {
+      await selectPierreLine(line, side, options);
+      button = await waitFor(() => {
+        const element = findGutterUtilityButton();
+        expect(element).toBeTruthy();
+        return element!;
+      });
+    }
+    await fireEvent.pointerDown(button!, {
       button: 0,
-      shiftKey: options.shiftKey,
-    });
-    await fireEvent.pointerUp(button, {
-      pointerId: 1,
+      pointerId: 2,
       pointerType: "mouse",
       shiftKey: options.shiftKey,
     });
-    await fireEvent.click(button, { shiftKey: options.shiftKey });
+    await fireEvent.pointerUp(button!, {
+      button: 0,
+      pointerId: 2,
+      pointerType: "mouse",
+      shiftKey: options.shiftKey,
+    });
   }
 
   async function keyboardActivateLineCommentButton(line: number, side: "left" | "right"): Promise<void> {
     const button = await findLineCommentButton(line, side);
     button.focus();
-    await fireEvent.click(button);
+    await fireEvent.click(button, { detail: 0 });
   }
 
   async function findLineCommentButton(line: number, side: "left" | "right"): Promise<HTMLButtonElement> {
-    const sideLabel = side === "left" ? "old" : "new";
     return await waitFor(() => {
-      const element = document
-        .querySelector(".pierre-diff")
-        ?.shadowRoot?.querySelector<HTMLButtonElement>(
-          `[data-kenn-forge-line-comment-button][aria-label="Comment on ${sideLabel} line ${line}"]`,
-        );
+      const element = findGutterUtilityButton();
+      const utilityLine = element?.closest<HTMLElement>("[data-column-number]");
+      expect(element).toBeTruthy();
+      expect(utilityLine?.getAttribute("data-column-number")).toBe(String(line));
+      expect(utilityLine?.hasAttribute(side === "left" ? "data-diff-old-line" : "data-diff-new-line")).toBe(true);
+      return element!;
+    });
+  }
+
+  function findGutterUtilityButton(): HTMLButtonElement | null | undefined {
+    return document
+      .querySelector(".pierre-diff")
+      ?.shadowRoot?.querySelector<HTMLButtonElement>("[data-utility-button]");
+  }
+
+  async function findPierreLineNumber(line: number, side: "left" | "right"): Promise<HTMLElement> {
+    return await waitFor(() => {
+      const sideAttribute = side === "left" ? "data-diff-old-line" : "data-diff-new-line";
+      const elements =
+        document
+          .querySelector(".pierre-diff")
+          ?.shadowRoot?.querySelectorAll<HTMLElement>(`[data-column-number="${line}"][${sideAttribute}="${line}"]`) ??
+        [];
+      const element = elements[0];
       expect(element).toBeTruthy();
       return element!;
     });
@@ -739,7 +777,13 @@ describe("DiffFile", () => {
     await selectPierreLine(1, "right");
     await selectPierreLine(2, "right", { shiftKey: true });
 
-    expect(selectedPierreLines()?.length).toBeGreaterThanOrEqual(2);
+    await waitFor(() => {
+      expect(selectedPierreLines()?.length).toBeGreaterThanOrEqual(2);
+    });
+    expect(screen.queryByPlaceholderText("Leave a comment")).toBeNull();
+
+    await clickLineCommentButton(2, "right");
+    expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy();
 
     unmount();
     renderDiffFile(makeFile(), {
@@ -751,7 +795,12 @@ describe("DiffFile", () => {
     await selectPierreLine(1, "right");
     await selectPierreLine(2, "right", { shiftKey: true });
 
-    expect(selectedPierreLines()).toHaveLength(4);
+    await waitFor(() => {
+      expect(selectedPierreLines()).toHaveLength(2);
+      expect(
+        Array.from(selectedPierreLines() ?? []).every((line) => line.getAttribute("data-diff-new-line") === "2"),
+      ).toBe(true);
+    });
   });
 
   it("toggles an empty inline composer from the line comment button", async () => {
@@ -804,13 +853,12 @@ describe("DiffFile", () => {
     });
 
     async function assertRightSideComposer(line: number): Promise<void> {
-      const button = await findLineCommentButton(line, "right");
-      expect(splitColumnSide(button)).toBe("additions");
-
       await clickLineCommentButton(line, "right");
 
       await waitFor(() => {
         expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy();
+        const button = findGutterUtilityButton();
+        expect(splitColumnSide(button)).toBe("additions");
         const slot = document
           .querySelector(".pierre-diff")
           ?.shadowRoot?.querySelector<HTMLSlotElement>(`slot[name="annotation-additions-${line}"]`);
@@ -885,27 +933,6 @@ describe("DiffFile", () => {
     expect(selectedPierreLines()).toHaveLength(0);
   });
 
-  it("keeps shift-click line comment button selection from collapsing active ranges", async () => {
-    renderDiffFile(makeFile(), {
-      reviewEnabled: true,
-      diffHeadSHA: "diff-head",
-      nativeMultilineRanges: true,
-    });
-
-    await selectPierreLine(1, "right");
-    await clickLineCommentButton(2, "right", { shiftKey: true });
-
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy();
-      expect(selectedPierreLines()?.length).toBeGreaterThanOrEqual(2);
-    });
-
-    await clickLineCommentButton(2, "right", { shiftKey: true });
-
-    expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy();
-    expect(selectedPierreLines()?.length).toBeGreaterThanOrEqual(2);
-  });
-
   it("toggles an active multiline composer from keyboard line comment button activation", async () => {
     renderDiffFile(makeFile(), {
       reviewEnabled: true,
@@ -915,6 +942,9 @@ describe("DiffFile", () => {
 
     await selectPierreLine(1, "right");
     await selectPierreLine(2, "right", { shiftKey: true });
+    expect(screen.queryByPlaceholderText("Leave a comment")).toBeNull();
+
+    await clickLineCommentButton(2, "right");
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy();
@@ -966,6 +996,9 @@ describe("DiffFile", () => {
 
     await selectPierreLine(1, "right");
     await selectPierreLine(20, "right", { shiftKey: true });
+    expect(screen.queryByPlaceholderText("Leave a comment")).toBeNull();
+
+    await clickLineCommentButton(20, "right");
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy();
@@ -2068,7 +2101,7 @@ describe("DiffFile", () => {
       diffHeadSHA: "diff-head",
     });
 
-    await selectPierreLine(1, "right");
+    await clickLineCommentButton(1, "right");
     expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy();
     expect(selectedPierreLines()).toHaveLength(4);
 
@@ -2095,7 +2128,7 @@ describe("DiffFile", () => {
       reviewEnabled: true,
       diffHeadSHA: "new-diff-head",
     });
-    await selectPierreLine(1, "right");
+    await clickLineCommentButton(1, "right");
     expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy();
 
     await rerender({

--- a/frontend/src/lib/components/diff/DiffFile.test.ts
+++ b/frontend/src/lib/components/diff/DiffFile.test.ts
@@ -980,14 +980,21 @@ describe("DiffFile", () => {
     await keyboardSelectPierreLine(1, "right");
     await keyboardSelectPierreLine(2, "right", { shiftKey: true });
 
+    const selectedNewLineNumbers = () =>
+      new Set(
+        Array.from(selectedPierreLines() ?? [], (line) => line.getAttribute("data-diff-new-line")).filter(
+          (line): line is string => line !== null,
+        ),
+      );
+
     await findLineCommentButton(2, "right");
     expect(screen.queryByPlaceholderText("Leave a comment")).toBeNull();
-    expect(selectedPierreLines()?.length).toBeGreaterThanOrEqual(2);
+    expect(selectedNewLineNumbers()).toEqual(new Set(["1", "2"]));
 
     await keyboardActivateLineCommentButton(2, "right");
 
     expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy();
-    expect(selectedPierreLines()?.length).toBeGreaterThanOrEqual(2);
+    expect(selectedNewLineNumbers()).toEqual(new Set(["1", "2"]));
   });
 
   it("toggles an active multiline composer from keyboard line comment button activation", async () => {

--- a/frontend/src/lib/components/diff/PierreFileDiff.svelte
+++ b/frontend/src/lib/components/diff/PierreFileDiff.svelte
@@ -61,6 +61,7 @@
     selectedRanges?: SelectedLineRange[];
     enableLineSelection?: boolean;
     onLineSelected?: (selection: SelectedLineRange | null) => void;
+    onGutterUtilityClick?: (selection: SelectedLineRange) => void;
     renderAnnotation?: (annotation: DiffLineAnnotation<unknown>) => HTMLElement | undefined;
     virtualizer?: Virtualizer | undefined;
   }
@@ -115,6 +116,7 @@
     selectedRanges = [],
     enableLineSelection = false,
     onLineSelected = undefined,
+    onGutterUtilityClick = undefined,
     renderAnnotation = undefined,
     virtualizer = undefined,
   }: Props = $props();
@@ -158,8 +160,6 @@
   let lineAnnotationWrappers = new Map<string, HTMLElement>();
   let transientAnnotationRow: TransientAnnotationRow | undefined;
   let pendingContextExpansion: PendingContextExpansion | undefined;
-  let lineCommentButtonHasPointerSnapshot = false;
-  let lineCommentButtonWasSelectedOnPointerDown = false;
   let syntaxHighlightWorkerActive = false;
   let syntaxHighlightWorkerPool: WorkerPoolManager | undefined;
   let appWorkerPool = $state.raw<WorkerPoolManager | undefined>();
@@ -193,10 +193,13 @@
     diffStyle: viewMode,
     diffIndicators: "bars",
     disableFileHeader: true,
-    enableLineSelection: false,
+    enableLineSelection,
+    enableGutterUtility: enableLineSelection,
     hunkSeparators: "line-info",
     lineDiffType: "word",
-    lineHoverHighlight: "disabled",
+    lineHoverHighlight: enableLineSelection ? "number" : "disabled",
+    ...(onGutterUtilityClick && { onGutterUtilityClick }),
+    ...(onLineSelected && { onLineSelected }),
     ...(renderAnnotation && { renderAnnotation }),
     overflow: wordWrap ? "wrap" : "scroll",
     theme: { dark: "pierre-dark", light: "pierre-light" },
@@ -258,39 +261,6 @@
       }
       [data-expand-button] {
         cursor: pointer;
-      }
-      [data-kenn-forge-line-comment-cell] {
-        position: relative;
-      }
-      [data-kenn-forge-line-comment-cell] > [data-line-number-content] {
-        pointer-events: none;
-      }
-      [data-kenn-forge-line-comment-button] {
-        position: absolute;
-        top: 50%;
-        right: 2px;
-        z-index: 1;
-        display: grid;
-        place-items: center;
-        width: 18px;
-        height: 18px;
-        padding: 0;
-        transform: translateY(-50%);
-        border: 1px solid var(--border-muted);
-        border-radius: 4px;
-        background: var(--bg-surface);
-        color: var(--text-secondary);
-        cursor: pointer;
-        font: inherit;
-        line-height: 1;
-        opacity: 0;
-      }
-      [data-line-type]:hover > [data-kenn-forge-line-comment-button],
-      [data-kenn-forge-line-comment-button]:focus-visible {
-        opacity: 1;
-      }
-      [data-kenn-forge-line-comment-button]::before {
-        content: "+";
       }
     `,
   }));
@@ -492,6 +462,7 @@
 
   $effect(() => {
     pierreDiff?.setSelectedLines(selectedRange);
+    labelGutterUtility();
     scheduleSelectedRangesApplication();
   });
 
@@ -519,6 +490,7 @@
     removeDemandContextHandler();
     demandContextHandlerRoot = root;
     root.addEventListener("click", handleDemandContextClick, { capture: true });
+    root.addEventListener("click", handleGutterUtilityKeyboardClick, { capture: true });
     root.addEventListener("slotchange", handleAnnotationSlotChange);
   }
 
@@ -596,6 +568,9 @@
 
   function removeDemandContextHandler(): void {
     demandContextHandlerRoot?.removeEventListener("click", handleDemandContextClick, {
+      capture: true,
+    });
+    demandContextHandlerRoot?.removeEventListener("click", handleGutterUtilityKeyboardClick, {
       capture: true,
     });
     demandContextHandlerRoot?.removeEventListener("slotchange", handleAnnotationSlotChange);
@@ -852,7 +827,7 @@
     removeStalePlaceholderPres();
     applyLineTargetAttributes();
     applyHunkHeaderLabels();
-    applyLineCommentButtons();
+    labelGutterUtility();
     syncLineAnnotationWrappers();
     installDemandContextHandler();
     scheduleSelectedRangesApplication();
@@ -972,7 +947,7 @@
     removeStalePlaceholderPres();
     applyLineTargetAttributes();
     applyHunkHeaderLabels();
-    applyLineCommentButtons();
+    labelGutterUtility();
     syncLineAnnotationWrappers();
 
     // Latch visibility: scroll-driven virtualized re-renders fire onPostRender
@@ -1262,132 +1237,24 @@
     }
   }
 
-  function applyLineCommentButtons(): void {
-    const root = host?.shadowRoot;
-    const pre = renderedDiffPre(root);
-    if (!root || !pre) return;
-    for (const button of root.querySelectorAll("[data-kenn-forge-line-comment-button]")) {
-      button.remove();
-    }
-    for (const cell of root.querySelectorAll("[data-kenn-forge-line-comment-cell]")) {
-      cell.removeAttribute("data-kenn-forge-line-comment-cell");
-    }
-    if (!enableLineSelection || !onLineSelected) return;
-
-    for (const code of Array.from(pre.children)) {
-      const [gutter, content] = Array.from(code.children);
-      if (!gutter || !content) continue;
-      const contentRows = Array.from(content.children);
-      const gutterRows = Array.from(gutter.children);
-      for (let index = 0; index < contentRows.length; index += 1) {
-        const contentElement = contentRows[index];
-        const gutterElement = gutterRows[index];
-        if (!(contentElement instanceof HTMLElement) || !(gutterElement instanceof HTMLElement)) {
-          continue;
-        }
-        const target = lineCommentTarget(contentElement);
-        if (!target) continue;
-        gutterElement.setAttribute("data-kenn-forge-line-comment-cell", "");
-        gutterElement.appendChild(lineCommentButton(target));
-      }
-    }
+  function labelGutterUtility(): void {
+    const button = host?.shadowRoot?.querySelector("[data-utility-button]");
+    if (!(button instanceof HTMLButtonElement)) return;
+    button.setAttribute("aria-label", "Add comment to selected lines");
+    button.title = "Add comment to selected lines";
   }
 
-  function lineCommentTarget(
-    element: HTMLElement,
-  ): { lineNumber: number; side: PierreSide } | undefined {
-    const newLine = parseLineAttribute(element, "data-diff-new-line");
-    if (newLine != null) return { lineNumber: newLine, side: "additions" };
-    const oldLine = parseLineAttribute(element, "data-diff-old-line");
-    if (oldLine != null) return { lineNumber: oldLine, side: "deletions" };
-    return undefined;
-  }
-
-  function parseLineAttribute(element: HTMLElement, name: string): number | undefined {
-    const value = Number.parseInt(element.getAttribute(name) ?? "", 10);
-    return Number.isFinite(value) ? value : undefined;
-  }
-
-  function lineCommentButton(target: { lineNumber: number; side: PierreSide }): HTMLButtonElement {
-    const button = document.createElement("button");
-    const sideLabel = target.side === "additions" ? "new" : "old";
-    const label = `Comment on ${sideLabel} line ${target.lineNumber}`;
-    button.type = "button";
-    button.title = label;
-    button.setAttribute("aria-label", label);
-    button.setAttribute("data-kenn-forge-line-comment-button", "");
-    button.addEventListener("pointerdown", (event) => {
-      event.stopPropagation();
-      lineCommentButtonHasPointerSnapshot = true;
-      lineCommentButtonWasSelectedOnPointerDown = lineCommentTargetIsSelected(target, event);
-    });
-    button.addEventListener("mousedown", (event) => {
-      event.stopPropagation();
-      lineCommentButtonHasPointerSnapshot = true;
-      lineCommentButtonWasSelectedOnPointerDown = lineCommentTargetIsSelected(target, event);
-    });
-    button.addEventListener("click", (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      const collapse = lineCommentButtonHasPointerSnapshot
-        ? lineCommentButtonWasSelectedOnPointerDown
-        : lineCommentTargetIsSelected(target, event);
-      lineCommentButtonHasPointerSnapshot = false;
-      lineCommentButtonWasSelectedOnPointerDown = false;
-      onLineSelected?.(
-        collapse
-          ? null
-          : lineCommentSelection(target, event),
-      );
-    });
-    return button;
-  }
-
-  function selectedRangeMatchesLineCommentTarget(
-    target: { lineNumber: number; side: PierreSide },
-    event: MouseEvent,
-  ): boolean {
-    if (event.shiftKey || !selectedRange) return false;
-    const selectedSide = selectedRange.side ?? target.side;
-    const selectedEndSide = selectedRange.endSide ?? selectedSide;
-    return selectedSide === target.side &&
-      selectedEndSide === target.side &&
-      selectedRange.start === target.lineNumber &&
-      selectedRange.end === target.lineNumber;
-  }
-
-  function lineCommentTargetIsSelected(
-    target: { lineNumber: number; side: PierreSide },
-    event: MouseEvent,
-  ): boolean {
-    return selectedRangeMatchesLineCommentTarget(target, event) ||
-      (!event.shiftKey && selectedLineTargetExists(target));
-  }
-
-  function selectedLineTargetExists(target: { lineNumber: number; side: PierreSide }): boolean {
-    const attr = target.side === "additions" ? "data-diff-new-line" : "data-diff-old-line";
-    return host?.shadowRoot?.querySelector(
-      `[data-active-review-range-line][${attr}="${target.lineNumber}"]`,
-    ) != null;
-  }
-
-  function lineCommentSelection(
-    target: { lineNumber: number; side: PierreSide },
-    event: MouseEvent,
-  ): SelectedLineRange {
-    if (event.shiftKey && selectedRange) {
-      return {
-        start: selectedRange.start,
-        side: selectedRange.side ?? target.side,
-        end: target.lineNumber,
-        endSide: target.side,
-      };
-    }
-    return {
-      start: target.lineNumber,
-      side: target.side,
-      end: target.lineNumber,
-    };
+  function handleGutterUtilityKeyboardClick(event: Event): void {
+    // Pierre handles pointer activation itself. Native keyboard activation
+    // emits a click with no detail, so bridge that path to the same callback.
+    if (
+      !(event instanceof MouseEvent) ||
+      event.detail !== 0 ||
+      !closestFromEvent(event, "[data-utility-button]") ||
+      !selectedRange
+    ) return;
+    onGutterUtilityClick?.(selectedRange);
+    onLineSelected?.(selectedRange);
   }
 
   function applyTransientLineAnnotation(): void {

--- a/frontend/src/lib/components/diff/PierreFileDiff.svelte
+++ b/frontend/src/lib/components/diff/PierreFileDiff.svelte
@@ -262,6 +262,10 @@
       [data-expand-button] {
         cursor: pointer;
       }
+      [data-kenn-forge-review-line-number]:focus-visible {
+        outline: 2px solid var(--accent-blue);
+        outline-offset: -2px;
+      }
     `,
   }));
 
@@ -491,6 +495,7 @@
     demandContextHandlerRoot = root;
     root.addEventListener("click", handleDemandContextClick, { capture: true });
     root.addEventListener("click", handleGutterUtilityKeyboardClick, { capture: true });
+    root.addEventListener("keydown", handleLineNumberKeyboardSelection, { capture: true });
     root.addEventListener("slotchange", handleAnnotationSlotChange);
   }
 
@@ -571,6 +576,9 @@
       capture: true,
     });
     demandContextHandlerRoot?.removeEventListener("click", handleGutterUtilityKeyboardClick, {
+      capture: true,
+    });
+    demandContextHandlerRoot?.removeEventListener("keydown", handleLineNumberKeyboardSelection, {
       capture: true,
     });
     demandContextHandlerRoot?.removeEventListener("slotchange", handleAnnotationSlotChange);
@@ -1204,6 +1212,12 @@
       line.removeAttribute("data-diff-path");
       line.removeAttribute("data-diff-old-line");
       line.removeAttribute("data-diff-new-line");
+      if (line.hasAttribute("data-kenn-forge-review-line-number")) {
+        line.tabIndex = -1;
+        line.removeAttribute("aria-label");
+        line.removeAttribute("data-kenn-forge-review-line-number");
+        line.removeAttribute("role");
+      }
     }
 
     const split = pre.getAttribute("data-diff-type") === "split";
@@ -1235,6 +1249,56 @@
         }
       }
     }
+  }
+
+  function configureLineNumberKeyboardTarget(
+    gutter: HTMLElement,
+    side: PierreSide,
+    attributes: Record<string, string>,
+  ): void {
+    if (!enableLineSelection || !onLineSelected) {
+      gutter.tabIndex = -1;
+      gutter.removeAttribute("aria-label");
+      gutter.removeAttribute("data-kenn-forge-review-line-number");
+      gutter.removeAttribute("role");
+      return;
+    }
+    const lineNumber = attributes[side === "additions" ? "data-diff-new-line" : "data-diff-old-line"];
+    if (!lineNumber) return;
+    gutter.tabIndex = 0;
+    gutter.setAttribute("role", "button");
+    gutter.setAttribute("data-kenn-forge-review-line-number", "");
+    gutter.setAttribute(
+      "aria-label",
+      `Select ${side === "additions" ? "new" : "old"} line ${lineNumber} for review`,
+    );
+  }
+
+  function handleLineNumberKeyboardSelection(event: Event): void {
+    if (
+      !(event instanceof KeyboardEvent) ||
+      (event.key !== "Enter" && event.key !== " ") ||
+      closestFromEvent(event, "[data-utility-button]")
+    ) return;
+    const gutter = closestFromEvent(event, "[data-kenn-forge-review-line-number]");
+    if (!(gutter instanceof HTMLElement)) return;
+    const selection = keyboardLineSelection(gutter);
+    if (!selection) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    onLineSelected?.(selection);
+  }
+
+  function keyboardLineSelection(gutter: HTMLElement): SelectedLineRange | undefined {
+    const newLine = Number.parseInt(gutter.getAttribute("data-diff-new-line") ?? "", 10);
+    if (Number.isFinite(newLine)) {
+      return { start: newLine, end: newLine, side: "additions" };
+    }
+    const oldLine = Number.parseInt(gutter.getAttribute("data-diff-old-line") ?? "", 10);
+    if (Number.isFinite(oldLine)) {
+      return { start: oldLine, end: oldLine, side: "deletions" };
+    }
+    return undefined;
   }
 
   function labelGutterUtility(): void {
@@ -1508,7 +1572,7 @@
     const pair = renderedLinePair(pre, lineIndex, split, side);
     if (!pair) return;
     pair.content.tabIndex = -1;
-    pair.gutter.tabIndex = -1;
+    configureLineNumberKeyboardTarget(pair.gutter, side, attributes);
     pair.content.setAttribute("data-diff-path", renderFile.path);
     pair.gutter.setAttribute("data-diff-path", renderFile.path);
     for (const [name, value] of Object.entries(attributes)) {

--- a/frontend/src/lib/components/diff/PierreFileDiff.svelte
+++ b/frontend/src/lib/components/diff/PierreFileDiff.svelte
@@ -1208,16 +1208,13 @@
     const root = host?.shadowRoot;
     const pre = renderedDiffPre(root);
     if (!root || !pre || !pierreDiff) return;
+    for (const target of root.querySelectorAll<HTMLElement>("[data-kenn-forge-review-line-number]")) {
+      resetLineNumberKeyboardTarget(target);
+    }
     for (const line of root.querySelectorAll<HTMLElement>("[data-diff-path]")) {
       line.removeAttribute("data-diff-path");
       line.removeAttribute("data-diff-old-line");
       line.removeAttribute("data-diff-new-line");
-      if (line.hasAttribute("data-kenn-forge-review-line-number")) {
-        line.tabIndex = -1;
-        line.removeAttribute("aria-label");
-        line.removeAttribute("data-kenn-forge-review-line-number");
-        line.removeAttribute("role");
-      }
     }
 
     const split = pre.getAttribute("data-diff-type") === "split";
@@ -1256,22 +1253,29 @@
     side: PierreSide,
     attributes: Record<string, string>,
   ): void {
+    gutter.tabIndex = -1;
+    const target = gutter.querySelector<HTMLElement>("[data-line-number-content]");
+    if (!target) return;
     if (!enableLineSelection || !onLineSelected) {
-      gutter.tabIndex = -1;
-      gutter.removeAttribute("aria-label");
-      gutter.removeAttribute("data-kenn-forge-review-line-number");
-      gutter.removeAttribute("role");
+      resetLineNumberKeyboardTarget(target);
       return;
     }
     const lineNumber = attributes[side === "additions" ? "data-diff-new-line" : "data-diff-old-line"];
     if (!lineNumber) return;
-    gutter.tabIndex = 0;
-    gutter.setAttribute("role", "button");
-    gutter.setAttribute("data-kenn-forge-review-line-number", "");
-    gutter.setAttribute(
+    target.tabIndex = 0;
+    target.setAttribute("role", "button");
+    target.setAttribute("data-kenn-forge-review-line-number", "");
+    target.setAttribute(
       "aria-label",
       `Select ${side === "additions" ? "new" : "old"} line ${lineNumber} for review`,
     );
+  }
+
+  function resetLineNumberKeyboardTarget(target: HTMLElement): void {
+    target.tabIndex = -1;
+    target.removeAttribute("aria-label");
+    target.removeAttribute("data-kenn-forge-review-line-number");
+    target.removeAttribute("role");
   }
 
   function handleLineNumberKeyboardSelection(event: Event): void {
@@ -1280,16 +1284,29 @@
       (event.key !== "Enter" && event.key !== " ") ||
       closestFromEvent(event, "[data-utility-button]")
     ) return;
-    const gutter = closestFromEvent(event, "[data-kenn-forge-review-line-number]");
-    if (!(gutter instanceof HTMLElement)) return;
-    const selection = keyboardLineSelection(gutter);
+    const target = closestFromEvent(event, "[data-kenn-forge-review-line-number]");
+    if (!(target instanceof HTMLElement)) return;
+    const selection = keyboardLineSelection(target);
     if (!selection) return;
     event.preventDefault();
     event.stopImmediatePropagation();
-    onLineSelected?.(selection);
+    onLineSelected?.(
+      event.shiftKey && selectedRange
+        ? {
+            start: selectedRange.start,
+            side: selectedRange.side ?? selection.side,
+            end: selection.end,
+            endSide: selection.side,
+          }
+        : selection,
+    );
   }
 
-  function keyboardLineSelection(gutter: HTMLElement): SelectedLineRange | undefined {
+  function keyboardLineSelection(
+    target: HTMLElement,
+  ): { start: number; end: number; side: PierreSide } | undefined {
+    const gutter = target.closest<HTMLElement>("[data-column-number]");
+    if (!gutter) return undefined;
     const newLine = Number.parseInt(gutter.getAttribute("data-diff-new-line") ?? "", 10);
     if (Number.isFinite(newLine)) {
       return { start: newLine, end: newLine, side: "additions" };

--- a/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
+++ b/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
@@ -433,27 +433,6 @@ async function renderTerminalLink(
   return dimensions;
 }
 
-async function renderRawTerminalLink(
-  page: Page,
-  output: ReturnType<typeof observeTerminalOutput>,
-  server: IsolatedE2EServer,
-  tmuxSession: string,
-  renderedText: string,
-  marker: string,
-): Promise<TerminalDimensions> {
-  writeTmuxClientTTY(server, tmuxSession, new TextEncoder().encode(`\x1b[2J\x1b[H${renderedText}\r\n${marker}\r\n`));
-  await expect.poll(() => output.includes(marker), { timeout: TERMINAL_OUTPUT_TIMEOUT_MS }).toBe(true);
-  await page.evaluate(
-    () =>
-      new Promise<void>((resolve) => {
-        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
-      }),
-  );
-  const dimensions = output.dimensionsForLatestInput();
-  if (!dimensions) throw new Error(`terminal dimensions unavailable for link marker ${marker}`);
-  return dimensions;
-}
-
 async function terminalCellCenter(
   container: Locator,
   dimensions: TerminalDimensions,
@@ -818,7 +797,7 @@ async function dragTerminalPastTop(page: Page, container: Locator, dimensions: T
 
 test.describe.configure({ mode: "serial", timeout: 120_000 });
 
-test("real xterm links disclose destinations and require a modified click", async ({ page }) => {
+test("detected terminal URLs disclose destinations and require a modified click", async ({ page }) => {
   test.skip(!hasCommand("git") || !hasCommand("tmux", ["-V"]), "git and tmux are required for the real workspace flow");
 
   let isolatedServer: IsolatedE2EServer | null = null;
@@ -832,62 +811,40 @@ test("real xterm links disclose destinations and require a modified click", asyn
 
     await page.goto(`${isolatedServer.info.base_url}/terminal/${workspace.id}`);
     const terminal = await openTerminalPanel(page);
-    const tmuxSession = await runningRuntimeTmuxSession(api, workspace.id);
     const usesMetaKey = await page.evaluate(() => /Mac/.test(navigator.platform));
     const modifier = usesMetaKey ? "Meta" : "Control";
     const modifierLabel = usesMetaKey ? "Cmd" : "Ctrl";
-    const links = [
-      {
-        destination: "https://example.com/detected-link",
-        renderedText: "https://example.com/detected-link",
-        marker: "detected-link-ready",
-        raw: false,
-      },
-      {
-        destination: "https://example.org/osc8-destination",
-        renderedText: "\x1b]8;;https://example.org/osc8-destination\x07Open release notes\x1b]8;;\x07",
-        marker: "osc8-link-ready",
-        raw: true,
-      },
-    ];
+    const destination = "https://example.com/detected-link";
+    const marker = "detected-link-ready";
 
-    for (const link of links) {
-      await page.mouse.move(1, 1);
-      await expect(terminal.locator(".terminal-link-tooltip")).toHaveCount(0);
-      const dimensions = link.raw
-        ? await renderRawTerminalLink(page, output, isolatedServer, tmuxSession, link.renderedText, link.marker)
-        : await renderTerminalLink(page, terminal, output, link.renderedText, link.marker);
-      expect(output.includes(link.destination), `${link.marker} destination did not reach the terminal stream`).toBe(
-        true,
-      );
-      const point = await terminalCellCenter(terminal, dimensions, 4, 0);
-      const resetPoint = await terminalCellCenter(terminal, dimensions, 4, 2);
+    await page.mouse.move(1, 1);
+    await expect(terminal.locator(".terminal-link-tooltip")).toHaveCount(0);
+    const dimensions = await renderTerminalLink(page, terminal, output, destination, marker);
+    expect(output.includes(destination), `${marker} destination did not reach the terminal stream`).toBe(true);
+    const point = await terminalCellCenter(terminal, dimensions, 4, 0);
+    const resetPoint = await terminalCellCenter(terminal, dimensions, 4, 2);
 
-      const tooltip = await hoverTerminalLink(page, terminal, resetPoint, point, link.destination);
-      await expect(tooltip).toContainText(`${modifierLabel}+Click to open link`);
+    const tooltip = await hoverTerminalLink(page, terminal, resetPoint, point, destination);
+    await expect(tooltip).toContainText(`${modifierLabel}+Click to open link`);
 
-      const opensBeforeClick = await terminalLinkOpens(page);
-      await page.mouse.click(point.x, point.y);
-      expect(await terminalLinkOpens(page)).toEqual(opensBeforeClick);
+    await page.mouse.click(point.x, point.y);
+    expect(await terminalLinkOpens(page)).toEqual([]);
 
-      await page.mouse.move(resetPoint.x, resetPoint.y);
-      await expect(tooltip).toHaveCount(0);
-      await hoverTerminalLink(page, terminal, resetPoint, point, link.destination);
-      await page.keyboard.down(modifier);
-      await page.mouse.click(point.x, point.y);
-      await page.keyboard.up(modifier);
-      await expect.poll(() => terminalLinkOpens(page)).toHaveLength(opensBeforeClick.length + 1);
-    }
-
+    await page.mouse.move(resetPoint.x, resetPoint.y);
+    await expect(tooltip).toHaveCount(0);
+    await hoverTerminalLink(page, terminal, resetPoint, point, destination);
+    await page.keyboard.down(modifier);
+    await page.mouse.click(point.x, point.y);
+    await page.keyboard.up(modifier);
     await expect
       .poll(() => terminalLinkOpens(page))
-      .toEqual(
-        links.map((link) => ({
-          url: link.destination,
+      .toEqual([
+        {
+          url: destination,
           target: "_blank",
           features: "noopener,noreferrer",
-        })),
-      );
+        },
+      ]);
   } finally {
     await api?.dispose();
     await isolatedServer?.stop();

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -1605,9 +1605,10 @@ async function selectPierreReviewLine(file: Locator, line: number, side: "left" 
     `[data-column-number="${line}"][data-line-type="${type}"]`,
     ...fallback.map((lineType) => `[data-column-number="${line}"][data-line-type="${lineType}"]`),
   ].join(",");
-  const target = file.locator(`.pierre-diff ${selector}`).first();
+  const target = file.locator(`.pierre-diff ${selector}`).first().locator("[data-line-number-content]");
   await expect(target).toBeVisible({ timeout: 10_000 });
-  await clickVisibleTarget(target.locator("[data-kenn-forge-line-comment-button]"));
+  await target.press("Enter");
+  await clickVisibleTarget(file.getByRole("button", { name: "Add comment to selected lines" }));
 }
 
 function inlineComposerFor(textarea: Locator): Locator {
@@ -4292,7 +4293,7 @@ test.describe("diff view (git-backed)", () => {
     }
   });
 
-  test("inline review composer only opens from the gutter comment button", async ({ page }) => {
+  test("inline review composer only opens from the gutter utility", async ({ page }) => {
     const server = await startIsolatedE2EServer();
     try {
       const baseURL = server.info.base_url;

--- a/frontend/tests/e2e/inline-review.spec.ts
+++ b/frontend/tests/e2e/inline-review.spec.ts
@@ -615,6 +615,31 @@ async function firstDiffGutterRight(page: Page): Promise<number> {
     });
 }
 
+function reviewLineControl(page: Page, line: number, side: "new" | "old" = "new") {
+  return page.locator(".diff-area").getByRole("button", {
+    name: `Select ${side} line ${line} for review`,
+  });
+}
+
+async function selectReviewLine(page: Page, line: number, side: "new" | "old" = "new", extend = false): Promise<void> {
+  const control = reviewLineControl(page, line, side);
+  await expect(control).toBeVisible();
+  await control.press(extend ? "Shift+Enter" : "Enter");
+}
+
+async function openSelectedReviewRange(page: Page): Promise<void> {
+  const utility = page.locator(".diff-area").getByRole("button", {
+    name: "Add comment to selected lines",
+  });
+  await expect(utility).toBeVisible();
+  await utility.click();
+}
+
+async function openReviewComposer(page: Page, line: number, side: "new" | "old" = "new"): Promise<void> {
+  await selectReviewLine(page, line, side);
+  await openSelectedReviewRange(page);
+}
+
 test.beforeEach(async ({ page }) => {
   await mockApi(page);
 });
@@ -643,7 +668,7 @@ test("unavailable operations disable inline review authoring and thread replies"
 
   await page.goto("/pulls/github/acme/widgets/42/files");
   await expect(page.locator(".file-content").first()).toBeVisible();
-  await expect(page.getByRole("button", { name: /Comment on new line/ })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: /Select new line .* for review/ })).toHaveCount(0);
   await expect(page.getByPlaceholder("Leave a comment")).toHaveCount(0);
   // The existing review thread renders read-only: no reply composer
   // or reply affordance, and no reply request can fire.
@@ -739,11 +764,11 @@ test("adds and publishes an inline draft review comment", async ({ page }) => {
 
   await page.goto("/pulls/github/acme/widgets/42");
   await page.getByRole("tab", { name: "Files changed" }).click();
-  await page.getByRole("button", { name: "Comment on new line 2" }).click();
+  await openReviewComposer(page, 2);
   const composer = page.getByPlaceholder("Leave a comment");
   await composer.fill("Please cover this line.");
   await expect(composer).toHaveValue("Please cover this line.");
-  const addCommentButton = page.getByRole("button", { name: "Add comment" });
+  const addCommentButton = page.getByRole("button", { name: "Add comment", exact: true });
   await expect(addCommentButton).toBeEnabled();
   await addCommentButton.click();
 
@@ -810,18 +835,18 @@ test("keeps split-mode inline composers on trailing right-side hunk lines", asyn
 
   await page.goto("/pulls/github/acme/widgets/42/files");
   async function assertRightSideComposer(line: number): Promise<void> {
-    const button = page.getByRole("button", { name: `Comment on new line ${line}` });
-    await expect(button).toBeVisible();
+    const control = reviewLineControl(page, line);
+    await expect(control).toBeVisible();
     await expect(
       page
         .locator(".pierre-diff")
         .first()
         .evaluate((host, lineNumber) => {
           const root = host.shadowRoot;
-          const button = Array.from(
-            root?.querySelectorAll<HTMLButtonElement>("[data-kenn-forge-line-comment-button]") ?? [],
-          ).find((candidate) => candidate.getAttribute("aria-label") === `Comment on new line ${lineNumber}`);
-          return button ? pierreCodeSide(root, button) : null;
+          const control = Array.from(
+            root?.querySelectorAll<HTMLElement>("[data-kenn-forge-review-line-number]") ?? [],
+          ).find((candidate) => candidate.getAttribute("aria-label") === `Select new line ${lineNumber} for review`);
+          return control ? pierreCodeSide(root, control) : null;
 
           function pierreCodeSide(
             root: ShadowRoot | null | undefined,
@@ -844,7 +869,7 @@ test("keeps split-mode inline composers on trailing right-side hunk lines", asyn
         }, line),
     ).resolves.toBe("additions");
 
-    await button.click();
+    await openReviewComposer(page, line);
     await expect(page.getByPlaceholder("Leave a comment")).toBeVisible();
     const diff = page.locator(".pierre-diff").first();
     const composerSide = () =>
@@ -890,7 +915,7 @@ test("keeps final added-file line visible when opening an inline composer", asyn
   await expect(page.getByText("blank_issues_enabled: false")).toBeVisible();
 
   async function assertComposerLayout(lineNumber: number, lineText: string, followingText?: string): Promise<void> {
-    await page.getByRole("button", { name: `Comment on new line ${lineNumber}` }).click();
+    await openReviewComposer(page, lineNumber);
     await expect(page.getByPlaceholder("Leave a comment")).toBeVisible();
     await expect(page.getByText(lineText)).toBeVisible();
 
@@ -989,7 +1014,7 @@ test("shows a visible composer focus indicator without focus flicker", async ({ 
     );
   });
 
-  await page.getByRole("button", { name: "Comment on new line 2" }).click();
+  await openReviewComposer(page, 2);
   const composer = page.getByPlaceholder("Leave a comment");
   await expect(composer).toBeVisible();
 
@@ -1077,7 +1102,7 @@ test("keeps inline composer inside the visible diff pane on long lines", async (
   await mockInlineReviewAPI(page, baseCapabilities, "github", "github.com", longLineDiffResponse);
 
   await page.goto("/pulls/github/acme/widgets/42/files");
-  await page.getByRole("button", { name: "Comment on new line 1141" }).click();
+  await openReviewComposer(page, 1141);
 
   const scrollPane = page.locator(".diff-area .file-content").first();
   const composer = page.locator(".inline-composer");
@@ -1124,12 +1149,11 @@ test("shows saved draft comments inline and jumps from the tray", async ({ page 
   await mockInlineReviewAPI(page);
 
   await page.goto("/pulls/github/acme/widgets/42/files");
-  await page.getByRole("button", { name: "Comment on new line 1" }).click();
-  await page.getByRole("button", { name: "Comment on new line 2" }).click({
-    modifiers: ["Shift"],
-  });
+  await selectReviewLine(page, 1);
+  await selectReviewLine(page, 2, "new", true);
+  await openSelectedReviewRange(page);
   await page.getByPlaceholder("Leave a comment").fill("Please cover both lines.");
-  await page.getByRole("button", { name: "Add comment" }).click();
+  await page.getByRole("button", { name: "Add comment", exact: true }).click();
 
   const inlineDraft = page.locator(".inline-draft-comment");
   const scrollPane = page.locator(".diff-area .file-content").first();
@@ -1173,9 +1197,9 @@ test("keeps remaining GitLab draft state visible after a partial publish", async
   });
 
   await page.goto("/pulls/gitlab/acme/widgets/42/files");
-  await page.getByRole("button", { name: "Comment on new line 2" }).click();
+  await openReviewComposer(page, 2);
   await page.getByPlaceholder("Leave a comment").fill("Please cover this line.");
-  await page.getByRole("button", { name: "Add comment" }).click();
+  await page.getByRole("button", { name: "Add comment", exact: true }).click();
 
   const summary = page.getByPlaceholder("Review summary");
   await summary.fill("Summary should not stay in the composer.");
@@ -1196,7 +1220,7 @@ test("hides inline review controls when provider draft review is unsupported", a
 
   await page.goto("/pulls/github/acme/widgets/42");
   await page.getByRole("tab", { name: "Files changed" }).click();
-  await expect(page.getByRole("button", { name: "Comment on new line 2" })).toHaveCount(0);
+  await expect(reviewLineControl(page, 2)).toHaveCount(0);
 });
 
 test("resolves a published inline review thread from the timeline", async ({ page }) => {
@@ -1218,9 +1242,7 @@ test("shows published inline review context in conversation and jumps to the dif
 
   await expect(page.getByRole("tab", { name: "Files changed" })).toHaveAttribute("aria-selected", "true");
   await expect(
-    page.locator(
-      '.diff-area [data-diff-path="src/main.ts"][data-diff-new-line="2"]:not([data-kenn-forge-line-comment-cell])',
-    ),
+    page.locator('.diff-area [data-diff-path="src/main.ts"][data-diff-new-line="2"][data-line]'),
   ).toBeVisible();
 });
 
@@ -1399,11 +1421,11 @@ test("opens the sticky draft review action menu upward", async ({ page }) => {
 test("enables inline review on public Forgejo and Gitea files routes", async ({ page }) => {
   await mockInlineReviewAPI(page, baseCapabilities, "forgejo", "codeberg.org");
   await page.goto("/pulls/forgejo/acme/widgets/42/files");
-  await expect(page.getByRole("button", { name: "Comment on new line 2" })).toBeVisible();
+  await expect(reviewLineControl(page, 2)).toBeVisible();
 
   await mockInlineReviewAPI(page, baseCapabilities, "gitea", "gitea.com");
   await page.goto("/pulls/gitea/acme/widgets/42/files");
-  await expect(page.getByRole("button", { name: "Comment on new line 2" })).toBeVisible();
+  await expect(reviewLineControl(page, 2)).toBeVisible();
 });
 
 test("does not create multiline draft ranges across separate PR diff hunks", async ({ page }) => {
@@ -1416,17 +1438,16 @@ test("does not create multiline draft ranges across separate PR diff hunks", asy
   });
 
   await page.goto("/pulls/github/acme/widgets/42/files");
-  await page.getByRole("button", { name: "Comment on new line 1" }).click();
-  await page.getByRole("button", { name: "Comment on new line 20" }).click({
-    modifiers: ["Shift"],
-  });
+  await selectReviewLine(page, 1);
+  await selectReviewLine(page, 20, "new", true);
 
   const selected = page.locator(".gutter-new.gutter--selected");
   await expect(selected).toHaveCount(1);
   await expect(selected).toHaveText("20");
 
+  await openSelectedReviewRange(page);
   await page.getByPlaceholder("Leave a comment").fill("Only the second hunk.");
-  await page.getByRole("button", { name: "Add comment" }).click();
+  await page.getByRole("button", { name: "Add comment", exact: true }).click();
 
   const createdRange = await createdRangePromise;
   expect(createdRange).toMatchObject({

--- a/frontend/tests/e2e/inline-review.spec.ts
+++ b/frontend/tests/e2e/inline-review.spec.ts
@@ -1177,6 +1177,46 @@ test("shows saved draft comments inline and jumps from the tray", async ({ page 
   await expect(inlineDraft).toBeFocused();
 });
 
+test("drags across line numbers to create a multiline draft", async ({ page }) => {
+  let resolveCreatedRange!: (range: Record<string, unknown>) => void;
+  const createdRangePromise = new Promise<Record<string, unknown>>((resolve) => {
+    resolveCreatedRange = resolve;
+  });
+  await mockInlineReviewAPI(page, baseCapabilities, "github", "github.com", diffResponse, (body) => {
+    resolveCreatedRange(body.range);
+  });
+
+  await page.goto("/pulls/github/acme/widgets/42/files");
+  const firstLine = reviewLineControl(page, 1);
+  const secondLine = reviewLineControl(page, 2);
+  await expect(firstLine).toBeVisible();
+  await expect(secondLine).toBeVisible();
+  const firstLineBox = await firstLine.boundingBox();
+  const secondLineBox = await secondLine.boundingBox();
+  expect(firstLineBox).not.toBeNull();
+  expect(secondLineBox).not.toBeNull();
+
+  await page.mouse.move(firstLineBox!.x + 1, firstLineBox!.y + firstLineBox!.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(secondLineBox!.x + 1, secondLineBox!.y + secondLineBox!.height / 2);
+  await page.mouse.up();
+
+  await openSelectedReviewRange(page);
+  const composer = page.getByPlaceholder("Leave a comment");
+  await expect(composer).toBeVisible();
+  await composer.fill("Please cover both lines.");
+  await page.getByRole("button", { name: "Add comment", exact: true }).click();
+
+  await expect(createdRangePromise).resolves.toMatchObject({
+    path: "src/main.ts",
+    start_side: "right",
+    start_line: 1,
+    side: "right",
+    line: 2,
+    new_line: 2,
+  });
+});
+
 test("keeps remaining GitLab draft state visible after a partial publish", async ({ page }) => {
   await mockInlineReviewAPI(page, baseCapabilities, "gitlab", "gitlab.com", diffResponse, undefined, {
     publishStatus: "partially_published",


### PR DESCRIPTION
Reviewers can now select a contiguous range of diff lines and open one inline composer for the range. Closes #936.

- Click a line number to select one line. Drag over line numbers, Shift-click, or Shift+Enter/Space extends the range.
- Selection alone does not open the composer. Pierre's native gutter `+` opens it for the selected range.
- Ranges stay within one file, diff side, and hunk, and providers without multiline support keep single-line comments. Dragging over code still selects text normally.
