### PR TITLE
chore: prepare lint tools for Go 1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,11 +245,11 @@ jobs:
 
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.11.4
+          version: v2.13.1
 
       - name: Install NilAway
         run: |
-          go install go.uber.org/nilaway/cmd/nilaway@v0.0.0-20260318203545-ad240b12fb4c
+          go install go.uber.org/nilaway/cmd/nilaway@v0.0.0-20260808063849-8649a03c818a
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run NilAway

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 version: "2"
 run:
   tests: true
+  go: "1.26"
   allow-parallel-runners: true
 linters:
   default: none

--- a/Makefile
+++ b/Makefile
@@ -390,7 +390,7 @@ lint-check: ensure-embed-dir check-mise
 nilaway: ensure-embed-dir
 	@if [ -z "$(NILAWAY_BIN)" ]; then \
 		echo "nilaway not found. Install with:" >&2; \
-		echo "go install go.uber.org/nilaway/cmd/nilaway@v0.0.0-20260318203545-ad240b12fb4c" >&2; \
+		echo "go install go.uber.org/nilaway/cmd/nilaway@v0.0.0-20260808063849-8649a03c818a" >&2; \
 		exit 1; \
 	fi
 	@module_path="$$(go list -m)" || { \

--- a/cmd/e2e-server/main_test.go
+++ b/cmd/e2e-server/main_test.go
@@ -116,8 +116,7 @@ func (tracker *testTmuxTracker) stop(key string, tmuxCommand []string) error {
 			killErr, killOutput, listOutput,
 		)
 	}
-	var listExitErr *exec.ExitError
-	if !errors.As(listErr, &listExitErr) {
+	if _, ok := errors.AsType[*exec.ExitError](listErr); !ok {
 		return fmt.Errorf("verify e2e-server test tmux stopped: %w: %s", listErr, listOutput)
 	}
 	if !strings.HasPrefix(strings.TrimSpace(string(listOutput)), "no server running on ") {

--- a/cmd/kenn-forge/api_verb.go
+++ b/cmd/kenn-forge/api_verb.go
@@ -174,8 +174,7 @@ func runAPIVerb(method, requestPath string, opts apiVerbOptions, stdout io.Write
 
 // exitCodeForAPIVerb maps a runAPICLI error to its process exit code.
 func exitCodeForAPIVerb(err error) int {
-	var verr *apiVerbError
-	if errors.As(err, &verr) {
+	if verr, ok := errors.AsType[*apiVerbError](err); ok {
 		return verr.code
 	}
 	return apiVerbExitNoRequest

--- a/cmd/kenn-forge/daemon_lifecycle.go
+++ b/cmd/kenn-forge/daemon_lifecycle.go
@@ -28,8 +28,8 @@ type daemonLifecycleLocks []daemonLifecycleLock
 
 func (locks daemonLifecycleLocks) Release() error {
 	errs := make([]error, 0, len(locks))
-	for index := len(locks) - 1; index >= 0; index-- {
-		if err := locks[index].Release(); err != nil {
+	for _, lock := range slices.Backward(locks) {
+		if err := lock.Release(); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -129,8 +129,7 @@ func (l *daemonLifecycle) Start(
 
 	record, err := l.deps.ensureBackground(ctx, mutation.configPath, mutation.config)
 	if err != nil {
-		var mismatch *daemonruntime.VersionMismatchError
-		if errors.As(err, &mismatch) {
+		if _, ok := errors.AsType[*daemonruntime.VersionMismatchError](err); ok {
 			return fmt.Errorf(
 				"daemon start: %w; run `kenn-forge daemon restart` to replace it",
 				err,

--- a/cmd/kenn-forge/main.go
+++ b/cmd/kenn-forge/main.go
@@ -152,8 +152,7 @@ func main() {
 	}()
 
 	if err := runCLI(os.Args[1:], os.Stdout); err != nil {
-		var apiErr *apiVerbError
-		if errors.As(err, &apiErr) {
+		if _, ok := errors.AsType[*apiVerbError](err); ok {
 			_, _ = fmt.Fprintln(os.Stderr, err)
 			os.Exit(exitCodeForAPIVerb(err))
 			return
@@ -342,8 +341,7 @@ func run(opts serve.Options) error {
 
 	lockHandle, err := runtimelock.Acquire(cfg.DataDir)
 	if err != nil {
-		var cerr *runtimelock.CollisionError
-		if errors.As(err, &cerr) {
+		if cerr, ok := errors.AsType[*runtimelock.CollisionError](err); ok {
 			runtimelock.FormatCollisionBanner(
 				os.Stderr, cerr, configPath, config.DefaultConfigPath(),
 			)

--- a/cmd/kenn-forge/provider_startup.go
+++ b/cmd/kenn-forge/provider_startup.go
@@ -378,8 +378,7 @@ func buildProviderStartupOrDegraded(
 		if err == nil {
 			return startup, nil
 		}
-		var hostErr *providerHostStartupError
-		if errors.As(err, &hostErr) {
+		if hostErr, ok := errors.AsType[*providerHostStartupError](err); ok {
 			key := providerHostKey(hostErr.platformName, hostErr.host)
 			if _, ok := sources[key]; ok {
 				slog.Warn(

--- a/internal/archive/hydrate.go
+++ b/internal/archive/hydrate.go
@@ -98,8 +98,7 @@ func archiveTerminalSyncOutcome(
 }
 
 func archiveSyncErrorCode(err error) string {
-	var platformErr *platform.Error
-	if errors.As(err, &platformErr) {
+	if platformErr, ok := errors.AsType[*platform.Error](err); ok {
 		return string(platformErr.Code)
 	}
 	return string(db.ArchiveErrorCodeTransient)

--- a/internal/archive/inventory.go
+++ b/internal/archive/inventory.go
@@ -134,12 +134,10 @@ func archiveInventoryFeatureDisabled(err error, itemType db.ArchiveItemType) boo
 // traversal without failing it.
 func (s *Service) commitInventoryPage(ctx context.Context, commit db.ArchiveInventoryCommit) (bool, error) {
 	err := s.db.CommitArchiveInventoryPage(ctx, commit)
-	var stale *db.StaleArchiveScanError
-	if errors.As(err, &stale) {
+	if _, ok := errors.AsType[*db.StaleArchiveScanError](err); ok {
 		return true, nil
 	}
-	var blocked *db.ScanBlockedError
-	if errors.As(err, &blocked) {
+	if _, ok := errors.AsType[*db.ScanBlockedError](err); ok {
 		return true, nil
 	}
 	return err != nil, err

--- a/internal/archive/service.go
+++ b/internal/archive/service.go
@@ -485,8 +485,7 @@ func (s *Service) resolveRepositoriesTolerant(ctx context.Context, refs []platfo
 			// configured, missing capability) are repository-scoped. Anything
 			// else — a broken store above all — is infrastructure and must
 			// surface instead of emptying the pass into a silent success.
-			var platformErr *platform.Error
-			if !errors.As(err, &platformErr) {
+			if _, ok := errors.AsType[*platform.Error](err); !ok {
 				return nil, err
 			}
 			slog.Debug("skip unresolvable archive repository",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2987,8 +2987,7 @@ func runGHAuthToken(ctx context.Context, extraArgs ...string) ([]byte, []byte, e
 // context-deadline, auth-failure, and unrelated nonzero exits all
 // return false so the caller does not retry bare.
 func isUnsupportedHostnameFlag(err error, stderr []byte) bool {
-	var exitErr *exec.ExitError
-	if !errors.As(err, &exitErr) {
+	if _, ok := errors.AsType[*exec.ExitError](err); !ok {
 		return false
 	}
 	text := string(stderr)

--- a/internal/daemonruntime/runtime.go
+++ b/internal/daemonruntime/runtime.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -375,8 +376,8 @@ func CanonicalConfigPath(configPath string) (string, error) {
 					"resolve daemon config path casing: %w", err,
 				)
 			}
-			for index := len(missingSuffix) - 1; index >= 0; index-- {
-				resolvedPath = filepath.Join(resolvedPath, missingSuffix[index])
+			for _, m := range slices.Backward(missingSuffix) {
+				resolvedPath = filepath.Join(resolvedPath, m)
 			}
 			return filepath.Clean(resolvedPath), nil
 		}

--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -877,8 +877,7 @@ func wrapGitError(err error, stderr []byte) error {
 		message: errMsg + ": " + msg,
 		cause:   safeGitErrorCause(err),
 	}
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 		wrapped.exitCode = exitErr.ExitCode()
 		wrapped.hasExitCode = true
 	}

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -1293,8 +1293,7 @@ func (m *Manager) refreshRepoBrowserClone(
 		return err
 	}
 	if res.Err != nil {
-		var invalidated *repoBrowserCloneValidationError
-		if !errors.As(res.Err, &invalidated) {
+		if _, ok := errors.AsType[*repoBrowserCloneValidationError](res.Err); !ok {
 			if errors.Is(res.Err, ErrRepoBrowserRouteFenceChanged) {
 				if ownErr := m.validateRepoBrowserRouteFence(ctx, repo); ownErr != nil {
 					m.evictStaleRepoBrowserRegistration(repo, ownErr)

--- a/internal/github/notifications_sync.go
+++ b/internal/github/notifications_sync.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -227,8 +228,8 @@ func (w *notificationProviderWork) addRepo(repo RepoRef) {
 }
 
 func (w *notificationProviderWork) release() {
-	for i := len(w.releases) - 1; i >= 0; i-- {
-		w.releases[i]()
+	for _, v := range slices.Backward(w.releases) {
+		v()
 	}
 }
 
@@ -1253,16 +1254,14 @@ func (s *Syncer) reopenLegacyNotificationAckAfterRouteChange(
 }
 
 func notificationReadRateLimitNextAttempt(err error, now time.Time) (time.Time, bool) {
-	var rateLimitErr *gh.RateLimitError
-	if errors.As(err, &rateLimitErr) {
+	if rateLimitErr, ok := errors.AsType[*gh.RateLimitError](err); ok {
 		resetAt := rateLimitErr.Rate.Reset.UTC()
 		if resetAt.After(now) {
 			return resetAt, true
 		}
 		return now.Add(notificationReadBackoff(1)), true
 	}
-	var abuseRateLimitErr *gh.AbuseRateLimitError
-	if errors.As(err, &abuseRateLimitErr) {
+	if abuseRateLimitErr, ok := errors.AsType[*gh.AbuseRateLimitError](err); ok {
 		if abuseRateLimitErr.RetryAfter != nil && *abuseRateLimitErr.RetryAfter > 0 {
 			return now.Add(*abuseRateLimitErr.RetryAfter), true
 		}

--- a/internal/github/pages.go
+++ b/internal/github/pages.go
@@ -838,8 +838,7 @@ func (p *gitHubClientProvider) archiveTransportError(capability platform.Archive
 			return disabled
 		}
 	}
-	var existing *platform.Error
-	if errors.As(err, &existing) {
+	if existing, ok := errors.AsType[*platform.Error](err); ok {
 		mapped := *existing
 		if mapped.Provider == "" {
 			mapped.Provider = platform.KindGitHub
@@ -854,8 +853,7 @@ func (p *gitHubClientProvider) archiveTransportError(capability platform.Archive
 	}
 	response := githubArchiveErrorResponse(err)
 	resetAt := githubArchiveResetAt(response)
-	var rateLimit *gh.RateLimitError
-	if errors.As(err, &rateLimit) {
+	if rateLimit, ok := errors.AsType[*gh.RateLimitError](err); ok {
 		if !rateLimit.Rate.Reset.IsZero() {
 			reset := rateLimit.Rate.Reset.UTC()
 			resetAt = &reset
@@ -863,8 +861,7 @@ func (p *gitHubClientProvider) archiveTransportError(capability platform.Archive
 		return &platform.Error{Code: platform.ErrCodeRateLimited, Provider: platform.KindGitHub,
 			PlatformHost: p.host, Capability: string(capability), ResetAt: resetAt, Err: err}
 	}
-	var abuseLimit *gh.AbuseRateLimitError
-	if errors.As(err, &abuseLimit) {
+	if abuseLimit, ok := errors.AsType[*gh.AbuseRateLimitError](err); ok {
 		if resetAt == nil && abuseLimit.RetryAfter != nil {
 			reset := time.Now().UTC().Add(*abuseLimit.RetryAfter)
 			resetAt = &reset
@@ -886,16 +883,13 @@ func (p *gitHubClientProvider) archiveTransportError(capability platform.Archive
 }
 
 func githubArchiveErrorResponse(err error) *http.Response {
-	var rateLimit *gh.RateLimitError
-	if errors.As(err, &rateLimit) {
+	if rateLimit, ok := errors.AsType[*gh.RateLimitError](err); ok {
 		return rateLimit.Response
 	}
-	var abuseLimit *gh.AbuseRateLimitError
-	if errors.As(err, &abuseLimit) {
+	if abuseLimit, ok := errors.AsType[*gh.AbuseRateLimitError](err); ok {
 		return abuseLimit.Response
 	}
-	var response *gh.ErrorResponse
-	if errors.As(err, &response) {
+	if response, ok := errors.AsType[*gh.ErrorResponse](err); ok {
 		return response.Response
 	}
 	return nil
@@ -1073,8 +1067,7 @@ func githubStatusCode(err error) int {
 	if errors.As(err, &response) && response.Response != nil {
 		return response.Response.StatusCode
 	}
-	var redirect *url.Error
-	if errors.As(err, &redirect) {
+	if redirect, ok := errors.AsType[*url.Error](err); ok {
 		var responseError *gh.ErrorResponse
 		if errors.As(redirect.Err, &responseError) && responseError.Response != nil {
 			return responseError.Response.StatusCode

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5059,8 +5059,7 @@ func (s *Syncer) syncWatchedMRs(ctx context.Context) {
 				"number", mr.Number,
 				"err", err,
 			)
-			var diffErr *DiffSyncError
-			if errors.As(err, &diffErr) {
+			if _, ok := errors.AsType[*DiffSyncError](err); ok {
 				syncedAny = true
 			}
 			continue
@@ -5676,8 +5675,7 @@ func (s *Syncer) recordRunError(
 				string(repoPlatform(repo)), identity.Host, identity.Principal,
 			)
 		}
-		var exhausted *syncBudgetExhaustedError
-		if errors.As(err, &exhausted) {
+		if exhausted, ok := errors.AsType[*syncBudgetExhaustedError](err); ok {
 			ceilingResetAt = exhausted.resetAt.UTC().Format(time.RFC3339)
 		}
 	}
@@ -13730,8 +13728,7 @@ func (s *Syncer) SyncItemByNumber(
 			// freshness can react, but report itemType so callers that
 			// just need to route the user (e.g. /items/{n}/resolve) can
 			// proceed.
-			var diffErr *DiffSyncError
-			if errors.As(err, &diffErr) {
+			if _, ok := errors.AsType[*DiffSyncError](err); ok {
 				return "pr", err
 			}
 			return "", fmt.Errorf(

--- a/internal/mcpserver/tools_read.go
+++ b/internal/mcpserver/tools_read.go
@@ -124,8 +124,7 @@ func wrapTool[In, Out any](
 		payload := toolErrorOutput{Error: toolErrorEvidence{
 			Kind: "tool_error", Message: err.Error(),
 		}}
-		var backendErr *Error
-		if errors.As(err, &backendErr) {
+		if backendErr, ok := errors.AsType[*Error](err); ok {
 			payload.Error = toolErrorEvidence{
 				Kind: backendErr.Kind, Code: backendErr.Code, Message: backendErr.Message,
 				Retryable: backendErr.Retryable, Ambiguous: backendErr.Ambiguous,

--- a/internal/platform/gitealike/pages.go
+++ b/internal/platform/gitealike/pages.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -315,8 +316,8 @@ func createdOrderMergeRequestsPage(
 		return nextCursorPage([]platform.MergeRequest(nil), cursor, true)
 	}
 	out := normalizeMergeRequestPage(ref, items, boundary, pin)
-	for i := len(items) - 1; i >= 0; i-- {
-		created := items[i].Created
+	for _, item := range slices.Backward(items) {
+		created := item.Created
 		if created.After(pin) {
 			continue
 		}

--- a/internal/platform/gitlab/client.go
+++ b/internal/platform/gitlab/client.go
@@ -973,11 +973,10 @@ func mapGitLabErrorForHost(platformHost, capability string, err error) error {
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return err
 	}
-	var gitlabErr *gitlab.ErrorResponse
 	code := platform.ErrCodeProviderContract
 	if errors.Is(err, gitlab.ErrNotFound) {
 		code = platform.ErrCodeNotFound
-	} else if errors.As(err, &gitlabErr) {
+	} else if gitlabErr, ok := errors.AsType[*gitlab.ErrorResponse](err); ok {
 		switch {
 		case gitlabErr.HasStatusCode(http.StatusUnauthorized), gitlabErr.HasStatusCode(http.StatusForbidden):
 			code = platform.ErrCodePermissionDenied
@@ -1005,8 +1004,7 @@ func mapSourceProjectLookupError(err error) error {
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, gitlab.ErrNotFound) {
 		return err
 	}
-	var gitlabErr *gitlab.ErrorResponse
-	if errors.As(err, &gitlabErr) {
+	if gitlabErr, ok := errors.AsType[*gitlab.ErrorResponse](err); ok {
 		switch {
 		case gitlabErr.HasStatusCode(http.StatusUnauthorized),
 			gitlabErr.HasStatusCode(http.StatusForbidden),
@@ -1042,8 +1040,7 @@ func isGitLabNotFound(err error) bool {
 }
 
 func isUnavailableSourceProjectError(err error) bool {
-	var platformErr *platform.Error
-	if errors.As(err, &platformErr) {
+	if platformErr, ok := errors.AsType[*platform.Error](err); ok {
 		if platformErr.Code == platform.ErrCodePermissionDenied ||
 			platformErr.Code == platform.ErrCodeNotFound {
 			return true
@@ -1054,8 +1051,7 @@ func isUnavailableSourceProjectError(err error) bool {
 
 func partialError(namespace string, page int64, err error) PartialError {
 	code := "upstream_error"
-	var platformErr *platform.Error
-	if errors.As(mapGitLabError("preview_page", err), &platformErr) {
+	if platformErr, ok := errors.AsType[*platform.Error](mapGitLabError("preview_page", err)); ok {
 		code = string(platformErr.Code)
 		if code == string(platform.ErrCodeProviderContract) {
 			code = "upstream_error"

--- a/internal/platform/gitlab/mutation.go
+++ b/internal/platform/gitlab/mutation.go
@@ -490,8 +490,7 @@ func (c *Client) ApproveMergeRequest(
 		if notePosted {
 			// The note side effect must survive problem mapping so the
 			// client knows a retry repeats the comment.
-			var platformErr *platform.Error
-			if errors.As(mapped, &platformErr) {
+			if platformErr, ok := errors.AsType[*platform.Error](mapped); ok {
 				platformErr.Hint = "the review comment was already posted; retrying will repeat it"
 			}
 			return platform.MergeRequestEvent{}, fmt.Errorf(

--- a/internal/projects/identity.go
+++ b/internal/projects/identity.go
@@ -64,8 +64,7 @@ func resolveIdentityFromPathWithGitEnv(
 	cmd.Env = gitEnv
 	out, err := cmd.Output()
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if _, ok := errors.AsType[*exec.ExitError](err); ok {
 			// `git remote get-url origin` exits non-zero when origin is
 			// unset; treat as a clean no-identity result.
 			return nil, nil

--- a/internal/ptyowner/owner.go
+++ b/internal/ptyowner/owner.go
@@ -709,8 +709,7 @@ func waitExitCode(waitErr error) int {
 	if waitErr == nil {
 		return 0
 	}
-	var exitErr *exec.ExitError
-	if errors.As(waitErr, &exitErr) {
+	if exitErr, ok := errors.AsType[*exec.ExitError](waitErr); ok {
 		return exitErr.ExitCode()
 	}
 	return -1

--- a/internal/server/archive_routes.go
+++ b/internal/server/archive_routes.go
@@ -450,8 +450,7 @@ func archiveStatusResponses(statuses []archive.Status) []archiveStatusResponse {
 }
 
 func archiveOperationProblem(err error) error {
-	var limit *report.LimitError
-	if errors.As(err, &limit) {
+	if limit, ok := errors.AsType[*report.LimitError](err); ok {
 		return httpapi.NewProblem(
 			http.StatusRequestEntityTooLarge, httpapi.CodePayloadTooLarge,
 			"archive report exceeds detailed limits", map[string]any{
@@ -464,12 +463,10 @@ func archiveOperationProblem(err error) error {
 	if errors.Is(err, archive.ErrEmptyReportScope) {
 		return httpapi.BadRequest(httpapi.CodeBadRequest, err.Error(), nil)
 	}
-	var platformErr *platform.Error
-	if errors.As(err, &platformErr) {
+	if _, ok := errors.AsType[*platform.Error](err); ok {
 		return httpapi.MapPlatformError(err)
 	}
-	var missingState *db.ArchiveRepoStateNotFoundError
-	if errors.As(err, &missingState) {
+	if _, ok := errors.AsType[*db.ArchiveRepoStateNotFoundError](err); ok {
 		return httpapi.BadRequest(httpapi.CodeBadRequest, "repository is not available for archiving", nil)
 	}
 	return httpapi.Internal("archive operation failed")

--- a/internal/server/host_runtime_handlers.go
+++ b/internal/server/host_runtime_handlers.go
@@ -136,8 +136,7 @@ func (s *Server) launchHostRuntimeSession(
 		},
 	)
 	if err != nil {
-		var persistenceErr *localruntime.CommandSessionPersistenceError
-		if errors.As(err, &persistenceErr) {
+		if persistenceErr, ok := errors.AsType[*localruntime.CommandSessionPersistenceError](err); ok {
 			if persistenceErr.RollbackErr != nil {
 				slog.Warn(
 					"roll back unrecorded host runtime session",

--- a/internal/server/httpapi/problems.go
+++ b/internal/server/httpapi/problems.go
@@ -508,8 +508,7 @@ func ProviderMutationProblem(err error, provider, host string) huma.StatusError 
 	if errors.Is(err, tokenauth.ErrMissingToken) {
 		return ProviderCallProblem(err, provider, host)
 	}
-	var pe *platform.Error
-	if errors.As(err, &pe) {
+	if pe, ok := errors.AsType[*platform.Error](err); ok {
 		switch pe.Code {
 		case platform.ErrCodeUnsupportedCapability,
 			platform.ErrCodeRepositoryFeatureDisabled,
@@ -548,8 +547,7 @@ func ProviderCallProblemWithDetail(
 	if errors.Is(err, platform.ErrSyncDisabled) {
 		return ServiceUnavailable(err.Error())
 	}
-	var pe *platform.Error
-	if errors.As(err, &pe) {
+	if _, ok := errors.AsType[*platform.Error](err); ok {
 		if mapped := MapPlatformError(err); mapped != nil {
 			return mapped
 		}

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -2273,12 +2273,10 @@ func (s *Server) resolveItem(
 		// Classified lookup outcomes (removed, inaccessible, moved with
 		// its destination) arrive as platform errors; map them to their
 		// typed problems instead of collapsing into an internal error.
-		var platformErr *platform.Error
-		if errors.As(err, &platformErr) {
+		if _, ok := errors.AsType[*platform.Error](err); ok {
 			return nil, httpapi.MapPlatformError(err)
 		}
-		var ghErr *gh.ErrorResponse
-		if errors.As(err, &ghErr) {
+		if ghErr, ok := errors.AsType[*gh.ErrorResponse](err); ok {
 			if ghErr.Response != nil &&
 				ghErr.Response.StatusCode == 404 {
 				return nil, httpapi.NotFound(httpapi.CodeNotFound,

--- a/internal/server/kata/client.go
+++ b/internal/server/kata/client.go
@@ -453,8 +453,7 @@ func (c *kataDaemonClient) get(
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return kataDaemonReadResult{}, ctxErr
 		}
-		var urlErr *url.Error
-		if errors.As(err, &urlErr) {
+		if urlErr, ok := errors.AsType[*url.Error](err); ok {
 			err = urlErr.Err
 		}
 		return kataDaemonReadResult{}, fmt.Errorf("read Kata daemon %q: %w", c.daemon.ID, err)

--- a/internal/server/mcp_backend.go
+++ b/internal/server/mcp_backend.go
@@ -411,8 +411,7 @@ func (b mcpBackend) SetWorkflowState(
 		Status: update.Status, ExpectedStatus: update.ExpectedStatus,
 		Source: update.Source, Actor: update.Actor, Reason: update.Reason,
 	})
-	var conflict *db.WorkflowStateConflictError
-	if errors.As(err, &conflict) {
+	if conflict, ok := errors.AsType[*db.WorkflowStateConflictError](err); ok {
 		return mcpserver.WorkflowMutation{}, &mcpserver.Error{
 			Kind: "conflict", Code: string(httpapi.CodeConflict),
 			Message: "workflow state changed", Details: map[string]any{
@@ -587,8 +586,7 @@ func (b mcpBackend) SubmitInitialMessage(
 	if err != nil {
 		converted := mcpBackendError(err)
 		if result.State == "pending" || result.State == "uncertain" {
-			var backendErr *mcpserver.Error
-			if errors.As(converted, &backendErr) {
+			if backendErr, ok := errors.AsType[*mcpserver.Error](converted); ok {
 				copy := *backendErr
 				copy.Ambiguous = true
 				copy.Retryable = false
@@ -720,8 +718,7 @@ func mcpBackendError(err error) error {
 	if err == nil {
 		return nil
 	}
-	var existing *mcpserver.Error
-	if errors.As(err, &existing) {
+	if existing, ok := errors.AsType[*mcpserver.Error](err); ok {
 		return existing
 	}
 	var problem *httpapi.ProblemError

--- a/internal/server/pullapi/diff_review_handlers.go
+++ b/internal/server/pullapi/diff_review_handlers.go
@@ -589,8 +589,7 @@ func (s *Handler) publishDiffReviewDraft(
 		HeadSHA:  reviewHeadSHA,
 		Comments: comments,
 	}); err != nil {
-		var partialErr *platform.DiffReviewPublishPartialError
-		if errors.As(err, &partialErr) {
+		if partialErr, ok := errors.AsType[*platform.DiffReviewPublishPartialError](err); ok {
 			if len(partialErr.PublishedCommentIDs) > 0 {
 				if discardErr := s.deletePublishedReviewDraftComments(ctx, draft.ID, mr.ID, partialErr.PublishedCommentIDs); discardErr != nil {
 					return nil, huma.Error500InternalServerError("discard partially published review draft comments failed")

--- a/internal/server/repo_import_handlers.go
+++ b/internal/server/repo_import_handlers.go
@@ -644,8 +644,7 @@ func (s *Server) bulkAddRepos(
 	}
 	resp, err := s.applyBulkExactRepos(ctx, resolved)
 	if err != nil {
-		var bae *bulkApplyError
-		if errors.As(err, &bae) {
+		if bae, ok := errors.AsType[*bulkApplyError](err); ok {
 			return nil, bae.problem
 		}
 		return nil, httpapi.Internal(err.Error())

--- a/internal/server/workspaceapi/projects_handlers.go
+++ b/internal/server/workspaceapi/projects_handlers.go
@@ -1461,8 +1461,7 @@ func (s *Handler) launchProjectWorktreeRuntimeCommandSession(
 		},
 	)
 	if err != nil {
-		var persistenceErr *localruntime.CommandSessionPersistenceError
-		if errors.As(err, &persistenceErr) {
+		if persistenceErr, ok := errors.AsType[*localruntime.CommandSessionPersistenceError](err); ok {
 			if persistenceErr.RollbackErr != nil {
 				slog.Warn(
 					"roll back unrecorded project worktree runtime session",

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -627,8 +627,7 @@ func (s *Handler) createIssueWorkspaceRouteCore(
 			return nil, problem
 		}
 		msg := err.Error()
-		var recoveryErr *workspace.WorkspaceDirectoryRecoveryError
-		if errors.As(err, &recoveryErr) {
+		if recoveryErr, ok := errors.AsType[*workspace.WorkspaceDirectoryRecoveryError](err); ok {
 			details := map[string]any{
 				"reason": string(recoveryErr.Reason),
 			}
@@ -642,8 +641,7 @@ func (s *Handler) createIssueWorkspaceRouteCore(
 				details,
 			)
 		}
-		var branchConflict *workspace.WorkspaceBranchConflictError
-		if errors.As(err, &branchConflict) {
+		if branchConflict, ok := errors.AsType[*workspace.WorkspaceBranchConflictError](err); ok {
 			// Branch-conflict gets the typed problem envelope with
 			// Type carrying the URN and Details carrying the conflicting
 			// branch + suggested alternative. The legacy Errors[]
@@ -892,8 +890,7 @@ func (s *Handler) adHocWorkspaceCreateError(
 		return nil, problem
 	}
 	msg := err.Error()
-	var branchConflict *workspace.WorkspaceBranchConflictError
-	if errors.As(err, &branchConflict) {
+	if branchConflict, ok := errors.AsType[*workspace.WorkspaceBranchConflictError](err); ok {
 		conflict := httpapi.NewProblem(
 			http.StatusConflict,
 			httpapi.CodeBranchConflict,
@@ -2753,8 +2750,7 @@ func (s *Handler) DeleteWorkspace(
 		if admitted {
 			s.persistWorkspaceDeletionFailure(input.ID, err.Error())
 		}
-		var dirty *workspaceDirtyDeletionError
-		if errors.As(err, &dirty) {
+		if _, ok := errors.AsType[*workspaceDirtyDeletionError](err); ok {
 			current, getErr := s.db.GetWorkspace(ctx, input.ID)
 			if getErr != nil {
 				return nil, httpapi.Internal("recheck workspace before dirty response: " + getErr.Error())

--- a/internal/workspace/diff_totals.go
+++ b/internal/workspace/diff_totals.go
@@ -149,8 +149,7 @@ func worktreeNumstatAgainst(
 	defer release()
 
 	if runErr := cmd.Run(); runErr != nil {
-		var exitErr *exec.ExitError
-		if errors.As(runErr, &exitErr) {
+		if _, ok := errors.AsType[*exec.ExitError](runErr); ok {
 			msg := stderr.String()
 			if isNoMergeBaseStderr(msg) {
 				return 0, 0, false, true, nil

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -2741,8 +2741,7 @@ func waitExitCode(waitErr error) int {
 	if waitErr == nil {
 		return 0
 	}
-	var exitErr *exec.ExitError
-	if errors.As(waitErr, &exitErr) {
+	if exitErr, ok := errors.AsType[*exec.ExitError](waitErr); ok {
 		return exitErr.ExitCode()
 	}
 	return -1

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -534,8 +534,7 @@ func (m *Manager) CreateIssue(
 	} else if opts.ReuseExistingDirectory {
 		return nil, directoryErr
 	} else {
-		var recoveryErr *WorkspaceDirectoryRecoveryError
-		if !errors.As(directoryErr, &recoveryErr) {
+		if _, ok := errors.AsType[*WorkspaceDirectoryRecoveryError](directoryErr); !ok {
 			return nil, directoryErr
 		}
 	}
@@ -760,8 +759,7 @@ func (m *Manager) CreateAdHoc(
 			ctx, branchDir, gitHeadRef, opts.ReuseExistingBranch, localBase,
 		)
 		if err != nil {
-			var conflict *WorkspaceBranchConflictError
-			if !errors.As(err, &conflict) {
+			if _, ok := errors.AsType[*WorkspaceBranchConflictError](err); !ok {
 				return nil, err
 			}
 			branch, nextHashAttempt, err = nextAvailableAdHocBranchName(

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 bun = "latest"
 "github:F1bonacc1/process-compose" = "latest"
-golangci-lint = "2.11.4"
+golangci-lint = "2.13.1"
 node = "24.16.0"
 "npm:vite-plus" = "0.1.24"
 prek = "latest"


### PR DESCRIPTION
Updates golangci-lint to 2.13.1 and NilAway to the canonical Kenn pin while keeping Forge's lint target at Go 1.26. It applies only the modernize rewrites supported by the current build floor, allowing main's reusable CI workflow to support the dependent Go 1.27 migration in #962.
