### PR TITLE
perf: keep mobile triage compact and bounded

### DIFF
--- a/context/mobile-ux.md
+++ b/context/mobile-ux.md
@@ -90,6 +90,13 @@ Avoid by default:
 - Mobile Activity starts with 30 collapsed parents and autoloads one 30-parent chunk per
   end-of-list scroll gesture. Event previews stay bounded and viewport-driven
   (`frontend/src/lib/views/MobileActivityView.svelte::autoloadMoreActivity`).
+- Phone PR and issue lists start with 30 items and autoload one 30-item chunk per
+  end-of-list scroll gesture
+  (`frontend/src/lib/views/FocusListView.svelte::autoloadMore`).
+- Phone startup and repository changes defer list loading to the current phone view
+  (`frontend/src/App.svelte::shouldDeferInitialListsToActiveView`).
+- Config and provider events refresh only the current list
+  (`frontend/src/lib/app-stores.svelte.ts::refreshVisibleData`).
 - Phone Activity, PR, and issue filters use the shared repository selector for Global,
   saved presets, and custom selections; preset management remains outside the phone
   workflow (`frontend/src/lib/components/RepoTypeahead.svelte`).

--- a/context/mobile-ux.md
+++ b/context/mobile-ux.md
@@ -87,9 +87,9 @@ Avoid by default:
 - Tiny icon-only actions without accessible names and visible context.
 - Routing mobile taps into desktop drawer/query state with no visible phone result.
 
-Mobile Activity requires a full event projection because its cards expose event actions
-without desktop thread expansion; a collapsed desktop projection is not a valid mobile
-data source (`frontend/src/lib/views/MobileActivityView.svelte`).
+Mobile Activity starts with 30 collapsed parents, expands in 30-parent chunks on demand,
+and loads one bounded event preview only near the phone viewport. Keep this separate from
+desktop thread expansion (`frontend/src/lib/views/MobileActivityView.svelte`).
 
 ## Routing expectations
 

--- a/context/mobile-ux.md
+++ b/context/mobile-ux.md
@@ -93,6 +93,9 @@ Avoid by default:
 - Phone Activity, PR, and issue filters use the shared repository selector for Global,
   saved presets, and custom selections; preset management remains outside the phone
   workflow (`frontend/src/lib/components/RepoTypeahead.svelte`).
+- Phone triage shares one full-width search strip and grouped filter surface. Repository
+  selection comes first; hierarchical selectors use divider rows and booleans use
+  unframed kit switches (`frontend/src/lib/views/MobileActivityView.svelte`, `frontend/src/lib/views/FocusListView.svelte`).
 
 ## Routing expectations
 

--- a/context/mobile-ux.md
+++ b/context/mobile-ux.md
@@ -100,9 +100,9 @@ Avoid by default:
 - Phone Activity, PR, and issue filters use the shared repository selector for Global,
   saved presets, and custom selections; preset management remains outside the phone
   workflow (`frontend/src/lib/components/RepoTypeahead.svelte`).
-- Phone triage shares one full-width search strip and grouped filter surface. Repository
-  selection comes first; hierarchical selectors use divider rows and booleans use
-  unframed kit switches (`frontend/src/lib/views/MobileActivityView.svelte`, `frontend/src/lib/views/FocusListView.svelte`).
+- Phone Activity, PR, and issue lists share one full-width search/filter trigger; each
+  view owns its filter content. Repository selection comes first, hierarchical selectors
+  use divider rows, and booleans use unframed kit switches (`frontend/src/lib/components/mobile/MobileTriageSearchBar.svelte`).
 
 ## Routing expectations
 

--- a/context/mobile-ux.md
+++ b/context/mobile-ux.md
@@ -87,9 +87,12 @@ Avoid by default:
 - Tiny icon-only actions without accessible names and visible context.
 - Routing mobile taps into desktop drawer/query state with no visible phone result.
 
-Mobile Activity starts with 30 collapsed parents, expands in 30-parent chunks on demand,
-and loads one bounded event preview only near the phone viewport. Keep this separate from
-desktop thread expansion (`frontend/src/lib/views/MobileActivityView.svelte`).
+- Mobile Activity starts with 30 collapsed parents and autoloads one 30-parent chunk per
+  end-of-list scroll gesture. Event previews stay bounded and viewport-driven
+  (`frontend/src/lib/views/MobileActivityView.svelte::autoloadMoreActivity`).
+- Phone Activity, PR, and issue filters use the shared repository selector for Global,
+  saved presets, and custom selections; preset management remains outside the phone
+  workflow (`frontend/src/lib/components/RepoTypeahead.svelte`).
 
 ## Routing expectations
 

--- a/context/mobile-ux.md
+++ b/context/mobile-ux.md
@@ -88,11 +88,11 @@ Avoid by default:
 - Routing mobile taps into desktop drawer/query state with no visible phone result.
 
 - Mobile Activity starts with 30 collapsed parents and autoloads one 30-parent chunk per
-  end-of-list scroll gesture. Event previews stay bounded and viewport-driven
-  (`frontend/src/lib/views/MobileActivityView.svelte::autoloadMoreActivity`).
+  end-of-list scroll gesture. The response limit counts distinct parents after event
+  matching, while event scans remain separately bounded (`internal/server/huma_routes.go::Server.listActivityRouteCore`).
 - Phone PR and issue lists start with 30 items and autoload one 30-item chunk per
-  end-of-list scroll gesture
-  (`frontend/src/lib/views/FocusListView.svelte::autoloadMore`).
+  end-of-list scroll gesture. Mutation reloads retain the active chunk size
+  (`frontend/src/lib/stores/pulls.svelte.ts::createPullsStore`, `frontend/src/lib/stores/issues.svelte.ts::createIssuesStore`).
 - Phone startup and repository changes defer list loading to the current phone view
   (`frontend/src/App.svelte::shouldDeferInitialListsToActiveView`).
 - Config and provider events refresh only the current list

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -500,6 +500,7 @@
     const cancelStartup = runAppStartup(runtime, {
       stores: startupStores,
       beforeInitialLoad: () => syncGlobalRepoWithRoute(startupStores),
+      loadInitialLists: !shouldDeferInitialListsToActiveView(),
       onReady: () => {
         appReady = true;
       },
@@ -613,6 +614,12 @@
     if (shouldUseDesktopOnPhone()) return false;
     if (getPage() !== "activity") return false;
     return isCompactViewport() || shouldForceMobileRoutes();
+  }
+
+  function shouldDeferInitialListsToActiveView(): boolean {
+    return isMobilePage(getPage())
+      || shouldUseResponsiveMobileActivityPresentation()
+      || (shouldUseFocusPresentation() && useFocusLayoutClass());
   }
 
   function flashTopOffset(): string {
@@ -752,6 +759,7 @@
     }
     if (repo === lastRepo) return;
     lastRepo = repo;
+    if (shouldDeferInitialListsToActiveView()) return;
     stores.pulls.loadPulls();
     stores.issues.loadIssues();
     stores.activity.loadActivity();
@@ -1091,11 +1099,13 @@
         <FocusListView
           listType="mrs"
           {...r.repo ? { repo: r.repo } : {}}
+          chunked={useFocusLayoutClass()}
         />
       {:else if r.page === "focus" && r.itemType === "issues"}
         <FocusListView
           listType="issues"
           {...r.repo ? { repo: r.repo } : {}}
+          chunked={useFocusLayoutClass()}
         />
       {:else if r.page === "focus" && r.itemType === "pr"}
         {@const selectedPR = {
@@ -1139,6 +1149,7 @@
         <FocusListView
           listType="mrs"
           routeFamily="canonical"
+          chunked={useFocusLayoutClass()}
         />
       {:else if r.page === "issues" && r.selected}
         <IssueListView
@@ -1150,6 +1161,7 @@
         <FocusListView
           listType="issues"
           routeFamily="canonical"
+          chunked={useFocusLayoutClass()}
         />
       {/if}
     </main>
@@ -1233,9 +1245,9 @@
             </div>
           {/if}
         {:else if getPage() === "mobile-pulls"}
-          <FocusListView listType="mrs" showRepoSelector />
+          <FocusListView listType="mrs" showRepoSelector chunked />
         {:else if getPage() === "mobile-issues"}
-          <FocusListView listType="issues" showRepoSelector />
+          <FocusListView listType="issues" showRepoSelector chunked />
         {:else}
           <MobileActivityView
             selectedRepo={getNormalizedGlobalRepo()}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1233,9 +1233,9 @@
             </div>
           {/if}
         {:else if getPage() === "mobile-pulls"}
-          <FocusListView listType="mrs" />
+          <FocusListView listType="mrs" showRepoSelector />
         {:else if getPage() === "mobile-issues"}
-          <FocusListView listType="issues" />
+          <FocusListView listType="issues" showRepoSelector />
         {:else}
           <MobileActivityView
             selectedRepo={getNormalizedGlobalRepo()}

--- a/frontend/src/app-stores.test.ts
+++ b/frontend/src/app-stores.test.ts
@@ -300,7 +300,7 @@ describe("app store event wiring", () => {
     expect(acknowledged).toBe(true);
   });
 
-  it("replaces stale launch targets after a valid config reload", async () => {
+  it("replaces stale launch targets and refreshes only the visible phone list after a valid config reload", async () => {
     const codexTarget = {
       key: "codex",
       label: "Codex",
@@ -352,7 +352,7 @@ describe("app store event wiring", () => {
     >;
     getSettings.mockResolvedValue({ data: settings });
 
-    compose();
+    compose({ getPage: () => "mobile-activity" });
     captured.settings?.setLaunchTargets([staleTarget]);
 
     await acceptEvent(captured.store?.options.onConfigChanged?.({ valid: true, restart_required: false }));
@@ -360,6 +360,9 @@ describe("app store event wiring", () => {
     await vi.waitFor(() => {
       expect(captured.settings?.getLaunchTargets()).toEqual([codexTarget]);
     });
+    expect(reconcilePullsEffect).not.toHaveBeenCalled();
+    expect(reconcileIssuesEffect).not.toHaveBeenCalled();
+    expect(reconcileActivityEffect).toHaveBeenCalledTimes(1);
   });
 
   it.each([

--- a/frontend/src/lib/app-stores.svelte.ts
+++ b/frontend/src/lib/app-stores.svelte.ts
@@ -186,14 +186,7 @@ export function createAppStores(options: AppStoreOptions): AppStoreComposition {
           workspaceHydration,
         );
       });
-      yield* Effect.all(
-        [
-          pullsStore.reconcilePullsEffect(),
-          issuesStore.reconcileIssuesEffect(),
-          activityStore.reconcileActivityEffect(),
-        ],
-        { concurrency: "unbounded", discard: true },
-      );
+      yield* refreshVisibleData();
     });
   }
 

--- a/frontend/src/lib/components/RepoTypeahead.svelte
+++ b/frontend/src/lib/components/RepoTypeahead.svelte
@@ -57,9 +57,17 @@
     selected: string | undefined;
     onchange: (repo: string | undefined) => void;
     initialOpen?: boolean;
+    allowPresetManagement?: boolean;
+    mobile?: boolean;
   }
 
-  let { selected, onchange, initialOpen = false }: Props = $props();
+  let {
+    selected,
+    onchange,
+    initialOpen = false,
+    allowPresetManagement = true,
+    mobile = false,
+  }: Props = $props();
 
   const stores = getStores();
   const runtime = getAppRuntime();
@@ -518,7 +526,7 @@
   }
 </script>
 
-<div class="typeahead" bind:this={containerEl}>
+<div class="typeahead" class:typeahead--mobile={mobile} bind:this={containerEl}>
   {#if open}
     <input
       bind:this={inputEl}
@@ -574,18 +582,20 @@
               />
               <span class="preset-name">{preset.name}</span>
             </div>
-            <button
-              type="button"
-              class="preset-delete"
-              aria-label={`Delete preset ${preset.name}`}
-              disabled={mutationBusy}
-              onclick={() => {
-                mutationError = undefined;
-                deletePreset = preset;
-              }}
-            >
-              <TrashIcon size="13" strokeWidth="2" aria-hidden="true" />
-            </button>
+            {#if allowPresetManagement}
+              <button
+                type="button"
+                class="preset-delete"
+                aria-label={`Delete preset ${preset.name}`}
+                disabled={mutationBusy}
+                onclick={() => {
+                  mutationError = undefined;
+                  deletePreset = preset;
+                }}
+              >
+                <TrashIcon size="13" strokeWidth="2" aria-hidden="true" />
+              </button>
+            {/if}
           </li>
         {/each}
       </ul>
@@ -615,19 +625,21 @@
         {/each}
       </ul>
 
-      <div class="typeahead-footer">
-        {#if mutationError && !saveDialogOpen && !deletePreset}
-          <p class="typeahead-error" role="alert">{mutationError}</p>
-        {/if}
-        <Button
-          class="save-preset-button"
-          size="sm"
-          disabled={selectedValues.length === 0 || selectedPresetRepos === undefined || mutationBusy}
-          onclick={openSaveDialog}
-        >
-          Save preset
-        </Button>
-      </div>
+      {#if allowPresetManagement}
+        <div class="typeahead-footer">
+          {#if mutationError && !saveDialogOpen && !deletePreset}
+            <p class="typeahead-error" role="alert">{mutationError}</p>
+          {/if}
+          <Button
+            class="save-preset-button"
+            size="sm"
+            disabled={selectedValues.length === 0 || selectedPresetRepos === undefined || mutationBusy}
+            onclick={openSaveDialog}
+          >
+            Save preset
+          </Button>
+        </div>
+      {/if}
     </div>
   {:else}
     <Button
@@ -647,7 +659,7 @@
   {/if}
 </div>
 
-{#if saveDialogOpen}
+{#if allowPresetManagement && saveDialogOpen}
   <RepoPresetSaveDialog
     open
     presets={repoPresets}
@@ -663,22 +675,24 @@
   />
 {/if}
 
-<ConfirmDialog
-  open={deletePreset !== undefined}
-  title="Delete repository preset?"
-  message={`Delete the preset ‘${deletePreset?.name ?? ""}’?`}
-  hint="The repositories remain selected as a custom filter."
-  confirmLabel="Delete preset"
-  pendingLabel="Deleting…"
-  busy={mutationBusy}
-  tone="danger"
-  onCancel={() => {
-    if (mutationBusy) return;
-    deletePreset = undefined;
-    mutationError = undefined;
-  }}
-  onConfirm={confirmDeletePreset}
-/>
+{#if allowPresetManagement}
+  <ConfirmDialog
+    open={deletePreset !== undefined}
+    title="Delete repository preset?"
+    message={`Delete the preset ‘${deletePreset?.name ?? ""}’?`}
+    hint="The repositories remain selected as a custom filter."
+    confirmLabel="Delete preset"
+    pendingLabel="Deleting…"
+    busy={mutationBusy}
+    tone="danger"
+    onCancel={() => {
+      if (mutationBusy) return;
+      deletePreset = undefined;
+      mutationError = undefined;
+    }}
+    onConfirm={confirmDeletePreset}
+  />
+{/if}
 
 <style>
   .typeahead {
@@ -865,5 +879,39 @@
     font-size: var(--font-size-xs);
     line-height: 1.35;
     white-space: normal;
+  }
+
+  .typeahead--mobile {
+    width: 100%;
+    min-width: 0;
+    max-width: none;
+  }
+
+  .typeahead--mobile :global(.typeahead-trigger.kit-button),
+  .typeahead--mobile .typeahead-input {
+    min-height: 44px;
+    border-radius: var(--radius-md);
+    font-size: var(--font-size-md);
+  }
+
+  .typeahead--mobile .typeahead-popover {
+    width: min(360px, calc(100vw - 26px));
+    max-width: calc(100vw - 26px);
+    max-height: min(60vh, 520px);
+  }
+
+  .typeahead--mobile .typeahead-popover :global(.typeahead-option) {
+    min-height: 44px;
+    box-sizing: border-box;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    font-size: var(--font-size-md);
+  }
+
+  .typeahead--mobile .typeahead-empty {
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    font-size: var(--font-size-md);
   }
 </style>

--- a/frontend/src/lib/components/RepoTypeahead.svelte
+++ b/frontend/src/lib/components/RepoTypeahead.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { Button } from "@kenn-io/kit-ui";
+  import ChevronRightIcon from "@lucide/svelte/icons/chevron-right";
+  import FolderGit2Icon from "@lucide/svelte/icons/folder-git-2";
   import TrashIcon from "@lucide/svelte/icons/trash-2";
   import { Effect } from "effect";
   import { onDestroy, onMount, tick, untrack } from "svelte";
@@ -279,6 +281,11 @@
     if (selectedValues.length === 1) return displayRepoFilterValue(selectedValues[0]!);
     return `${selectedValues.length} repos`;
   });
+  const selectionSummary = $derived(
+    selectedValues.length === 0
+      ? "All repositories"
+      : `${selectedValues.length} ${selectedValues.length === 1 ? "repository" : "repositories"}`,
+  );
 
   const expansion = createRepoTreeExpansionStore();
 
@@ -353,6 +360,11 @@
     openExecution = null;
     open = false;
     query = "";
+  }
+
+  function toggleDropdown(): void {
+    if (open) closeDropdown();
+    else openDropdown();
   }
 
   function clearSelection() {
@@ -527,21 +539,64 @@
 </script>
 
 <div class="typeahead" class:typeahead--mobile={mobile} bind:this={containerEl}>
+  {#if !open || mobile}
+    <Button
+      class="typeahead-trigger"
+      size="sm"
+      ariaLabel={`Select repository: ${displayValue}`}
+      ariaExpanded={open}
+      onclick={mobile ? toggleDropdown : openDropdown}
+    >
+      {#if mobile}
+        <span class="typeahead-mobile-icon">
+          <FolderGit2Icon size="16" strokeWidth="2" aria-hidden="true" />
+        </span>
+        <span class="typeahead-mobile-copy">
+          <span class="typeahead-value">{displayValue}</span>
+          <span class="typeahead-selection-summary">{selectionSummary}</span>
+        </span>
+        <ChevronRightIcon
+          class="typeahead-chevron"
+          size="16"
+          strokeWidth="2"
+          aria-hidden="true"
+        />
+      {:else}
+        <span class="typeahead-value">{displayValue}</span>
+        <ChevronDownIcon
+          class="typeahead-chevron"
+          size="10"
+          strokeWidth="2"
+          aria-hidden="true"
+        />
+      {/if}
+    </Button>
+  {/if}
   {#if open}
-    <input
-      bind:this={inputEl}
-      class="typeahead-input"
-      type="text"
-      bind:value={query}
-      oninput={handleInput}
-      onkeydown={handleKeydown}
-      onblur={handleBlur}
-      placeholder="Filter repos..."
-      aria-label="Filter repos"
-      autocomplete="off"
-    />
-    <!-- kit-ui-check-ignore: checkable provider tree owns tri-state multi-selection, named presets, persistent expansion, and provider-host-qualified identity; kit Typeahead is single-select -->
-    <div class="typeahead-popover kit-popover-card" role="presentation" onmousedown={preventBlur}>
+    <div
+      class="typeahead-menu-shell"
+      class:typeahead-menu-shell--mobile={mobile}
+      class:kit-popover-card={mobile}
+    >
+      <input
+        bind:this={inputEl}
+        class="typeahead-input"
+        type="text"
+        bind:value={query}
+        oninput={handleInput}
+        onkeydown={handleKeydown}
+        onblur={handleBlur}
+        placeholder="Filter repos..."
+        aria-label="Filter repos"
+        autocomplete="off"
+      />
+      <!-- kit-ui-check-ignore: checkable provider tree owns tri-state multi-selection, named presets, persistent expansion, and provider-host-qualified identity; kit Typeahead is single-select -->
+      <div
+        class="typeahead-popover"
+        class:kit-popover-card={!mobile}
+        role="presentation"
+        onmousedown={preventBlur}
+      >
       <!-- kit-ui-check-ignore: preset rows share keyboard highlighting and selection with the tri-state repository tree below -->
       <ul class="typeahead-presets" role="listbox" aria-label="Repository presets">
         <li
@@ -640,22 +695,8 @@
           </Button>
         </div>
       {/if}
+      </div>
     </div>
-  {:else}
-    <Button
-      class="typeahead-trigger"
-      size="sm"
-      ariaLabel={`Select repository: ${displayValue}`}
-      onclick={openDropdown}
-    >
-      <span class="typeahead-value">{displayValue}</span>
-      <ChevronDownIcon
-        class="typeahead-chevron"
-        size="10"
-        strokeWidth="2"
-        aria-hidden="true"
-      />
-    </Button>
   {/if}
 </div>
 
@@ -699,6 +740,10 @@
     position: relative;
     min-width: 160px;
     max-width: 260px;
+  }
+
+  .typeahead-menu-shell {
+    display: contents;
   }
 
   :global(.typeahead-trigger.kit-button) {
@@ -894,10 +939,94 @@
     font-size: var(--font-size-md);
   }
 
-  .typeahead--mobile .typeahead-popover {
+  .typeahead--mobile :global(.typeahead-trigger.kit-button) {
+    height: auto;
+    min-height: 48px;
+    gap: var(--space-4);
+    padding: var(--space-1) var(--space-2);
+    border: 0;
+    border-top: thin solid var(--border-muted);
+    border-bottom: thin solid var(--border-muted);
+    border-radius: 0;
+    background: transparent;
+  }
+
+  .typeahead--mobile :global(.typeahead-trigger.kit-button[aria-expanded="true"]) {
+    color: var(--accent-blue);
+    background: color-mix(in srgb, var(--accent-blue) 10%, transparent);
+  }
+
+  .typeahead-mobile-icon {
+    width: 28px;
+    height: 28px;
+    flex: 0 0 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-sm);
+    color: var(--accent-blue);
+    background: color-mix(in srgb, var(--accent-blue) 13%, transparent);
+  }
+
+  .typeahead-mobile-copy {
+    min-width: 0;
+    flex: 1;
+    display: grid;
+    gap: var(--space-1);
+    text-align: left;
+  }
+
+  .typeahead-mobile-copy .typeahead-value {
+    flex: none;
+    color: var(--text-primary);
+    font-size: var(--font-size-md);
+    font-weight: 700;
+    line-height: 1.15;
+  }
+
+  .typeahead-selection-summary {
+    overflow: hidden;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    line-height: 1.15;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .typeahead--mobile .typeahead-menu-shell--mobile {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 90;
     width: min(360px, calc(100vw - 26px));
     max-width: calc(100vw - 26px);
     max-height: min(60vh, 520px);
+    margin-top: var(--space-1);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    overflow: hidden;
+    padding: var(--space-2);
+  }
+
+  .typeahead--mobile .typeahead-menu-shell--mobile .typeahead-input {
+    width: 100%;
+    flex: 0 0 auto;
+  }
+
+  .typeahead--mobile .typeahead-popover {
+    position: static;
+    width: 100%;
+    min-width: 0;
+    max-width: none;
+    max-height: none;
+    margin: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+    z-index: auto;
   }
 
   .typeahead--mobile .typeahead-popover :global(.typeahead-option) {

--- a/frontend/src/lib/components/RepoTypeahead.test.ts
+++ b/frontend/src/lib/components/RepoTypeahead.test.ts
@@ -69,6 +69,21 @@ describe("RepoTypeahead", () => {
     cleanup();
   });
 
+  it("renders the mobile picker as one menu row with selection context", () => {
+    render(RepoTypeahead, {
+      props: {
+        selected: undefined,
+        onchange: vi.fn(),
+        mobile: true,
+      },
+    });
+
+    const trigger = screen.getByRole("button", { name: "Select repository: Global" });
+    expect(trigger.textContent).toContain("Global");
+    expect(trigger.textContent).toContain("All repositories");
+    expect(trigger.querySelector(".typeahead-mobile-icon")).toBeTruthy();
+  });
+
   it("updates dropdown options when configured repos change", async () => {
     render(RepoTypeahead, {
       props: {

--- a/frontend/src/lib/components/RepoTypeahead.test.ts
+++ b/frontend/src/lib/components/RepoTypeahead.test.ts
@@ -907,6 +907,34 @@ describe("RepoTypeahead", () => {
     expect(localStorage.getItem("kenn-forge-filter-repo-preset")).toBe("Backend");
   });
 
+  it("can apply saved presets without exposing preset management", async () => {
+    const onchange = vi.fn();
+    settingsStore.setConfiguredRepos([
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "api",
+        repo_path: "acme/api",
+        platform_repo_id: "R_api",
+        is_glob: false,
+        matched_repo_count: 1,
+        hidden_from_ui: false,
+      },
+    ]);
+    settingsStore.setRepoPresets([{ name: "Backend", repos: [presetRepo("acme/api", "R_api")] }]);
+    render(RepoTypeahead, {
+      props: { selected: undefined, onchange, allowPresetManagement: false },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Select repository: Global" }));
+    await fireEvent.mouseDown(screen.getByRole("option", { name: "Backend" }));
+
+    expect(onchange).toHaveBeenLastCalledWith("github|github.com/acme/api");
+    expect(screen.queryByRole("button", { name: "Save preset" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Delete preset Backend" })).toBeNull();
+  });
+
   it("resolves a renamed configured repository without selecting a replacement at its old route", async () => {
     const onchange = vi.fn();
     settingsStore.setConfiguredRepos([

--- a/frontend/src/lib/components/mobile/MobileTriageSearchBar.svelte
+++ b/frontend/src/lib/components/mobile/MobileTriageSearchBar.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  import { IconButton, SearchInput } from "@kenn-io/kit-ui";
+  import FunnelIcon from "@lucide/svelte/icons/funnel";
+
+  interface Props {
+    value?: string;
+    placeholder: string;
+    searchAriaLabel: string;
+    filterAriaLabel?: string;
+    filterControls: string;
+    filtersExpanded: boolean;
+    filtersActive?: boolean;
+    oninput: (value: string) => void;
+    ontoggle: () => void;
+  }
+
+  let {
+    value = $bindable(""),
+    placeholder,
+    searchAriaLabel,
+    filterAriaLabel = "Filters",
+    filterControls,
+    filtersExpanded,
+    filtersActive = filtersExpanded,
+    oninput,
+    ontoggle,
+  }: Props = $props();
+</script>
+
+<div class="mobile-triage-search-bar">
+  <div class="mobile-triage-search-bar__search">
+    <SearchInput
+      bind:value
+      size="sm"
+      block
+      {placeholder}
+      ariaLabel={searchAriaLabel}
+      {oninput}
+    />
+  </div>
+
+  <div class="mobile-triage-search-bar__filter">
+    <IconButton
+      size="md"
+      tone="info"
+      ariaLabel={filterAriaLabel}
+      title="Filters"
+      ariaExpanded={filtersExpanded}
+      ariaControls={filterControls}
+      ariaPressed={filtersActive}
+      onclick={ontoggle}
+    >
+      <FunnelIcon size={18} strokeWidth={2} aria-hidden="true" />
+    </IconButton>
+  </div>
+</div>
+
+<style>
+  .mobile-triage-search-bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--border-default);
+    flex-shrink: 0;
+    background: var(--bg-surface);
+  }
+
+  .mobile-triage-search-bar__search {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .mobile-triage-search-bar__filter {
+    display: none;
+  }
+
+  :global(.mobile-main) .mobile-triage-search-bar {
+    --mobile-triage-space-sm: 10px;
+    order: 1;
+    gap: var(--mobile-triage-space-sm);
+    padding: var(--mobile-triage-space-sm) 13px;
+    border-bottom: thin solid var(--border-default);
+  }
+
+  :global(.mobile-main) .mobile-triage-search-bar__filter {
+    display: flex;
+    align-items: stretch;
+    flex: 0 0 auto;
+  }
+
+  :global(.mobile-main) .mobile-triage-search-bar__filter :global(.kit-icon-button) {
+    width: 44px;
+    height: 100%;
+    min-height: 44px;
+    border: thin solid var(--border-default);
+    border-radius: 8.5px;
+    background: var(--bg-inset);
+  }
+
+  :global(.mobile-main) .mobile-triage-search-bar__search :global(.kit-search-input) {
+    min-height: 44px;
+    border-radius: 8.5px;
+    font-size: var(--font-size-md);
+  }
+</style>

--- a/frontend/src/lib/stores/activity.svelte.test.ts
+++ b/frontend/src/lib/stores/activity.svelte.test.ts
@@ -218,6 +218,73 @@ describe("activity store collapse state", () => {
     expect(store.getActivityEventCursor()).toBe("hidden:9");
   });
 
+  it("requests a bounded collapsed projection for mobile", async () => {
+    const get = vi.fn(async () => ({
+      data: { items: [], item_activity: [], workspace_activity: [], capped: false, event_cursor: "hidden:9" },
+      error: null,
+    }));
+    const store = createActivityStore({ client: { GET: get } as unknown as GeneratedClient });
+    store.hydrateDefaults(settings(true));
+
+    store.setActivityPageLimit(30);
+    store.loadActivity();
+    await vi.waitFor(() => expect(store.isActivityLoading()).toBe(false));
+
+    expect(get).toHaveBeenCalledWith(
+      "/activity",
+      expect.objectContaining({
+        params: { query: expect.objectContaining({ projection: "collapsed", limit: 30 }) },
+      }),
+    );
+  });
+
+  it("loads one bounded event-preview page for a visible mobile card", async () => {
+    const subject = {
+      ...itemActivity(7),
+      repo: {
+        provider: "github",
+        platform_host: "github.com",
+        platform_repo_id: "repo-7",
+        repo_path: "acme/widgets",
+        owner: "acme",
+        name: "widgets",
+        host: "github.com",
+      },
+    } satisfies ActivitySubject;
+    const threadQueries: Array<Record<string, unknown>> = [];
+    const get = vi.fn(async (path: string, options: { params?: { query?: Record<string, unknown> } }) => {
+      if (path === "/activity/thread-events") {
+        threadQueries.push(options.params?.query ?? {});
+        return {
+          data: {
+            items: [],
+            item_activity: [],
+            workspace_activity: [],
+            capped: true,
+            next_cursor: "another-page",
+          },
+          error: null,
+        };
+      }
+      return {
+        data: { items: [], item_activity: [subject], workspace_activity: [], capped: false, event_cursor: "hidden:9" },
+        error: null,
+      };
+    });
+    const store = createActivityStore({ client: { GET: get } as unknown as GeneratedClient });
+    store.hydrateDefaults(settings(false));
+    store.setActivityPageLimit(30);
+    store.loadActivity();
+    await vi.waitFor(() => expect(store.getItemActivity()).toEqual([subject]));
+    expect(threadQueries).toHaveLength(0);
+
+    store.loadThreadPreview("github|github.com|id|repo-7:pr:7");
+    await vi.waitFor(() => expect(threadQueries).toHaveLength(1));
+
+    expect(threadQueries[0]).toEqual(expect.objectContaining({ limit: 10, at_or_before: "hidden:9" }));
+    expect(threadQueries[0]).not.toHaveProperty("before");
+  });
+
   it("pages a capped feed when persisted settings initialize threaded mode expanded", async () => {
     await expectInitialExpandedFeedToPage((store) => {
       store.hydrateDefaults(settings(false));

--- a/frontend/src/lib/stores/activity.svelte.ts
+++ b/frontend/src/lib/stores/activity.svelte.ts
@@ -217,6 +217,7 @@ export function createActivityStore(opts: ActivityStoreOptions) {
   let rollUpCommits = $state(false);
   let collapseThreadsDefault = false;
   let fullEventProjectionRequired = false;
+  let activityPageLimit: number | undefined;
   let expandOverrides = $state<Set<string>>(new Set());
   let pagedActivityGeneration = 0;
   let childProjectionInvalidationGeneration = 0;
@@ -363,6 +364,10 @@ export function createActivityStore(opts: ActivityStoreOptions) {
     fullEventProjectionRequired = required;
     invalidatePagedActivityRequests();
   }
+  function setActivityPageLimit(limit: number | undefined): void {
+    activityPageLimit = limit;
+    invalidatePagedActivityRequests();
+  }
   function setRollUpCommits(value: boolean): void {
     rollUpCommits = value;
   }
@@ -452,7 +457,11 @@ export function createActivityStore(opts: ActivityStoreOptions) {
 
   function buildParams(): ActivityParams {
     const p: ActivityParams = { since: computeSince() };
-    p.projection = viewMode === "threaded" && collapseThreads && !fullEventProjectionRequired ? "collapsed" : "full";
+    p.projection =
+      activityPageLimit !== undefined || (viewMode === "threaded" && collapseThreads && !fullEventProjectionRequired)
+        ? "collapsed"
+        : "full";
+    if (activityPageLimit !== undefined) p.limit = activityPageLimit;
     const repo = getGlobalRepo();
     if (repo) p.repo = repo;
     if (filterTypes.length > 0) p.types = filterTypes;
@@ -470,7 +479,7 @@ export function createActivityStore(opts: ActivityStoreOptions) {
   }
 
   function shouldUseCollapsedAuthoritativeProjection(): boolean {
-    return viewMode === "threaded" && !fullEventProjectionRequired;
+    return activityPageLimit !== undefined || (viewMode === "threaded" && !fullEventProjectionRequired);
   }
 
   function activityProjectionScope(params: ActivityParams): string {
@@ -486,6 +495,7 @@ export function createActivityStore(opts: ActivityStoreOptions) {
       params.hide_closed_merged ?? false,
       params.hide_bots ?? false,
       params.hide_default_branch ?? false,
+      params.limit ?? 0,
     ]);
   }
 
@@ -669,7 +679,7 @@ export function createActivityStore(opts: ActivityStoreOptions) {
     projectedChildInvalidationGeneration = childProjectionInvalidationGeneration;
     loading = false;
     storeError = null;
-    if (projection === "collapsed") {
+    if (projection === "collapsed" && activityPageLimit === undefined) {
       for (const subject of itemActivity) {
         const key = stableParentKey(subject);
         if (key && isThreadItemExpanded(key)) loadThreadEvents(key);
@@ -687,6 +697,7 @@ export function createActivityStore(opts: ActivityStoreOptions) {
 
   function projectAuthoritativeActivitySnapshot(result: OwnedActivityResponse): void {
     const reconcileCollapsedThreads = shouldUseCollapsedAuthoritativeProjection();
+    const autoLoadExpandedThreadEvents = activityPageLimit === undefined;
     const childProjectionStale =
       reconcileCollapsedThreads && projectedChildInvalidationGeneration !== childProjectionInvalidationGeneration;
     const received = projectOwnedNotificationStates(result);
@@ -729,7 +740,7 @@ export function createActivityStore(opts: ActivityStoreOptions) {
       ) {
         changedThreadKeys.add(key);
       }
-      if (reconcileCollapsedThreads && key && !previous && isThreadItemExpanded(key)) {
+      if (reconcileCollapsedThreads && autoLoadExpandedThreadEvents && key && !previous && isThreadItemExpanded(key)) {
         newExpandedThreadKeys.add(key);
       }
     }
@@ -763,17 +774,18 @@ export function createActivityStore(opts: ActivityStoreOptions) {
       threadLoadError = null;
       threadRequestTokens.clear();
       bulkRequestToken = undefined;
-      if (!collapseThreads) {
+      if (autoLoadExpandedThreadEvents && !collapseThreads) {
         restartBulkActivity = true;
-      } else {
+      } else if (autoLoadExpandedThreadEvents) {
         for (const key of receivedSubjectKeys) {
           if (isThreadItemExpanded(key)) loadThreadEvents(key);
         }
       }
     } else if (reconcileCollapsedThreads && (changedThreadKeys.size > 0 || newExpandedThreadKeys.size > 0)) {
       restartBulkActivity =
-        (changedThreadKeys.size > 0 && bulkRequestToken !== undefined) ||
-        (!collapseThreads && newExpandedThreadKeys.size > 0);
+        autoLoadExpandedThreadEvents &&
+        ((changedThreadKeys.size > 0 && bulkRequestToken !== undefined) ||
+          (!collapseThreads && newExpandedThreadKeys.size > 0));
       if (!restartBulkActivity) {
         const reloadThreadKeys = new Set([...changedThreadKeys, ...newExpandedThreadKeys]);
         loadedThreadKeys = new Set([...loadedThreadKeys].filter((key) => !reloadThreadKeys.has(key)));
@@ -781,8 +793,10 @@ export function createActivityStore(opts: ActivityStoreOptions) {
         failedThreadKeys = new Set([...failedThreadKeys].filter((key) => !reloadThreadKeys.has(key)));
         if (failedThreadKeys.size === 0) threadLoadError = null;
         for (const key of reloadThreadKeys) threadRequestTokens.delete(key);
-        for (const key of reloadThreadKeys) {
-          if (isThreadItemExpanded(key)) loadThreadEvents(key);
+        if (autoLoadExpandedThreadEvents) {
+          for (const key of reloadThreadKeys) {
+            if (isThreadItemExpanded(key)) loadThreadEvents(key);
+          }
         }
       }
     }
@@ -850,7 +864,7 @@ export function createActivityStore(opts: ActivityStoreOptions) {
     });
   }
 
-  function loadThreadEvents(key: string): void {
+  function loadThreadEvents(key: string, loadAllPages = true): void {
     if (loadedThreadKeys.has(key) || loadingThreadKeys.has(key)) return;
     const subject = itemActivity.find((candidate) => stableParentKey(candidate) === key);
     const platformRepoID = subject?.repo.platform_repo_id?.trim();
@@ -874,7 +888,7 @@ export function createActivityStore(opts: ActivityStoreOptions) {
       item_number: subject.item_number,
       since: computeSince(),
       ...(snapshotCursor ? { at_or_before: snapshotCursor } : {}),
-      limit: 100,
+      limit: loadAllPages ? 100 : 10,
       ...(filterTypes.length > 0 ? { types: [...filterTypes] } : {}),
       ...(searchQuery ? { search: searchQuery } : {}),
       ...(hideClosedMerged ? { hide_closed_merged: true } : {}),
@@ -899,6 +913,7 @@ export function createActivityStore(opts: ActivityStoreOptions) {
         ).pipe(retryIdempotentRead);
         if (!(yield* Effect.sync(isCurrentRequest))) return;
         pageResults.push({ response, startedAt });
+        if (!loadAllPages) break;
         const next = response.next_cursor ?? "";
         if (next === "") break;
         before = next;
@@ -946,6 +961,10 @@ export function createActivityStore(opts: ActivityStoreOptions) {
         onFailure: () => {},
       },
     );
+  }
+
+  function loadThreadPreview(key: string): void {
+    loadThreadEvents(key, false);
   }
 
   function retryFailedThreadLoads(): void {
@@ -1317,11 +1336,13 @@ export function createActivityStore(opts: ActivityStoreOptions) {
     setTimeRange,
     setViewMode,
     setFullEventProjectionRequired,
+    setActivityPageLimit,
     setRollUpCommits,
     collapseAllThreads,
     expandAllThreads,
     toggleThreadItem,
     retryFailedThreadLoads,
+    loadThreadPreview,
     setHideClosedMerged,
     setHideBots,
     setHideDefaultBranchActivity,

--- a/frontend/src/lib/stores/issues.svelte.test.ts
+++ b/frontend/src/lib/stores/issues.svelte.test.ts
@@ -238,6 +238,68 @@ describe("createIssuesStore", () => {
     );
   });
 
+  it("preserves the bounded list request after starring an issue", async () => {
+    const listed = issue(7, "alice");
+    const get = vi.fn(async () => ({ data: [listed], error: undefined }));
+    const store = createIssuesStore({
+      client: mockClient({
+        GET: get,
+        PUT: vi.fn(async () => ({ data: undefined, error: undefined })),
+      }),
+    });
+    const ref = {
+      provider: "github",
+      platformHost: "github.com",
+      owner: "acme",
+      name: "widgets",
+      repoPath: "acme/widgets",
+    };
+    store.loadIssues({ limit: 30 });
+    await vi.waitFor(() => expect(store.isIssuesLoading()).toBe(false));
+    get.mockClear();
+
+    store.toggleIssueStar(ref, 7, false);
+
+    await vi.waitFor(() => expect(get).toHaveBeenCalledTimes(1));
+    expect(get).toHaveBeenCalledWith(
+      "/issues",
+      expect.objectContaining({ params: { query: expect.objectContaining({ limit: 30 }) } }),
+    );
+  });
+
+  it("preserves the bounded list request after changing issue state", async () => {
+    const listed = issue(7, "alice");
+    const detail = issueDetail();
+    const get = vi.fn(async (path: string) =>
+      path === "/issues" ? { data: [listed], error: undefined } : { data: detail, error: undefined },
+    );
+    const store = createIssuesStore({
+      client: mockClient({
+        GET: get,
+        POST: vi.fn(async () => ({ data: undefined, error: undefined })),
+      }),
+    });
+    const ref = {
+      provider: "github",
+      platformHost: "github.com",
+      owner: "acme",
+      name: "widget",
+      repoPath: "acme/widget",
+    };
+    store.loadIssues({ limit: 30 });
+    await vi.waitFor(() => expect(store.isIssuesLoading()).toBe(false));
+    await loadIssueDetail(store, "acme", "widget", 7, { ...ref, sync: false });
+    get.mockClear();
+
+    store.setIssueState(ref, 7, "closed");
+
+    await vi.waitFor(() => expect(get.mock.calls.some(([path]) => path === "/issues")).toBe(true));
+    const listCall = get.mock.calls.find(([path]) => path === "/issues");
+    expect(listCall?.[1]).toEqual(
+      expect.objectContaining({ params: { query: expect.objectContaining({ limit: 30 }) } }),
+    );
+  });
+
   it("persists and sends the Involves me filter", async () => {
     const get = vi.fn(async () => ({ data: [], error: undefined }));
     const store = createIssuesStore({ client: { GET: get } as unknown as GeneratedClient });

--- a/frontend/src/lib/stores/issues.svelte.test.ts
+++ b/frontend/src/lib/stores/issues.svelte.test.ts
@@ -210,6 +210,34 @@ function mockClient(overrides: Partial<GeneratedClient> = {}): GeneratedClient {
 }
 
 describe("createIssuesStore", () => {
+  it("reports when a bounded list filled the requested chunk", async () => {
+    const get = vi.fn(async () => ({
+      data: Array.from({ length: 30 }, (_, index) => issue(index + 1, "alice")),
+      error: undefined,
+    }));
+    const store = createIssuesStore({
+      client: mockClient({ GET: get }),
+    });
+
+    store.loadIssues({ limit: 30 });
+    await vi.waitFor(() => expect(store.isIssuesLoading()).toBe(false));
+
+    expect(store.isIssueListCapped()).toBe(true);
+
+    get.mockClear();
+    const refresh = runtime!.runCommand(store.reconcileIssuesEffect(), {
+      operation: "reconcile bounded issues",
+      safeContext: {},
+      onFailure: () => {},
+    });
+    await refresh.exit;
+
+    expect(get).toHaveBeenCalledWith(
+      "/issues",
+      expect.objectContaining({ params: { query: expect.objectContaining({ limit: 30 }) } }),
+    );
+  });
+
   it("persists and sends the Involves me filter", async () => {
     const get = vi.fn(async () => ({ data: [], error: undefined }));
     const store = createIssuesStore({ client: { GET: get } as unknown as GeneratedClient });

--- a/frontend/src/lib/stores/issues.svelte.ts
+++ b/frontend/src/lib/stores/issues.svelte.ts
@@ -136,6 +136,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
   let confirmedHideBots = false;
   let hideBotsMutationGeneration = 0;
   let loading = $state(false);
+  let listCapped = $state(false);
   let storeError = $state<string | null>(null);
   let filterStarred = $state(false);
   let involvesMe = $state(readInvolvesMeFilter("issues"));
@@ -143,6 +144,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
   let filterState = $state<string>("open");
   let searchQuery = $state<string | undefined>(undefined);
   let selectedIssue = $state<IssueSelection | null>(null);
+  let activeListParams: IssuesParams | undefined;
 
   // --- detail state ---
 
@@ -194,6 +196,9 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
   }
   function isIssuesLoading(): boolean {
     return loading;
+  }
+  function isIssueListCapped(): boolean {
+    return listCapped;
   }
   function getIssuesError(): string | null {
     return storeError;
@@ -414,6 +419,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
       Effect.tap((result) =>
         Effect.sync(() => {
           issues = result;
+          listCapped = query.limit !== undefined && result.length === query.limit;
           loading = false;
         }),
       ),
@@ -426,7 +432,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
     );
   }
 
-  function reconcileIssuesEffect(params?: IssuesParams) {
+  function reconcileIssuesEffect(params: IssuesParams | undefined = activeListParams) {
     return Effect.suspend(() => {
       const globalRepo = getGlobalRepo();
       const query: IssuesParams = {
@@ -449,6 +455,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
         yield* workflow.reconcile(read, (result) =>
           Effect.sync(() => {
             issues = [...result];
+            listCapped = query.limit !== undefined && result.length === query.limit;
           }),
         );
       });
@@ -456,6 +463,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
   }
 
   function loadIssues(params?: IssuesParams): void {
+    activeListParams = params;
     runtime.runCommand(loadIssuesEffect(params), {
       operation: "load issues",
       safeContext: {},
@@ -1863,6 +1871,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
     getIssues,
     getHideBots,
     isIssuesLoading,
+    isIssueListCapped,
     getIssuesError,
     getSelectedIssue,
     getIssueFilterStarred,

--- a/frontend/src/lib/stores/issues.svelte.ts
+++ b/frontend/src/lib/stores/issues.svelte.ts
@@ -389,7 +389,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
     selectedIssue = null;
   }
 
-  function loadIssuesEffect(params?: IssuesParams) {
+  function loadIssuesEffect(params: IssuesParams | undefined = activeListParams) {
     const globalRepo = getGlobalRepo();
     const query: IssuesParams = {
       state: filterState,

--- a/frontend/src/lib/stores/pulls.svelte.test.ts
+++ b/frontend/src/lib/stores/pulls.svelte.test.ts
@@ -76,6 +76,34 @@ function clientWithPulls(data: PullRequest[]): GeneratedClient {
 }
 
 describe("pulls store display order", () => {
+  it("reports when a bounded list filled the requested chunk", async () => {
+    const get = vi.fn(async () => ({
+      data: Array.from({ length: 30 }, (_, index) => pull(index + 1, "api", "2026-05-20T15:00:00Z")),
+      error: undefined,
+    }));
+    const store = createPullsStore({
+      client: { GET: get } as unknown as GeneratedClient,
+    });
+
+    store.loadPulls({ limit: 30 });
+    await vi.waitFor(() => expect(store.isLoading()).toBe(false));
+
+    expect(store.isListCapped()).toBe(true);
+
+    get.mockClear();
+    const refresh = runtime!.runCommand(store.reconcilePullsEffect(), {
+      operation: "reconcile bounded pulls",
+      safeContext: {},
+      onFailure: () => {},
+    });
+    await refresh.exit;
+
+    expect(get).toHaveBeenCalledWith(
+      "/pulls",
+      expect.objectContaining({ params: { query: expect.objectContaining({ limit: 30 }) } }),
+    );
+  });
+
   it("persists and sends the Involves me filter", async () => {
     const get = vi.fn(async () => ({ data: [], error: undefined }));
     const store = createPullsStore({ client: { GET: get } as unknown as GeneratedClient });

--- a/frontend/src/lib/stores/pulls.svelte.test.ts
+++ b/frontend/src/lib/stores/pulls.svelte.test.ts
@@ -104,6 +104,35 @@ describe("pulls store display order", () => {
     );
   });
 
+  it("preserves the bounded list request after starring a pull request", async () => {
+    const listed = pull(7, "api", "2026-05-20T15:00:00Z");
+    const get = vi.fn(async () => ({ data: [listed], error: undefined }));
+    const store = createPullsStore({
+      client: {
+        GET: get,
+        PUT: vi.fn(async () => ({ data: undefined, error: undefined })),
+      } as unknown as GeneratedClient,
+    });
+    const ref = {
+      provider: "github",
+      platformHost: "github.com",
+      owner: "acme",
+      name: "api",
+      repoPath: "acme/api",
+    };
+    store.loadPulls({ limit: 30 });
+    await vi.waitFor(() => expect(store.isLoading()).toBe(false));
+    get.mockClear();
+
+    store.togglePRStar(ref, 7, false);
+
+    await vi.waitFor(() => expect(get).toHaveBeenCalledTimes(1));
+    expect(get).toHaveBeenCalledWith(
+      "/pulls",
+      expect.objectContaining({ params: { query: expect.objectContaining({ limit: 30 }) } }),
+    );
+  });
+
   it("persists and sends the Involves me filter", async () => {
     const get = vi.fn(async () => ({ data: [], error: undefined }));
     const store = createPullsStore({ client: { GET: get } as unknown as GeneratedClient });

--- a/frontend/src/lib/stores/pulls.svelte.ts
+++ b/frontend/src/lib/stores/pulls.svelte.ts
@@ -61,6 +61,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
 
   let pulls = $state<PullRequest[]>([]);
   let loading = $state(false);
+  let listCapped = $state(false);
   let storeError = $state<string | null>(null);
   let filterKanban = $state<KanbanStatus | undefined>(undefined);
   let attributeFilters = $state<PullAttributeFilter[]>([]);
@@ -70,6 +71,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
   let filterState = $state<string>("open");
   let searchQuery = $state<string | undefined>(undefined);
   let selectedPR = $state<PullSelection | null>(null);
+  let activeListParams: PullsParams | undefined;
 
   // --- reads ---
 
@@ -83,6 +85,10 @@ export function createPullsStore(opts: PullsStoreOptions) {
 
   function isLoading(): boolean {
     return loading;
+  }
+
+  function isListCapped(): boolean {
+    return listCapped;
   }
 
   function getError(): string | null {
@@ -486,6 +492,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
       Effect.tap((result) =>
         Effect.sync(() => {
           pulls = result;
+          listCapped = query.limit !== undefined && result.length === query.limit;
           loading = false;
         }),
       ),
@@ -498,7 +505,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
     );
   }
 
-  function reconcilePullsEffect(params?: PullsParams) {
+  function reconcilePullsEffect(params: PullsParams | undefined = activeListParams) {
     return Effect.suspend(() => {
       const globalRepo = getGlobalRepo();
       const query: PullsParams = {
@@ -521,6 +528,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
         yield* workflow.reconcile(read, (result) =>
           Effect.sync(() => {
             pulls = [...result];
+            listCapped = query.limit !== undefined && result.length === query.limit;
           }),
         );
       });
@@ -528,6 +536,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
   }
 
   function loadPulls(params?: PullsParams): void {
+    activeListParams = params;
     runtime.runCommand(loadPullsEffect(params), {
       operation: "load pull requests",
       safeContext: {},
@@ -587,6 +596,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
     getPulls,
     getFilteredPulls,
     isLoading,
+    isListCapped,
     getError,
     getSelectedPR,
     pullsByRepo,

--- a/frontend/src/lib/stores/pulls.svelte.ts
+++ b/frontend/src/lib/stores/pulls.svelte.ts
@@ -462,7 +462,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
     });
   }
 
-  function loadPullsEffect(params?: PullsParams) {
+  function loadPullsEffect(params: PullsParams | undefined = activeListParams) {
     const globalRepo = getGlobalRepo();
     const query: PullsParams = {
       state: filterState,

--- a/frontend/src/lib/utils/appStartup.test.ts
+++ b/frontend/src/lib/utils/appStartup.test.ts
@@ -230,6 +230,29 @@ it.layer(SuccessfulStartup)("application startup hydration", (it) => {
       }),
     ),
   );
+
+  it.effect("does not prefetch pull requests or issues when the active phone view owns its list", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const stores = makeStores();
+        const ready = yield* Deferred.make<void>();
+        const fiber = yield* Effect.forkScoped(
+          appStartupProgram({
+            stores,
+            loadInitialLists: false,
+            onReady: () => Deferred.doneUnsafe(ready, Effect.void),
+          }),
+        );
+
+        yield* Deferred.await(ready);
+        yield* Effect.yieldNow;
+
+        assert.strictEqual(vi.mocked(stores.pulls.loadPulls).mock.calls.length, 0);
+        assert.strictEqual(vi.mocked(stores.issues.loadIssues).mock.calls.length, 0);
+        yield* Fiber.interrupt(fiber);
+      }),
+    ),
+  );
 });
 
 it.layer(FailedStartup)("application startup defaults", (it) => {

--- a/frontend/src/lib/utils/appStartup.ts
+++ b/frontend/src/lib/utils/appStartup.ts
@@ -11,6 +11,7 @@ export interface AppStartupDeps {
   readonly afterBackendReady?: Effect.Effect<void, never, AppServices>;
   readonly onReady: () => void;
   readonly beforeInitialLoad?: () => void;
+  readonly loadInitialLists?: boolean;
 }
 
 export const appStartupProgram = Effect.fn("AppStartup.run")(function* (deps: AppStartupDeps) {
@@ -47,10 +48,12 @@ export const appStartupProgram = Effect.fn("AppStartup.run")(function* (deps: Ap
   }
   yield* Effect.sync(() => deps.beforeInitialLoad?.());
   yield* Effect.sync(deps.onReady);
-  yield* Effect.sync(() => {
-    deps.stores.pulls.loadPulls();
-    deps.stores.issues.loadIssues();
-  });
+  if (deps.loadInitialLists !== false) {
+    yield* Effect.sync(() => {
+      deps.stores.pulls.loadPulls();
+      deps.stores.issues.loadIssues();
+    });
+  }
   yield* Effect.forkChild(deps.stores.sync.pollingEffect, { startImmediately: true });
   yield* Effect.forkChild(deps.stores.events.streamEffect, { startImmediately: true });
   return yield* Effect.never;

--- a/frontend/src/lib/views/FocusListView.svelte
+++ b/frontend/src/lib/views/FocusListView.svelte
@@ -232,7 +232,6 @@
   >
     {#if showRepoSelector && filtersExpanded}
       <div class="mobile-repo-filter">
-        <span>Repository</span>
         <RepoTypeahead
           selected={selectedRepo}
           onchange={setGlobalRepo}
@@ -690,20 +689,6 @@
   :global(.mobile-main) .mobile-repo-filter {
     flex: 1 0 100%;
     min-width: 0;
-    display: grid;
-    grid-template-columns: auto minmax(0, 1fr);
-    align-items: center;
-    gap: var(--focus-mobile-space-sm);
-    padding: 0 var(--focus-mobile-space-sm);
-    border: thin solid var(--border-default);
-    border-radius: var(--focus-mobile-radius-md);
-    background: var(--bg-inset);
-  }
-
-  :global(.mobile-main) .mobile-repo-filter > span {
-    color: var(--text-muted);
-    font-size: var(--font-size-sm);
-    font-weight: 700;
   }
 
   :global(.mobile-main) .mobile-repo-filter :global(.typeahead-popover) {

--- a/frontend/src/lib/views/FocusListView.svelte
+++ b/frontend/src/lib/views/FocusListView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Effect, Schedule } from "effect";
   import { onDestroy, untrack } from "svelte";
+  import type { Attachment } from "svelte/attachments";
   import { IconButton, ScrollBox, SearchInput, StatusDot } from "@kenn-io/kit-ui";
   import FunnelIcon from "@lucide/svelte/icons/funnel";
   import { getAppRuntime } from "../app/runtime-context.js";
@@ -13,6 +14,7 @@
   import { createRepoLabelFormatter } from "../utils/repo-label.js";
   import RepoTypeahead from "../components/RepoTypeahead.svelte";
   import { getGlobalRepo, setGlobalRepo } from "../stores/filter.svelte.js";
+  import { observeIntersection } from "../browser/observers.js";
   import {
     buildFocusIssueRoute,
     buildFocusPullRequestRoute,
@@ -44,6 +46,7 @@
     repo?: string;
     routeFamily?: "focus" | "canonical";
     showRepoSelector?: boolean;
+    chunked?: boolean;
   }
 
   const {
@@ -51,10 +54,14 @@
     repo,
     routeFamily = "focus",
     showRepoSelector = false,
+    chunked = false,
   }: Props = $props();
 
   let searchInput = $state("");
   let filtersExpanded = $state(false);
+  let pageLimit = $state(30);
+  let paginationArmed = true;
+  let paginationIntersecting = false;
   let searchExecution: AppExecution<void, never> | null = null;
 
   function loadList(): void {
@@ -68,24 +75,30 @@
     } else {
       issues.setInvolvesMe(!issues.getInvolvesMe());
     }
-    loadList();
+    resetPageAndLoad();
   }
 
   function toggleReferencedByPR(): void {
     issues.setReferencedByPR(!issues.getReferencedByPR());
-    loadList();
+    resetPageAndLoad();
   }
 
   const selectedRepo = $derived(showRepoSelector ? getGlobalRepo() : repo);
   const repoLabel = $derived(selectedRepo ?? "All repositories");
 
   const repoParams = $derived(
-    selectedRepo ? { repo: selectedRepo } : undefined,
+    !selectedRepo && !chunked
+      ? undefined
+      : {
+          ...(selectedRepo ? { repo: selectedRepo } : {}),
+          ...(chunked ? { limit: pageLimit } : {}),
+        },
   );
 
   $effect(() => {
-    listType;
-    repoParams;
+    const identity = `${listType}:${selectedRepo ?? ""}:${chunked}`;
+    pageLimit = 30;
+    paginationArmed = true;
     filtersExpanded = false;
     searchInput = untrack(() => listType === "mrs"
       ? pulls.getSearchQuery() ?? ""
@@ -94,7 +107,7 @@
       Effect.sync(loadList).pipe(Effect.repeat(Schedule.spaced("15 seconds")), Effect.asVoid),
       {
         operation: "poll focus list",
-        safeContext: { listType },
+        safeContext: { listType, identity },
         onFailure: () => {},
       },
     ));
@@ -119,7 +132,7 @@
           const q = value.trim() === "" ? undefined : value.trim();
           if (listType === "mrs") pulls.setSearchQuery(q);
           else issues.setIssueSearchQuery(q);
-          loadList();
+          resetPageAndLoad();
         })),
       ),
       {
@@ -181,6 +194,75 @@
   const issueItems = $derived(issues.getIssues());
   const issueLoading = $derived(issues.isIssuesLoading());
   const issueError = $derived(issues.getIssuesError());
+  const listCapped = $derived(
+    listType === "mrs" ? pulls.isListCapped() : issues.isIssueListCapped(),
+  );
+
+  function resetPageAndLoad(): void {
+    pageLimit = 30;
+    paginationArmed = true;
+    loadList();
+  }
+
+  function loadMore(): void {
+    pageLimit = Math.min(pageLimit + 30, 500);
+    loadList();
+  }
+
+  const autoloadMore: Attachment<HTMLElement> = (node) => {
+    if (typeof IntersectionObserver === "undefined") {
+      if (paginationArmed) {
+        paginationArmed = false;
+        loadMore();
+      }
+      return;
+    }
+
+    const root = node.closest<HTMLElement>(".kit-scrollbox__viewport");
+    const armPagination = () => {
+      const loading = listType === "mrs" ? pulls.isLoading() : issues.isIssuesLoading();
+      if (paginationArmed || loading) return;
+      paginationArmed = true;
+      if (!paginationIntersecting) return;
+      paginationArmed = false;
+      loadMore();
+    };
+    root?.addEventListener("touchstart", armPagination, { passive: true });
+    root?.addEventListener("wheel", armPagination, { passive: true });
+    root?.addEventListener("pointerdown", armPagination, { passive: true });
+    root?.addEventListener("keydown", armPagination);
+
+    const execution = runtime.runCommand(
+      Effect.scoped(
+        observeIntersection(
+          node,
+          (entries) => {
+            const nextIntersecting = entries[0]?.isIntersecting === true;
+            paginationIntersecting = nextIntersecting;
+            if (nextIntersecting && paginationArmed) {
+              paginationArmed = false;
+              loadMore();
+            }
+          },
+          { root, rootMargin: "240px 0px" },
+        ).pipe(Effect.andThen(Effect.never)),
+      ),
+      {
+        operation: "observe focus list pagination",
+        safeContext: { listType },
+        onFailure: () => {},
+      },
+    );
+
+    return () => {
+      paginationIntersecting = false;
+      root?.removeEventListener("touchstart", armPagination);
+      root?.removeEventListener("wheel", armPagination);
+      root?.removeEventListener("pointerdown", armPagination);
+      root?.removeEventListener("keydown", armPagination);
+      execution.interrupt();
+    };
+  };
 
   const prRepoLabelFormatter = $derived(
     createRepoLabelFormatter(
@@ -248,7 +330,7 @@
             class:state-btn--active={prFilterState === s}
             onclick={() => {
               pulls.setFilterState(s);
-              pulls.loadPulls(repoParams);
+              resetPageAndLoad();
             }}
           >
             {s === "open"
@@ -265,7 +347,7 @@
             class:state-btn--active={issueFilterState === s}
             onclick={() => {
               issues.setIssueFilterState(s);
-              issues.loadIssues(repoParams);
+              resetPageAndLoad();
             }}
           >
             {s === "open"
@@ -451,6 +533,15 @@
           />
         {/each}
       {/if}
+    {/if}
+    {#if chunked && listCapped && pageLimit < 500}
+      <div
+        class="focus-list-loading-sentinel"
+        aria-live="polite"
+        {@attach autoloadMore}
+      >
+        {#if prLoading || issueLoading}Loading more…{/if}
+      </div>
     {/if}
   </ScrollBox>
 </div>
@@ -638,6 +729,9 @@
     gap: 8px;
   }
 
+  .focus-list-loading-sentinel {
+    min-height: 1px;
+  }
 
   :global(.mobile-main) .focus-list {
     --focus-mobile-space-2xs: 4.5px;

--- a/frontend/src/lib/views/FocusListView.svelte
+++ b/frontend/src/lib/views/FocusListView.svelte
@@ -2,8 +2,7 @@
   import { Effect, Schedule } from "effect";
   import { onDestroy, untrack } from "svelte";
   import type { Attachment } from "svelte/attachments";
-  import { IconButton, ScrollBox, SearchInput, StatusDot } from "@kenn-io/kit-ui";
-  import FunnelIcon from "@lucide/svelte/icons/funnel";
+  import { ScrollBox, StatusDot } from "@kenn-io/kit-ui";
   import { getAppRuntime } from "../app/runtime-context.js";
   import type { AppExecution } from "../app/runtime.js";
   import { getStores, getNavigate, getActions } from "../context.js";
@@ -13,6 +12,7 @@
   import type { Issue, PullRequest } from "../api/types.js";
   import { createRepoLabelFormatter } from "../utils/repo-label.js";
   import RepoTypeahead from "../components/RepoTypeahead.svelte";
+  import MobileTriageSearchBar from "../components/mobile/MobileTriageSearchBar.svelte";
   import { getGlobalRepo, setGlobalRepo } from "../stores/filter.svelte.js";
   import { observeIntersection } from "../browser/observers.js";
   import {
@@ -401,32 +401,15 @@
       {/if}
     </div>
   </div>
-  <div class="search-bar">
-    <div class="search-wrap">
-      <SearchInput
-        bind:value={searchInput}
-        size="sm"
-        block
-        placeholder="Search {itemLabel}..."
-        ariaLabel="Search {itemLabel}"
-        oninput={onSearchInput}
-      />
-    </div>
-    <div class="mobile-filter-button">
-      <IconButton
-        size="md"
-        tone="info"
-        ariaLabel="Filters"
-        title="Filters"
-        ariaExpanded={filtersExpanded}
-        ariaControls="focus-list-filters"
-        ariaPressed={filtersExpanded}
-        onclick={() => filtersExpanded = !filtersExpanded}
-      >
-        <FunnelIcon size={18} strokeWidth={2} aria-hidden="true" />
-      </IconButton>
-    </div>
-  </div>
+  <MobileTriageSearchBar
+    bind:value={searchInput}
+    placeholder="Search {itemLabel}..."
+    searchAriaLabel="Search {itemLabel}"
+    filterControls="focus-list-filters"
+    {filtersExpanded}
+    oninput={onSearchInput}
+    ontoggle={() => filtersExpanded = !filtersExpanded}
+  />
 
   {#if listType === "mrs" && prFilterState !== "open"}
     <p class="state-note">
@@ -659,25 +642,6 @@
     z-index: 1;
   }
 
-  .search-bar {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 6px 10px;
-    border-bottom: 1px solid var(--border-default);
-    flex-shrink: 0;
-    background: var(--bg-surface);
-  }
-
-  .search-wrap {
-    flex: 1;
-    min-width: 0;
-  }
-
-  .mobile-filter-button {
-    display: none;
-  }
-
   .state-toggle {
     display: flex;
     gap: 2px;
@@ -819,40 +783,12 @@
     font-weight: 600;
   }
 
-  :global(.mobile-main) .search-bar {
-    order: 1;
-    gap: var(--focus-mobile-space-sm);
-    padding: var(--focus-mobile-space-sm) var(--focus-mobile-space-md);
-    border-bottom: thin solid var(--border-default);
-  }
-
   :global(.mobile-main) .state-note {
     order: 3;
   }
 
   :global(.mobile-main) .focus-list > :global(.list-body) {
     order: 4;
-  }
-
-  :global(.mobile-main) .mobile-filter-button {
-    display: flex;
-    align-items: stretch;
-    flex: 0 0 auto;
-  }
-
-  :global(.mobile-main) .mobile-filter-button :global(.kit-icon-button) {
-    width: var(--focus-mobile-hit-target);
-    height: 100%;
-    min-height: var(--focus-mobile-hit-target);
-    border: thin solid var(--border-default);
-    border-radius: var(--focus-mobile-radius-sm);
-    background: var(--bg-inset);
-  }
-
-  :global(.mobile-main) .search-wrap :global(.kit-search-input) {
-    min-height: var(--focus-mobile-hit-target);
-    border-radius: var(--focus-mobile-radius-sm);
-    font-size: var(--font-size-md);
   }
 
   :global(.mobile-main) .group-header {

--- a/frontend/src/lib/views/FocusListView.svelte
+++ b/frontend/src/lib/views/FocusListView.svelte
@@ -11,6 +11,8 @@
   import IssueItem from "../components/sidebar/IssueItem.svelte";
   import type { Issue, PullRequest } from "../api/types.js";
   import { createRepoLabelFormatter } from "../utils/repo-label.js";
+  import RepoTypeahead from "../components/RepoTypeahead.svelte";
+  import { getGlobalRepo, setGlobalRepo } from "../stores/filter.svelte.js";
   import {
     buildFocusIssueRoute,
     buildFocusPullRequestRoute,
@@ -41,9 +43,15 @@
     listType: "mrs" | "issues";
     repo?: string;
     routeFamily?: "focus" | "canonical";
+    showRepoSelector?: boolean;
   }
 
-  const { listType, repo, routeFamily = "focus" }: Props = $props();
+  const {
+    listType,
+    repo,
+    routeFamily = "focus",
+    showRepoSelector = false,
+  }: Props = $props();
 
   let searchInput = $state("");
   let filtersExpanded = $state(false);
@@ -68,10 +76,11 @@
     loadList();
   }
 
-  const repoLabel = $derived(repo ?? "All repositories");
+  const selectedRepo = $derived(showRepoSelector ? getGlobalRepo() : repo);
+  const repoLabel = $derived(selectedRepo ?? "All repositories");
 
   const repoParams = $derived(
-    repo ? { repo } : undefined,
+    selectedRepo ? { repo: selectedRepo } : undefined,
   );
 
   $effect(() => {
@@ -210,15 +219,28 @@
 </script>
 
 <div class="focus-list">
-  <div class="header">
-    <span class="header-label">{repoLabel}</span>
-    <span class="count-badge">{itemCount} {itemLabel}</span>
-  </div>
+  {#if !showRepoSelector}
+    <div class="header">
+      <span class="header-label">{repoLabel}</span>
+      <span class="count-badge">{itemCount} {itemLabel}</span>
+    </div>
+  {/if}
   <div
     id="focus-list-filters"
     class="filter-bar"
     class:filter-bar--expanded={filtersExpanded}
   >
+    {#if showRepoSelector && filtersExpanded}
+      <div class="mobile-repo-filter">
+        <span>Repository</span>
+        <RepoTypeahead
+          selected={selectedRepo}
+          onchange={setGlobalRepo}
+          allowPresetManagement={false}
+          mobile
+        />
+      </div>
+    {/if}
     <div class="state-toggle">
       {#if listType === "mrs"}
         {#each ["open", "closed", "all"] as s (s)}
@@ -663,6 +685,30 @@
 
   :global(.mobile-main) .filter-bar--expanded {
     display: flex;
+  }
+
+  :global(.mobile-main) .mobile-repo-filter {
+    flex: 1 0 100%;
+    min-width: 0;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
+    gap: var(--focus-mobile-space-sm);
+    padding: 0 var(--focus-mobile-space-sm);
+    border: thin solid var(--border-default);
+    border-radius: var(--focus-mobile-radius-md);
+    background: var(--bg-inset);
+  }
+
+  :global(.mobile-main) .mobile-repo-filter > span {
+    color: var(--text-muted);
+    font-size: var(--font-size-sm);
+    font-weight: 700;
+  }
+
+  :global(.mobile-main) .mobile-repo-filter :global(.typeahead-popover) {
+    left: auto;
+    right: 0;
   }
 
   :global(.mobile-main) .state-toggle,

--- a/frontend/src/lib/views/FocusListView.svelte
+++ b/frontend/src/lib/views/FocusListView.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { Effect, Schedule } from "effect";
   import { onDestroy, untrack } from "svelte";
-  import { ScrollBox, SearchInput, StatusDot } from "@kenn-io/kit-ui";
+  import { IconButton, ScrollBox, SearchInput, StatusDot } from "@kenn-io/kit-ui";
+  import FunnelIcon from "@lucide/svelte/icons/funnel";
   import { getAppRuntime } from "../app/runtime-context.js";
   import type { AppExecution } from "../app/runtime.js";
   import { getStores, getNavigate, getActions } from "../context.js";
@@ -45,6 +46,7 @@
   const { listType, repo, routeFamily = "focus" }: Props = $props();
 
   let searchInput = $state("");
+  let filtersExpanded = $state(false);
   let searchExecution: AppExecution<void, never> | null = null;
 
   function loadList(): void {
@@ -75,6 +77,7 @@
   $effect(() => {
     listType;
     repoParams;
+    filtersExpanded = false;
     searchInput = untrack(() => listType === "mrs"
       ? pulls.getSearchQuery() ?? ""
       : issues.getIssueSearchQuery() ?? "");
@@ -211,7 +214,11 @@
     <span class="header-label">{repoLabel}</span>
     <span class="count-badge">{itemCount} {itemLabel}</span>
   </div>
-  <div class="filter-bar">
+  <div
+    id="focus-list-filters"
+    class="filter-bar"
+    class:filter-bar--expanded={filtersExpanded}
+  >
     <div class="state-toggle">
       {#if listType === "mrs"}
         {#each ["open", "closed", "all"] as s (s)}
@@ -301,6 +308,20 @@
         ariaLabel="Search {itemLabel}"
         oninput={onSearchInput}
       />
+    </div>
+    <div class="mobile-filter-button">
+      <IconButton
+        size="md"
+        tone="info"
+        ariaLabel="Filters"
+        title="Filters"
+        ariaExpanded={filtersExpanded}
+        ariaControls="focus-list-filters"
+        ariaPressed={filtersExpanded}
+        onclick={() => filtersExpanded = !filtersExpanded}
+      >
+        <FunnelIcon size={18} strokeWidth={2} aria-hidden="true" />
+      </IconButton>
     </div>
   </div>
 
@@ -541,6 +562,10 @@
     min-width: 0;
   }
 
+  .mobile-filter-button {
+    display: none;
+  }
+
   .state-toggle {
     display: flex;
     gap: 2px;
@@ -627,11 +652,17 @@
   }
 
   :global(.mobile-main) .filter-bar {
+    display: none;
+    order: 2;
     flex-wrap: wrap;
     align-items: stretch;
     gap: var(--focus-mobile-space-sm);
     padding: var(--focus-mobile-space-sm) var(--focus-mobile-space-md);
     border-bottom: thin solid var(--border-muted);
+  }
+
+  :global(.mobile-main) .filter-bar--expanded {
+    display: flex;
   }
 
   :global(.mobile-main) .state-toggle,
@@ -664,9 +695,33 @@
   }
 
   :global(.mobile-main) .search-bar {
+    order: 1;
     gap: var(--focus-mobile-space-sm);
     padding: var(--focus-mobile-space-sm) var(--focus-mobile-space-md);
     border-bottom: thin solid var(--border-default);
+  }
+
+  :global(.mobile-main) .state-note {
+    order: 3;
+  }
+
+  :global(.mobile-main) .focus-list > :global(.list-body) {
+    order: 4;
+  }
+
+  :global(.mobile-main) .mobile-filter-button {
+    display: flex;
+    align-items: stretch;
+    flex: 0 0 auto;
+  }
+
+  :global(.mobile-main) .mobile-filter-button :global(.kit-icon-button) {
+    width: var(--focus-mobile-hit-target);
+    height: 100%;
+    min-height: var(--focus-mobile-hit-target);
+    border: thin solid var(--border-default);
+    border-radius: var(--focus-mobile-radius-sm);
+    background: var(--bg-inset);
   }
 
   :global(.mobile-main) .search-wrap :global(.kit-search-input) {

--- a/frontend/src/lib/views/FocusListView.test.ts
+++ b/frontend/src/lib/views/FocusListView.test.ts
@@ -150,6 +150,20 @@ describe("FocusListView search", () => {
     view.unmount();
   });
 
+  it.each(["mrs", "issues"] as const)("discloses %s filters from an icon-only control", async (listType) => {
+    const { container } = render(FocusListView, { props: { listType, repo: "acme/one" } });
+
+    const filters = screen.getByRole("button", { name: "Filters" });
+    expect(filters.textContent?.trim()).toBe("");
+    expect(filters.getAttribute("aria-expanded")).toBe("false");
+    expect(container.querySelector(".filter-bar")?.classList.contains("filter-bar--expanded")).toBe(false);
+
+    await fireEvent.click(filters);
+
+    expect(filters.getAttribute("aria-expanded")).toBe("true");
+    expect(container.querySelector(".filter-bar")?.classList.contains("filter-bar--expanded")).toBe(true);
+  });
+
   it.each([
     ["mrs" as const, setPullsInvolvesMe, loadPulls],
     ["issues" as const, setIssuesInvolvesMe, loadIssues],

--- a/frontend/src/lib/views/FocusListView.test.ts
+++ b/frontend/src/lib/views/FocusListView.test.ts
@@ -15,6 +15,7 @@ import {
   setPullInvolvesMe,
   setPullSearch,
 } from "../../test/focusListViewState.svelte.js";
+import { getGlobalRepo, setGlobalRepo } from "../stores/filter.svelte.js";
 
 const pullSearch = vi.hoisted(() => vi.fn());
 const issueSearch = vi.hoisted(() => vi.fn());
@@ -79,6 +80,32 @@ vi.mock("../context.js", () => ({
       },
     },
     settings: {
+      getConfiguredRepos: () => [
+        {
+          provider: "github",
+          platform_host: "github.com",
+          owner: "acme",
+          name: "api",
+          repo_path: "acme/api",
+          platform_repo_id: "R_api",
+          is_glob: false,
+          matched_repo_count: 1,
+          hidden_from_ui: false,
+        },
+      ],
+      getRepoPresets: () => [
+        {
+          name: "Backend",
+          repos: [
+            {
+              provider: "github",
+              platform_host: "github.com",
+              platform_repo_id: "R_api",
+              repo_path: "acme/api",
+            },
+          ],
+        },
+      ],
       hasConfiguredRepos: () => true,
       isSettingsLoaded: () => true,
     },
@@ -102,6 +129,7 @@ describe("FocusListView search", () => {
     unsubscribeSync.mockClear();
     subscribeSyncComplete.mockClear();
     resetFocusListViewState();
+    setGlobalRepo(undefined);
   });
 
   afterEach(() => {
@@ -162,6 +190,23 @@ describe("FocusListView search", () => {
 
     expect(filters.getAttribute("aria-expanded")).toBe("true");
     expect(container.querySelector(".filter-bar")?.classList.contains("filter-bar--expanded")).toBe(true);
+  });
+
+  it.each([
+    ["mrs" as const, loadPulls],
+    ["issues" as const, loadIssues],
+  ])("applies saved repository presets to the mobile %s query", async (listType, loadList) => {
+    render(FocusListView, { props: { listType, showRepoSelector: true } });
+
+    expect(screen.queryByRole("button", { name: "Select repository: Global" })).toBeNull();
+    await fireEvent.click(screen.getByRole("button", { name: "Filters" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Select repository: Global" }));
+    await fireEvent.mouseDown(screen.getByRole("option", { name: "Backend" }));
+
+    expect(getGlobalRepo()).toBe("github|github.com/acme/api");
+    expect(loadList).toHaveBeenLastCalledWith({ repo: "github|github.com/acme/api" });
+    expect(screen.queryByRole("button", { name: "Save preset" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Delete preset Backend" })).toBeNull();
   });
 
   it.each([

--- a/frontend/src/lib/views/FocusListView.test.ts
+++ b/frontend/src/lib/views/FocusListView.test.ts
@@ -26,6 +26,8 @@ const setIssuesInvolvesMe = vi.hoisted(() => vi.fn());
 const setIssuesReferencedByPR = vi.hoisted(() => vi.fn());
 const unsubscribeSync = vi.hoisted(() => vi.fn());
 const subscribeSyncComplete = vi.hoisted(() => vi.fn(() => unsubscribeSync));
+const pullListCapped = vi.hoisted(() => ({ value: false }));
+const issueListCapped = vi.hoisted(() => ({ value: false }));
 vi.mock("../context.js", () => ({
   getActions: () => ({ importItem: vi.fn() }),
   getNavigate: () => vi.fn(),
@@ -45,6 +47,7 @@ vi.mock("../context.js", () => ({
       getIssues: () => [],
       getIssuesError: () => null,
       isIssuesLoading: () => false,
+      isIssueListCapped: () => issueListCapped.value,
       loadIssues,
       setHideBots: vi.fn(),
       setInvolvesMe: (value: boolean) => {
@@ -68,6 +71,7 @@ vi.mock("../context.js", () => ({
       getFilterState: () => "open",
       getPulls: () => [],
       isLoading: () => false,
+      isListCapped: () => pullListCapped.value,
       loadPulls,
       setFilterState: vi.fn(),
       setInvolvesMe: (value: boolean) => {
@@ -129,6 +133,8 @@ describe("FocusListView search", () => {
     unsubscribeSync.mockClear();
     subscribeSyncComplete.mockClear();
     resetFocusListViewState();
+    pullListCapped.value = false;
+    issueListCapped.value = false;
     setGlobalRepo(undefined);
   });
 
@@ -176,6 +182,43 @@ describe("FocusListView search", () => {
     expect(subscribeSyncComplete).toHaveBeenCalledTimes(1);
     expect(unsubscribeSync).not.toHaveBeenCalled();
     view.unmount();
+  });
+
+  it.each([
+    ["mrs" as const, loadPulls, pullListCapped],
+    ["issues" as const, loadIssues, issueListCapped],
+  ])("loads mobile %s results in bounded chunks and autoloads the next chunk", async (listType, loadList, capped) => {
+    const observed = new Map<Element, IntersectionObserverCallback>();
+    class IntersectionObserverStub {
+      constructor(private readonly callback: IntersectionObserverCallback) {}
+      observe(target: Element): void {
+        observed.set(target, this.callback);
+      }
+      disconnect(): void {}
+      unobserve(): void {}
+      takeRecords(): IntersectionObserverEntry[] {
+        return [];
+      }
+      readonly root = null;
+      readonly rootMargin = "0px";
+      readonly thresholds = [0];
+    }
+    vi.stubGlobal("IntersectionObserver", IntersectionObserverStub);
+    capped.value = true;
+
+    const { container } = render(FocusListView, {
+      props: { listType, repo: "acme/one", chunked: true },
+    });
+
+    expect(loadList).toHaveBeenCalledWith({ repo: "acme/one", limit: 30 });
+    const sentinel = container.querySelector(".focus-list-loading-sentinel");
+    expect(sentinel).toBeTruthy();
+    const notify = observed.get(sentinel!);
+    expect(notify).toBeTruthy();
+
+    notify!([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver);
+
+    expect(loadList).toHaveBeenLastCalledWith({ repo: "acme/one", limit: 60 });
   });
 
   it.each(["mrs", "issues"] as const)("discloses %s filters from an icon-only control", async (listType) => {

--- a/frontend/src/lib/views/MobileActivityView.svelte
+++ b/frontend/src/lib/views/MobileActivityView.svelte
@@ -28,10 +28,12 @@
     type TypeaheadOption,
     type TimelineTone,
   } from "@kenn-io/kit-ui";
+  import { showFlash } from "../stores/flash.svelte.js";
   import { parseAPITimestamp } from "../utils/time.js";
   import { latestActivityAt } from "../utils/effective-activity.js";
   import ItemKindChip from "../components/shared/ItemKindChip.svelte";
   import ItemStateChip from "../components/shared/ItemStateChip.svelte";
+  import RepoTypeahead from "../components/RepoTypeahead.svelte";
   import { SelectDropdown } from "@kenn-io/kit-ui";
   import WorkspaceIndicator from "../components/shared/WorkspaceIndicator.svelte";
   import CheckIcon from "@lucide/svelte/icons/check";
@@ -45,9 +47,6 @@
     notificationReasonLabel,
     shortSha,
   } from "../components/activityRows.js";
-  import {
-    buildMobileActivityRepoOptions,
-  } from "./mobileActivityRepoOptions.js";
   import {
     createRepoLabelFormatter,
     type RepoLabelIdentity,
@@ -91,15 +90,12 @@
   let searchInput = $state("");
   let activityPageLimit = $state(30);
   let filtersExpanded = $state(false);
+  let flashedActivityError: string | null = null;
+  let paginationArmed = true;
+  let paginationIntersecting = false;
   let searchExecution: AppExecution<void, never> | null = null;
   let unsubSync: (() => void) | undefined;
 
-  const repoOptions = $derived.by(() =>
-    [
-      { value: "", label: "All repos" },
-      ...buildMobileActivityRepoOptions(settings.getConfiguredRepos()),
-    ],
-  );
   onMount(() => {
     activity.initializeFromMount();
     searchInput = activity.getActivitySearch() ?? "";
@@ -111,6 +107,17 @@
       activity.loadActivity();
       activity.loadActivityAuthors(true);
     });
+  });
+
+  $effect(() => {
+    const error = activity.getActivityError();
+    if (!error) {
+      flashedActivityError = null;
+      return;
+    }
+    if (error === flashedActivityError) return;
+    flashedActivityError = error;
+    showFlash(error, { tone: "warning", durationMs: 8_000 });
   });
 
   onDestroy(() => {
@@ -394,8 +401,8 @@
     setTimeRange(value as TimeRange);
   }
 
-  function handleRepoChange(value: string): void {
-    onRepoChange?.(value || undefined);
+  function handleRepoChange(value: string | undefined): void {
+    onRepoChange?.(value);
     activity.loadActivity();
   }
 
@@ -501,6 +508,60 @@
     activity.setActivityPageLimit(activityPageLimit);
     activity.loadActivity();
   }
+
+  const autoloadMoreActivity: Attachment<HTMLElement> = (node) => {
+    if (typeof IntersectionObserver === "undefined") {
+      if (paginationArmed) {
+        paginationArmed = false;
+        loadMoreActivity();
+      }
+      return;
+    }
+
+    const root = node.closest<HTMLElement>(".kit-scrollbox__viewport");
+    const armPagination = () => {
+      if (paginationArmed || activity.isActivityLoading()) return;
+      paginationArmed = true;
+      if (!paginationIntersecting) return;
+      paginationArmed = false;
+      loadMoreActivity();
+    };
+    root?.addEventListener("touchstart", armPagination, { passive: true });
+    root?.addEventListener("wheel", armPagination, { passive: true });
+    root?.addEventListener("pointerdown", armPagination, { passive: true });
+    root?.addEventListener("keydown", armPagination);
+
+    const execution = runtime.runCommand(
+      Effect.scoped(
+        observeIntersection(
+          node,
+          (entries) => {
+            const nextIntersecting = entries[0]?.isIntersecting === true;
+            paginationIntersecting = nextIntersecting;
+            if (nextIntersecting && paginationArmed) {
+              paginationArmed = false;
+              loadMoreActivity();
+            }
+          },
+          { root, rootMargin: "240px 0px" },
+        ).pipe(Effect.andThen(Effect.never)),
+      ),
+      {
+        operation: "observe mobile activity pagination",
+        safeContext: {},
+        onFailure: () => {},
+      },
+    );
+
+    return () => {
+      paginationIntersecting = false;
+      root?.removeEventListener("touchstart", armPagination);
+      root?.removeEventListener("wheel", armPagination);
+      root?.removeEventListener("pointerdown", armPagination);
+      root?.removeEventListener("keydown", armPagination);
+      execution.interrupt();
+    };
+  };
 
   function subjectSelectionItem(
     subject: ActivitySubject | WorkspaceActivitySubject,
@@ -754,12 +815,11 @@
 
       <div class="mobile-filter-select mobile-filter-select--repo">
         <span>Repo</span>
-        <SelectDropdown
-          class="mobile-filter-dropdown"
-          title="Repository"
-          value={selectedRepo ?? ""}
-          options={repoOptions}
+        <RepoTypeahead
+          selected={selectedRepo}
           onchange={handleRepoChange}
+          allowPresetManagement={false}
+          mobile
         />
       </div>
 
@@ -806,10 +866,6 @@
     </div>
     {/if}
 
-
-    {#if activity.getActivityError()}
-      <div class="mobile-activity-error">{activity.getActivityError()}</div>
-    {/if}
 
     {#if settings.isSettingsLoaded() && !settings.hasConfiguredRepos()}
       <div class="mobile-activity-empty">No repositories configured.</div>
@@ -903,24 +959,14 @@
       </div>
     {/if}
 
-    {#if activity.isActivityCapped()}
-      <div class="mobile-activity-capped event-capped-notice">
-        Showing the most recent activity. Narrow the range or filters to see more.
+    {#if activity.isItemActivityCapped() && activityPageLimit < 500}
+      <div
+        class="mobile-activity-loading-sentinel"
+        aria-live="polite"
+        {@attach autoloadMoreActivity}
+      >
+        {#if activity.isActivityLoading()}Loading more…{/if}
       </div>
-    {/if}
-
-    {#if activity.isItemActivityCapped()}
-      <div class="mobile-activity-capped item-activity-capped-notice">
-        Showing the most recently active pull requests and issues. Narrow the range or item filters to see more.
-      </div>
-      {#if activityPageLimit < 500}
-        <button
-          type="button"
-          class="mobile-activity-load-more"
-          disabled={activity.isActivityLoading()}
-          onclick={loadMoreActivity}
-        >Load 30 more</button>
-      {/if}
     {/if}
   </div>
   </ScrollBox>
@@ -1059,6 +1105,11 @@
 
   .mobile-filter-select--repo {
     grid-column: 1 / -1;
+  }
+
+  .mobile-filter-select--repo :global(.typeahead-popover) {
+    left: auto;
+    right: 0;
   }
 
   .mobile-filter-select span {
@@ -1312,9 +1363,7 @@
     font-weight: 750;
   }
 
-  .mobile-activity-empty,
-  .mobile-activity-error,
-  .mobile-activity-capped {
+  .mobile-activity-empty {
     padding: var(--mobile-space-lg);
     border: thin solid var(--border-default);
     border-radius: var(--radius-lg);
@@ -1324,20 +1373,12 @@
     text-align: center;
   }
 
-  .mobile-activity-load-more {
-    min-height: var(--mobile-hit-target);
-    border: thin solid var(--border-default);
-    border-radius: var(--mobile-radius-sm);
-    color: var(--text-primary);
-    background: var(--bg-inset);
-  }
-
-  .mobile-activity-error {
-    color: var(--accent-red);
-  }
-
-  .mobile-activity-capped {
-    margin-top: var(--mobile-space-md);
-    color: var(--accent-amber);
+  .mobile-activity-loading-sentinel {
+    display: grid;
+    min-height: var(--mobile-space-lg);
+    place-items: center;
+    overflow-anchor: none;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
   }
 </style>

--- a/frontend/src/lib/views/MobileActivityView.svelte
+++ b/frontend/src/lib/views/MobileActivityView.svelte
@@ -329,7 +329,7 @@
     return result;
   });
 
-  const visibleGroups = $derived(groups.slice(0, 30));
+  const visibleGroups = $derived(groups.slice(0, activityPageLimit));
 
   const authorOptions = $derived.by<TypeaheadOption[]>(() =>
     activity.getActivityAuthors().map((author) => ({
@@ -958,7 +958,7 @@
       </div>
     {/if}
 
-    {#if activity.isItemActivityCapped() && activityPageLimit < 500}
+    {#if (activity.isActivityCapped() || activity.isItemActivityCapped()) && activityPageLimit < 500}
       <div
         class="mobile-activity-loading-sentinel"
         aria-live="polite"

--- a/frontend/src/lib/views/MobileActivityView.svelte
+++ b/frontend/src/lib/views/MobileActivityView.svelte
@@ -739,37 +739,44 @@
       />
     </div>
 
-    {#if filtersExpanded}
-    <div id="mobile-activity-filters" class="mobile-activity-filter-grid" aria-label="Activity filters">
-      <div class="mobile-filter-select mobile-filter-select--repo">
-        <RepoTypeahead
-          selected={selectedRepo}
-          onchange={handleRepoChange}
-          allowPresetManagement={false}
-          mobile
-        />
-      </div>
-
-      <div class="mobile-author-filter">
-        <span class="mobile-author-icon">
-          <UserRoundIcon size="16" strokeWidth="2" aria-hidden="true" />
-        </span>
-        <div class="mobile-author-picker">
-          <Typeahead
-            options={authorOptions}
-            value={activity.getActivityAuthor() ?? ""}
-            fallbackLabel="Anyone"
-            placeholder="Filter authors"
-            title="Filter by PR or issue author"
-            allowClear
-            clearLabel="Anyone"
-            loading={activity.isActivityAuthorsLoading()}
-            error={activity.getActivityAuthorsError() ?? ""}
-            onselect={handleAuthorSelect}
+    <div
+      id="mobile-activity-filters"
+      class="mobile-activity-filter-grid"
+      class:mobile-activity-filter-grid--expanded={filtersExpanded}
+      aria-label="Activity filters"
+      hidden={!filtersExpanded}
+    >
+      <div class="mobile-identity-filters">
+        <div class="mobile-filter-select mobile-filter-select--repo">
+          <RepoTypeahead
+            selected={selectedRepo}
+            onchange={handleRepoChange}
+            allowPresetManagement={false}
+            mobile
           />
-          <span class="mobile-author-summary">
-            {activity.getActivityAuthor() ? "Selected author" : "All authors"}
+        </div>
+
+        <div class="mobile-author-filter">
+          <span class="mobile-author-icon">
+            <UserRoundIcon size="16" strokeWidth="2" aria-hidden="true" />
           </span>
+          <div class="mobile-author-picker">
+            <Typeahead
+              options={authorOptions}
+              value={activity.getActivityAuthor() ?? ""}
+              fallbackLabel="Anyone"
+              placeholder="Filter authors"
+              title="Filter by PR or issue author"
+              allowClear
+              clearLabel="Anyone"
+              loading={activity.isActivityAuthorsLoading()}
+              error={activity.getActivityAuthorsError() ?? ""}
+              onselect={handleAuthorSelect}
+            />
+            <span class="mobile-author-summary">
+              {activity.getActivityAuthor() ? "Selected author" : "All authors"}
+            </span>
+          </div>
         </div>
       </div>
 
@@ -857,10 +864,7 @@
           onchange={() => toggleHideOrgName()}
         />
       </div>
-
     </div>
-    {/if}
-
 
     {#if settings.isSettingsLoaded() && !settings.hasConfiguredRepos()}
       <div class="mobile-activity-empty">No repositories configured.</div>
@@ -1013,7 +1017,7 @@
   }
 
   .mobile-activity-filter-grid {
-    display: grid;
+    display: none;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: var(--mobile-space-xs);
     margin:
@@ -1023,6 +1027,17 @@
     padding: var(--mobile-space-sm);
     border-bottom: thin solid var(--border-muted);
     background: var(--bg-surface);
+  }
+
+  .mobile-activity-filter-grid--expanded {
+    display: grid;
+  }
+
+  .mobile-identity-filters {
+    grid-column: 1 / -1;
+    min-width: 0;
+    display: grid;
+    gap: 0;
   }
 
   .mobile-author-filter {
@@ -1035,7 +1050,7 @@
     min-height: 48px;
     padding: var(--mobile-space-2xs) var(--mobile-space-xs);
     border: 0;
-    border-top: thin solid var(--border-muted);
+    border-top: 0;
     border-bottom: thin solid var(--border-muted);
     border-radius: 0;
     color: var(--text-secondary);
@@ -1082,7 +1097,10 @@
   }
 
   .mobile-author-picker :global(.kit-typeahead__chevron) {
+    width: 16px;
+    height: 16px;
     transform: rotate(-90deg);
+    opacity: 0.5;
   }
 
   .mobile-author-picker :global(.kit-typeahead__input) {

--- a/frontend/src/lib/views/MobileActivityView.svelte
+++ b/frontend/src/lib/views/MobileActivityView.svelte
@@ -18,9 +18,7 @@
   import {
     Card,
     Chip,
-    IconButton,
     ScrollBox,
-    SearchInput,
     Timeline,
     TimelineItem,
     Toggle,
@@ -34,10 +32,10 @@
   import ItemKindChip from "../components/shared/ItemKindChip.svelte";
   import ItemStateChip from "../components/shared/ItemStateChip.svelte";
   import RepoTypeahead from "../components/RepoTypeahead.svelte";
+  import MobileTriageSearchBar from "../components/mobile/MobileTriageSearchBar.svelte";
   import { SelectDropdown } from "@kenn-io/kit-ui";
   import WorkspaceIndicator from "../components/shared/WorkspaceIndicator.svelte";
   import CheckIcon from "@lucide/svelte/icons/check";
-  import FunnelIcon from "@lucide/svelte/icons/funnel";
   import UserRoundIcon from "@lucide/svelte/icons/user-round";
   import {
     activityBranchKey,
@@ -723,35 +721,22 @@
   <ScrollBox label="Activity inbox">
   <div class="mobile-activity-scroll">
     <div
-      class="mobile-activity-toolbar"
-      class:mobile-activity-toolbar--expanded={filtersExpanded}
+      class="mobile-activity-search-strip"
+      class:mobile-activity-search-strip--expanded={filtersExpanded}
     >
-      <div class="mobile-activity-search">
-        <SearchInput
-          bind:value={searchInput}
-          block
-          placeholder="Search activity"
-          ariaLabel="Search activity"
-          oninput={handleSearchInput}
-        />
-      </div>
-
-      <div class="mobile-filter-summary">
-        <IconButton
-          size="md"
-          tone="info"
-          ariaLabel={activity.getActivityAuthor()
+      <MobileTriageSearchBar
+        bind:value={searchInput}
+        placeholder="Search activity"
+        searchAriaLabel="Search activity"
+        filterAriaLabel={activity.getActivityAuthor()
           ? `Filters · ${activity.getActivityAuthor()}`
           : "Filters"}
-          title="Filters"
-          ariaExpanded={filtersExpanded}
-          ariaControls="mobile-activity-filters"
-          ariaPressed={filtersExpanded || activeFilterCount > 0}
-          onclick={() => filtersExpanded = !filtersExpanded}
-        >
-          <FunnelIcon size={18} strokeWidth={2} aria-hidden="true" />
-        </IconButton>
-      </div>
+        filterControls="mobile-activity-filters"
+        {filtersExpanded}
+        filtersActive={filtersExpanded || activeFilterCount > 0}
+        oninput={handleSearchInput}
+        ontoggle={() => filtersExpanded = !filtersExpanded}
+      />
     </div>
 
     {#if filtersExpanded}
@@ -1016,54 +1001,15 @@
     font-size: var(--font-size-md);
   }
 
-  .mobile-activity-toolbar {
-    box-sizing: border-box;
-    height: 65px;
-    display: flex;
-    align-items: stretch;
-    gap: var(--mobile-space-sm);
+  .mobile-activity-search-strip {
     margin:
       calc(-1 * var(--mobile-space-md))
       calc(-1 * var(--mobile-space-sm))
       var(--mobile-space-sm);
-    padding: var(--mobile-space-sm) var(--mobile-space-md);
-    border-bottom: thin solid var(--border-default);
-    background: var(--bg-surface);
   }
 
-  .mobile-activity-toolbar--expanded {
+  .mobile-activity-search-strip--expanded {
     margin-bottom: 0;
-  }
-
-  .mobile-activity-search {
-    flex: 1;
-    min-width: 0;
-  }
-
-  .mobile-activity-search :global(.kit-search-input) {
-    height: 44px;
-    min-height: 44px;
-    border-radius: var(--radius-lg);
-    font-size: var(--font-size-md);
-    /* The phone inbox keeps the inset field look of the original
-       hand-rolled search (mobile-routes e2e pins this against
-       --bg-inset). */
-    background: var(--bg-inset);
-  }
-
-  .mobile-filter-summary {
-    display: flex;
-    align-items: center;
-    flex: 0 0 auto;
-  }
-
-  .mobile-filter-summary :global(.kit-icon-button) {
-    width: 44px;
-    height: 44px;
-    min-height: 44px;
-    border: thin solid var(--border-default);
-    border-radius: var(--radius-md);
-    background: var(--bg-inset);
   }
 
   .mobile-activity-filter-grid {

--- a/frontend/src/lib/views/MobileActivityView.svelte
+++ b/frontend/src/lib/views/MobileActivityView.svelte
@@ -38,6 +38,7 @@
   import WorkspaceIndicator from "../components/shared/WorkspaceIndicator.svelte";
   import CheckIcon from "@lucide/svelte/icons/check";
   import FunnelIcon from "@lucide/svelte/icons/funnel";
+  import UserRoundIcon from "@lucide/svelte/icons/user-round";
   import {
     activityBranchKey,
     activityItemKey,
@@ -721,7 +722,10 @@
 <section class="mobile-activity-inbox" aria-label="Mobile activity inbox">
   <ScrollBox label="Activity inbox">
   <div class="mobile-activity-scroll">
-    <div class="mobile-activity-toolbar">
+    <div
+      class="mobile-activity-toolbar"
+      class:mobile-activity-toolbar--expanded={filtersExpanded}
+    >
       <div class="mobile-activity-search">
         <SearchInput
           bind:value={searchInput}
@@ -752,20 +756,36 @@
 
     {#if filtersExpanded}
     <div id="mobile-activity-filters" class="mobile-activity-filter-grid" aria-label="Activity filters">
-      <div class="mobile-author-filter">
-        <span>Author</span>
-        <Typeahead
-          options={authorOptions}
-          value={activity.getActivityAuthor() ?? ""}
-          fallbackLabel="Anyone"
-          placeholder="Filter authors"
-          title="Filter by PR or issue author"
-          allowClear
-          clearLabel="Anyone"
-          loading={activity.isActivityAuthorsLoading()}
-          error={activity.getActivityAuthorsError() ?? ""}
-          onselect={handleAuthorSelect}
+      <div class="mobile-filter-select mobile-filter-select--repo">
+        <RepoTypeahead
+          selected={selectedRepo}
+          onchange={handleRepoChange}
+          allowPresetManagement={false}
+          mobile
         />
+      </div>
+
+      <div class="mobile-author-filter">
+        <span class="mobile-author-icon">
+          <UserRoundIcon size="16" strokeWidth="2" aria-hidden="true" />
+        </span>
+        <div class="mobile-author-picker">
+          <Typeahead
+            options={authorOptions}
+            value={activity.getActivityAuthor() ?? ""}
+            fallbackLabel="Anyone"
+            placeholder="Filter authors"
+            title="Filter by PR or issue author"
+            allowClear
+            clearLabel="Anyone"
+            loading={activity.isActivityAuthorsLoading()}
+            error={activity.getActivityAuthorsError() ?? ""}
+            onselect={handleAuthorSelect}
+          />
+          <span class="mobile-author-summary">
+            {activity.getActivityAuthor() ? "Selected author" : "All authors"}
+          </span>
+        </div>
       </div>
 
       <div class="mobile-item-type-toggle">
@@ -813,55 +833,45 @@
         />
       </div>
 
-      <div class="mobile-filter-select mobile-filter-select--repo">
-        <span>Repo</span>
-        <RepoTypeahead
-          selected={selectedRepo}
-          onchange={handleRepoChange}
-          allowPresetManagement={false}
-          mobile
+      <div class="mobile-boolean-toggle">
+        <Toggle
+          checked={activity.getInvolvesMe()}
+          label="Involves me"
+          onchange={() => toggleInvolvesMe()}
         />
       </div>
 
-      <button
-        type="button"
-        class="mobile-filter-toggle"
-        class:active={activity.getInvolvesMe()}
-        aria-pressed={activity.getInvolvesMe()}
-        onclick={toggleInvolvesMe}
-      >Involves me</button>
+      <div class="mobile-boolean-toggle">
+        <Toggle
+          checked={activity.getHideClosedMerged()}
+          label="Hide closed/merged"
+          onchange={() => toggleHideClosedMerged()}
+        />
+      </div>
 
-      <button
-        type="button"
-        class="mobile-filter-toggle"
-        class:active={activity.getHideClosedMerged()}
-        aria-pressed={activity.getHideClosedMerged()}
-        onclick={toggleHideClosedMerged}
-      >Hide closed/merged</button>
+      <div class="mobile-boolean-toggle">
+        <Toggle
+          checked={activity.getHideBots()}
+          label="Hide bots"
+          onchange={() => toggleHideBots()}
+        />
+      </div>
 
-      <button
-        type="button"
-        class="mobile-filter-toggle"
-        class:active={activity.getHideBots()}
-        aria-pressed={activity.getHideBots()}
-        onclick={toggleHideBots}
-      >Hide bots</button>
+      <div class="mobile-boolean-toggle">
+        <Toggle
+          checked={activity.getHideDefaultBranchActivity()}
+          label="Hide branch"
+          onchange={() => toggleHideDefaultBranchActivity()}
+        />
+      </div>
 
-      <button
-        type="button"
-        class="mobile-filter-toggle"
-        class:active={activity.getHideDefaultBranchActivity()}
-        aria-pressed={activity.getHideDefaultBranchActivity()}
-        onclick={toggleHideDefaultBranchActivity}
-      >Hide branch</button>
-
-      <button
-        type="button"
-        class="mobile-filter-toggle"
-        class:active={grouping.getHideOrgName()}
-        aria-pressed={grouping.getHideOrgName()}
-        onclick={toggleHideOrgName}
-      >Hide org</button>
+      <div class="mobile-boolean-toggle">
+        <Toggle
+          checked={grouping.getHideOrgName()}
+          label="Hide org"
+          onchange={() => toggleHideOrgName()}
+        />
+      </div>
 
     </div>
     {/if}
@@ -1007,10 +1017,22 @@
   }
 
   .mobile-activity-toolbar {
+    box-sizing: border-box;
+    height: 65px;
     display: flex;
     align-items: stretch;
-    gap: var(--mobile-space-xs);
-    margin-bottom: var(--mobile-space-sm);
+    gap: var(--mobile-space-sm);
+    margin:
+      calc(-1 * var(--mobile-space-md))
+      calc(-1 * var(--mobile-space-sm))
+      var(--mobile-space-sm);
+    padding: var(--mobile-space-sm) var(--mobile-space-md);
+    border-bottom: thin solid var(--border-default);
+    background: var(--bg-surface);
+  }
+
+  .mobile-activity-toolbar--expanded {
+    margin-bottom: 0;
   }
 
   .mobile-activity-search {
@@ -1019,7 +1041,8 @@
   }
 
   .mobile-activity-search :global(.kit-search-input) {
-    min-height: calc(var(--mobile-hit-target) + var(--mobile-space-xs));
+    height: 44px;
+    min-height: 44px;
     border-radius: var(--radius-lg);
     font-size: var(--font-size-md);
     /* The phone inbox keeps the inset field look of the original
@@ -1035,9 +1058,9 @@
   }
 
   .mobile-filter-summary :global(.kit-icon-button) {
-    width: calc(var(--mobile-hit-target) + var(--mobile-space-xs));
-    height: 100%;
-    min-height: var(--mobile-hit-target);
+    width: 44px;
+    height: 44px;
+    min-height: 44px;
     border: thin solid var(--border-default);
     border-radius: var(--radius-md);
     background: var(--bg-inset);
@@ -1047,38 +1070,93 @@
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: var(--mobile-space-xs);
-    margin-bottom: var(--mobile-space-sm);
+    margin:
+      0
+      calc(-1 * var(--mobile-space-sm))
+      var(--mobile-space-sm);
+    padding: var(--mobile-space-sm);
+    border-bottom: thin solid var(--border-muted);
+    background: var(--bg-surface);
   }
 
   .mobile-author-filter {
     grid-column: 1 / -1;
     min-width: 0;
     display: grid;
-    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-columns: 28px minmax(0, 1fr);
     align-items: center;
-    gap: var(--mobile-space-xs);
-    min-height: var(--mobile-hit-target);
-    padding: 0 var(--mobile-space-sm);
-    border: thin solid var(--border-default);
-    border-radius: var(--radius-md);
+    gap: var(--mobile-space-sm);
+    min-height: 48px;
+    padding: var(--mobile-space-2xs) var(--mobile-space-xs);
+    border: 0;
+    border-top: thin solid var(--border-muted);
+    border-bottom: thin solid var(--border-muted);
+    border-radius: 0;
     color: var(--text-secondary);
-    background: var(--bg-inset);
+    background: transparent;
   }
 
-  .mobile-author-filter > span {
-    color: var(--text-muted);
-    font-size: var(--font-size-xs);
-    font-weight: 750;
+  .mobile-author-icon {
+    width: 28px;
+    height: 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-sm);
+    color: var(--accent-blue);
+    background: color-mix(in srgb, var(--accent-blue) 13%, transparent);
   }
 
-  .mobile-author-filter :global(.kit-typeahead) {
+  .mobile-author-picker {
+    min-width: 0;
+    display: grid;
+    gap: var(--mobile-space-2xs);
+  }
+
+  .mobile-author-picker :global(.kit-typeahead) {
     width: 100%;
     min-width: 0;
+    max-width: none;
+  }
+
+  .mobile-author-picker :global(.kit-typeahead__trigger) {
+    height: auto;
+    min-height: 20px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--text-primary);
+    font-size: var(--font-size-md);
+    font-weight: 700;
+  }
+
+  .mobile-author-picker :global(.kit-typeahead__trigger:hover),
+  .mobile-author-picker :global(.kit-typeahead__trigger:focus) {
+    border: 0;
+  }
+
+  .mobile-author-picker :global(.kit-typeahead__chevron) {
+    transform: rotate(-90deg);
+  }
+
+  .mobile-author-picker :global(.kit-typeahead__input) {
+    min-height: 24px;
+    font-size: var(--font-size-sm);
+  }
+
+  .mobile-author-summary {
+    overflow: hidden;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    line-height: 1.15;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .mobile-filter-select,
   .mobile-item-type-toggle,
-  .mobile-event-type-toggle {
+  .mobile-event-type-toggle,
+  .mobile-boolean-toggle {
     min-width: 0;
     min-height: var(--mobile-hit-target);
     display: grid;
@@ -1093,18 +1171,30 @@
   }
 
   .mobile-item-type-toggle,
-  .mobile-event-type-toggle {
+  .mobile-event-type-toggle,
+  .mobile-boolean-toggle {
     display: flex;
+    padding: 0 var(--mobile-space-2xs);
+    border: 0;
+    border-radius: 0;
+    background: transparent;
   }
 
   .mobile-item-type-toggle :global(.kit-toggle),
-  .mobile-event-type-toggle :global(.kit-toggle) {
+  .mobile-event-type-toggle :global(.kit-toggle),
+  .mobile-boolean-toggle :global(.kit-toggle) {
     width: 100%;
     min-height: var(--mobile-hit-target);
   }
 
   .mobile-filter-select--repo {
     grid-column: 1 / -1;
+    display: block;
+    min-height: 0;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
   }
 
   .mobile-filter-select--repo :global(.typeahead-popover) {
@@ -1155,25 +1245,6 @@
   .mobile-filter-select :global(.mobile-filter-dropdown .kit-select-dropdown__check) {
     width: 13px;
   }
-
-  .mobile-filter-toggle {
-    min-height: var(--mobile-hit-target);
-    flex: 0 0 auto;
-    padding: var(--mobile-space-sm) var(--mobile-space-md);
-    border: thin solid var(--border-default);
-    border-radius: var(--radius-md);
-    color: var(--text-secondary);
-    background: var(--bg-inset);
-    font-size: var(--font-size-sm);
-    font-weight: 750;
-  }
-
-  .mobile-filter-toggle.active {
-    color: var(--accent-blue);
-    background: color-mix(in srgb, var(--accent-blue) 12%, transparent);
-    border-color: color-mix(in srgb, var(--accent-blue) 34%, transparent);
-  }
-
 
   .mobile-activity-card-list {
     display: grid;

--- a/frontend/src/lib/views/MobileActivityView.svelte
+++ b/frontend/src/lib/views/MobileActivityView.svelte
@@ -15,6 +15,7 @@
   import {
     Card,
     Chip,
+    IconButton,
     ScrollBox,
     SearchInput,
     Timeline,
@@ -31,6 +32,7 @@
   import { SelectDropdown } from "@kenn-io/kit-ui";
   import WorkspaceIndicator from "../components/shared/WorkspaceIndicator.svelte";
   import CheckIcon from "@lucide/svelte/icons/check";
+  import FunnelIcon from "@lucide/svelte/icons/funnel";
   import {
     activityBranchKey,
     activityItemKey,
@@ -587,46 +589,33 @@
 <section class="mobile-activity-inbox" aria-label="Mobile activity inbox">
   <ScrollBox label="Activity inbox">
   <div class="mobile-activity-scroll">
-    <header class="mobile-activity-hero">
-      <p class="mobile-activity-eyebrow">
-        Activity inbox · {activity.getTimeRange()}
-      </p>
-      <h1>What needs attention?</h1>
-    </header>
+    <div class="mobile-activity-toolbar">
+      <div class="mobile-activity-search">
+        <SearchInput
+          bind:value={searchInput}
+          block
+          placeholder="Search activity"
+          ariaLabel="Search activity"
+          oninput={handleSearchInput}
+        />
+      </div>
 
-    <div class="mobile-activity-search">
-      <SearchInput
-        bind:value={searchInput}
-        block
-        placeholder="Search activity"
-        ariaLabel="Search activity"
-        oninput={handleSearchInput}
-      />
-    </div>
-
-    <div class="mobile-filter-summary">
-      <button
-        type="button"
-        class="mobile-filter-disclosure"
-        aria-label={activity.getActivityAuthor()
+      <div class="mobile-filter-summary">
+        <IconButton
+          size="md"
+          tone="info"
+          ariaLabel={activity.getActivityAuthor()
           ? `Filters · ${activity.getActivityAuthor()}`
           : "Filters"}
-        aria-expanded={filtersExpanded}
-        aria-controls="mobile-activity-filters"
-        onclick={() => filtersExpanded = !filtersExpanded}
-      >
-        <span>Filters</span>
-        {#if activity.getActivityAuthor()}
-          <span class="mobile-filter-author">· {activity.getActivityAuthor()}</span>
-        {/if}
-        {#if activeFilterCount > 0}
-          <span class="mobile-filter-count" aria-label={`${activeFilterCount} active filters`}>
-            {activeFilterCount}
-          </span>
-        {/if}
-        <span aria-hidden="true">{filtersExpanded ? "−" : "+"}</span>
-      </button>
-
+          title="Filters"
+          ariaExpanded={filtersExpanded}
+          ariaControls="mobile-activity-filters"
+          ariaPressed={filtersExpanded || activeFilterCount > 0}
+          onclick={() => filtersExpanded = !filtersExpanded}
+        >
+          <FunnelIcon size={18} strokeWidth={2} aria-hidden="true" />
+        </IconButton>
+      </div>
     </div>
 
     {#if filtersExpanded}
@@ -874,28 +863,16 @@
     font-size: var(--font-size-md);
   }
 
-  .mobile-activity-hero {
-    margin: var(--mobile-space-2xs) var(--mobile-space-2xs) var(--mobile-space-sm);
-  }
-
-  .mobile-activity-eyebrow {
-    margin: 0 0 var(--mobile-space-2xs);
-    color: var(--text-secondary);
-    font-size: var(--font-size-sm);
-    font-weight: 700;
-    letter-spacing: 0.02em;
-  }
-
-  .mobile-activity-hero h1 {
-    margin: 0;
-    color: var(--text-primary);
-    font-size: var(--font-size-xl);
-    line-height: 1.16;
-    letter-spacing: 0;
+  .mobile-activity-toolbar {
+    display: flex;
+    align-items: stretch;
+    gap: var(--mobile-space-xs);
+    margin-bottom: var(--mobile-space-sm);
   }
 
   .mobile-activity-search {
-    margin-bottom: var(--mobile-space-sm);
+    flex: 1;
+    min-width: 0;
   }
 
   .mobile-activity-search :global(.kit-search-input) {
@@ -911,44 +888,16 @@
   .mobile-filter-summary {
     display: flex;
     align-items: center;
-    flex-wrap: wrap;
-    gap: var(--mobile-space-xs);
-    margin-bottom: var(--mobile-space-sm);
+    flex: 0 0 auto;
   }
 
-  .mobile-filter-disclosure {
-    max-width: 100%;
+  .mobile-filter-summary :global(.kit-icon-button) {
+    width: calc(var(--mobile-hit-target) + var(--mobile-space-xs));
+    height: 100%;
     min-height: var(--mobile-hit-target);
-    display: inline-flex;
-    align-items: center;
-    gap: var(--mobile-space-xs);
-    padding: 0 var(--mobile-space-md);
     border: thin solid var(--border-default);
     border-radius: var(--radius-md);
-    color: var(--text-primary);
     background: var(--bg-inset);
-    font: inherit;
-    font-weight: 750;
-  }
-
-  .mobile-filter-author {
-    min-width: 0;
-    max-width: 12rem;
-    overflow: hidden;
-    color: var(--text-secondary);
-    font-weight: var(--font-weight-medium, 500);
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .mobile-filter-count {
-    min-width: 20px;
-    padding: 1px 6px;
-    border-radius: 999px;
-    color: var(--accent-blue);
-    background: color-mix(in srgb, var(--accent-blue) 14%, transparent);
-    font-size: var(--font-size-xs);
-    text-align: center;
   }
 
   .mobile-activity-filter-grid {

--- a/frontend/src/lib/views/MobileActivityView.svelte
+++ b/frontend/src/lib/views/MobileActivityView.svelte
@@ -1,13 +1,16 @@
 <script lang="ts">
   import { Effect } from "effect";
   import { onDestroy, onMount } from "svelte";
+  import type { Attachment } from "svelte/attachments";
   import { SvelteMap, SvelteSet } from "svelte/reactivity";
   import { getAppRuntime } from "../app/runtime-context.js";
+  import { observeIntersection } from "../browser/observers.js";
   import type { AppExecution } from "../app/runtime.js";
   import type { ActivityItem, ActivitySubject, WorkspaceActivitySubject } from "../api/types.js";
   import { getStores } from "../context.js";
   import {
     buildActivityFilterTypes,
+    DEFAULT_EVENT_TYPES,
     isActivityItemTypeEnabled,
     type ActivityItemType,
     type TimeRange,
@@ -67,16 +70,26 @@
     events: ActivityItem[];
     eventCount: number;
     latestTime: string;
+    previewRevision: string;
     workspaceActivityAt?: string;
   };
 
   const BOT_SUFFIXES = ["[bot]", "-bot", "bot"];
+  const EVENT_TYPES = DEFAULT_EVENT_TYPES;
+  type EventType = (typeof EVENT_TYPES)[number];
+  const EVENT_LABELS: Record<EventType, string> = {
+    comment: "Comments",
+    review: "Reviews",
+    commit: "Commits",
+    force_push: "Force pushes",
+  };
   const timeRanges: TimeRange[] = ["24h", "7d", "30d", "90d"];
   const timeRangeOptions = timeRanges.map((range) => ({
     value: range,
     label: range,
   }));
   let searchInput = $state("");
+  let activityPageLimit = $state(30);
   let filtersExpanded = $state(false);
   let searchExecution: AppExecution<void, never> | null = null;
   let unsubSync: (() => void) | undefined;
@@ -90,7 +103,8 @@
   onMount(() => {
     activity.initializeFromMount();
     searchInput = activity.getActivitySearch() ?? "";
-    activity.setFullEventProjectionRequired(true);
+    activityPageLimit = 30;
+    activity.setActivityPageLimit(activityPageLimit);
     activity.loadActivity(true);
     activity.startActivityPolling();
     unsubSync = sync.subscribeSyncComplete(() => {
@@ -100,7 +114,7 @@
   });
 
   onDestroy(() => {
-    activity.setFullEventProjectionRequired(false);
+    activity.setActivityPageLimit(undefined);
     activity.stopActivityPolling();
     unsubSync?.();
     searchExecution?.interrupt();
@@ -210,6 +224,7 @@
           representative.created_at,
           representative.item_last_activity_at,
         ),
+        previewRevision: "",
       });
     }
 
@@ -244,6 +259,7 @@
           repo: subject.repo,
           ...(subject.workspace ? { workspace: subject.workspace } : {}),
         };
+        existing.previewRevision = subject.event_ledger_revision ?? subject.activity_at;
         continue;
       }
       groupsByKey.set(key, {
@@ -252,6 +268,7 @@
         events: [],
         eventCount: 0,
         latestTime: subject.activity_at,
+        previewRevision: subject.event_ledger_revision ?? subject.activity_at,
       });
     }
 
@@ -291,6 +308,7 @@
         events: [],
         eventCount: 0,
         latestTime: subject.activity_at,
+        previewRevision: subject.activity_at,
         workspaceActivityAt: subject.activity_at,
       });
     }
@@ -319,7 +337,9 @@
     + (selectedRepo ? 1 : 0)
     + (activity.getEnabledItemTypes().has("pr") ? 0 : 1)
     + (activity.getEnabledItemTypes().has("issue") ? 0 : 1)
+    + (EVENT_TYPES.length - activity.getEnabledEvents().size)
     + (activity.getHideBots() ? 1 : 0)
+    + (activity.getHideClosedMerged() ? 1 : 0)
     + (activity.getHideDefaultBranchActivity() ? 1 : 0)
     + (grouping.getHideOrgName() ? 1 : 0)
     + (activity.getShowNotifications() ? 0 : 1)
@@ -356,6 +376,14 @@
     applyFilters();
   }
 
+  function toggleEvent(eventType: EventType): void {
+    const next = new SvelteSet(activity.getEnabledEvents());
+    if (next.has(eventType)) next.delete(eventType);
+    else next.add(eventType);
+    activity.setEnabledEvents(next);
+    applyFilters();
+  }
+
   function setTimeRange(range: TimeRange): void {
     activity.setTimeRange(range);
     activity.syncToURL();
@@ -380,6 +408,11 @@
   function toggleHideBots(): void {
     activity.setHideBots(!activity.getHideBots());
     applyFilters();
+  }
+
+  function toggleHideClosedMerged(): void {
+    activity.setHideClosedMerged(!activity.getHideClosedMerged());
+    activity.loadActivity();
   }
 
   function toggleHideNotifications(): void {
@@ -429,6 +462,44 @@
       return;
     }
     onSelectItem?.(group.representative);
+  }
+
+  function loadPreviewWhenVisible(key: string, previewRevision: string): Attachment<HTMLElement> {
+    return (node) => {
+      void previewRevision;
+      const load = () => activity.loadThreadPreview(key);
+
+      if (typeof IntersectionObserver === "undefined") {
+        load();
+        return;
+      }
+
+      const root = node.closest(".kit-scrollbox__viewport");
+      const execution = runtime.runCommand(
+        Effect.scoped(
+          observeIntersection(
+            node,
+            (entries) => {
+              if (entries[0]?.isIntersecting) load();
+            },
+            { root, rootMargin: "240px 0px" },
+          ).pipe(Effect.andThen(Effect.never)),
+        ),
+        {
+          operation: "observe mobile activity preview",
+          safeContext: {},
+          onFailure: () => {},
+        },
+      );
+
+      return () => execution.interrupt();
+    };
+  }
+
+  function loadMoreActivity(): void {
+    activityPageLimit = Math.min(activityPageLimit + 30, 500);
+    activity.setActivityPageLimit(activityPageLimit);
+    activity.loadActivity();
   }
 
   function subjectSelectionItem(
@@ -652,6 +723,24 @@
         />
       </div>
 
+      {#each EVENT_TYPES as eventType (eventType)}
+        <div class="mobile-event-type-toggle">
+          <Toggle
+            checked={activity.getEnabledEvents().has(eventType)}
+            label={EVENT_LABELS[eventType]}
+            onchange={() => toggleEvent(eventType)}
+          />
+        </div>
+      {/each}
+
+      <div class="mobile-event-type-toggle">
+        <Toggle
+          checked={activity.getShowNotifications()}
+          label="Notifications"
+          onchange={toggleHideNotifications}
+        />
+      </div>
+
       <div class="mobile-filter-select">
         <span>Range</span>
         <SelectDropdown
@@ -685,6 +774,14 @@
       <button
         type="button"
         class="mobile-filter-toggle"
+        class:active={activity.getHideClosedMerged()}
+        aria-pressed={activity.getHideClosedMerged()}
+        onclick={toggleHideClosedMerged}
+      >Hide closed/merged</button>
+
+      <button
+        type="button"
+        class="mobile-filter-toggle"
         class:active={activity.getHideBots()}
         aria-pressed={activity.getHideBots()}
         onclick={toggleHideBots}
@@ -706,13 +803,6 @@
         onclick={toggleHideOrgName}
       >Hide org</button>
 
-      <button
-        type="button"
-        class="mobile-filter-toggle"
-        class:active={!activity.getShowNotifications()}
-        aria-pressed={!activity.getShowNotifications()}
-        onclick={toggleHideNotifications}
-      >Hide notifications</button>
     </div>
     {/if}
 
@@ -731,7 +821,7 @@
       <div class="mobile-activity-card-list">
         {#each visibleGroups as group (group.key)}
           {@const item = group.representative}
-          <article>
+          <article {@attach loadPreviewWhenVisible(group.key, group.previewRevision)}>
             <Card level="raised" padding="none" class="mobile-activity-card">
               <button
                 type="button"
@@ -766,7 +856,7 @@
                 </span>
                 <span class="mobile-activity-card__meta">
                   <span>{repoLabel(item)}</span>
-                  <span>{group.eventCount} {group.eventCount === 1 ? "event" : "events"}</span>
+                  <span>Recent activity</span>
                 </span>
               </button>
 
@@ -815,15 +905,22 @@
 
     {#if activity.isActivityCapped()}
       <div class="mobile-activity-capped event-capped-notice">
-        Showing most recent 5,000 events. Narrow the range or filters to see more.
+        Showing the most recent activity. Narrow the range or filters to see more.
       </div>
     {/if}
 
     {#if activity.isItemActivityCapped()}
       <div class="mobile-activity-capped item-activity-capped-notice">
-        Showing the 5,000 most recently active pull requests and issues. Item totals may be incomplete; narrow the
-        range or item filters to see fewer results.
+        Showing the most recently active pull requests and issues. Narrow the range or item filters to see more.
       </div>
+      {#if activityPageLimit < 500}
+        <button
+          type="button"
+          class="mobile-activity-load-more"
+          disabled={activity.isActivityLoading()}
+          onclick={loadMoreActivity}
+        >Load 30 more</button>
+      {/if}
     {/if}
   </div>
   </ScrollBox>
@@ -934,7 +1031,8 @@
   }
 
   .mobile-filter-select,
-  .mobile-item-type-toggle {
+  .mobile-item-type-toggle,
+  .mobile-event-type-toggle {
     min-width: 0;
     min-height: var(--mobile-hit-target);
     display: grid;
@@ -948,11 +1046,13 @@
     background: var(--bg-inset);
   }
 
-  .mobile-item-type-toggle {
+  .mobile-item-type-toggle,
+  .mobile-event-type-toggle {
     display: flex;
   }
 
-  .mobile-item-type-toggle :global(.kit-toggle) {
+  .mobile-item-type-toggle :global(.kit-toggle),
+  .mobile-event-type-toggle :global(.kit-toggle) {
     width: 100%;
     min-height: var(--mobile-hit-target);
   }
@@ -1222,6 +1322,14 @@
     background: var(--bg-surface);
     font-size: var(--font-size-sm);
     text-align: center;
+  }
+
+  .mobile-activity-load-more {
+    min-height: var(--mobile-hit-target);
+    border: thin solid var(--border-default);
+    border-radius: var(--mobile-radius-sm);
+    color: var(--text-primary);
+    background: var(--bg-inset);
   }
 
   .mobile-activity-error {

--- a/frontend/src/lib/views/MobileActivityView.test.ts
+++ b/frontend/src/lib/views/MobileActivityView.test.ts
@@ -93,6 +93,26 @@ const setActivityAuthor = vi.hoisted(() =>
   }),
 );
 
+function stubIntersectionObserver(): Map<Element, IntersectionObserverCallback> {
+  const observed = new Map<Element, IntersectionObserverCallback>();
+  class IntersectionObserverStub {
+    constructor(private readonly callback: IntersectionObserverCallback) {}
+    observe(target: Element): void {
+      observed.set(target, this.callback);
+    }
+    disconnect(): void {}
+    unobserve(): void {}
+    takeRecords(): IntersectionObserverEntry[] {
+      return [];
+    }
+    readonly root = null;
+    readonly rootMargin = "0px";
+    readonly thresholds = [0];
+  }
+  vi.stubGlobal("IntersectionObserver", IntersectionObserverStub);
+  return observed;
+}
+
 vi.mock("../stores/flash.svelte.js", () => ({ showFlash }));
 
 vi.mock("../context.js", () => ({
@@ -307,24 +327,9 @@ describe("MobileActivityView branch activity", () => {
     expect(setActivityPageLimit).toHaveBeenLastCalledWith(undefined);
   });
 
-  it("autoloads one parent chunk when the end sentinel enters the viewport", async () => {
-    const observed = new Map<Element, IntersectionObserverCallback>();
-    class IntersectionObserverStub {
-      constructor(private readonly callback: IntersectionObserverCallback) {}
-      observe(target: Element): void {
-        observed.set(target, this.callback);
-      }
-      disconnect(): void {}
-      unobserve(): void {}
-      takeRecords(): IntersectionObserverEntry[] {
-        return [];
-      }
-      readonly root = null;
-      readonly rootMargin = "0px";
-      readonly thresholds = [0];
-    }
-    vi.stubGlobal("IntersectionObserver", IntersectionObserverStub);
-    itemActivityCapped.value = true;
+  it("autoloads one direct-activity chunk when the end sentinel enters the viewport", async () => {
+    const observed = stubIntersectionObserver();
+    activityCapped.value = true;
     activityLoading.value = true;
     const { container } = render(MobileActivityView, { props: { onSelectItem } });
     const sentinel = container.querySelector(".mobile-activity-loading-sentinel");
@@ -346,6 +351,25 @@ describe("MobileActivityView branch activity", () => {
     await fireEvent.touchStart(viewport!);
     expect(setActivityPageLimit).toHaveBeenLastCalledWith(90);
     expect(loadActivity).toHaveBeenCalledTimes(3);
+  });
+
+  it("renders the next parent chunk after autoloading it", async () => {
+    const observed = stubIntersectionObserver();
+    items.value = Array.from({ length: 31 }, (_, index) =>
+      branchActivityItem(`branch-commit-${index + 1}`, {
+        body_preview: `Branch activity ${index + 1}`,
+        branch_name: `branch-${index + 1}`,
+      }),
+    );
+    itemActivityCapped.value = true;
+    const { container } = render(MobileActivityView, { props: { onSelectItem } });
+    expect(container.querySelectorAll("article")).toHaveLength(30);
+
+    const sentinel = container.querySelector(".mobile-activity-loading-sentinel");
+    expect(sentinel).toBeTruthy();
+    observed.get(sentinel!)?.([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver);
+
+    await waitFor(() => expect(container.querySelectorAll("article")).toHaveLength(31));
   });
 
   it("does not render truncation warnings or a manual load control", () => {

--- a/frontend/src/lib/views/MobileActivityView.test.ts
+++ b/frontend/src/lib/views/MobileActivityView.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/svelte";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { ActivityItem, ActivitySubject, WorkspaceActivitySubject } from "../api/types.js";
 import MobileActivityView from "./MobileActivityViewRuntimeHarness.svelte";
@@ -46,6 +46,9 @@ const hideOrgName = vi.hoisted(() => ({ value: false }));
 const showNotifications = vi.hoisted(() => ({ value: true }));
 const activityCapped = vi.hoisted(() => ({ value: false }));
 const itemActivityCapped = vi.hoisted(() => ({ value: false }));
+const activityLoading = vi.hoisted(() => ({ value: false }));
+const activityError = vi.hoisted(() => ({ value: null as string | null }));
+const showFlash = vi.hoisted(() => vi.fn());
 const involvesMe = vi.hoisted(() => ({ value: false }));
 const enabledEvents = vi.hoisted(() => ({
   value: new Set(["comment", "review", "commit", "force_push"]),
@@ -90,6 +93,8 @@ const setActivityAuthor = vi.hoisted(() =>
   }),
 );
 
+vi.mock("../stores/flash.svelte.js", () => ({ showFlash }));
+
 vi.mock("../context.js", () => ({
   getStores: () => ({
     activity: {
@@ -105,7 +110,7 @@ vi.mock("../context.js", () => ({
       getActivityItems: () => items.value,
       getItemActivity: () => itemActivity.value,
       getWorkspaceActivity: () => workspaceActivity.value,
-      getActivityError: () => null,
+      getActivityError: () => activityError.value,
       getTimeRange: () => "7d",
       getEnabledItemTypes: () => enabledItemTypes.value,
       getEnabledEvents: () => enabledEvents.value,
@@ -115,7 +120,7 @@ vi.mock("../context.js", () => ({
       getHideBots: () => hideBots.value,
       getUseWorkspaceActivityForRecency: () => useWorkspaceActivityForRecency.value,
       getHideDefaultBranchActivity: () => false,
-      isActivityLoading: () => false,
+      isActivityLoading: () => activityLoading.value,
       isActivityCapped: () => activityCapped.value,
       isItemActivityCapped: () => itemActivityCapped.value,
       setActivityFilterTypes: vi.fn(),
@@ -138,7 +143,32 @@ vi.mock("../context.js", () => ({
       syncToURL: vi.fn(),
     },
     settings: {
-      getConfiguredRepos: () => [],
+      getConfiguredRepos: () => [
+        {
+          provider: "github",
+          platform_host: "github.com",
+          owner: "acme",
+          name: "api",
+          repo_path: "acme/api",
+          platform_repo_id: "R_api",
+          is_glob: false,
+          matched_repo_count: 1,
+          hidden_from_ui: false,
+        },
+      ],
+      getRepoPresets: () => [
+        {
+          name: "Backend",
+          repos: [
+            {
+              provider: "github",
+              platform_host: "github.com",
+              platform_repo_id: "R_api",
+              repo_path: "acme/api",
+            },
+          ],
+        },
+      ],
       isSettingsLoaded: () => true,
       hasConfiguredRepos: () => true,
     },
@@ -166,6 +196,8 @@ describe("MobileActivityView branch activity", () => {
     hideClosedMerged.value = false;
     activityCapped.value = false;
     itemActivityCapped.value = false;
+    activityLoading.value = false;
+    activityError.value = null;
     enabledEvents.value = new Set(["comment", "review", "commit", "force_push"]);
     enabledItemTypes.value = new Set(["pr", "issue"]);
     onSelectItem.mockClear();
@@ -179,10 +211,12 @@ describe("MobileActivityView branch activity", () => {
     setFullEventProjectionRequired.mockClear();
     setActivityPageLimit.mockClear();
     loadThreadPreview.mockClear();
+    showFlash.mockClear();
   });
 
   afterEach(() => {
     cleanup();
+    vi.unstubAllGlobals();
   });
 
   it("keeps search and icon-only filters in one compact toolbar", () => {
@@ -208,6 +242,22 @@ describe("MobileActivityView branch activity", () => {
     await fireEvent.click(comments);
 
     expect([...setEnabledEvents.mock.calls[0]![0]]).toEqual(["review", "commit", "force_push"]);
+  });
+
+  it("uses the shared repository picker inside the filter panel", async () => {
+    const onRepoChange = vi.fn();
+    render(MobileActivityView, { props: { onSelectItem, onRepoChange } });
+
+    expect(screen.queryByRole("button", { name: "Select repository: Global" })).toBeNull();
+    await fireEvent.click(screen.getByRole("button", { name: "Filters" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Select repository: Global" }));
+    loadActivity.mockClear();
+    await fireEvent.mouseDown(screen.getByRole("option", { name: "Backend" }));
+
+    expect(onRepoChange).toHaveBeenCalledWith("github|github.com/acme/api");
+    expect(loadActivity).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("button", { name: "Save preset" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Delete preset Backend" })).toBeNull();
   });
 
   it("exposes closed and merged visibility", async () => {
@@ -250,23 +300,67 @@ describe("MobileActivityView branch activity", () => {
     expect(setActivityPageLimit).toHaveBeenLastCalledWith(undefined);
   });
 
-  it("loads the next bounded parent chunk on demand", async () => {
+  it("autoloads one parent chunk when the end sentinel enters the viewport", async () => {
+    const observed = new Map<Element, IntersectionObserverCallback>();
+    class IntersectionObserverStub {
+      constructor(private readonly callback: IntersectionObserverCallback) {}
+      observe(target: Element): void {
+        observed.set(target, this.callback);
+      }
+      disconnect(): void {}
+      unobserve(): void {}
+      takeRecords(): IntersectionObserverEntry[] {
+        return [];
+      }
+      readonly root = null;
+      readonly rootMargin = "0px";
+      readonly thresholds = [0];
+    }
+    vi.stubGlobal("IntersectionObserver", IntersectionObserverStub);
     itemActivityCapped.value = true;
-    render(MobileActivityView, { props: { onSelectItem } });
+    activityLoading.value = true;
+    const { container } = render(MobileActivityView, { props: { onSelectItem } });
+    const sentinel = container.querySelector(".mobile-activity-loading-sentinel");
+    expect(sentinel).toBeTruthy();
+    const notify = observed.get(sentinel!);
+    expect(notify).toBeTruthy();
 
-    await fireEvent.click(screen.getByRole("button", { name: "Load 30 more" }));
+    notify!([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver);
 
     expect(setActivityPageLimit).toHaveBeenLastCalledWith(60);
     expect(loadActivity).toHaveBeenCalledTimes(2);
+
+    notify!([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver);
+    expect(loadActivity).toHaveBeenCalledTimes(2);
+
+    activityLoading.value = false;
+    const viewport = sentinel!.closest(".kit-scrollbox__viewport");
+    expect(viewport).toBeTruthy();
+    await fireEvent.touchStart(viewport!);
+    expect(setActivityPageLimit).toHaveBeenLastCalledWith(90);
+    expect(loadActivity).toHaveBeenCalledTimes(3);
   });
 
-  it("warns about parent truncation separately from event truncation", () => {
+  it("does not render truncation warnings or a manual load control", () => {
+    activityCapped.value = true;
     itemActivityCapped.value = true;
 
     render(MobileActivityView, { props: { onSelectItem } });
 
-    expect(screen.getByText(/most recently active pull requests and issues/)).toBeTruthy();
     expect(screen.queryByText(/most recent activity/)).toBeNull();
+    expect(screen.queryByText(/most recently active pull requests and issues/)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Load 30 more" })).toBeNull();
+  });
+
+  it("reports connection errors through the shared Kit UI warning banner", async () => {
+    activityError.value = "Could not reach Kenn Forge";
+
+    const { container } = render(MobileActivityView, { props: { onSelectItem } });
+
+    await waitFor(() => {
+      expect(showFlash).toHaveBeenCalledWith("Could not reach Kenn Forge", { tone: "warning", durationMs: 8_000 });
+    });
+    expect(container.querySelector(".mobile-activity-error")).toBeNull();
   });
 
   it("exposes independent PR and issue toggles", async () => {

--- a/frontend/src/lib/views/MobileActivityView.test.ts
+++ b/frontend/src/lib/views/MobileActivityView.test.ts
@@ -47,9 +47,22 @@ const showNotifications = vi.hoisted(() => ({ value: true }));
 const activityCapped = vi.hoisted(() => ({ value: false }));
 const itemActivityCapped = vi.hoisted(() => ({ value: false }));
 const involvesMe = vi.hoisted(() => ({ value: false }));
+const enabledEvents = vi.hoisted(() => ({
+  value: new Set(["comment", "review", "commit", "force_push"]),
+}));
 const enabledItemTypes = vi.hoisted(() => ({
   value: new Set<"pr" | "issue">(["pr", "issue"]),
 }));
+const setEnabledEvents = vi.hoisted(() =>
+  vi.fn((events: Set<string>) => {
+    enabledEvents.value = events;
+  }),
+);
+const setHideClosedMerged = vi.hoisted(() =>
+  vi.fn((value: boolean) => {
+    hideClosedMerged.value = value;
+  }),
+);
 const setEnabledItemTypes = vi.hoisted(() =>
   vi.fn((itemTypes: Set<"pr" | "issue">) => {
     enabledItemTypes.value = itemTypes;
@@ -68,6 +81,8 @@ const setShowNotifications = vi.hoisted(() =>
 const markNotificationSeen = vi.hoisted(() => vi.fn(async () => undefined));
 const loadActivity = vi.hoisted(() => vi.fn(async () => undefined));
 const setFullEventProjectionRequired = vi.hoisted(() => vi.fn());
+const setActivityPageLimit = vi.hoisted(() => vi.fn());
+const loadThreadPreview = vi.hoisted(() => vi.fn());
 const selectedAuthor = vi.hoisted(() => ({ value: undefined as string | undefined }));
 const setActivityAuthor = vi.hoisted(() =>
   vi.fn((author: string | undefined) => {
@@ -93,7 +108,7 @@ vi.mock("../context.js", () => ({
       getActivityError: () => null,
       getTimeRange: () => "7d",
       getEnabledItemTypes: () => enabledItemTypes.value,
-      getEnabledEvents: () => new Set(["comment", "review", "commit", "force_push"]),
+      getEnabledEvents: () => enabledEvents.value,
       getShowNotifications: () => showNotifications.value,
       getInvolvesMe: () => involvesMe.value,
       getHideClosedMerged: () => hideClosedMerged.value,
@@ -107,12 +122,16 @@ vi.mock("../context.js", () => ({
       setActivitySearch: vi.fn(),
       setActivityAuthor,
       setTimeRange: vi.fn(),
+      setEnabledEvents,
       setEnabledItemTypes,
+      setHideClosedMerged,
       setShowNotifications,
       setInvolvesMe: vi.fn((value: boolean) => {
         involvesMe.value = value;
       }),
       setFullEventProjectionRequired,
+      setActivityPageLimit,
+      loadThreadPreview,
       markNotificationSeen,
       setHideBots: vi.fn(),
       setHideDefaultBranchActivity: vi.fn(),
@@ -147,14 +166,19 @@ describe("MobileActivityView branch activity", () => {
     hideClosedMerged.value = false;
     activityCapped.value = false;
     itemActivityCapped.value = false;
+    enabledEvents.value = new Set(["comment", "review", "commit", "force_push"]);
     enabledItemTypes.value = new Set(["pr", "issue"]);
     onSelectItem.mockClear();
     setEnabledItemTypes.mockClear();
     setHideOrgName.mockClear();
     selectedAuthor.value = undefined;
     setActivityAuthor.mockClear();
+    setEnabledEvents.mockClear();
+    setHideClosedMerged.mockClear();
     loadActivity.mockClear();
     setFullEventProjectionRequired.mockClear();
+    setActivityPageLimit.mockClear();
+    loadThreadPreview.mockClear();
   });
 
   afterEach(() => {
@@ -174,6 +198,30 @@ describe("MobileActivityView branch activity", () => {
     expect(filters.querySelector("svg")).toBeTruthy();
   });
 
+  it("exposes the desktop event-type filters", async () => {
+    render(MobileActivityView, { props: { onSelectItem } });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Filters" }));
+    const comments = screen.getByRole<HTMLInputElement>("switch", { name: "Comments" });
+    expect(comments.checked).toBe(true);
+
+    await fireEvent.click(comments);
+
+    expect([...setEnabledEvents.mock.calls[0]![0]]).toEqual(["review", "commit", "force_push"]);
+  });
+
+  it("exposes closed and merged visibility", async () => {
+    render(MobileActivityView, { props: { onSelectItem } });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Filters" }));
+    const control = screen.getByRole("button", { name: "Hide closed/merged" });
+    expect(control.getAttribute("aria-pressed")).toBe("false");
+
+    await fireEvent.click(control);
+
+    expect(setHideClosedMerged).toHaveBeenCalledWith(true);
+  });
+
   it("renders branch activity without a fake PR or issue number", () => {
     const { container } = render(MobileActivityView, {
       props: { onSelectItem },
@@ -189,16 +237,27 @@ describe("MobileActivityView branch activity", () => {
     expect(article?.querySelector(".chip--kind-issue")).toBeNull();
   });
 
-  it("requires full event projection for its mounted lifetime", () => {
+  it("uses a bounded projection for its mounted lifetime", () => {
     const view = render(MobileActivityView, { props: { onSelectItem } });
 
-    expect(setFullEventProjectionRequired).toHaveBeenCalledWith(true);
-    expect(setFullEventProjectionRequired.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(setActivityPageLimit).toHaveBeenCalledWith(30);
+    expect(setActivityPageLimit.mock.invocationCallOrder[0]).toBeLessThan(
       loadActivity.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
     );
+    expect(setFullEventProjectionRequired).not.toHaveBeenCalled();
 
     view.unmount();
-    expect(setFullEventProjectionRequired).toHaveBeenLastCalledWith(false);
+    expect(setActivityPageLimit).toHaveBeenLastCalledWith(undefined);
+  });
+
+  it("loads the next bounded parent chunk on demand", async () => {
+    itemActivityCapped.value = true;
+    render(MobileActivityView, { props: { onSelectItem } });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Load 30 more" }));
+
+    expect(setActivityPageLimit).toHaveBeenLastCalledWith(60);
+    expect(loadActivity).toHaveBeenCalledTimes(2);
   });
 
   it("warns about parent truncation separately from event truncation", () => {
@@ -206,8 +265,8 @@ describe("MobileActivityView branch activity", () => {
 
     render(MobileActivityView, { props: { onSelectItem } });
 
-    expect(screen.getByText(/5,000 most recently active pull requests and issues/)).toBeTruthy();
-    expect(screen.queryByText(/most recent 5,000 events/)).toBeNull();
+    expect(screen.getByText(/most recently active pull requests and issues/)).toBeTruthy();
+    expect(screen.queryByText(/most recent activity/)).toBeNull();
   });
 
   it("exposes independent PR and issue toggles", async () => {
@@ -471,7 +530,7 @@ describe("MobileActivityView workspace activity", () => {
     const { container } = render(MobileActivityView, { props: { onSelectItem } });
 
     expect(screen.getByText("Workspace-only pull")).toBeTruthy();
-    expect(screen.getByText("0 events")).toBeTruthy();
+    expect(screen.getByText("Recent activity")).toBeTruthy();
     expect(screen.getByLabelText("Workspace attached (ready)")).toBeTruthy();
     expect(container.querySelector(".mobile-activity-events")).toBeNull();
 
@@ -502,7 +561,7 @@ describe("MobileActivityView workspace activity", () => {
     const { container } = render(MobileActivityView, { props: { onSelectItem } });
 
     expect(screen.getByText("Old pull with recent hidden activity")).toBeTruthy();
-    expect(screen.getByText("0 events")).toBeTruthy();
+    expect(screen.getByText("Recent activity")).toBeTruthy();
     expect(container.querySelector(".mobile-activity-card time")?.textContent).toBe("5m ago");
     expect(container.querySelector(".mobile-activity-events")).toBeNull();
   });
@@ -627,8 +686,8 @@ describe("MobileActivityView notifications", () => {
     });
 
     await fireEvent.click(getByRole("button", { name: /^Filters/ }));
-    const button = getByRole("button", { name: "Hide notifications" });
-    expect(button.getAttribute("aria-pressed")).toBe("false");
+    const button = getByRole<HTMLInputElement>("switch", { name: "Notifications" });
+    expect(button.checked).toBe(true);
 
     await fireEvent.click(button);
 

--- a/frontend/src/lib/views/MobileActivityView.test.ts
+++ b/frontend/src/lib/views/MobileActivityView.test.ts
@@ -161,6 +161,19 @@ describe("MobileActivityView branch activity", () => {
     cleanup();
   });
 
+  it("keeps search and icon-only filters in one compact toolbar", () => {
+    render(MobileActivityView, { props: { onSelectItem } });
+
+    const search = screen.getByPlaceholderText("Search activity");
+    const filters = screen.getByRole("button", { name: "Filters" });
+    const toolbar = search.closest(".mobile-activity-toolbar");
+
+    expect(toolbar).toBeTruthy();
+    expect(filters.closest(".mobile-activity-toolbar")).toBe(toolbar);
+    expect(filters.textContent?.trim()).toBe("");
+    expect(filters.querySelector("svg")).toBeTruthy();
+  });
+
   it("renders branch activity without a fake PR or issue number", () => {
     const { container } = render(MobileActivityView, {
       props: { onSelectItem },

--- a/frontend/src/lib/views/MobileActivityView.test.ts
+++ b/frontend/src/lib/views/MobileActivityView.test.ts
@@ -250,7 +250,14 @@ describe("MobileActivityView branch activity", () => {
 
     expect(screen.queryByRole("button", { name: "Select repository: Global" })).toBeNull();
     await fireEvent.click(screen.getByRole("button", { name: "Filters" }));
-    await fireEvent.click(screen.getByRole("button", { name: "Select repository: Global" }));
+    const repoPicker = screen.getByRole("button", { name: "Select repository: Global" });
+    const filterPanel = screen.getByLabelText("Activity filters");
+    expect(filterPanel.firstElementChild?.contains(repoPicker)).toBe(true);
+    const authorPicker = screen.getByRole("button", { name: "Filter authors" });
+    const authorRow = authorPicker.closest(".mobile-author-filter");
+    expect(authorRow?.querySelector(".mobile-author-icon")).toBeTruthy();
+    expect(authorRow?.textContent).toContain("All authors");
+    await fireEvent.click(repoPicker);
     loadActivity.mockClear();
     await fireEvent.mouseDown(screen.getByRole("option", { name: "Backend" }));
 
@@ -264,8 +271,8 @@ describe("MobileActivityView branch activity", () => {
     render(MobileActivityView, { props: { onSelectItem } });
 
     await fireEvent.click(screen.getByRole("button", { name: "Filters" }));
-    const control = screen.getByRole("button", { name: "Hide closed/merged" });
-    expect(control.getAttribute("aria-pressed")).toBe("false");
+    const control = screen.getByRole<HTMLInputElement>("switch", { name: "Hide closed/merged" });
+    expect(control.checked).toBe(false);
 
     await fireEvent.click(control);
 
@@ -461,8 +468,8 @@ describe("MobileActivityView branch activity", () => {
     });
 
     await fireEvent.click(getByRole("button", { name: /^Filters/ }));
-    const button = getByRole("button", { name: "Hide org" });
-    expect(button.getAttribute("aria-pressed")).toBe("false");
+    const button = getByRole<HTMLInputElement>("switch", { name: "Hide org" });
+    expect(button.checked).toBe(false);
 
     await fireEvent.click(button);
 

--- a/frontend/src/lib/views/MobileActivityView.test.ts
+++ b/frontend/src/lib/views/MobileActivityView.test.ts
@@ -224,10 +224,10 @@ describe("MobileActivityView branch activity", () => {
 
     const search = screen.getByPlaceholderText("Search activity");
     const filters = screen.getByRole("button", { name: "Filters" });
-    const toolbar = search.closest(".mobile-activity-toolbar");
+    const toolbar = search.closest(".mobile-triage-search-bar");
 
     expect(toolbar).toBeTruthy();
-    expect(filters.closest(".mobile-activity-toolbar")).toBe(toolbar);
+    expect(filters.closest(".mobile-triage-search-bar")).toBe(toolbar);
     expect(filters.textContent?.trim()).toBe("");
     expect(filters.querySelector("svg")).toBeTruthy();
   });

--- a/frontend/tests/e2e-full/mobile-activity-notifications.spec.ts
+++ b/frontend/tests/e2e-full/mobile-activity-notifications.spec.ts
@@ -39,7 +39,7 @@ test.describe("mobile activity notifications", () => {
         (r) => r.request().method() === "GET" && r.url().includes("/api/v1/activity"),
       );
       await page.getByRole("button", { name: /^Filters/ }).click();
-      await page.getByRole("button", { name: "Hide notifications" }).click();
+      await page.getByRole("switch", { name: "Notifications" }).click();
       expect((await reload).status()).toBe(200);
 
       await expect(page.locator(".mobile-activity-event__body strong", { hasText: "Review requested" })).toHaveCount(0);

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -184,16 +184,20 @@ test.describe("phone routes", () => {
     await expect(page.getByText("Readable threads first")).toHaveCount(0);
     const search = page.getByPlaceholder("Search activity");
     const filters = page.getByRole("button", { name: /^Filters/ });
+    const activityFilters = page.locator("#mobile-activity-filters");
     await expect(filters).toHaveText("");
     await expect(filters).toHaveAttribute("aria-expanded", "false");
+    await expect(activityFilters).toBeAttached();
+    await expect(activityFilters).toBeHidden();
     const [searchBounds, filterBounds] = await Promise.all([search.boundingBox(), filters.boundingBox()]);
     expect(searchBounds).not.toBeNull();
     expect(filterBounds).not.toBeNull();
     expect(Math.abs(searchBounds!.y - filterBounds!.y)).toBeLessThan(2);
     expect(filterBounds!.height).toBeGreaterThanOrEqual(44);
-    await filters.click();
+    await filters.locator("svg").click();
     await expect(filters).toHaveAttribute("aria-expanded", "true");
-    await expect(page.locator("#mobile-activity-filters")).toBeVisible();
+    await expect(activityFilters).toBeVisible();
+    expect((await activityFilters.boundingBox())?.height ?? 0).toBeGreaterThan(0);
     await expect(page.getByRole("switch", { name: "PRs" })).toBeVisible();
     await expect(page.getByRole("switch", { name: "Issues" })).toBeVisible();
     await expect(page.getByRole("switch", { name: "Comments" })).toBeVisible();
@@ -225,9 +229,11 @@ test.describe("phone routes", () => {
       const itemTypeToggle = document.querySelector(".mobile-item-type-toggle .kit-toggle");
       const rangeSelect = document.querySelector(".mobile-filter-dropdown button[aria-label^='Time range']");
       const repoSelect = document.querySelector(".mobile-filter-select--repo .typeahead-trigger");
+      const repoChevron = repoSelect?.querySelector(".typeahead-chevron") ?? null;
       const toolbar = document.querySelector(".mobile-triage-search-bar");
       const filterPanel = document.querySelector(".mobile-activity-filter-grid");
       const authorFilter = document.querySelector(".mobile-author-filter");
+      const authorChevron = authorFilter?.querySelector(".kit-typeahead__chevron") ?? null;
       const search = document.querySelector(".kit-search-input");
       const cardRect = firstCard?.getBoundingClientRect();
       const buttonRect = firstButton?.getBoundingClientRect();
@@ -257,7 +263,7 @@ test.describe("phone routes", () => {
       document.body.append(surfaceSample);
       const compactRect = (node: Element | null) => {
         const r = node?.getBoundingClientRect();
-        return r ? { top: r.top, left: r.left, right: r.right, height: r.height } : null;
+        return r ? { top: r.top, left: r.left, right: r.right, width: r.width, height: r.height } : null;
       };
       const fontSize = (node: Element | null): number =>
         node ? Number.parseFloat(getComputedStyle(node).fontSize) : 0;
@@ -305,7 +311,9 @@ test.describe("phone routes", () => {
         itemTypeToggleRect: compactRect(itemTypeToggle),
         rangeSelectRect: compactRect(rangeSelect),
         repoSelectRect: compactRect(repoSelect),
+        repoChevronRect: compactRect(repoChevron),
         authorFilterRect: compactRect(authorFilter),
+        authorChevronRect: compactRect(authorChevron),
         searchLeft: searchRect?.left ?? 0,
         searchRight: searchRect?.right ?? 0,
       };
@@ -347,6 +355,13 @@ test.describe("phone routes", () => {
     expect(metrics.rangeSelectFontSize).toBeGreaterThanOrEqual(15);
     expect(metrics.repoSelectFontSize).toBeGreaterThanOrEqual(15);
     expect(metrics.repoSelectRect?.top ?? Infinity).toBeLessThan(metrics.authorFilterRect?.top ?? 0);
+    expect(
+      (metrics.authorFilterRect?.top ?? Infinity) -
+        (metrics.repoSelectRect?.top ?? 0) -
+        (metrics.repoSelectRect?.height ?? 0),
+    ).toBeLessThanOrEqual(1);
+    expect(metrics.authorChevronRect?.width).toBe(metrics.repoChevronRect?.width);
+    expect(metrics.authorChevronRect?.height).toBe(metrics.repoChevronRect?.height);
     for (const bounds of [metrics.itemTypeToggleRect, metrics.rangeSelectRect, metrics.repoSelectRect]) {
       expect(bounds?.left ?? 0).toBeGreaterThanOrEqual(0);
       expect(bounds?.right ?? 0).toBeLessThanOrEqual(metrics.viewportWidth);

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -166,6 +166,12 @@ test.describe("phone routes", () => {
     await filters.click();
     await expect(page.getByRole("switch", { name: "PRs" })).toBeVisible();
     await expect(page.getByRole("switch", { name: "Issues" })).toBeVisible();
+    await expect(page.getByRole("switch", { name: "Comments" })).toBeVisible();
+    await expect(page.getByRole("switch", { name: "Reviews" })).toBeVisible();
+    await expect(page.getByRole("switch", { name: "Commits" })).toBeVisible();
+    await expect(page.getByRole("switch", { name: "Force pushes" })).toBeVisible();
+    await expect(page.getByRole("switch", { name: "Notifications" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Hide closed/merged" })).toBeVisible();
     await expect(page.getByLabel("Time range")).toBeVisible();
     await expect(page.getByLabel("Repository")).toBeVisible();
     await expect(page.locator(".threaded-view")).toHaveCount(0);
@@ -377,10 +383,10 @@ test.describe("phone routes", () => {
     const response = await filteredResponse;
     expect(response.status()).toBe(200);
     const payload = await response.json();
-    expect(payload.items.length).toBeGreaterThan(0);
-    expect(payload.items.every((item: { item_author: string }) => item.item_author.toLowerCase() === "carol")).toBe(
-      true,
-    );
+    expect(payload.item_activity.length).toBeGreaterThan(0);
+    expect(
+      payload.item_activity.every((item: { item_author: string }) => item.item_author.toLowerCase() === "carol"),
+    ).toBe(true);
 
     await expect(page).toHaveURL(/author=carol/);
     await expect(page.getByRole("button", { name: "Filters · carol" })).toBeVisible();
@@ -570,6 +576,18 @@ test.describe("phone routes", () => {
     const modePicker = page.getByRole("combobox", { name: /Phone mode/ });
     await expect(modePicker).toHaveText("PRs");
     await expect(page.locator(".focus-list")).toBeVisible();
+    const pullSearch = page.getByRole("searchbox", { name: "Search PRs" });
+    const pullFilters = page.getByRole("button", { name: "Filters" });
+    await expect(pullFilters).toHaveText("");
+    await expect(pullFilters).toHaveAttribute("aria-expanded", "false");
+    await expect(page.locator(".filter-bar")).toBeHidden();
+    const [pullSearchBounds, pullFilterBounds] = await Promise.all([
+      pullSearch.boundingBox(),
+      pullFilters.boundingBox(),
+    ]);
+    expect(Math.abs(pullSearchBounds!.y - pullFilterBounds!.y)).toBeLessThan(2);
+    await pullFilters.click();
+    await expect(page.locator(".filter-bar")).toBeVisible();
     await expectReadableFocusList(page, ".pull-item");
 
     await modePicker.click();
@@ -577,6 +595,17 @@ test.describe("phone routes", () => {
     await expect(page).toHaveURL(/\/m\/issues(?:\?|$)/);
     await expect(modePicker).toHaveText("Issues");
     await expect(page.locator(".focus-list")).toBeVisible();
+    const issueSearch = page.getByRole("searchbox", { name: "Search issues" });
+    const issueFilters = page.getByRole("button", { name: "Filters" });
+    await expect(issueFilters).toHaveAttribute("aria-expanded", "false");
+    await expect(page.locator(".filter-bar")).toBeHidden();
+    const [issueSearchBounds, issueFilterBounds] = await Promise.all([
+      issueSearch.boundingBox(),
+      issueFilters.boundingBox(),
+    ]);
+    expect(Math.abs(issueSearchBounds!.y - issueFilterBounds!.y)).toBeLessThan(2);
+    await issueFilters.click();
+    await expect(page.locator(".filter-bar")).toBeVisible();
     await expectReadableFocusList(page, ".issue-item");
   });
 
@@ -590,6 +619,7 @@ test.describe("phone routes", () => {
       await expect(botIssue).toBeVisible();
       await expect(humanIssue).toBeVisible();
 
+      await page.getByRole("button", { name: "Filters" }).click();
       const hideBots = page.getByRole("button", { name: "Hide bot-authored issues" });
       await expect(hideBots).toHaveAttribute("aria-pressed", "false");
       const settingsUpdate = page.waitForResponse(
@@ -608,6 +638,7 @@ test.describe("phone routes", () => {
 
       await page.reload();
       await expect(page.locator(".issue-item").first()).toBeVisible();
+      await page.getByRole("button", { name: "Filters" }).click();
       await expect(hideBots).toHaveAttribute("aria-pressed", "true");
       await expect(botIssue).toHaveCount(0);
       await expect(humanIssue).toBeVisible();

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -173,7 +173,7 @@ test.describe("phone routes", () => {
     await expect(page.getByRole("switch", { name: "Notifications" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Hide closed/merged" })).toBeVisible();
     await expect(page.getByLabel("Time range")).toBeVisible();
-    await expect(page.getByLabel("Repository")).toBeVisible();
+    await expect(page.getByRole("button", { name: /^Select repository:/ })).toBeVisible();
     await expect(page.locator(".threaded-view")).toHaveCount(0);
 
     const metrics = await page.evaluate(() => {
@@ -194,7 +194,7 @@ test.describe("phone routes", () => {
       const appIcon = document.querySelector(".mobile-app-icon");
       const itemTypeToggle = document.querySelector(".mobile-item-type-toggle .kit-toggle");
       const rangeSelect = document.querySelector(".mobile-filter-dropdown button[aria-label^='Time range']");
-      const repoSelect = document.querySelector(".mobile-filter-dropdown button[aria-label^='Repository']");
+      const repoSelect = document.querySelector(".mobile-filter-select--repo .typeahead-trigger");
       const search = document.querySelector(".kit-search-input");
       const cardRect = firstCard?.getBoundingClientRect();
       const buttonRect = firstButton?.getBoundingClientRect();
@@ -339,9 +339,10 @@ test.describe("phone routes", () => {
       const url = new URL(response.url());
       return url.pathname === "/api/v1/activity" && url.searchParams.get("repo") === "github|github.com/acme/widgets";
     });
-    await page.getByRole("combobox", { name: /Repository/ }).click();
-    await page.getByRole("option", { name: "github/github.com/acme/widgets" }).click();
-    await expect(page.getByRole("combobox", { name: "Repository: acme/widgets" })).toHaveText("acme/widgets");
+    await page.getByRole("button", { name: /^Select repository:/ }).click();
+    await page.getByRole("option", { name: "github/github.com/acme/widgets", exact: true }).dispatchEvent("mousedown");
+    await page.getByRole("textbox", { name: "Filter repos" }).press("Escape");
+    await expect(page.getByRole("button", { name: /^Select repository:/ })).toContainText("acme/widgets");
     expect((await activityForRepo).ok()).toBe(true);
 
     const repoLabels = page.locator(".mobile-activity-card__meta > span:first-child");

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -152,10 +152,17 @@ test.describe("phone routes", () => {
 
     await expect(page.locator(".mobile-shell")).toBeVisible();
     await expect(page.locator(".mobile-activity-inbox")).toBeVisible();
-    await expect(page.getByRole("heading", { name: "What needs attention?" })).toBeVisible();
+    await expect(page.locator(".mobile-activity-toolbar")).toBeVisible();
     await expect(page.getByText("Readable threads first")).toHaveCount(0);
+    const search = page.getByPlaceholder("Search activity");
     const filters = page.getByRole("button", { name: /^Filters/ });
+    await expect(filters).toHaveText("");
     await expect(filters).toHaveAttribute("aria-expanded", "false");
+    const [searchBounds, filterBounds] = await Promise.all([search.boundingBox(), filters.boundingBox()]);
+    expect(searchBounds).not.toBeNull();
+    expect(filterBounds).not.toBeNull();
+    expect(Math.abs(searchBounds!.y - filterBounds!.y)).toBeLessThan(2);
+    expect(filterBounds!.height).toBeGreaterThanOrEqual(44);
     await filters.click();
     await expect(page.getByRole("switch", { name: "PRs" })).toBeVisible();
     await expect(page.getByRole("switch", { name: "Issues" })).toBeVisible();

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -12,6 +12,34 @@ async function expectPathname(page: Page, pathname: string): Promise<void> {
   await expect.poll(() => new URL(page.url()).pathname).toBe(pathname);
 }
 
+async function mobileSearchBarMetrics(page: Page) {
+  return await page.evaluate(() => {
+    const bar = document.querySelector(".mobile-triage-search-bar");
+    const search = bar?.querySelector(".kit-search-input");
+    const filter = bar?.querySelector(".kit-icon-button");
+    const barStyle = bar ? getComputedStyle(bar) : null;
+    const searchStyle = search ? getComputedStyle(search) : null;
+    const filterStyle = filter ? getComputedStyle(filter) : null;
+    const rect = (element: Element | null | undefined) => {
+      const bounds = element?.getBoundingClientRect();
+      return bounds ? { width: bounds.width, height: bounds.height } : null;
+    };
+    return {
+      bar: rect(bar),
+      search: rect(search),
+      filter: rect(filter),
+      gap: barStyle?.gap,
+      padding: barStyle
+        ? [barStyle.paddingTop, barStyle.paddingRight, barStyle.paddingBottom, barStyle.paddingLeft]
+        : null,
+      searchRadius: searchStyle?.borderRadius,
+      filterRadius: filterStyle?.borderRadius,
+      searchBackground: searchStyle?.backgroundColor,
+      filterBackground: filterStyle?.backgroundColor,
+    };
+  });
+}
+
 async function expectReadableFocusList(page: Page, itemSelector: string): Promise<void> {
   await expect(page.locator(itemSelector).first()).toBeVisible();
 
@@ -152,7 +180,7 @@ test.describe("phone routes", () => {
 
     await expect(page.locator(".mobile-shell")).toBeVisible();
     await expect(page.locator(".mobile-activity-inbox")).toBeVisible();
-    await expect(page.locator(".mobile-activity-toolbar")).toBeVisible();
+    await expect(page.locator(".mobile-triage-search-bar")).toBeVisible();
     await expect(page.getByText("Readable threads first")).toHaveCount(0);
     const search = page.getByPlaceholder("Search activity");
     const filters = page.getByRole("button", { name: /^Filters/ });
@@ -197,7 +225,7 @@ test.describe("phone routes", () => {
       const itemTypeToggle = document.querySelector(".mobile-item-type-toggle .kit-toggle");
       const rangeSelect = document.querySelector(".mobile-filter-dropdown button[aria-label^='Time range']");
       const repoSelect = document.querySelector(".mobile-filter-select--repo .typeahead-trigger");
-      const toolbar = document.querySelector(".mobile-activity-toolbar");
+      const toolbar = document.querySelector(".mobile-triage-search-bar");
       const filterPanel = document.querySelector(".mobile-activity-filter-grid");
       const authorFilter = document.querySelector(".mobile-author-filter");
       const search = document.querySelector(".kit-search-input");
@@ -227,16 +255,6 @@ test.describe("phone routes", () => {
         "border-radius:var(--radius-lg)",
       ].join(";");
       document.body.append(surfaceSample);
-      const insetSample = document.createElement("div");
-      insetSample.style.cssText = [
-        "position:absolute",
-        "left:-9999px",
-        "top:0",
-        "width:1px",
-        "height:1px",
-        "background:var(--bg-inset)",
-      ].join(";");
-      document.body.append(insetSample);
       const compactRect = (node: Element | null) => {
         const r = node?.getBoundingClientRect();
         return r ? { top: r.top, left: r.left, right: r.right, height: r.height } : null;
@@ -273,15 +291,12 @@ test.describe("phone routes", () => {
         cardBackground: styleFor(firstCard)?.backgroundColor ?? "",
         cardBorderColor: styleFor(firstCard)?.borderColor ?? "",
         cardRadius: styleFor(firstCard)?.borderRadius ?? "",
-        searchBackground:
-          styleFor(document.querySelector(".mobile-activity-search .kit-search-input"))?.backgroundColor ?? "",
         toolbarBackground: styleFor(toolbar)?.backgroundColor ?? "",
         toolbarBorderBottom: styleFor(toolbar)?.borderBottomColor ?? "",
         toolbarRect: compactRect(toolbar),
         filterPanelBackground: styleFor(filterPanel)?.backgroundColor ?? "",
         themeBgPrimary: getComputedStyle(themeSample).backgroundColor,
         themeBgSurface: getComputedStyle(surfaceSample).backgroundColor,
-        themeBgInset: getComputedStyle(insetSample).backgroundColor,
         themeBorder: getComputedStyle(themeSample).borderColor,
         themeRadiusLg: getComputedStyle(surfaceSample).borderRadius,
         itemTypeToggleFontSize: fontSize(document.querySelector(".mobile-item-type-toggle .kit-toggle__label")),
@@ -321,7 +336,6 @@ test.describe("phone routes", () => {
     expect(metrics.cardBackground).toBe(metrics.themeBgSurface);
     expect(metrics.cardBorderColor).toBe(metrics.themeBorder);
     expect(metrics.cardRadius).toBe(metrics.themeRadiusLg);
-    expect(metrics.searchBackground).toBe(metrics.themeBgInset);
     expect(metrics.toolbarBackground).toBe(metrics.themeBgSurface);
     expect(metrics.toolbarBorderBottom).toBe(metrics.themeBorder);
     expect(metrics.toolbarRect?.left ?? -1).toBe(0);
@@ -411,7 +425,7 @@ test.describe("phone routes", () => {
     await expect(page.getByRole("button", { name: "Filters · carol" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Clear author filter carol" })).toHaveCount(0);
 
-    const summaryMetrics = await page.locator(".mobile-filter-summary").evaluate((summary) => {
+    const summaryMetrics = await page.locator(".mobile-triage-search-bar__filter").evaluate((summary) => {
       const bounds = summary.getBoundingClientRect();
       return {
         viewportWidth: window.innerWidth,
@@ -626,6 +640,23 @@ test.describe("phone routes", () => {
     await issueFilters.click();
     await expect(page.locator(".filter-bar")).toBeVisible();
     await expectReadableFocusList(page, ".issue-item");
+  });
+
+  test("mobile activity, pull, and issue lists share one search bar geometry", async ({ page }) => {
+    await page.goto("/m/pulls");
+    await expect(page.getByRole("searchbox", { name: "Search PRs" })).toBeVisible();
+    const pullMetrics = await mobileSearchBarMetrics(page);
+
+    await page.goto("/m?view=threaded");
+    await expect(page.getByRole("searchbox", { name: "Search activity" })).toBeVisible();
+    const activityMetrics = await mobileSearchBarMetrics(page);
+
+    await page.goto("/m/issues");
+    await expect(page.getByRole("searchbox", { name: "Search issues" })).toBeVisible();
+    const issueMetrics = await mobileSearchBarMetrics(page);
+
+    expect(activityMetrics).toEqual(pullMetrics);
+    expect(issueMetrics).toEqual(pullMetrics);
   });
 
   test("mobile issue bot visibility can be toggled and persists through the real settings API", async ({ page }) => {

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -164,6 +164,8 @@ test.describe("phone routes", () => {
     expect(Math.abs(searchBounds!.y - filterBounds!.y)).toBeLessThan(2);
     expect(filterBounds!.height).toBeGreaterThanOrEqual(44);
     await filters.click();
+    await expect(filters).toHaveAttribute("aria-expanded", "true");
+    await expect(page.locator("#mobile-activity-filters")).toBeVisible();
     await expect(page.getByRole("switch", { name: "PRs" })).toBeVisible();
     await expect(page.getByRole("switch", { name: "Issues" })).toBeVisible();
     await expect(page.getByRole("switch", { name: "Comments" })).toBeVisible();
@@ -171,7 +173,7 @@ test.describe("phone routes", () => {
     await expect(page.getByRole("switch", { name: "Commits" })).toBeVisible();
     await expect(page.getByRole("switch", { name: "Force pushes" })).toBeVisible();
     await expect(page.getByRole("switch", { name: "Notifications" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Hide closed/merged" })).toBeVisible();
+    await expect(page.getByRole("switch", { name: "Hide closed/merged" })).toBeVisible();
     await expect(page.getByLabel("Time range")).toBeVisible();
     await expect(page.getByRole("button", { name: /^Select repository:/ })).toBeVisible();
     await expect(page.locator(".threaded-view")).toHaveCount(0);
@@ -195,6 +197,9 @@ test.describe("phone routes", () => {
       const itemTypeToggle = document.querySelector(".mobile-item-type-toggle .kit-toggle");
       const rangeSelect = document.querySelector(".mobile-filter-dropdown button[aria-label^='Time range']");
       const repoSelect = document.querySelector(".mobile-filter-select--repo .typeahead-trigger");
+      const toolbar = document.querySelector(".mobile-activity-toolbar");
+      const filterPanel = document.querySelector(".mobile-activity-filter-grid");
+      const authorFilter = document.querySelector(".mobile-author-filter");
       const search = document.querySelector(".kit-search-input");
       const cardRect = firstCard?.getBoundingClientRect();
       const buttonRect = firstButton?.getBoundingClientRect();
@@ -234,7 +239,7 @@ test.describe("phone routes", () => {
       document.body.append(insetSample);
       const compactRect = (node: Element | null) => {
         const r = node?.getBoundingClientRect();
-        return r ? { left: r.left, right: r.right, height: r.height } : null;
+        return r ? { top: r.top, left: r.left, right: r.right, height: r.height } : null;
       };
       const fontSize = (node: Element | null): number =>
         node ? Number.parseFloat(getComputedStyle(node).fontSize) : 0;
@@ -270,6 +275,10 @@ test.describe("phone routes", () => {
         cardRadius: styleFor(firstCard)?.borderRadius ?? "",
         searchBackground:
           styleFor(document.querySelector(".mobile-activity-search .kit-search-input"))?.backgroundColor ?? "",
+        toolbarBackground: styleFor(toolbar)?.backgroundColor ?? "",
+        toolbarBorderBottom: styleFor(toolbar)?.borderBottomColor ?? "",
+        toolbarRect: compactRect(toolbar),
+        filterPanelBackground: styleFor(filterPanel)?.backgroundColor ?? "",
         themeBgPrimary: getComputedStyle(themeSample).backgroundColor,
         themeBgSurface: getComputedStyle(surfaceSample).backgroundColor,
         themeBgInset: getComputedStyle(insetSample).backgroundColor,
@@ -281,6 +290,7 @@ test.describe("phone routes", () => {
         itemTypeToggleRect: compactRect(itemTypeToggle),
         rangeSelectRect: compactRect(rangeSelect),
         repoSelectRect: compactRect(repoSelect),
+        authorFilterRect: compactRect(authorFilter),
         searchLeft: searchRect?.left ?? 0,
         searchRight: searchRect?.right ?? 0,
       };
@@ -312,9 +322,17 @@ test.describe("phone routes", () => {
     expect(metrics.cardBorderColor).toBe(metrics.themeBorder);
     expect(metrics.cardRadius).toBe(metrics.themeRadiusLg);
     expect(metrics.searchBackground).toBe(metrics.themeBgInset);
+    expect(metrics.toolbarBackground).toBe(metrics.themeBgSurface);
+    expect(metrics.toolbarBorderBottom).toBe(metrics.themeBorder);
+    expect(metrics.toolbarRect?.left ?? -1).toBe(0);
+    expect(metrics.toolbarRect?.right ?? Infinity).toBe(metrics.viewportWidth);
+    expect(metrics.toolbarRect?.height ?? 0).toBeGreaterThanOrEqual(64);
+    expect(metrics.toolbarRect?.height ?? Infinity).toBeLessThanOrEqual(66);
+    expect(metrics.filterPanelBackground).toBe(metrics.themeBgSurface);
     expect(metrics.itemTypeToggleFontSize).toBeGreaterThanOrEqual(15);
     expect(metrics.rangeSelectFontSize).toBeGreaterThanOrEqual(15);
     expect(metrics.repoSelectFontSize).toBeGreaterThanOrEqual(15);
+    expect(metrics.repoSelectRect?.top ?? Infinity).toBeLessThan(metrics.authorFilterRect?.top ?? 0);
     for (const bounds of [metrics.itemTypeToggleRect, metrics.rangeSelectRect, metrics.repoSelectRect]) {
       expect(bounds?.left ?? 0).toBeGreaterThanOrEqual(0);
       expect(bounds?.right ?? 0).toBeLessThanOrEqual(metrics.viewportWidth);
@@ -446,15 +464,15 @@ test.describe("phone routes", () => {
     await expect(card).toBeVisible({ timeout: 10_000 });
 
     const repoLabel = card.locator(".mobile-activity-card__meta span").first();
-    const hideOrgToggle = page.getByRole("button", {
+    const hideOrgToggle = page.getByRole("switch", {
       name: "Hide org",
     });
-    await expect(hideOrgToggle).toHaveAttribute("aria-pressed", "false");
+    await expect(hideOrgToggle).not.toBeChecked();
     await expect(repoLabel).toHaveText("acme/widgets");
 
     await hideOrgToggle.click();
 
-    await expect(hideOrgToggle).toHaveAttribute("aria-pressed", "true");
+    await expect(hideOrgToggle).toBeChecked();
     await expect(repoLabel).toHaveText("widgets");
     await expect(repoLabel).not.toHaveText("acme/widgets");
 
@@ -462,7 +480,7 @@ test.describe("phone routes", () => {
 
     await expect(card).toBeVisible({ timeout: 10_000 });
     await page.getByRole("button", { name: /^Filters/ }).click();
-    await expect(hideOrgToggle).toHaveAttribute("aria-pressed", "true");
+    await expect(hideOrgToggle).toBeChecked();
     await expect(repoLabel).toHaveText("widgets");
   });
 
@@ -713,7 +731,7 @@ test.describe("high-density phone routes", () => {
         node ? getComputedStyle(node).getPropertyValue(name).trim() : "";
       const filterControls = [
         ...document.querySelectorAll(
-          ".mobile-activity-filter-grid .kit-select-dropdown__trigger, .mobile-item-type-toggle .kit-toggle, .mobile-filter-toggle",
+          ".mobile-activity-filter-grid .kit-select-dropdown__trigger, .mobile-item-type-toggle .kit-toggle, .mobile-boolean-toggle .kit-toggle",
         ),
       ]
         .map((control) => control.getBoundingClientRect())

--- a/frontend/tests/e2e-full/workspace-session-activity.spec.ts
+++ b/frontend/tests/e2e-full/workspace-session-activity.spec.ts
@@ -336,7 +336,6 @@ test.describe("workspace session activity across item surfaces", () => {
         expect(new Set(topTitles)).toEqual(new Set(["Add widget caching layer", "Widget rendering broken on Safari"]));
 
         const mobileIssueCard = mobileCards.filter({ hasText: "Widget rendering broken on Safari" }).first();
-        await expect(mobileIssueCard).toContainText("0 events");
         await expect(mobileIssueCard.locator('time[title="Recent workspace activity"]')).toBeVisible();
         await expect(mobileIssueCard.getByLabel("Workspace attached (ready)")).toBeVisible();
         await expect(mobileIssueCard.locator(".mobile-activity-events")).toHaveCount(0);
@@ -456,7 +455,7 @@ test.describe("workspace session activity across item surfaces", () => {
         const botIssueCard = botPhonePage.locator(".mobile-activity-card", { hasText: botIssueTitle });
         await expect(botPullCard).toBeVisible();
         await expect(botIssueCard).toBeVisible();
-        await botPhonePage.getByRole("button", { name: "Hide bots", exact: true }).click();
+        await botPhonePage.getByRole("switch", { name: "Hide bots", exact: true }).click();
         await expect(botPullCard).toHaveCount(0);
         await expect(botIssueCard).toHaveCount(0);
       } finally {

--- a/frontend/tests/e2e/default-branch-activity.spec.ts
+++ b/frontend/tests/e2e/default-branch-activity.spec.ts
@@ -624,7 +624,7 @@ test.describe("mobile default branch activity", () => {
     });
     await expect(branchCard).toBeVisible();
     await expect(branchCard).toContainText("Branch");
-    await expect(branchCard).toContainText("6 events");
+    await expect(branchCard).toContainText("Recent activity");
     await expect(page.locator(".mobile-activity-card", { hasText: "#0" })).toHaveCount(0);
 
     await branchCard

--- a/frontend/tests/e2e/mobile-activity-repos.spec.ts
+++ b/frontend/tests/e2e/mobile-activity-repos.spec.ts
@@ -84,13 +84,12 @@ test.describe("mobile activity repository selector", () => {
 
     await page.goto("/m?range=30d&view=threaded");
     await page.getByRole("button", { name: /Filters/ }).click();
-    const repoSelect = page.getByRole("combobox", {
-      name: /Repository/,
-    });
+    const repoSelect = page.getByRole("button", { name: "Select repository: Global" });
     await expect(repoSelect).toBeVisible();
+    await expect(repoSelect).toContainText("All repositories");
 
     await repoSelect.click();
-    await expect(page.getByRole("option", { name: "All repos" })).toBeVisible();
+    await expect(page.getByRole("option", { name: "Global" })).toBeVisible();
     await expect(page.getByRole("option", { name: "github/github.com/acme/widgets" })).toBeVisible();
     await expect(page.getByRole("option", { name: "gitea/github.com/acme/widgets" })).toBeVisible();
     await expect(
@@ -101,7 +100,7 @@ test.describe("mobile activity repository selector", () => {
     await expect(page.getByRole("option", { name: "acme/*" })).toHaveCount(0);
 
     await page.getByRole("option", { name: "gitea/github.com/acme/widgets" }).click();
-    await expect(page.getByRole("combobox", { name: "Repository: gitea/github.com/acme/widgets" })).toHaveText(
+    await expect(page.getByRole("button", { name: "Select repository: gitea/github.com/acme/widgets" })).toContainText(
       "gitea/github.com/acme/widgets",
     );
     await expect.poll(() => activityRepos).toContain("gitea|github.com/acme/widgets");

--- a/frontend/tests/e2e/mobile-activity-repos.spec.ts
+++ b/frontend/tests/e2e/mobile-activity-repos.spec.ts
@@ -217,6 +217,7 @@ test.describe("mobile PR status grouping", () => {
     await page.goto("/m/pulls");
     await expect(page.locator(".focus-list")).toBeVisible();
 
+    await page.getByRole("button", { name: "Filters" }).click();
     await page.getByRole("button", { name: "Status" }).click();
 
     await expect(page.locator(".workflow-group .group-header")).toHaveText(["New", "Reviewing"]);

--- a/internal/db/queries_activity_projection.go
+++ b/internal/db/queries_activity_projection.go
@@ -40,7 +40,11 @@ func (d *DB) ListCollapsedActivityProjection(
 
 	var searchMatched []WorkspaceSubjectKey
 	if opts.Search != "" {
-		searchRows, searchErr := listActivityWithQueryer(ctx, tx, opts.ListActivityOpts)
+		searchOpts := opts.ListActivityOpts
+		if opts.SearchEventLimit > 0 {
+			searchOpts.Limit = opts.SearchEventLimit
+		}
+		searchRows, searchErr := listActivityWithQueryer(ctx, tx, searchOpts)
 		if searchErr != nil {
 			return ActivityProjection{}, searchErr
 		}

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -1411,7 +1411,8 @@ type ActivityProjection struct {
 
 type ListActivityProjectionOpts struct {
 	ListActivityOpts
-	SubjectLimit int
+	SubjectLimit     int
+	SearchEventLimit int
 }
 
 // ListActivityAuthorsOpts holds the repository and time scopes used to build

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -23950,6 +23950,35 @@ func TestAPIListActivity(t *testing.T) {
 	assert.Len(*unfiltered.JSON200.Items, len(*resp.JSON200.Items))
 }
 
+func TestAPIListCollapsedActivityHonorsLimit(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, database := setupTestServer(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	for number := 1; number <= 11; number++ {
+		activityAt := now.Add(-time.Duration(number) * time.Minute)
+		seedPR(
+			t, database, "acme", "widget", number,
+			withSeedPRTimes(activityAt, activityAt, activityAt),
+		)
+	}
+
+	since := url.QueryEscape(now.Add(-7 * 24 * time.Hour).Format(time.RFC3339))
+	rr := doJSON(
+		t,
+		srv,
+		http.MethodGet,
+		"/api/v1/activity?since="+since+"&projection=collapsed&limit=10",
+		nil,
+	)
+	require.Equal(http.StatusOK, rr.Code)
+	var body activityResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&body))
+	require.Len(body.ItemActivity, 10)
+	assert.True(body.ItemActivityCapped)
+	assert.Equal(1, body.ItemActivity[0].ItemNumber)
+}
+
 func TestAPIListCollapsedActivityIncludesParentRecentOnlyByNotification(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -23979,6 +23979,60 @@ func TestAPIListCollapsedActivityHonorsLimit(t *testing.T) {
 	assert.Equal(1, body.ItemActivity[0].ItemNumber)
 }
 
+func TestAPIListCollapsedActivitySearchLimitCountsDistinctParents(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, database := setupTestServer(t)
+	ctx := t.Context()
+	base := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Second)
+
+	olderPRID := seedPR(
+		t, database, "acme", "widget", 1,
+		withSeedPRTitle("Unrelated older parent"),
+		withSeedPRTimes(base, base, base),
+	)
+	require.NoError(database.UpsertMREvents(ctx, []db.MREvent{{
+		MergeRequestID: olderPRID,
+		EventType:      "issue_comment",
+		Author:         "reviewer",
+		Body:           "needle in an older event",
+		CreatedAt:      base.Add(time.Minute),
+		DedupeKey:      "older-search-match",
+	}}))
+	newerPRID := seedPR(
+		t, database, "acme", "widget", 2,
+		withSeedPRTitle("Unrelated newer parent"),
+		withSeedPRTimes(base, base, base),
+	)
+	newerEvents := make([]db.MREvent, 31)
+	for i := range newerEvents {
+		newerEvents[i] = db.MREvent{
+			MergeRequestID: newerPRID,
+			EventType:      "issue_comment",
+			Author:         "reviewer",
+			Body:           "needle repeated",
+			CreatedAt:      base.Add(2*time.Minute + time.Duration(i)*time.Second),
+			DedupeKey:      fmt.Sprintf("newer-search-match-%d", i),
+		}
+	}
+	require.NoError(database.UpsertMREvents(ctx, newerEvents))
+
+	since := url.QueryEscape(base.Add(-time.Minute).Format(time.RFC3339))
+	rr := doJSON(
+		t,
+		srv,
+		http.MethodGet,
+		"/api/v1/activity?since="+since+"&projection=collapsed&limit=30&search=needle",
+		nil,
+	)
+	require.Equal(http.StatusOK, rr.Code)
+	var body activityResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&body))
+	require.Len(body.ItemActivity, 2)
+	assert.Equal([]int{2, 1}, []int{body.ItemActivity[0].ItemNumber, body.ItemActivity[1].ItemNumber})
+	assert.False(body.ItemActivityCapped)
+}
+
 func TestAPIListCollapsedActivityIncludesParentRecentOnlyByNotification(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1498,6 +1498,7 @@ func (s *Server) listActivityRouteCore(ctx context.Context, input *listActivityI
 		collapsed, projectionErr := s.db.ListCollapsedActivityProjection(ctx, db.ListActivityProjectionOpts{
 			ListActivityOpts: opts,
 			SubjectLimit:     pageLimit + 1,
+			SearchEventLimit: activitySafetyCap + 1,
 		})
 		if projectionErr != nil {
 			slog.Error("list collapsed activity failed", "err", projectionErr)
@@ -1524,6 +1525,7 @@ func (s *Server) listActivityRouteCore(ctx context.Context, input *listActivityI
 		workspaceOpts.AfterTime = nil
 		workspaceOpts.AfterSource = ""
 		workspaceOpts.AfterSourceID = 0
+		workspaceOpts.Limit = activitySafetyCap + 1
 		workspaceEventItems, err = s.db.ListActivity(ctx, workspaceOpts)
 		if err != nil {
 			slog.Error("list activity search subjects failed", "err", err)

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1408,7 +1408,7 @@ func (s *Server) listActivityRouteCore(ctx context.Context, input *listActivityI
 		projection = "full"
 	}
 	pageLimit := activitySafetyCap
-	if projection == "events" {
+	if projection == "events" || (projection == "collapsed" && input.Limit > 0) {
 		pageLimit = input.Limit
 		if pageLimit == 0 {
 			pageLimit = 500
@@ -1497,7 +1497,7 @@ func (s *Server) listActivityRouteCore(ctx context.Context, input *listActivityI
 	if projection == "collapsed" {
 		collapsed, projectionErr := s.db.ListCollapsedActivityProjection(ctx, db.ListActivityProjectionOpts{
 			ListActivityOpts: opts,
-			SubjectLimit:     activitySafetyCap + 1,
+			SubjectLimit:     pageLimit + 1,
 		})
 		if projectionErr != nil {
 			slog.Error("list collapsed activity failed", "err", projectionErr)
@@ -1605,7 +1605,11 @@ func (s *Server) listActivityRouteCore(ctx context.Context, input *listActivityI
 	}
 
 	eventsCapped := len(items) > pageLimit
-	itemActivityCapped := len(itemActivity) > activitySafetyCap || searchMatchesTruncated
+	itemActivityLimit := activitySafetyCap
+	if projection == "collapsed" {
+		itemActivityLimit = pageLimit
+	}
+	itemActivityCapped := len(itemActivity) > itemActivityLimit || searchMatchesTruncated
 	if len(items) > pageLimit {
 		items = items[:pageLimit]
 	}
@@ -1614,8 +1618,8 @@ func (s *Server) listActivityRouteCore(ctx context.Context, input *listActivityI
 		last := items[len(items)-1]
 		nextCursor = db.EncodeCursor(last.CreatedAt, last.Source, last.SourceID)
 	}
-	if len(itemActivity) > activitySafetyCap {
-		itemActivity = itemActivity[:activitySafetyCap]
+	if len(itemActivity) > itemActivityLimit {
+		itemActivity = itemActivity[:itemActivityLimit]
 	}
 	if hasFullWorkspaceEventItems {
 		if len(workspaceEventItems) > activitySafetyCap {


### PR DESCRIPTION
Mobile Activity, pull requests, and issues now share one compact phone search and filter surface. Each view keeps its own filter content while repository selection and interaction behavior stay consistent.

- bounds initial mobile Activity, pull request, and issue loads to 30 items, then autoloads additional chunks near the viewport
- loads Activity thread previews only as cards approach the viewport
- moves repository presets, authors, event types, status, and visibility controls into consistent filter disclosures
- uses the shared kit controls for switches, warnings, repository selection, and the search/filter header

<sup>generated by a clanker</sup>
