### PR TITLE
fix: dismiss approval popover on outside click

### DIFF
--- a/frontend/src/lib/components/detail/ApproveButton.svelte
+++ b/frontend/src/lib/components/detail/ApproveButton.svelte
@@ -74,6 +74,7 @@
   let body = $state("");
   let submitting = $state(false);
   let submittingAction = $state<"approve" | "request_changes" | null>(null);
+  let sectionEl = $state<HTMLDivElement | undefined>();
   let commentInput = $state<HTMLTextAreaElement | undefined>();
   const canRequestChanges = $derived(supportedReviewActions.includes("request_changes"));
 
@@ -226,9 +227,18 @@
       },
     );
   }
+
+  function handleDocumentPointerDown(event: PointerEvent): void {
+    if (!expanded || submitting) return;
+    if (event.target instanceof Node && !sectionEl?.contains(event.target)) {
+      expanded = false;
+    }
+  }
 </script>
 
-<div class={["approve-section", expanded && "approve-section--open"]}>
+<svelte:document onpointerdowncapture={handleDocumentPointerDown} />
+
+<div bind:this={sectionEl} class={["approve-section", expanded && "approve-section--open"]}>
   <Button
     class="btn btn--approve"
     onclick={() => {

--- a/frontend/tests/e2e/head-pinned-actions.spec.ts
+++ b/frontend/tests/e2e/head-pinned-actions.spec.ts
@@ -183,6 +183,17 @@ test.describe("head-pinned merge and approve", () => {
     await mockApi(page);
   });
 
+  test("clicking outside the approval popover dismisses it", async ({ page }) => {
+    await gotoPull42(page);
+    await page.locator(".btn--approve").first().click();
+
+    const popover = page.locator(".approve-popover");
+    await expect(popover).toBeVisible();
+    await page.locator(".detail-title").click();
+
+    await expect(popover).toHaveCount(0);
+  });
+
   test("merge echoes the rendered head as expected_head_sha", async ({ page }) => {
     let mergeBody: Record<string, unknown> | null = null;
     await page.route(MERGE_PATH, async (route: Route) => {


### PR DESCRIPTION
Clicking outside the approval form now dismisses it, so the form no longer covers the pull request after a reviewer returns to the detail. The form stays locked while an approval is submitting, and a Playwright regression opens it, clicks the pull request title, and checks that the popover leaves the DOM.
