### PR TITLE
feat: mark dirty worktrees in the workspace list

### DIFF
--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -81,6 +81,9 @@ embedder protocol for arbitrary host state.
 - List/detail reads return persisted plus last-known-good enrichment without
   foreground git or tmux probes; stale components reconcile through bounded
   background workers (`internal/server/workspaceapi/workspace_enrichment.go::toCachedWorkspaceResponse`).
+- Background Git enrichment must not take optional repository locks; cached
+  probes cannot interfere with a maintainer's foreground Git commands
+  (`internal/server/workspaceapi/routes_handlers.go::readOnlyWorktreeIsDirty`).
 - Activity and Issue/Pull Request list and detail responses share one cached
   subject snapshot: every resolvable subject keeps a workspace reference, while
   tmux activity remains optional and ephemeral (`internal/server/workspaceapi/subject_activity.go::Handler.WorkspaceSubjectSnapshot`).

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -7822,7 +7822,7 @@ components:
           description: Oldest successful refresh time across the populated enrichment components.
           type: string
         enrichment_status:
-          description: Aggregate git-divergence and tmux-activity reconciliation status. Failed responses retain last-known-good component fields when available.
+          description: Aggregate git-state and tmux-activity reconciliation status. Failed responses retain last-known-good component fields when available.
           enum:
             - not_applicable
             - pending
@@ -7891,6 +7891,9 @@ components:
         tmux_session:
           type: string
         tmux_working:
+          type: boolean
+        worktree_dirty:
+          description: True when the worktree has staged, unstaged, or untracked changes; false when clean; omitted until git-state enrichment completes.
           type: boolean
         worktree_path:
           type: string

--- a/frontend/src/lib/api/generated/schema.ts
+++ b/frontend/src/lib/api/generated/schema.ts
@@ -8195,7 +8195,7 @@ export interface components {
             /** @description Oldest successful refresh time across the populated enrichment components. */
             enrichment_refreshed_at?: string;
             /**
-             * @description Aggregate git-divergence and tmux-activity reconciliation status. Failed responses retain last-known-good component fields when available.
+             * @description Aggregate git-state and tmux-activity reconciliation status. Failed responses retain last-known-good component fields when available.
              * @enum {string}
              */
             enrichment_status: "not_applicable" | "pending" | "fresh" | "stale" | "failed";
@@ -8232,6 +8232,8 @@ export interface components {
             tmux_pane_title?: string;
             tmux_session: string;
             tmux_working: boolean;
+            /** @description True when the worktree has staged, unstaged, or untracked changes; false when clean; omitted until git-state enrichment completes. */
+            worktree_dirty?: boolean;
             worktree_path: string;
         };
         WorkspaceRuntimeResponse: {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -7,6 +7,7 @@
     type StatusDotStatus,
   } from "@kenn-io/kit-ui";
   import PlusIcon from "@lucide/svelte/icons/plus";
+  import PencilIcon from "@lucide/svelte/icons/pencil";
   import {
     openNewWorkspaceDialog,
     type NewWorkspaceRepoSeed,
@@ -1462,6 +1463,17 @@
       {/each}
     {/if}
 
+    {#snippet worktreeDirtyIndicator()}
+      <span
+        class="worktree-dirty"
+        title="Dirty worktree"
+        role="img"
+        aria-label="Dirty worktree"
+      >
+        <PencilIcon size={10} strokeWidth={2.2} aria-hidden="true" />
+      </span>
+    {/snippet}
+
     {#snippet workspaceRow(ws: Workspace, showRepo: boolean)}
           {@const adds = ws.mr_additions}
           {@const dels = ws.mr_deletions}
@@ -1602,29 +1614,37 @@
                     />
                   </span>
                 {/if}
+                {#if ws.worktree_dirty && !hasItemBubble(ws)}
+                  {@render worktreeDirtyIndicator()}
+                {/if}
               </div>
             </div>
             <!-- An ad-hoc workspace with no detected PR has nothing for a
                  bubble to open, so it renders none rather than an empty one. -->
             {#if hasItemBubble(ws)}
-            <button
-              class={[
-                "item-bubble",
-                itemStateClass(ws),
-                ws.item_type === "kata_task" && "item-bubble--kata",
-              ]}
-              onclick={(e) => handleItemBubbleClick(e, ws)}
-              onkeydown={(e) => {
-                // Stop Enter/Space from bubbling to the row,
-                // since the row's keyboard handler also navigates.
-                if (e.key === "Enter" || e.key === " ") {
-                  e.stopPropagation();
-                }
-              }}
-              title={itemBubbleTitle(ws)}
-            >
-              {itemBubbleLabel(ws)}
-            </button>
+              <div class="ws-row-aside">
+                <button
+                  class={[
+                    "item-bubble",
+                    itemStateClass(ws),
+                    ws.item_type === "kata_task" && "item-bubble--kata",
+                  ]}
+                  onclick={(e) => handleItemBubbleClick(e, ws)}
+                  onkeydown={(e) => {
+                    // Stop Enter/Space from bubbling to the row,
+                    // since the row's keyboard handler also navigates.
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.stopPropagation();
+                    }
+                  }}
+                  title={itemBubbleTitle(ws)}
+                >
+                  {itemBubbleLabel(ws)}
+                </button>
+                {#if ws.worktree_dirty}
+                  {@render worktreeDirtyIndicator()}
+                {/if}
+              </div>
             {/if}
           </div>
     {/snippet}
@@ -2205,6 +2225,25 @@
     margin-right: 1px;
   }
 
+  .worktree-dirty {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+    color: var(--text-muted);
+    opacity: 0.5;
+    line-height: 1;
+    margin-top: 1px;
+  }
+
+  .ws-row-aside {
+    flex-shrink: 0;
+    align-self: flex-start;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-2);
+  }
+
   .item-bubble {
     /* GitHub-style state pill: a soft solid pastel fill with a
      * near-black foreground for legibility. The bg is mostly the
@@ -2217,7 +2256,6 @@
      * it pins to the row's top edge regardless of the meta line's
      * height. */
     flex-shrink: 0;
-    align-self: flex-start;
     margin-top: 1px;
     height: 16px;
     padding: 0 6px;

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -85,6 +85,7 @@ interface WorkspaceFixtureOptions {
   status?: string;
   errorMessage?: string | null;
   associatedPRNumber?: number | null;
+  worktreeDirty?: boolean;
 }
 
 function workspaceFixture({
@@ -115,6 +116,7 @@ function workspaceFixture({
   status = "ready",
   errorMessage = null,
   associatedPRNumber = null,
+  worktreeDirty,
 }: WorkspaceFixtureOptions) {
   // Kata and ad-hoc workspaces carry no joined provider item metadata.
   const noProviderItem = itemType === "kata_task" || itemType === "adhoc";
@@ -155,6 +157,7 @@ function workspaceFixture({
     commits_ahead: commitsAhead,
     commits_behind: commitsBehind,
     associated_pr_number: associatedPRNumber,
+    ...(worktreeDirty === undefined ? {} : { worktree_dirty: worktreeDirty }),
   };
 }
 
@@ -1540,6 +1543,48 @@ describe("WorkspaceListSidebar", () => {
 
     expect(container.querySelector(".workspace-diff-stats")).toBeNull();
     expect(container.querySelector(".branch-chip")).toBeTruthy();
+  });
+
+  it("marks dirty worktrees without marking clean rows", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [
+          workspaceFixture({
+            id: "ws-dirty",
+            provider: "github",
+            platformHost: "github.com",
+            owner: "kenn-io",
+            name: "kenn-forge",
+            number: 9,
+            title: "Dirty workspace",
+            worktreeDirty: true,
+          }),
+          workspaceFixture({
+            id: "ws-clean",
+            provider: "github",
+            platformHost: "github.com",
+            owner: "kenn-io",
+            name: "kenn-forge",
+            number: 10,
+            title: "Clean workspace",
+            worktreeDirty: false,
+          }),
+        ],
+      },
+    });
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-dirty" },
+    });
+    await screen.findByText("Dirty workspace");
+
+    expect(screen.queryByText("Dirty")).toBeNull();
+    expect(screen.getByLabelText("Dirty worktree")).toBeTruthy();
+    expect(container.querySelector('[title="Dirty worktree"]')).toBeTruthy();
+    expect(container.querySelectorAll(".worktree-dirty")).toHaveLength(1);
+    expect(container.querySelector(".worktree-dirty svg.lucide-pencil")).toBeTruthy();
+    expect(container.querySelector(".ws-row-aside > .item-bubble + .worktree-dirty")).toBeTruthy();
+    expect(container.querySelectorAll(".worktree-dirty-slot")).toHaveLength(0);
   });
 
   it("opens a host-aware context menu for local macOS workspaces", async () => {

--- a/frontend/src/lib/components/terminal/workspace-list-schema.ts
+++ b/frontend/src/lib/components/terminal/workspace-list-schema.ts
@@ -21,7 +21,7 @@ export type WorkspaceListItem = Pick<
   | "tmux_working"
   | "worktree_path"
 > &
-  Partial<Pick<GeneratedWorkspace, "item_key" | "kata">> & {
+  Partial<Pick<GeneratedWorkspace, "item_key" | "kata" | "worktree_dirty">> & {
     readonly agent_state?: GeneratedWorkspace["agent_state"] | null;
     readonly agent_state_updated_at?: string | null;
     readonly associated_pr_number?: Exclude<GeneratedWorkspace["associated_pr_number"], undefined> | null;
@@ -92,6 +92,7 @@ const Workspace = Schema.Struct({
   tmux_pane_title: Schema.optionalKey(Schema.NullOr(Schema.String)),
   tmux_working: Schema.Boolean,
   worktree_path: Schema.String,
+  worktree_dirty: Schema.optionalKey(Schema.Boolean),
 });
 
 const WorkspaceList = Schema.Struct({

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -4608,8 +4608,20 @@ test.describe("workspace list bubble opens right sidebar", () => {
       commits_behind: 5,
       mr_additions: 1500,
       mr_deletions: 2400,
+      worktree_dirty: true,
     };
-    const list = [wsBare, wsBranchOnly, wsAhead, wsAheadBehindDiff];
+    const wsAheadBehindDiffClean = {
+      ...testWorkspace,
+      id: "ws-busy-clean",
+      item_number: 5555,
+      git_head_ref: "feature/busy",
+      commits_ahead: 12,
+      commits_behind: 5,
+      mr_additions: 1500,
+      mr_deletions: 2400,
+      worktree_dirty: false,
+    };
+    const list = [wsBare, wsBranchOnly, wsAhead, wsAheadBehindDiff, wsAheadBehindDiffClean];
 
     await mockApi(page);
     await page.route("**/api/v1/events", async (route) => {
@@ -4656,13 +4668,43 @@ test.describe("workspace list bubble opens right sidebar", () => {
 
     await page.goto("/workspaces");
     await expect(page.locator(".workspace-list-sidebar .ws-row")).toHaveCount(list.length);
-    await expect(
-      page
-        .locator(".workspace-list-sidebar .ws-row", {
-          hasText: "feature/busy",
-        })
-        .locator(".kit-diff-stats"),
-    ).toHaveCount(1);
+    const busyRow = page.locator(".workspace-list-sidebar .ws-row", {
+      has: page.getByTitle("Open PR #4444"),
+    });
+    const cleanBusyRow = page.locator(".workspace-list-sidebar .ws-row", {
+      has: page.getByTitle("Open PR #5555"),
+    });
+    await expect(busyRow.locator(".kit-diff-stats")).toHaveCount(1);
+    await expect(page.locator(".workspace-list-sidebar .worktree-dirty")).toHaveCount(1);
+    await expect(page.locator(".workspace-list-sidebar .worktree-dirty-slot")).toHaveCount(0);
+    await expect(page.locator(".workspace-list-sidebar .ws-row-aside > .item-bubble + .worktree-dirty")).toHaveCount(1);
+
+    const diffBox = await busyRow.locator(".workspace-diff-stats").boundingBox();
+    const cleanDiffBox = await cleanBusyRow.locator(".workspace-diff-stats").boundingBox();
+    const pushBox = await busyRow.locator(".push-state").boundingBox();
+    const cleanPushBox = await cleanBusyRow.locator(".push-state").boundingBox();
+    const pencilBox = await busyRow.locator(".worktree-dirty").boundingBox();
+    const bubbleBox = await busyRow.locator(".item-bubble").boundingBox();
+    expect(diffBox).not.toBeNull();
+    expect(cleanDiffBox).not.toBeNull();
+    expect(pushBox).not.toBeNull();
+    expect(cleanPushBox).not.toBeNull();
+    expect(pencilBox).not.toBeNull();
+    expect(bubbleBox).not.toBeNull();
+    if (
+      diffBox != null &&
+      cleanDiffBox != null &&
+      pushBox != null &&
+      cleanPushBox != null &&
+      pencilBox != null &&
+      bubbleBox != null
+    ) {
+      expect(Math.abs(diffBox.x + diffBox.width - (cleanDiffBox.x + cleanDiffBox.width))).toBeLessThanOrEqual(1);
+      expect(Math.abs(pushBox.x - cleanPushBox.x)).toBeLessThanOrEqual(1);
+      expect(pencilBox.x).toBeGreaterThan(diffBox.x + diffBox.width);
+      expect(Math.abs(pencilBox.x - bubbleBox.x)).toBeLessThanOrEqual(1);
+      expect(pencilBox.y).toBeGreaterThan(bubbleBox.y + bubbleBox.height + 2);
+    }
 
     const bubbles = page.locator(".workspace-list-sidebar .ws-row .item-bubble");
     const boxes: Array<{ right: number }> = [];

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -4663,7 +4663,7 @@ type WorkspaceResponse struct {
 	// EnrichmentRefreshedAt Oldest successful refresh time across the populated enrichment components.
 	EnrichmentRefreshedAt *string `json:"enrichment_refreshed_at,omitempty"`
 
-	// EnrichmentStatus Aggregate git-divergence and tmux-activity reconciliation status. Failed responses retain last-known-good component fields when available.
+	// EnrichmentStatus Aggregate git-state and tmux-activity reconciliation status. Failed responses retain last-known-good component fields when available.
 	EnrichmentStatus   WorkspaceResponseEnrichmentStatus `json:"enrichment_status"`
 	ErrorMessage       *string                           `json:"error_message,omitempty"`
 	GitHeadRef         string                            `json:"git_head_ref"`
@@ -4693,13 +4693,16 @@ type WorkspaceResponse struct {
 	TmuxPaneTitle      *string                          `json:"tmux_pane_title,omitempty"`
 	TmuxSession        string                           `json:"tmux_session"`
 	TmuxWorking        bool                             `json:"tmux_working"`
-	WorktreePath       string                           `json:"worktree_path"`
+
+	// WorktreeDirty True when the worktree has staged, unstaged, or untracked changes; false when clean; omitted until git-state enrichment completes.
+	WorktreeDirty *bool  `json:"worktree_dirty,omitempty"`
+	WorktreePath  string `json:"worktree_path"`
 }
 
 // WorkspaceResponseAgentState Hook-reported aggregate state for live agent sessions. Omitted when no live session has reported lifecycle state.
 type WorkspaceResponseAgentState string
 
-// WorkspaceResponseEnrichmentStatus Aggregate git-divergence and tmux-activity reconciliation status. Failed responses retain last-known-good component fields when available.
+// WorkspaceResponseEnrichmentStatus Aggregate git-state and tmux-activity reconciliation status. Failed responses retain last-known-good component fields when available.
 type WorkspaceResponseEnrichmentStatus string
 
 // WorkspaceResponseMrHeadRepoKind Set only for pull_request workspaces: same_repo when the PR head is confirmed to be in the base repo, fork when it is a confirmed fork clone, unknown when repository identity could not be resolved.

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"slices"
@@ -19,7 +20,7 @@ import (
 	"go.kenn.io/forge/internal/tokenauth"
 	"go.kenn.io/forge/internal/workspace"
 	"go.kenn.io/forge/internal/workspace/localruntime"
-	managedworktree "go.kenn.io/kit/git/managed"
+	gitcmd "go.kenn.io/kit/git/cmd"
 )
 
 type createWorkspaceInput struct {
@@ -2149,7 +2150,7 @@ func applyWorktreeDirty(
 	probeCtx, cancel := context.WithTimeout(ctx, worktreeDivergenceTimeout)
 	defer cancel()
 
-	dirty, err := managedworktree.WorktreeIsDirty(probeCtx, worktreePath)
+	dirty, err := readOnlyWorktreeIsDirty(probeCtx, worktreePath)
 	if err != nil {
 		slog.Debug(
 			"worktree dirty-state probe failed",
@@ -2161,6 +2162,28 @@ func applyWorktreeDirty(
 	}
 	resp.WorktreeDirty = &dirty
 	return nil
+}
+
+func readOnlyWorktreeIsDirty(ctx context.Context, worktreePath string) (bool, error) {
+	stdout, stderr, err := gitcmd.New().Run(
+		ctx,
+		worktreePath,
+		nil,
+		"--no-optional-locks",
+		"status",
+		"--porcelain",
+		"--untracked-files=all",
+		"--ignore-submodules=none",
+	)
+	if err != nil {
+		out := append(stdout, stderr...)
+		return false, fmt.Errorf(
+			"check worktree dirty state: %w: %s",
+			err,
+			strings.TrimSpace(string(out)),
+		)
+	}
+	return strings.TrimSpace(string(stdout)) != "", nil
 }
 
 func isWorkingTmuxTitle(title string) bool {

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -19,6 +19,7 @@ import (
 	"go.kenn.io/forge/internal/tokenauth"
 	"go.kenn.io/forge/internal/workspace"
 	"go.kenn.io/forge/internal/workspace/localruntime"
+	managedworktree "go.kenn.io/kit/git/managed"
 )
 
 type createWorkspaceInput struct {
@@ -1888,6 +1889,8 @@ func (s *Handler) workspaceResponseWithEnrichment(
 	}
 
 	divergenceErr := applyWorktreeDivergence(ctx, &resp, summary.WorktreePath)
+	dirtyErr := applyWorktreeDirty(ctx, &resp, summary.WorktreePath)
+	gitStateErr := errors.Join(divergenceErr, dirtyErr)
 	sessions, sessionsErr := s.workspaceTmuxActivitySessions(ctx, summary)
 	activity, hasActivity, activityErr := s.probeWorkspaceTmuxActivity(
 		ctx, summary, sessions,
@@ -1895,12 +1898,12 @@ func (s *Handler) workspaceResponseWithEnrichment(
 	if hasActivity {
 		applyTmuxActivity(&resp, activity)
 	}
-	err := errors.Join(divergenceErr, sessionsErr, activityErr)
+	err := errors.Join(gitStateErr, sessionsErr, activityErr)
 	result := workspaceEnrichmentProbeResult{
 		response:           resp,
-		divergenceComplete: divergenceErr == nil,
+		divergenceComplete: gitStateErr == nil,
 		tmuxComplete:       sessionsErr == nil && activityErr == nil,
-		divergenceErr:      divergenceErr,
+		divergenceErr:      gitStateErr,
 		tmuxErr:            errors.Join(sessionsErr, activityErr),
 		err:                err,
 	}
@@ -2132,6 +2135,31 @@ func applyWorktreeDivergence(
 	behind := div.Behind
 	resp.CommitsAhead = &ahead
 	resp.CommitsBehind = &behind
+	return nil
+}
+
+func applyWorktreeDirty(
+	ctx context.Context,
+	resp *workspaceResponse,
+	worktreePath string,
+) error {
+	if worktreePath == "" {
+		return nil
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, worktreeDivergenceTimeout)
+	defer cancel()
+
+	dirty, err := managedworktree.WorktreeIsDirty(probeCtx, worktreePath)
+	if err != nil {
+		slog.Debug(
+			"worktree dirty-state probe failed",
+			"workspace_id", resp.ID,
+			"path", worktreePath,
+			"err", err,
+		)
+		return err
+	}
+	resp.WorktreeDirty = &dirty
 	return nil
 }
 

--- a/internal/server/workspaceapi/types.go
+++ b/internal/server/workspaceapi/types.go
@@ -56,7 +56,8 @@ type workspaceResponse struct {
 	MRDeletions           *int                      `json:"mr_deletions,omitempty"`
 	CommitsAhead          *int                      `json:"commits_ahead,omitempty"`
 	CommitsBehind         *int                      `json:"commits_behind,omitempty"`
-	EnrichmentStatus      string                    `json:"enrichment_status" enum:"not_applicable,pending,fresh,stale,failed" doc:"Aggregate git-divergence and tmux-activity reconciliation status. Failed responses retain last-known-good component fields when available."`
+	WorktreeDirty         *bool                     `json:"worktree_dirty,omitempty" doc:"True when the worktree has staged, unstaged, or untracked changes; false when clean; omitted until git-state enrichment completes."`
+	EnrichmentStatus      string                    `json:"enrichment_status" enum:"not_applicable,pending,fresh,stale,failed" doc:"Aggregate git-state and tmux-activity reconciliation status. Failed responses retain last-known-good component fields when available."`
 	EnrichmentRefreshedAt *string                   `json:"enrichment_refreshed_at,omitempty" doc:"Oldest successful refresh time across the populated enrichment components."`
 	EnrichmentError       *string                   `json:"enrichment_error,omitempty" doc:"Combined error from the most recent reconciliation attempt; populated component fields may still contain last-known-good values."`
 	AssociatedPRNumber    *int                      `json:"associated_pr_number,omitempty"`

--- a/internal/server/workspaceapi/workspace_enrichment.go
+++ b/internal/server/workspaceapi/workspace_enrichment.go
@@ -204,6 +204,7 @@ func applyWorkspaceEnrichmentCacheEntry(
 	if entry.hasDivergence {
 		resp.CommitsAhead = entry.response.CommitsAhead
 		resp.CommitsBehind = entry.response.CommitsBehind
+		resp.WorktreeDirty = entry.response.WorktreeDirty
 	}
 	if entry.hasTmux {
 		applyCachedWorkspaceTmux(resp, entry.response)
@@ -470,6 +471,7 @@ func (s *Handler) recordWorkspaceEnrichmentResult(
 	if result.divergenceComplete {
 		entry.response.CommitsAhead = result.response.CommitsAhead
 		entry.response.CommitsBehind = result.response.CommitsBehind
+		entry.response.WorktreeDirty = result.response.WorktreeDirty
 		entry.hasDivergence = true
 		entry.divergenceRefreshedAt = now
 	}
@@ -499,7 +501,7 @@ func (s *Handler) recordWorkspaceEnrichmentResult(
 
 // workspaceEnrichmentBroadcastWorthy reports whether a recorded enrichment
 // result should notify SSE clients. Completion of the first probe (the
-// pending → fresh transition clients wait on), a divergence change, and an
+// pending → fresh transition clients wait on), a git-state change, and an
 // error-state change are notification-worthy. Tmux-activity-only changes are
 // not: an active agent moves the activity timestamp on every probe, and
 // broadcasting those turned each completion into a client refetch that
@@ -515,10 +517,18 @@ func workspaceEnrichmentBroadcastWorthy(prior, next workspaceEnrichmentCacheEntr
 	}
 	return next.hasDivergence &&
 		(!intPointerEqual(prior.response.CommitsAhead, next.response.CommitsAhead) ||
-			!intPointerEqual(prior.response.CommitsBehind, next.response.CommitsBehind))
+			!intPointerEqual(prior.response.CommitsBehind, next.response.CommitsBehind) ||
+			!boolPointerEqual(prior.response.WorktreeDirty, next.response.WorktreeDirty))
 }
 
 func intPointerEqual(a, b *int) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func boolPointerEqual(a, b *bool) bool {
 	if a == nil || b == nil {
 		return a == b
 	}

--- a/internal/server/workspaceapi/workspace_enrichment_test.go
+++ b/internal/server/workspaceapi/workspace_enrichment_test.go
@@ -50,6 +50,32 @@ func runGit(t *testing.T, dir string, args ...string) {
 	require.NoError(t, err, "git %v failed: %s", args, stderr)
 }
 
+func TestApplyWorktreeDirtyDoesNotWriteTheGitIndex(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+
+	runGit(t, dir, "init", "--initial-branch=main", ".")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	trackedPath := filepath.Join(dir, "tracked.txt")
+	require.NoError(os.WriteFile(trackedPath, []byte("base\n"), 0o644))
+	runGit(t, dir, "add", "tracked.txt")
+	runGit(t, dir, "commit", "-m", "base")
+	indexPath := filepath.Join(dir, ".git", "index")
+	indexBefore, err := os.ReadFile(indexPath)
+	require.NoError(err)
+	future := time.Now().Add(2 * time.Hour)
+	require.NoError(os.Chtimes(trackedPath, future, future))
+
+	var resp workspaceResponse
+	require.NoError(applyWorktreeDirty(t.Context(), &resp, dir))
+	require.NotNil(resp.WorktreeDirty)
+	require.False(*resp.WorktreeDirty)
+	indexAfter, err := os.ReadFile(indexPath)
+	require.NoError(err)
+	require.Equal(indexBefore, indexAfter)
+}
+
 func TestFormatAgentActivityUpdatedAtPreservesSubsecondPrecision(t *testing.T) {
 	t.Parallel()
 	updatedAt := time.Date(2026, 7, 28, 12, 0, 0, 123456789, time.UTC)

--- a/internal/server/workspaceapi/workspace_enrichment_test.go
+++ b/internal/server/workspaceapi/workspace_enrichment_test.go
@@ -796,6 +796,8 @@ func TestWorkspaceEnrichmentBroadcastsOnlyDurableChanges(t *testing.T) {
 	}
 	ahead := 1
 	behind := 0
+	clean := false
+	dirty := true
 	title := "pane"
 	record := func(result workspaceEnrichmentProbeResult) bool {
 		_, recorded, changed := srv.recordWorkspaceEnrichmentResult("ws-1", 1, result)
@@ -805,7 +807,7 @@ func TestWorkspaceEnrichmentBroadcastsOnlyDurableChanges(t *testing.T) {
 
 	// First completion is the pending -> fresh transition clients wait on.
 	assert.True(record(workspaceEnrichmentProbeResult{
-		response:           workspaceResponse{CommitsAhead: &ahead, CommitsBehind: &behind, TmuxPaneTitle: &title},
+		response:           workspaceResponse{CommitsAhead: &ahead, CommitsBehind: &behind, WorktreeDirty: &clean, TmuxPaneTitle: &title},
 		divergenceComplete: true,
 		tmuxComplete:       true,
 	}))
@@ -817,6 +819,7 @@ func TestWorkspaceEnrichmentBroadcastsOnlyDurableChanges(t *testing.T) {
 		response: workspaceResponse{
 			CommitsAhead:  &ahead,
 			CommitsBehind: &behind,
+			WorktreeDirty: &clean,
 			TmuxPaneTitle: &spinnerTitle,
 			TmuxWorking:   true,
 		},
@@ -827,7 +830,14 @@ func TestWorkspaceEnrichmentBroadcastsOnlyDurableChanges(t *testing.T) {
 	// Divergence movement notifies.
 	newBehind := 3
 	assert.True(record(workspaceEnrichmentProbeResult{
-		response:           workspaceResponse{CommitsAhead: &ahead, CommitsBehind: &newBehind, TmuxPaneTitle: &spinnerTitle},
+		response:           workspaceResponse{CommitsAhead: &ahead, CommitsBehind: &newBehind, WorktreeDirty: &clean, TmuxPaneTitle: &spinnerTitle},
+		divergenceComplete: true,
+		tmuxComplete:       true,
+	}))
+
+	// Worktree cleanliness movement notifies.
+	assert.True(record(workspaceEnrichmentProbeResult{
+		response:           workspaceResponse{CommitsAhead: &ahead, CommitsBehind: &newBehind, WorktreeDirty: &dirty, TmuxPaneTitle: &spinnerTitle},
 		divergenceComplete: true,
 		tmuxComplete:       true,
 	}))
@@ -844,7 +854,7 @@ func TestWorkspaceEnrichmentBroadcastsOnlyDurableChanges(t *testing.T) {
 
 	// Recovery notifies.
 	assert.True(record(workspaceEnrichmentProbeResult{
-		response:           workspaceResponse{CommitsAhead: &ahead, CommitsBehind: &newBehind, TmuxPaneTitle: &spinnerTitle},
+		response:           workspaceResponse{CommitsAhead: &ahead, CommitsBehind: &newBehind, WorktreeDirty: &dirty, TmuxPaneTitle: &spinnerTitle},
 		divergenceComplete: true,
 		tmuxComplete:       true,
 	}))

--- a/internal/server/workspacetest/workspace_enrichment_wire_test.go
+++ b/internal/server/workspacetest/workspace_enrichment_wire_test.go
@@ -48,7 +48,8 @@ func TestWorkspaceListReportsCommitsAheadBehindE2E(t *testing.T) {
 	require.Eventually(func() bool {
 		initial := workspaceByID()
 		return initial != nil && initial.CommitsAhead != nil && initial.CommitsBehind != nil &&
-			*initial.CommitsAhead == 0 && *initial.CommitsBehind == 0
+			initial.WorktreeDirty != nil && *initial.CommitsAhead == 0 &&
+			*initial.CommitsBehind == 0 && !*initial.WorktreeDirty
 	}, 10*time.Second, 10*time.Millisecond)
 
 	runGit(t, ws.WorktreePath, "config", "user.email", "test@test.com")
@@ -58,15 +59,18 @@ func TestWorkspaceListReportsCommitsAheadBehindE2E(t *testing.T) {
 		runGit(t, ws.WorktreePath, "add", ".")
 		runGit(t, ws.WorktreePath, "commit", "-m", name)
 	}
+	require.NoError(os.WriteFile(filepath.Join(ws.WorktreePath, "uncommitted.txt"), []byte("dirty\n"), 0o644))
 	clockNow.Store(now.Add(workspaceapi.EnrichmentTTL + time.Second).UnixNano())
 
 	var found *generated.WorkspaceResponse
 	require.Eventually(func() bool {
 		found = workspaceByID()
 		return found != nil && found.CommitsAhead != nil && found.CommitsBehind != nil &&
-			*found.CommitsAhead == 2 && *found.CommitsBehind == 0
+			found.WorktreeDirty != nil && *found.CommitsAhead == 2 &&
+			*found.CommitsBehind == 0 && *found.WorktreeDirty
 	}, 10*time.Second, 10*time.Millisecond)
 	require.NotNil(found)
 	assert.Equal(int64(2), *found.CommitsAhead)
 	assert.Equal(int64(0), *found.CommitsBehind)
+	assert.True(*found.WorktreeDirty)
 }


### PR DESCRIPTION
Workspace rows now show a muted pencil when their local worktree has staged,
unstaged, or untracked changes. The list previously exposed branch divergence
but not local edits, so maintainers had to open each workspace to discover
them.

The workspace API computes `worktree_dirty` with the existing git-state
enrichment, keeps it in the enrichment cache, and notifies live clients when it
changes. Failed probes retain the last known good git state under the existing
enrichment status contract.

The sidebar renders an icon-only indicator with a `Dirty worktree` hover and
accessible label. It sits in the right rail beneath the pull request or issue
chip, while paired dirty and clean browser fixtures keep ahead, behind,
addition, and deletion stats aligned. The full affected Playwright suite passes
in Chromium and Firefox.
