### PR TITLE
test: reduce copied setup across frontend and provider suites

### DIFF
--- a/context/testing.md
+++ b/context/testing.md
@@ -538,6 +538,10 @@ Defaults for new code:
   comment the fault. The two `TestSSE_Terminates...` deadline tests are the
   legitimate exception.
 
+Test cleanup must not delete a failing test that still covers repository-owned
+behavior. Fix the test or production behavior; remove only obsolete assertions
+or behavior already covered at the same boundary.
+
 For TypeScript/Svelte cleanup, add tests only when user-visible behavior,
 cross-module contracts, or an actual regression risk changes. Do not fabricate
 large fake browser boundaries, console-spy cases, or component tests merely to

--- a/frontend/src/app-stores.test.ts
+++ b/frontend/src/app-stores.test.ts
@@ -4,11 +4,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import type { EventsStoreOptions } from "./lib/stores/events.svelte.js";
 import type { DetailStoreOptions } from "./lib/stores/detail.svelte.js";
 import type { IssuesStoreOptions } from "./lib/stores/issues.svelte.js";
-import type { ConfigRepo, Settings, SyncStatus } from "./lib/api/types.js";
+import { DEFAULT_TERMINAL_SETTINGS, type ConfigRepo, type Settings, type SyncStatus } from "./lib/api/types.js";
 import type { AppServices, OwnedAppRuntime } from "./lib/app/runtime.js";
 import { createAppStores, type AppStoreOptions } from "./lib/app-stores.svelte.js";
 import { client } from "./lib/api/runtime.js";
 import { makeTestAppRuntime } from "./lib/testing/effect-layers.js";
+import { makeStartupSnapshot } from "./test/startupSnapshot.js";
 
 type LaunchTargets = NonNullable<Settings["launch_targets"]>;
 
@@ -315,47 +316,10 @@ describe("app store event wiring", () => {
       disabled_reason: "",
     } satisfies LaunchTargets[number];
     const staleTarget = { ...codexTarget, key: "claude", label: "Claude", command: ["claude"] };
-    const settings = {
-      repos: [],
-      activity: {
-        view_mode: "threaded",
-        time_range: "7d",
-        hide_closed: false,
-        hide_bots: false,
-        collapse_threads: false,
-        default_branch_retention_days: 90,
-        default_branch_max_commits: 5000,
-        use_workspace_activity_for_recency: false,
-      },
-      issues: { hide_bots: true },
-      terminal: {
-        font_family: "",
-        font_size: 12,
-        scrollback: 1000,
-        line_height: 1,
-        letter_spacing: 0,
-        cursor_blink: false,
-        font_ligatures: false,
-        hide_tmux_status: false,
-        graphics: true,
-        tmux_mouse: true,
-      },
-      modes: {
-        activity: true,
-        repos: true,
-        docs: false,
-        pulls: true,
-        issues: true,
-        reviews: true,
-        workspaces: true,
-      },
-      pull_requests: { allow_mid_stack_merges: false, prefer_github_native_stacks: false },
-      detail: { initial_timeline_entry_limit: 50 },
+    const settings = makeStartupSnapshot({
+      terminal: { ...DEFAULT_TERMINAL_SETTINGS, cursor_blink: false },
       launch_targets: [codexTarget],
-    } satisfies Pick<
-      Settings,
-      "repos" | "activity" | "issues" | "terminal" | "modes" | "pull_requests" | "detail" | "launch_targets"
-    >;
+    });
     getSettings.mockResolvedValue({ data: settings });
 
     compose({ getPage: () => "mobile-activity" });

--- a/frontend/src/lib/app/startup-workflow.test.ts
+++ b/frontend/src/lib/app/startup-workflow.test.ts
@@ -2,11 +2,9 @@ import { afterEach, assert, it, vi } from "@effect/vitest";
 import { Effect, Exit, Fiber, Layer } from "effect";
 import { TestClock } from "effect/testing";
 import { GeneratedApiLive } from "../api/generated-api.js";
-import type { components } from "../api/generated/schema.js";
 import { StreamingFetchLive } from "../browser/streaming-fetch.js";
+import { makeStartupSnapshot } from "../../test/startupSnapshot.js";
 import { StartupWorkflow, StartupWorkflowLive, waitUntilBackendReady } from "./startup-workflow.js";
-
-type SettingsResponse = components["schemas"]["SettingsResponse"];
 
 const StartupTestLayer = Layer.provideMerge(StartupWorkflowLive, Layer.mergeAll(GeneratedApiLive, StreamingFetchLive));
 
@@ -17,58 +15,7 @@ afterEach(() => {
 it.layer(StartupTestLayer)("shares startup settings demand", (it) => {
   it.effect("performs one settings request until invalidated", () =>
     Effect.gen(function* () {
-      const settings = {
-        activity: {
-          view_mode: "threaded",
-          time_range: "7d",
-          hide_closed: false,
-          hide_bots: false,
-          collapse_threads: false,
-          default_branch_retention_days: 90,
-          default_branch_max_commits: 5000,
-          use_workspace_activity_for_recency: false,
-        },
-        agents: [],
-        fleet: {
-          enabled: false,
-          sessions: {},
-          peers: [],
-          ssh_peers: [],
-          restart_required: false,
-        },
-        issues: { hide_bots: true },
-        kata_projects: [],
-        launch_targets: [],
-        modes: {
-          activity: true,
-          repos: true,
-          kata: false,
-          docs: false,
-          pulls: true,
-          issues: true,
-          reviews: true,
-          workspaces: true,
-        },
-        notifications: { enabled: true },
-        pull_requests: {
-          allow_mid_stack_merges: false,
-          prefer_github_native_stacks: false,
-        },
-        repos: [],
-        terminal: {
-          font_family: "",
-          font_size: 12,
-          scrollback: 1000,
-          line_height: 1,
-          letter_spacing: 0,
-          cursor_blink: true,
-          font_ligatures: false,
-          hide_tmux_status: false,
-          graphics: true,
-          tmux_mouse: true,
-        },
-        workspaces: { auto_assign_on_create: false, default_sidebar_view: "diff" },
-      } satisfies SettingsResponse;
+      const settings = makeStartupSnapshot();
       const observedPaths: string[] = [];
       const fetch: typeof globalThis.fetch = (input, init) => {
         const request = input instanceof Request ? input : new Request(input, init);
@@ -94,55 +41,7 @@ it.layer(StartupTestLayer)("shares startup settings demand", (it) => {
 it.layer(StartupTestLayer)("startup invalidation", (it) => {
   it.effect("does not publish a settings snapshot invalidated while its request is in flight", () =>
     Effect.gen(function* () {
-      const first = {
-        activity: {
-          view_mode: "threaded",
-          time_range: "7d",
-          hide_closed: false,
-          hide_bots: false,
-          collapse_threads: false,
-          default_branch_retention_days: 90,
-          default_branch_max_commits: 5000,
-          use_workspace_activity_for_recency: false,
-        },
-        agents: [],
-        fleet: {
-          enabled: false,
-          sessions: {},
-          peers: [],
-          ssh_peers: [],
-          restart_required: false,
-        },
-        issues: { hide_bots: true },
-        kata_projects: [],
-        launch_targets: [],
-        modes: {
-          activity: true,
-          repos: true,
-          kata: false,
-          docs: false,
-          pulls: true,
-          issues: true,
-          reviews: true,
-          workspaces: true,
-        },
-        notifications: { enabled: true },
-        pull_requests: { allow_mid_stack_merges: false, prefer_github_native_stacks: false },
-        repos: [],
-        terminal: {
-          font_family: "",
-          font_size: 12,
-          scrollback: 1000,
-          line_height: 1,
-          letter_spacing: 0,
-          cursor_blink: true,
-          font_ligatures: false,
-          hide_tmux_status: false,
-          graphics: true,
-          tmux_mouse: true,
-        },
-        workspaces: { auto_assign_on_create: false, default_sidebar_view: "diff" },
-      } satisfies SettingsResponse;
+      const first = makeStartupSnapshot();
       const second = { ...first, activity: { ...first.activity, hide_bots: true } };
       let releaseFirst = () => {};
       const firstGate = new Promise<void>((resolve) => {
@@ -178,58 +77,7 @@ it.layer(StartupTestLayer)("startup retry after failure", (it) => {
   it.effect("requests settings again after a failed startup lookup", () =>
     Effect.gen(function* () {
       let settingsRequests = 0;
-      const settings = {
-        activity: {
-          view_mode: "threaded",
-          time_range: "7d",
-          hide_closed: false,
-          hide_bots: false,
-          collapse_threads: false,
-          default_branch_retention_days: 90,
-          default_branch_max_commits: 5000,
-          use_workspace_activity_for_recency: false,
-        },
-        agents: [],
-        fleet: {
-          enabled: false,
-          sessions: {},
-          peers: [],
-          ssh_peers: [],
-          restart_required: false,
-        },
-        issues: { hide_bots: true },
-        kata_projects: [],
-        launch_targets: [],
-        modes: {
-          activity: true,
-          repos: true,
-          kata: false,
-          docs: false,
-          pulls: true,
-          issues: true,
-          reviews: true,
-          workspaces: true,
-        },
-        notifications: { enabled: true },
-        pull_requests: {
-          allow_mid_stack_merges: false,
-          prefer_github_native_stacks: false,
-        },
-        repos: [],
-        terminal: {
-          font_family: "",
-          font_size: 12,
-          scrollback: 1000,
-          line_height: 1,
-          letter_spacing: 0,
-          cursor_blink: true,
-          font_ligatures: false,
-          hide_tmux_status: false,
-          graphics: true,
-          tmux_mouse: true,
-        },
-        workspaces: { auto_assign_on_create: false, default_sidebar_view: "diff" },
-      } satisfies SettingsResponse;
+      const settings = makeStartupSnapshot();
       const fetch: typeof globalThis.fetch = (input, init) => {
         const request = input instanceof Request ? input : new Request(input, init);
         if (new URL(request.url).pathname.endsWith("/healthz")) {

--- a/frontend/src/lib/components/settings/RepoImportModal.test.ts
+++ b/frontend/src/lib/components/settings/RepoImportModal.test.ts
@@ -1,8 +1,10 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
 import { Effect, Layer } from "effect";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
+import { DEFAULT_TERMINAL_SETTINGS } from "../../api/types.js";
 import type { RepoPreviewResponse, SettingsSnapshot } from "../../stores/settings-workflow.js";
 import RepoImportModalRuntimeHarness from "./RepoImportModalRuntimeHarness.svelte";
+import { makeStartupSnapshot } from "../../../test/startupSnapshot.js";
 import { installOffsetParentStub, removeOffsetParentStub } from "../../../test/stubOffsetParent.js";
 
 beforeAll(installOffsetParentStub);
@@ -50,14 +52,12 @@ function renderRepoImportModal(props: {
   render(RepoImportModalRuntimeHarness, { props });
 }
 
-function defaultFleetSettings() {
-  return {
-    enabled: false,
-    sessions: {},
-    peers: [],
-    ssh_peers: [],
-    restart_required: false,
-  };
+function settingsResponse() {
+  return makeStartupSnapshot({
+    issues: { hide_bots: false },
+    notifications: { enabled: false },
+    terminal: { ...DEFAULT_TERMINAL_SETTINGS, font_size: 14 },
+  });
 }
 
 const rows = [
@@ -154,40 +154,7 @@ describe("RepoImportModal", () => {
       pattern: "*",
       repos: rows,
     });
-    bulk.mockResolvedValue({
-      repos: [],
-      kata_projects: [],
-      pull_requests: { allow_mid_stack_merges: false, prefer_github_native_stacks: false },
-      workspaces: { auto_assign_on_create: false, default_sidebar_view: "diff" },
-      issues: { hide_bots: false },
-      activity: {
-        view_mode: "threaded",
-        time_range: "7d",
-        hide_closed: false,
-        hide_bots: false,
-        collapse_threads: false,
-        default_branch_retention_days: 90,
-        default_branch_max_commits: 5000,
-        use_workspace_activity_for_recency: false,
-      },
-      terminal: {
-        font_family: "",
-        font_size: 14,
-        scrollback: 1000,
-        line_height: 1,
-        letter_spacing: 0,
-        cursor_blink: true,
-        font_ligatures: false,
-        hide_tmux_status: false,
-        graphics: true,
-        tmux_mouse: true,
-      },
-      notifications: {
-        enabled: false,
-      },
-      agents: [],
-      fleet: defaultFleetSettings(),
-    });
+    bulk.mockResolvedValue(settingsResponse());
     renderRepoImportModal({ open: true, onClose: vi.fn(), onImported });
 
     await fireEvent.input(screen.getByLabelText("Repository pattern"), {
@@ -234,40 +201,7 @@ describe("RepoImportModal", () => {
       pattern: "*",
       repos: rows,
     });
-    bulk.mockResolvedValue({
-      repos: [],
-      kata_projects: [],
-      pull_requests: { allow_mid_stack_merges: false, prefer_github_native_stacks: false },
-      workspaces: { auto_assign_on_create: false, default_sidebar_view: "diff" },
-      issues: { hide_bots: false },
-      activity: {
-        view_mode: "threaded",
-        time_range: "7d",
-        hide_closed: false,
-        hide_bots: false,
-        collapse_threads: false,
-        default_branch_retention_days: 90,
-        default_branch_max_commits: 5000,
-        use_workspace_activity_for_recency: false,
-      },
-      terminal: {
-        font_family: "",
-        font_size: 14,
-        scrollback: 1000,
-        line_height: 1,
-        letter_spacing: 0,
-        cursor_blink: true,
-        font_ligatures: false,
-        hide_tmux_status: false,
-        graphics: true,
-        tmux_mouse: true,
-      },
-      notifications: {
-        enabled: false,
-      },
-      agents: [],
-      fleet: defaultFleetSettings(),
-    });
+    bulk.mockResolvedValue(settingsResponse());
     renderRepoImportModal({ open: true, onClose: vi.fn(), onImported: vi.fn() });
 
     await fireEvent.input(screen.getByLabelText("Repository pattern"), {

--- a/frontend/src/lib/components/settings/RepoSettings.test.ts
+++ b/frontend/src/lib/components/settings/RepoSettings.test.ts
@@ -1,8 +1,9 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
 import { Effect, Layer } from "effect";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
-import type { ConfigRepo } from "../../api/types.js";
+import { DEFAULT_TERMINAL_SETTINGS, type ConfigRepo } from "../../api/types.js";
 import * as flash from "../../stores/flash.svelte.js";
+import { makeStartupSnapshot } from "../../../test/startupSnapshot.js";
 
 const {
   mockAddRepo,
@@ -71,14 +72,13 @@ import type { RepoPreviewResponse } from "../../stores/settings-workflow.js";
 import RepoSettings from "./RepoSettings.svelte";
 import SettingsRuntimeHarness from "./SettingsRuntimeHarness.svelte";
 
-function defaultFleetSettings() {
-  return {
-    enabled: false,
-    sessions: {},
-    peers: [],
-    ssh_peers: [],
-    restart_required: false,
-  };
+function settingsResponse(repos: ConfigRepo[] = []) {
+  return makeStartupSnapshot({
+    repos,
+    issues: { hide_bots: false },
+    notifications: { enabled: false },
+    terminal: { ...DEFAULT_TERMINAL_SETTINGS, font_size: 14 },
+  });
 }
 
 function renderRepoSettings(props: { repos: ConfigRepo[]; onUpdate: (repos: ConfigRepo[]) => void }): void {
@@ -208,74 +208,8 @@ describe("RepoSettings", () => {
   });
 
   it("forwards add/refresh through the settings API", async () => {
-    mockAddRepo.mockResolvedValue({
-      repos: [],
-      kata_projects: [],
-      pull_requests: { allow_mid_stack_merges: false, prefer_github_native_stacks: false },
-      workspaces: { auto_assign_on_create: false, default_sidebar_view: "diff" },
-      issues: { hide_bots: false },
-      activity: {
-        view_mode: "threaded",
-        time_range: "7d",
-        hide_closed: false,
-        hide_bots: false,
-        collapse_threads: false,
-        default_branch_retention_days: 90,
-        default_branch_max_commits: 5000,
-        use_workspace_activity_for_recency: false,
-      },
-      terminal: {
-        font_family: "",
-        font_size: 14,
-        scrollback: 1000,
-        line_height: 1,
-        letter_spacing: 0,
-        cursor_blink: true,
-        font_ligatures: false,
-        hide_tmux_status: false,
-        graphics: true,
-        tmux_mouse: true,
-      },
-      notifications: {
-        enabled: false,
-      },
-      agents: [],
-      fleet: defaultFleetSettings(),
-    });
-    mockRefreshRepo.mockResolvedValue({
-      repos: [],
-      kata_projects: [],
-      pull_requests: { allow_mid_stack_merges: false, prefer_github_native_stacks: false },
-      workspaces: { auto_assign_on_create: false, default_sidebar_view: "diff" },
-      issues: { hide_bots: false },
-      activity: {
-        view_mode: "threaded",
-        time_range: "7d",
-        hide_closed: false,
-        hide_bots: false,
-        collapse_threads: false,
-        default_branch_retention_days: 90,
-        default_branch_max_commits: 5000,
-        use_workspace_activity_for_recency: false,
-      },
-      terminal: {
-        font_family: "",
-        font_size: 14,
-        scrollback: 1000,
-        line_height: 1,
-        letter_spacing: 0,
-        cursor_blink: true,
-        font_ligatures: false,
-        hide_tmux_status: false,
-        graphics: true,
-        tmux_mouse: true,
-      },
-      notifications: {
-        enabled: false,
-      },
-      agents: [],
-      fleet: defaultFleetSettings(),
-    });
+    mockAddRepo.mockResolvedValue(settingsResponse());
+    mockRefreshRepo.mockResolvedValue(settingsResponse());
 
     renderRepoSettings({
       repos: [
@@ -322,37 +256,7 @@ describe("RepoSettings", () => {
         matched_repo_count: 1,
       },
     ];
-    mockUpdateRepoWorktreeBasePath.mockResolvedValue({
-      repos: updatedRepos,
-      kata_projects: [],
-      pull_requests: { allow_mid_stack_merges: false, prefer_github_native_stacks: false },
-      workspaces: { auto_assign_on_create: false, default_sidebar_view: "diff" },
-      issues: { hide_bots: false },
-      activity: {
-        view_mode: "threaded",
-        time_range: "7d",
-        hide_closed: false,
-        hide_bots: false,
-        collapse_threads: false,
-        default_branch_retention_days: 90,
-        default_branch_max_commits: 5000,
-        use_workspace_activity_for_recency: false,
-      },
-      terminal: {
-        font_family: "",
-        font_size: 14,
-        scrollback: 1000,
-        line_height: 1,
-        letter_spacing: 0,
-        cursor_blink: true,
-        font_ligatures: false,
-        hide_tmux_status: false,
-        graphics: true,
-        tmux_mouse: true,
-      },
-      agents: [],
-      fleet: defaultFleetSettings(),
-    });
+    mockUpdateRepoWorktreeBasePath.mockResolvedValue(settingsResponse(updatedRepos));
 
     renderRepoSettings({
       repos: [
@@ -569,37 +473,7 @@ describe("RepoSettings", () => {
         },
       ],
     });
-    mockPromoteRepo.mockResolvedValue({
-      repos: promotedRepos,
-      kata_projects: [],
-      pull_requests: { allow_mid_stack_merges: false, prefer_github_native_stacks: false },
-      workspaces: { auto_assign_on_create: false, default_sidebar_view: "diff" },
-      issues: { hide_bots: false },
-      activity: {
-        view_mode: "threaded",
-        time_range: "7d",
-        hide_closed: false,
-        hide_bots: false,
-        collapse_threads: false,
-        default_branch_retention_days: 90,
-        default_branch_max_commits: 5000,
-        use_workspace_activity_for_recency: false,
-      },
-      terminal: {
-        font_family: "",
-        font_size: 14,
-        scrollback: 1000,
-        line_height: 1,
-        letter_spacing: 0,
-        cursor_blink: true,
-        font_ligatures: false,
-        hide_tmux_status: false,
-        graphics: true,
-        tmux_mouse: true,
-      },
-      agents: [],
-      fleet: defaultFleetSettings(),
-    });
+    mockPromoteRepo.mockResolvedValue(settingsResponse(promotedRepos));
 
     renderRepoSettings({
       repos: [
@@ -782,40 +656,7 @@ describe("RepoSettings", () => {
         },
       ],
     });
-    mockBulkAddRepos.mockResolvedValue({
-      repos: importedRepos,
-      kata_projects: [],
-      pull_requests: { allow_mid_stack_merges: false, prefer_github_native_stacks: false },
-      workspaces: { auto_assign_on_create: false, default_sidebar_view: "diff" },
-      issues: { hide_bots: false },
-      activity: {
-        view_mode: "threaded",
-        time_range: "7d",
-        hide_closed: false,
-        hide_bots: false,
-        collapse_threads: false,
-        default_branch_retention_days: 90,
-        default_branch_max_commits: 5000,
-        use_workspace_activity_for_recency: false,
-      },
-      terminal: {
-        font_family: "",
-        font_size: 14,
-        scrollback: 1000,
-        line_height: 1,
-        letter_spacing: 0,
-        cursor_blink: true,
-        font_ligatures: false,
-        hide_tmux_status: false,
-        graphics: true,
-        tmux_mouse: true,
-      },
-      notifications: {
-        enabled: false,
-      },
-      agents: [],
-      fleet: defaultFleetSettings(),
-    });
+    mockBulkAddRepos.mockResolvedValue(settingsResponse(importedRepos));
     renderRepoSettings({
       repos: [],
       onUpdate,

--- a/frontend/src/lib/components/settings/SettingsPage.test.ts
+++ b/frontend/src/lib/components/settings/SettingsPage.test.ts
@@ -2,6 +2,7 @@ import { cleanup, render, waitFor } from "@testing-library/svelte";
 import { Effect, Layer } from "effect";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { DEFAULT_TERMINAL_SETTINGS, type Settings } from "../../api/types.js";
+import { makeStartupSnapshot } from "../../../test/startupSnapshot.js";
 
 const { loadSettings, setDetailSettings, setLaunchTargets, setRepoPresets } = vi.hoisted(() => ({
   loadSettings: vi.fn(),
@@ -91,8 +92,7 @@ const codexTarget = {
 } satisfies LaunchTargets[number];
 
 function makeSettings(): Settings {
-  return {
-    repos: [],
+  return makeStartupSnapshot({
     repo_presets: [
       {
         name: "Review queue",
@@ -101,48 +101,8 @@ function makeSettings(): Settings {
         ],
       },
     ],
-    pull_requests: { allow_mid_stack_merges: false, prefer_github_native_stacks: false },
-    detail: { initial_timeline_entry_limit: 50 },
-    workspaces: { auto_assign_on_create: false, default_sidebar_view: "diff" },
-    issues: { hide_bots: true },
-    kata_projects: [],
-    fleet: {
-      enabled: false,
-      sessions: {},
-      peers: [],
-      ssh_peers: [],
-      restart_required: false,
-    },
-    mcp: {
-      enabled: false,
-      restart_required: false,
-      active_requires_auth: false,
-    },
-    roborev: { init_managed_clones: false },
-    activity: {
-      view_mode: "threaded",
-      time_range: "7d",
-      hide_closed: false,
-      hide_bots: false,
-      collapse_threads: false,
-      default_branch_retention_days: 90,
-      default_branch_max_commits: 5000,
-      use_workspace_activity_for_recency: false,
-    },
-    terminal: DEFAULT_TERMINAL_SETTINGS,
-    modes: {
-      activity: true,
-      repos: true,
-      docs: false,
-      pulls: true,
-      issues: true,
-      reviews: true,
-      workspaces: true,
-    },
-    notifications: { enabled: true },
-    agents: [],
     launch_targets: [codexTarget],
-  };
+  });
 }
 
 describe("SettingsPage", () => {

--- a/frontend/src/lib/components/settings/TerminalSettings.test.ts
+++ b/frontend/src/lib/components/settings/TerminalSettings.test.ts
@@ -1,8 +1,9 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
 import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { TerminalSettings as TerminalSettingsValue } from "../../api/types.js";
 import { makeAppRuntime, type OwnedAppRuntime } from "../../app/runtime.js";
-import type { StartupSnapshot } from "../../app/startup-workflow.js";
+import { makeStartupSnapshot } from "../../../test/startupSnapshot.js";
 
 const {
   mockEmbedded,
@@ -73,48 +74,8 @@ vi.mock("../../stores/embed-config.svelte.js", async (importOriginal) => {
 
 import TerminalSettings from "./TerminalSettings.svelte";
 
-function settingsResponse(terminal: StartupSnapshot["terminal"]): StartupSnapshot {
-  return {
-    activity: {
-      view_mode: "threaded",
-      time_range: "7d",
-      hide_closed: false,
-      hide_bots: false,
-      collapse_threads: false,
-      default_branch_retention_days: 90,
-      default_branch_max_commits: 5000,
-      use_workspace_activity_for_recency: false,
-    },
-    agents: [],
-    fleet: {
-      enabled: false,
-      sessions: {},
-      peers: [],
-      ssh_peers: [],
-      restart_required: false,
-    },
-    issues: { hide_bots: true },
-    kata_projects: [],
-    launch_targets: [],
-    modes: {
-      activity: true,
-      repos: true,
-      kata: false,
-      docs: false,
-      pulls: true,
-      issues: true,
-      reviews: true,
-      workspaces: true,
-    },
-    notifications: { enabled: true },
-    pull_requests: {
-      allow_mid_stack_merges: false,
-      prefer_github_native_stacks: false,
-    },
-    repos: [],
-    terminal,
-    workspaces: { auto_assign_on_create: false, default_sidebar_view: "diff" },
-  };
+function settingsResponse(terminal: TerminalSettingsValue) {
+  return makeStartupSnapshot({ terminal });
 }
 
 describe("TerminalSettings", () => {

--- a/frontend/src/lib/components/terminal/WorkspaceEmbedShell.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceEmbedShell.test.ts
@@ -1,13 +1,13 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
 import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
-import type { StartupSnapshot } from "../../app/startup-workflow.js";
 import type { OwnedAppRuntime } from "../../app/runtime.js";
 import { makeAppRuntime } from "../../app/runtime.js";
 import { createAppStores } from "../../app-stores.svelte.js";
 import { DEFAULT_TERMINAL_SETTINGS } from "../../api/types.js";
 import { STORES_KEY } from "../../context.js";
 import { replaceUrl } from "../../stores/router.svelte.js";
+import { makeStartupSnapshot } from "../../../test/startupSnapshot.js";
 
 const mocks = vi.hoisted(() => ({
   runtime: undefined as unknown as OwnedAppRuntime,
@@ -31,50 +31,12 @@ function renderShell() {
   return render(WorkspaceEmbedShell, { context: new Map([[STORES_KEY, stores]]) });
 }
 
-const settings = {
-  activity: {
-    view_mode: "threaded",
-    time_range: "7d",
-    hide_closed: false,
-    hide_bots: false,
-    collapse_threads: false,
-    default_branch_retention_days: 90,
-    default_branch_max_commits: 5000,
-    use_workspace_activity_for_recency: false,
-  },
-  agents: [],
-  fleet: {
-    enabled: false,
-    sessions: {},
-    peers: [],
-    ssh_peers: [],
-    restart_required: false,
-  },
-  issues: { hide_bots: true },
-  kata_projects: [],
-  launch_targets: [],
-  modes: {
-    activity: true,
-    repos: true,
-    kata: false,
-    docs: false,
-    pulls: true,
-    issues: true,
-    reviews: true,
-    workspaces: true,
-  },
-  notifications: { enabled: true },
-  pull_requests: {
-    allow_mid_stack_merges: false,
-    prefer_github_native_stacks: false,
-  },
-  repos: [],
+const settings = makeStartupSnapshot({
   terminal: {
     ...DEFAULT_TERMINAL_SETTINGS,
     font_size: 14,
   },
-  workspaces: { auto_assign_on_create: false, default_sidebar_view: "diff" },
-} satisfies StartupSnapshot;
+});
 
 describe("WorkspaceEmbedShell settings requests", () => {
   beforeEach(() => {

--- a/frontend/src/lib/components/terminal/terminalSettingsPersistence.test.ts
+++ b/frontend/src/lib/components/terminal/terminalSettingsPersistence.test.ts
@@ -2,7 +2,7 @@ import { DEFAULT_TERMINAL_SETTINGS, type TerminalSettings } from "../../api/type
 import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { makeAppRuntime, type OwnedAppRuntime } from "../../app/runtime.js";
-import type { StartupSnapshot } from "../../app/startup-workflow.js";
+import { makeStartupSnapshot } from "../../../test/startupSnapshot.js";
 import {
   beginTerminalSettingsHydration,
   hydrateTerminalSettings,
@@ -24,48 +24,8 @@ let runtime: OwnedAppRuntime;
 let persistSettings: (settings: TerminalSettings) => Promise<TerminalSettings>;
 let persistedTerminal: TerminalSettings;
 
-function settingsResponse(terminal: TerminalSettings): StartupSnapshot {
-  return {
-    activity: {
-      view_mode: "threaded",
-      time_range: "7d",
-      hide_closed: false,
-      hide_bots: false,
-      collapse_threads: false,
-      default_branch_retention_days: 90,
-      default_branch_max_commits: 5000,
-      use_workspace_activity_for_recency: false,
-    },
-    agents: [],
-    fleet: {
-      enabled: false,
-      sessions: {},
-      peers: [],
-      ssh_peers: [],
-      restart_required: false,
-    },
-    issues: { hide_bots: true },
-    kata_projects: [],
-    launch_targets: [],
-    modes: {
-      activity: true,
-      repos: true,
-      kata: false,
-      docs: false,
-      pulls: true,
-      issues: true,
-      reviews: true,
-      workspaces: true,
-    },
-    notifications: { enabled: true },
-    pull_requests: {
-      allow_mid_stack_merges: false,
-      prefer_github_native_stacks: false,
-    },
-    repos: [],
-    terminal,
-    workspaces: { auto_assign_on_create: false, default_sidebar_view: "diff" },
-  };
+function settingsResponse(terminal: TerminalSettings) {
+  return makeStartupSnapshot({ terminal });
 }
 
 function saveTerminalSettings(options: {

--- a/frontend/src/lib/components/terminal/terminalZoom.test.ts
+++ b/frontend/src/lib/components/terminal/terminalZoom.test.ts
@@ -2,7 +2,7 @@ import { DEFAULT_TERMINAL_SETTINGS, type TerminalSettings } from "../../api/type
 import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { makeAppRuntime, type OwnedAppRuntime } from "../../app/runtime.js";
-import type { StartupSnapshot } from "../../app/startup-workflow.js";
+import { makeStartupSnapshot } from "../../../test/startupSnapshot.js";
 import {
   MAX_TERMINAL_FONT_SIZE,
   MIN_TERMINAL_FONT_SIZE,
@@ -50,48 +50,8 @@ let persistSettings: (settings: TerminalSettings) => Promise<TerminalSettings>;
 let persistedTerminal: TerminalSettings;
 const runtimes: OwnedAppRuntime[] = [];
 
-function settingsResponse(terminal: TerminalSettings): StartupSnapshot {
-  return {
-    activity: {
-      view_mode: "threaded",
-      time_range: "7d",
-      hide_closed: false,
-      hide_bots: false,
-      collapse_threads: false,
-      default_branch_retention_days: 90,
-      default_branch_max_commits: 5000,
-      use_workspace_activity_for_recency: false,
-    },
-    agents: [],
-    fleet: {
-      enabled: false,
-      sessions: {},
-      peers: [],
-      ssh_peers: [],
-      restart_required: false,
-    },
-    issues: { hide_bots: true },
-    kata_projects: [],
-    launch_targets: [],
-    modes: {
-      activity: true,
-      repos: true,
-      kata: false,
-      docs: false,
-      pulls: true,
-      issues: true,
-      reviews: true,
-      workspaces: true,
-    },
-    notifications: { enabled: true },
-    pull_requests: {
-      allow_mid_stack_merges: false,
-      prefer_github_native_stacks: false,
-    },
-    repos: [],
-    terminal,
-    workspaces: { auto_assign_on_create: false, default_sidebar_view: "diff" },
-  };
+function settingsResponse(terminal: TerminalSettings) {
+  return makeStartupSnapshot({ terminal });
 }
 
 beforeEach(() => {

--- a/frontend/src/lib/stores/settings-hydration.test.ts
+++ b/frontend/src/lib/stores/settings-hydration.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from "vite-plus/test";
-import { DEFAULT_MODE_VISIBILITY, DEFAULT_PULL_REQUEST_SETTINGS, DEFAULT_TERMINAL_SETTINGS } from "../api/types.js";
 import type { ActivitySettings } from "../api/types.js";
-import type { StartupSnapshot } from "../app/startup-workflow.js";
+import { makeStartupSnapshot } from "../../test/startupSnapshot.js";
 import { applySettingsHydration } from "./settings-hydration.js";
 import { createSettingsStore } from "./settings.svelte.js";
 import { beginTerminalSettingsHydration } from "./terminal-settings-persistence.js";
@@ -29,8 +28,7 @@ const codexTarget = {
   disabled_reason: "",
 };
 
-const settingsPayload = {
-  repos: [],
+const settingsPayload = makeStartupSnapshot({
   repo_presets: [
     {
       name: "Review queue",
@@ -41,24 +39,10 @@ const settingsPayload = {
   ],
   activity: activitySettings,
   detail: { initial_timeline_entry_limit: 75 },
-  issues: { hide_bots: true },
-  terminal: DEFAULT_TERMINAL_SETTINGS,
-  modes: DEFAULT_MODE_VISIBILITY,
-  pull_requests: DEFAULT_PULL_REQUEST_SETTINGS,
   launch_targets: [codexTarget],
-  agents: [],
-  fleet: {
-    enabled: false,
-    sessions: {},
-    peers: [],
-    ssh_peers: [],
-    restart_required: false,
-  },
-  kata_projects: [],
-  notifications: { enabled: true },
   workspaces: { auto_assign_on_create: false, default_sidebar_view: "item" },
   roborev: { init_managed_clones: true },
-} satisfies StartupSnapshot;
+});
 
 function hydrate(
   launchTargets = [codexTarget],

--- a/frontend/src/lib/stores/settings-workflow.test.ts
+++ b/frontend/src/lib/stores/settings-workflow.test.ts
@@ -2,7 +2,9 @@ import { afterEach, assert, it, vi } from "@effect/vitest";
 import { Effect, Fiber, Layer } from "effect";
 import { GeneratedApiLive } from "../api/generated-api.js";
 import type { components } from "../api/generated/schema.js";
+import { DEFAULT_TERMINAL_SETTINGS } from "../api/types.js";
 import { StreamingFetchLive } from "../browser/streaming-fetch.js";
+import { makeStartupSnapshot } from "../../test/startupSnapshot.js";
 import { StartupWorkflowLive } from "../app/startup-workflow.js";
 import { SettingsWorkflow, SettingsWorkflowLive, settingsErrorMessage } from "./settings-workflow.js";
 
@@ -10,66 +12,10 @@ type SettingsResponse = components["schemas"]["SettingsResponse"];
 type FleetSettingsUpdate = components["schemas"]["UpdateFleetSettingsInputBody"];
 
 function makeSettings(repos: SettingsResponse["repos"] = []): SettingsResponse {
-  return {
-    activity: {
-      view_mode: "threaded",
-      time_range: "7d",
-      hide_closed: false,
-      hide_bots: false,
-      collapse_threads: false,
-      default_branch_retention_days: 90,
-      default_branch_max_commits: 5000,
-      use_workspace_activity_for_recency: false,
-    },
-    agents: [],
-    detail: { initial_timeline_entry_limit: 50 },
-    fleet: {
-      enabled: false,
-      sessions: {},
-      peers: [],
-      ssh_peers: [],
-      restart_required: false,
-    },
-    mcp: {
-      enabled: false,
-      restart_required: false,
-      active_requires_auth: false,
-    },
-    issues: { hide_bots: true },
-    kata_projects: [],
-    launch_targets: [],
-    modes: {
-      activity: true,
-      repos: true,
-      docs: false,
-      pulls: true,
-      issues: true,
-      reviews: true,
-      workspaces: true,
-    },
-    notifications: { enabled: true },
-    pull_requests: {
-      allow_mid_stack_merges: false,
-      prefer_github_native_stacks: false,
-    },
-    roborev: { init_managed_clones: false },
-    repo_presets: [],
+  return makeStartupSnapshot({
     repos,
-    terminal: {
-      font_family: "",
-      font_size: 12,
-      scrollback: 1000,
-      line_height: 1,
-      letter_spacing: 0,
-      cursor_blink: true,
-      font_ligatures: false,
-      hide_tmux_status: false,
-      graphics: true,
-      tmux_mouse: true,
-      retained_sessions: 0,
-    },
-    workspaces: { auto_assign_on_create: false, default_sidebar_view: "diff" },
-  };
+    terminal: { ...DEFAULT_TERMINAL_SETTINGS, retained_sessions: 0 },
+  });
 }
 
 const StartupTestLayer = Layer.provideMerge(StartupWorkflowLive, Layer.mergeAll(GeneratedApiLive, StreamingFetchLive));

--- a/frontend/src/lib/stores/workspace-settings-persistence.test.ts
+++ b/frontend/src/lib/stores/workspace-settings-persistence.test.ts
@@ -2,7 +2,7 @@ import { Effect } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { Settings } from "../api/types.js";
 import { makeAppRuntime, type OwnedAppRuntime } from "../app/runtime.js";
-import type { StartupSnapshot } from "../app/startup-workflow.js";
+import { makeStartupSnapshot } from "../../test/startupSnapshot.js";
 import { createSettingsStore } from "./settings.svelte.js";
 import {
   beginWorkspaceSettingsHydration,
@@ -17,52 +17,8 @@ const initial: WorkspaceSettings = {
   default_sidebar_view: "diff",
 };
 
-function settingsResponse(workspaces: WorkspaceSettings): StartupSnapshot {
-  return {
-    activity: {
-      view_mode: "threaded",
-      time_range: "7d",
-      hide_closed: false,
-      hide_bots: false,
-      collapse_threads: false,
-      default_branch_retention_days: 90,
-      default_branch_max_commits: 5000,
-      use_workspace_activity_for_recency: false,
-    },
-    agents: [],
-    fleet: { enabled: false, sessions: {}, peers: [], ssh_peers: [], restart_required: false },
-    issues: { hide_bots: true },
-    kata_projects: [],
-    launch_targets: [],
-    modes: {
-      activity: true,
-      repos: true,
-      kata: false,
-      docs: false,
-      pulls: true,
-      issues: true,
-      reviews: true,
-      workspaces: true,
-    },
-    notifications: { enabled: true },
-    pull_requests: { allow_mid_stack_merges: false, prefer_github_native_stacks: false },
-    repos: [],
-    terminal: {
-      font_family: "",
-      font_size: 14,
-      scrollback: 1000,
-      line_height: 1,
-      letter_spacing: 0,
-      cursor_blink: true,
-      font_ligatures: false,
-      hide_tmux_status: false,
-      graphics: true,
-      tmux_mouse: true,
-      retained_sessions: 10,
-    },
-    workspaces,
-    roborev: { init_managed_clones: false },
-  };
+function settingsResponse(workspaces: WorkspaceSettings) {
+  return makeStartupSnapshot({ workspaces });
 }
 
 function deferred<T>() {

--- a/frontend/src/lib/utils/appStartup.test.ts
+++ b/frontend/src/lib/utils/appStartup.test.ts
@@ -4,6 +4,7 @@ import type { StoreInstances } from "../types.js";
 import { DEFAULT_TERMINAL_SETTINGS, type Settings, type TerminalSettings } from "../api/types.js";
 import { TransientTransportError } from "../api/effect-errors.js";
 import { StartupWorkflow, type StartupSnapshot } from "../app/startup-workflow.js";
+import { makeStartupSnapshot } from "../../test/startupSnapshot.js";
 import { appStartupProgram } from "./appStartup.js";
 
 type LaunchTargets = NonNullable<StartupSnapshot["launch_targets"]>;
@@ -76,58 +77,15 @@ function makeStores(
   } as unknown as StoreInstances;
 }
 
-const settings = {
-  repos: [],
-  repo_presets: [],
-  pull_requests: { allow_mid_stack_merges: false, prefer_github_native_stacks: false },
-  detail: { initial_timeline_entry_limit: 50 },
-  workspaces: { auto_assign_on_create: false, default_sidebar_view: "diff" },
+const settings = makeStartupSnapshot({
   roborev: { init_managed_clones: true },
-  issues: { hide_bots: true },
-  kata_projects: [],
-  fleet: {
-    enabled: false,
-    sessions: {},
-    peers: [],
-    ssh_peers: [],
-    restart_required: false,
-  },
-  activity: {
-    view_mode: "threaded",
-    time_range: "7d",
-    hide_closed: false,
-    hide_bots: false,
-    collapse_threads: false,
-    default_branch_retention_days: 90,
-    default_branch_max_commits: 5000,
-    use_workspace_activity_for_recency: false,
-  },
   terminal: {
+    ...DEFAULT_TERMINAL_SETTINGS,
     font_family: '"Fira Code", monospace',
     font_size: 14,
-    scrollback: 1000,
-    line_height: 1,
-    letter_spacing: 0,
-    cursor_blink: true,
-    font_ligatures: false,
-    hide_tmux_status: false,
-    graphics: true,
-    tmux_mouse: true,
   },
-  modes: {
-    activity: true,
-    repos: true,
-    kata: false,
-    docs: false,
-    pulls: true,
-    issues: true,
-    reviews: true,
-    workspaces: true,
-  },
-  notifications: { enabled: true },
-  agents: [],
   launch_targets: [codexTarget],
-} satisfies StartupSnapshot;
+});
 
 const SuccessfulStartup = Layer.succeed(StartupWorkflow)({
   start: Effect.succeed(settings),

--- a/frontend/src/test/startupSnapshot.ts
+++ b/frontend/src/test/startupSnapshot.ts
@@ -1,0 +1,52 @@
+import {
+  DEFAULT_DETAIL_SETTINGS,
+  DEFAULT_MODE_VISIBILITY,
+  DEFAULT_PULL_REQUEST_SETTINGS,
+  DEFAULT_TERMINAL_SETTINGS,
+} from "../lib/api/types.js";
+import type { StartupSnapshot } from "../lib/app/startup-workflow.js";
+
+export function makeStartupSnapshot(overrides: Partial<StartupSnapshot> = {}): StartupSnapshot {
+  const defaults = {
+    activity: {
+      view_mode: "threaded",
+      time_range: "7d",
+      hide_closed: false,
+      hide_bots: false,
+      collapse_threads: false,
+      default_branch_retention_days: 90,
+      default_branch_max_commits: 5000,
+      use_workspace_activity_for_recency: false,
+    },
+    agents: [],
+    detail: { ...DEFAULT_DETAIL_SETTINGS },
+    fleet: {
+      enabled: false,
+      sessions: {},
+      peers: [],
+      ssh_peers: [],
+      restart_required: false,
+    },
+    mcp: {
+      enabled: false,
+      restart_required: false,
+      active_requires_auth: false,
+    },
+    issues: { hide_bots: true },
+    kata_projects: [],
+    launch_targets: [],
+    modes: { ...DEFAULT_MODE_VISIBILITY },
+    notifications: { enabled: true },
+    pull_requests: { ...DEFAULT_PULL_REQUEST_SETTINGS },
+    roborev: { init_managed_clones: false },
+    repo_presets: [],
+    repos: [],
+    terminal: { ...DEFAULT_TERMINAL_SETTINGS },
+    workspaces: {
+      auto_assign_on_create: false,
+      default_sidebar_view: "diff",
+    },
+  } satisfies StartupSnapshot;
+
+  return { ...defaults, ...overrides };
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1589,32 +1589,48 @@ name = "widgets"
 	)
 }
 
-func TestLoadPlatformConfigForgejoToken(t *testing.T) {
-	assert := assert.New(t)
-	path := writeConfig(t, `
+func TestLoadPlatformConfigGiteaLikeToken(t *testing.T) {
+	tests := []struct {
+		kind   string
+		host   string
+		env    string
+		secret string
+		owner  string
+		name   string
+	}{
+		{kind: "forgejo", host: "codeberg.org", env: "KENN_FORGE_FORGEJO_TOKEN", secret: "forgejo-secret", owner: "forgejo", name: "forgejo"},
+		{kind: "gitea", host: "gitea.com", env: "KENN_FORGE_GITEA_TOKEN", secret: "gitea-secret", owner: "gitea", name: "tea"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			assert := assert.New(t)
+			path := writeConfig(t, fmt.Sprintf(`
 [[platforms]]
-type = "forgejo"
-host = "codeberg.org"
-token_env = "KENN_FORGE_FORGEJO_TOKEN"
+type = %q
+host = %q
+token_env = %q
 
 [[repos]]
-platform = "forgejo"
-platform_host = "codeberg.org"
-owner = "forgejo"
-name = "forgejo"
-`)
-	t.Setenv("KENN_FORGE_FORGEJO_TOKEN", "forgejo-secret")
+platform = %q
+platform_host = %q
+owner = %q
+name = %q
+`, tt.kind, tt.host, tt.env, tt.kind, tt.host, tt.owner, tt.name))
+			t.Setenv(tt.env, tt.secret)
 
-	cfg, err := Load(path)
-	require.NoError(t, err)
-	require.Len(t, cfg.Platforms, 1)
-	require.Len(t, cfg.Repos, 1)
-	assert.Equal("forgejo", cfg.Platforms[0].Type)
-	assert.Equal("codeberg.org", cfg.Platforms[0].Host)
-	assert.Equal("KENN_FORGE_FORGEJO_TOKEN", cfg.Platforms[0].TokenEnv)
-	assert.Equal("forgejo", cfg.Repos[0].Platform)
-	assert.Equal("codeberg.org", cfg.Repos[0].PlatformHost)
-	assert.Equal("forgejo-secret", cfg.TokenForPlatformHost("forgejo", "codeberg.org", ""))
+			cfg, err := Load(path)
+			require.NoError(t, err)
+			require.Len(t, cfg.Platforms, 1)
+			require.Len(t, cfg.Repos, 1)
+			assert.Equal(tt.kind, cfg.Platforms[0].Type)
+			assert.Equal(tt.host, cfg.Platforms[0].Host)
+			assert.Equal(tt.env, cfg.Platforms[0].TokenEnv)
+			assert.Equal(tt.kind, cfg.Repos[0].Platform)
+			assert.Equal(tt.host, cfg.Repos[0].PlatformHost)
+			assert.Equal(tt.secret, cfg.TokenForPlatformHost(tt.kind, tt.host, ""))
+		})
+	}
 }
 
 func TestLoadForgejoDefaultHostUsesDefaultTokenEnv(t *testing.T) {
@@ -1633,37 +1649,52 @@ name = "forgejo"
 	assert.Empty(t, cfg.TokenForPlatformHost("forgejo", "forgejo.example.com", ""))
 }
 
-func TestLoadPlatformConfigForgejoTokensAreHostScoped(t *testing.T) {
-	path := writeConfig(t, `
+func TestLoadPlatformConfigGiteaLikeTokensAreHostScoped(t *testing.T) {
+	tests := []struct {
+		kind      string
+		public    string
+		private   string
+		publicEnv string
+		customEnv string
+	}{
+		{kind: "forgejo", public: "codeberg.org", private: "forgejo.example.com", publicEnv: "KENN_FORGE_FORGEJO_TOKEN", customEnv: "FORGEJO_EXAMPLE_TOKEN"},
+		{kind: "gitea", public: "gitea.com", private: "gitea.internal.example", publicEnv: "KENN_FORGE_GITEA_TOKEN", customEnv: "GITEA_INTERNAL_TOKEN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			path := writeConfig(t, fmt.Sprintf(`
 [[platforms]]
-type = "forgejo"
-host = "codeberg.org"
-token_env = "KENN_FORGE_FORGEJO_TOKEN"
+type = %q
+host = %q
+token_env = %q
 
 [[platforms]]
-type = "forgejo"
-host = "forgejo.example.com"
-token_env = "FORGEJO_EXAMPLE_TOKEN"
+type = %q
+host = %q
+token_env = %q
 
 [[repos]]
-platform = "forgejo"
-platform_host = "codeberg.org"
-owner = "forgejo"
-name = "forgejo"
-
-[[repos]]
-platform = "forgejo"
-platform_host = "forgejo.example.com"
-owner = "team"
+platform = %q
+platform_host = %q
+owner = "public"
 name = "service"
-`)
-	t.Setenv("KENN_FORGE_FORGEJO_TOKEN", "codeberg-secret")
-	t.Setenv("FORGEJO_EXAMPLE_TOKEN", "self-hosted-secret")
 
-	cfg, err := Load(path)
-	require.NoError(t, err)
-	assert.Equal(t, "codeberg-secret", cfg.TokenForPlatformHost("forgejo", "codeberg.org", ""))
-	assert.Equal(t, "self-hosted-secret", cfg.TokenForPlatformHost("forgejo", "forgejo.example.com", ""))
+[[repos]]
+platform = %q
+platform_host = %q
+owner = "private"
+name = "service"
+`, tt.kind, tt.public, tt.publicEnv, tt.kind, tt.private, tt.customEnv, tt.kind, tt.public, tt.kind, tt.private))
+			t.Setenv(tt.publicEnv, "public-secret")
+			t.Setenv(tt.customEnv, "private-secret")
+
+			cfg, err := Load(path)
+			require.NoError(t, err)
+			assert.Equal(t, "public-secret", cfg.TokenForPlatformHost(tt.kind, tt.public, ""))
+			assert.Equal(t, "private-secret", cfg.TokenForPlatformHost(tt.kind, tt.private, ""))
+		})
+	}
 }
 
 func TestLoadParsesForgejoCodebergURL(t *testing.T) {
@@ -1683,34 +1714,6 @@ name = "https://codeberg.org/forgejo/forgejo.git"
 	assert.Equal("forgejo/forgejo", cfg.Repos[0].RepoPath)
 }
 
-func TestLoadPlatformConfigGiteaToken(t *testing.T) {
-	assert := assert.New(t)
-	path := writeConfig(t, `
-[[platforms]]
-type = "gitea"
-host = "gitea.com"
-token_env = "KENN_FORGE_GITEA_TOKEN"
-
-[[repos]]
-platform = "gitea"
-platform_host = "gitea.com"
-owner = "gitea"
-name = "tea"
-`)
-	t.Setenv("KENN_FORGE_GITEA_TOKEN", "gitea-secret")
-
-	cfg, err := Load(path)
-	require.NoError(t, err)
-	require.Len(t, cfg.Platforms, 1)
-	require.Len(t, cfg.Repos, 1)
-	assert.Equal("gitea", cfg.Platforms[0].Type)
-	assert.Equal("gitea.com", cfg.Platforms[0].Host)
-	assert.Equal("KENN_FORGE_GITEA_TOKEN", cfg.Platforms[0].TokenEnv)
-	assert.Equal("gitea", cfg.Repos[0].Platform)
-	assert.Equal("gitea.com", cfg.Repos[0].PlatformHost)
-	assert.Equal("gitea-secret", cfg.TokenForPlatformHost("gitea", "gitea.com", ""))
-}
-
 func TestLoadGiteaDefaultHostUsesDefaultTokenEnv(t *testing.T) {
 	path := writeConfig(t, `
 [[repos]]
@@ -1725,39 +1728,6 @@ name = "tea"
 	require.NoError(t, err)
 	assert.Equal(t, "gitea-public-secret", cfg.TokenForPlatformHost("gitea", "gitea.com", ""))
 	assert.Empty(t, cfg.TokenForPlatformHost("gitea", "gitea.internal.example", ""))
-}
-
-func TestLoadPlatformConfigGiteaTokensAreHostScoped(t *testing.T) {
-	path := writeConfig(t, `
-[[platforms]]
-type = "gitea"
-host = "gitea.com"
-token_env = "KENN_FORGE_GITEA_TOKEN"
-
-[[platforms]]
-type = "gitea"
-host = "gitea.internal.example"
-token_env = "GITEA_INTERNAL_TOKEN"
-
-[[repos]]
-platform = "gitea"
-platform_host = "gitea.com"
-owner = "gitea"
-name = "tea"
-
-[[repos]]
-platform = "gitea"
-platform_host = "gitea.internal.example"
-owner = "team"
-name = "service"
-`)
-	t.Setenv("KENN_FORGE_GITEA_TOKEN", "gitea-public-secret")
-	t.Setenv("GITEA_INTERNAL_TOKEN", "gitea-internal-secret")
-
-	cfg, err := Load(path)
-	require.NoError(t, err)
-	assert.Equal(t, "gitea-public-secret", cfg.TokenForPlatformHost("gitea", "gitea.com", ""))
-	assert.Equal(t, "gitea-internal-secret", cfg.TokenForPlatformHost("gitea", "gitea.internal.example", ""))
 }
 
 func TestLoadParsesGiteaURL(t *testing.T) {

--- a/internal/github/token_source_test.go
+++ b/internal/github/token_source_test.go
@@ -1,23 +1,5 @@
 package github
 
-import (
-	"context"
+import "go.kenn.io/forge/internal/testutil/tokenauthtest"
 
-	"go.kenn.io/forge/internal/tokenauth"
-)
-
-type staticTestTokenSource string
-
-func testTokenSource(token string) tokenauth.Source {
-	return staticTestTokenSource(token)
-}
-
-func (s staticTestTokenSource) Token(context.Context) (string, error) {
-	return string(s), nil
-}
-
-func (s staticTestTokenSource) Invalidate(string) {}
-
-func (s staticTestTokenSource) Descriptor() tokenauth.Descriptor {
-	return tokenauth.Descriptor{Key: tokenauth.Key{Platform: "test", Host: "test"}}
-}
+var testTokenSource = tokenauthtest.Source

--- a/internal/platform/forgejo/token_source_test.go
+++ b/internal/platform/forgejo/token_source_test.go
@@ -1,23 +1,5 @@
 package forgejo
 
-import (
-	"context"
+import "go.kenn.io/forge/internal/testutil/tokenauthtest"
 
-	"go.kenn.io/forge/internal/tokenauth"
-)
-
-type staticTestTokenSource string
-
-func testTokenSource(token string) tokenauth.Source {
-	return staticTestTokenSource(token)
-}
-
-func (s staticTestTokenSource) Token(context.Context) (string, error) {
-	return string(s), nil
-}
-
-func (s staticTestTokenSource) Invalidate(string) {}
-
-func (s staticTestTokenSource) Descriptor() tokenauth.Descriptor {
-	return tokenauth.Descriptor{Key: tokenauth.Key{Platform: "test", Host: "test"}}
-}
+var testTokenSource = tokenauthtest.Source

--- a/internal/platform/gitea/token_source_test.go
+++ b/internal/platform/gitea/token_source_test.go
@@ -1,23 +1,5 @@
 package gitea
 
-import (
-	"context"
+import "go.kenn.io/forge/internal/testutil/tokenauthtest"
 
-	"go.kenn.io/forge/internal/tokenauth"
-)
-
-type staticTestTokenSource string
-
-func testTokenSource(token string) tokenauth.Source {
-	return staticTestTokenSource(token)
-}
-
-func (s staticTestTokenSource) Token(context.Context) (string, error) {
-	return string(s), nil
-}
-
-func (s staticTestTokenSource) Invalidate(string) {}
-
-func (s staticTestTokenSource) Descriptor() tokenauth.Descriptor {
-	return tokenauth.Descriptor{Key: tokenauth.Key{Platform: "test", Host: "test"}}
-}
+var testTokenSource = tokenauthtest.Source

--- a/internal/platform/gitlab/token_source_test.go
+++ b/internal/platform/gitlab/token_source_test.go
@@ -3,24 +3,11 @@ package gitlab
 import (
 	"context"
 
+	"go.kenn.io/forge/internal/testutil/tokenauthtest"
 	"go.kenn.io/forge/internal/tokenauth"
 )
 
-type staticTestTokenSource string
-
-func testTokenSource(token string) tokenauth.Source {
-	return staticTestTokenSource(token)
-}
-
-func (s staticTestTokenSource) Token(context.Context) (string, error) {
-	return string(s), nil
-}
-
-func (s staticTestTokenSource) Invalidate(string) {}
-
-func (s staticTestTokenSource) Descriptor() tokenauth.Descriptor {
-	return tokenauth.Descriptor{Key: tokenauth.Key{Platform: "test", Host: "test"}}
-}
+var testTokenSource = tokenauthtest.Source
 
 type mutableTestTokenSource struct {
 	token       string

--- a/internal/server/fleetapi/fleet_routes_test.go
+++ b/internal/server/fleetapi/fleet_routes_test.go
@@ -26,65 +26,50 @@ func TestSnapshotRoutesRegistered(t *testing.T) {
 	s.Register(api)
 
 	spec := api.OpenAPI()
-	for _, path := range []string{
-		"/snapshot",
-		"/snapshot/raw",
-		"/fleet/hosts/{host_key}/workspaces",
-		"/fleet/hosts/{host_key}/issues/{provider}/{owner}/{name}/{number}/workspace",
-		"/fleet/hosts/{host_key}/host/{platform_host}/issues/{provider}/{owner}/{name}/{number}/workspace",
-		"/fleet/hosts/{host_key}/workspaces/{id}/runtime/sessions",
-		"/fleet/hosts/{host_key}/workspaces/{id}/runtime/sessions/{session_key}",
-		"/fleet/hosts/{host_key}/workspaces/{id}/runtime/sessions/{session_key}/attach-spec",
-		"/fleet/hosts/{host_key}/workspaces/{id}/commits",
-		"/fleet/hosts/{host_key}/workspaces/{id}/diff",
-		"/fleet/hosts/{host_key}/workspaces/{id}/file-preview",
-		"/fleet/hosts/{host_key}/workspaces/{id}/files",
-		"/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/runtime",
-		"/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/runtime/shell",
-		"/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/runtime/sessions",
-		"/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/runtime/sessions/{session_key}",
-		"/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/runtime/sessions/{session_key}/attach-spec",
-		"/fleet/hosts/{host_key}/workspaces/{id}",
-		"/fleet/hosts/{host_key}/projects",
-		"/fleet/hosts/{host_key}/projects/{project_id}",
-		"/fleet/hosts/{host_key}/projects/{project_id}/worktrees",
-		"/fleet/hosts/{host_key}/projects/{project_id}/worktrees/from-merge-request",
-		"/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/delete",
-		"/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/session-backend",
-		"/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/linked-issues",
-		"/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/refresh-stats",
-	} {
-		require.NotNil(spec.Paths[path], "%s not registered", path)
+	operations := map[string]func(*huma.PathItem) *huma.Operation{
+		http.MethodGet:    func(item *huma.PathItem) *huma.Operation { return item.Get },
+		http.MethodPost:   func(item *huma.PathItem) *huma.Operation { return item.Post },
+		http.MethodPut:    func(item *huma.PathItem) *huma.Operation { return item.Put },
+		http.MethodDelete: func(item *huma.PathItem) *huma.Operation { return item.Delete },
 	}
-	require.NotNil(spec.Paths["/snapshot"].Get, "GET /snapshot not registered")
-	require.NotNil(spec.Paths["/snapshot/raw"].Get, "GET /snapshot/raw not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/workspaces"].Post, "POST fleet workspaces not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/issues/{provider}/{owner}/{name}/{number}/workspace"].Post, "POST fleet issue workspace not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/host/{platform_host}/issues/{provider}/{owner}/{name}/{number}/workspace"].Post, "POST fleet host issue workspace not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/workspaces/{id}/runtime/sessions"].Post, "POST fleet session not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/workspaces/{id}/runtime/sessions/{session_key}"].Delete, "DELETE fleet session not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/workspaces/{id}/runtime/sessions/{session_key}/attach-spec"].Get, "GET fleet session attach spec not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/workspaces/{id}/commits"].Get, "GET fleet workspace commits not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/workspaces/{id}/diff"].Get, "GET fleet workspace diff not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/workspaces/{id}/file-preview"].Get, "GET fleet workspace file preview not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/workspaces/{id}/files"].Get, "GET fleet workspace files not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/runtime"].Get, "GET fleet project worktree runtime not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/runtime/shell"].Post, "POST fleet project worktree shell not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/runtime/sessions"].Post, "POST fleet project worktree session not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/runtime/sessions/{session_key}"].Delete, "DELETE fleet project worktree session not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/runtime/sessions/{session_key}/attach-spec"].Get, "GET fleet project worktree session attach spec not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/workspaces/{id}"].Delete, "DELETE fleet workspace not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects"].Post, "POST fleet project register not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}"].Get, "GET fleet project not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}"].Delete, "DELETE fleet project not registered")
+	for _, route := range []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/snapshot"},
+		{http.MethodGet, "/snapshot/raw"},
+		{http.MethodPost, "/fleet/hosts/{host_key}/workspaces"},
+		{http.MethodPost, "/fleet/hosts/{host_key}/issues/{provider}/{owner}/{name}/{number}/workspace"},
+		{http.MethodPost, "/fleet/hosts/{host_key}/host/{platform_host}/issues/{provider}/{owner}/{name}/{number}/workspace"},
+		{http.MethodPost, "/fleet/hosts/{host_key}/workspaces/{id}/runtime/sessions"},
+		{http.MethodDelete, "/fleet/hosts/{host_key}/workspaces/{id}/runtime/sessions/{session_key}"},
+		{http.MethodGet, "/fleet/hosts/{host_key}/workspaces/{id}/runtime/sessions/{session_key}/attach-spec"},
+		{http.MethodGet, "/fleet/hosts/{host_key}/workspaces/{id}/commits"},
+		{http.MethodGet, "/fleet/hosts/{host_key}/workspaces/{id}/diff"},
+		{http.MethodGet, "/fleet/hosts/{host_key}/workspaces/{id}/file-preview"},
+		{http.MethodGet, "/fleet/hosts/{host_key}/workspaces/{id}/files"},
+		{http.MethodGet, "/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/runtime"},
+		{http.MethodPost, "/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/runtime/shell"},
+		{http.MethodPost, "/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/runtime/sessions"},
+		{http.MethodDelete, "/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/runtime/sessions/{session_key}"},
+		{http.MethodGet, "/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/runtime/sessions/{session_key}/attach-spec"},
+		{http.MethodDelete, "/fleet/hosts/{host_key}/workspaces/{id}"},
+		{http.MethodPost, "/fleet/hosts/{host_key}/projects"},
+		{http.MethodGet, "/fleet/hosts/{host_key}/projects/{project_id}"},
+		{http.MethodDelete, "/fleet/hosts/{host_key}/projects/{project_id}"},
+		{http.MethodGet, "/fleet/hosts/{host_key}/projects/{project_id}/worktrees"},
+		{http.MethodPost, "/fleet/hosts/{host_key}/projects/{project_id}/worktrees"},
+		{http.MethodPost, "/fleet/hosts/{host_key}/projects/{project_id}/worktrees/from-merge-request"},
+		{http.MethodPost, "/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/delete"},
+		{http.MethodPut, "/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/session-backend"},
+		{http.MethodPut, "/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/linked-issues"},
+		{http.MethodPost, "/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/refresh-stats"},
+	} {
+		item := spec.Paths[route.path]
+		require.NotNil(item, "%s not registered", route.path)
+		require.NotNil(operations[route.method](item), "%s %s not registered", route.method, route.path)
+	}
 
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}/worktrees"].Get, "GET fleet worktree list not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}/worktrees"].Post, "POST fleet worktree create not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}/worktrees/from-merge-request"].Post, "POST fleet worktree from-merge-request not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/delete"].Post, "POST fleet worktree remove not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/session-backend"].Put, "PUT fleet worktree session backend not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/linked-issues"].Put, "PUT fleet worktree linked issues not registered")
-	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/refresh-stats"].Post, "POST fleet worktree stats refresh not registered")
 	for _, path := range []string{
 		"/fleet/hosts/{host_key}/workspaces/{id}/diff",
 		"/fleet/hosts/{host_key}/workspaces/{id}/file-preview",

--- a/internal/testutil/tokenauthtest/source.go
+++ b/internal/testutil/tokenauthtest/source.go
@@ -1,0 +1,24 @@
+package tokenauthtest
+
+import (
+	"context"
+
+	"go.kenn.io/forge/internal/tokenauth"
+)
+
+type staticSource string
+
+// Source returns an immutable token source for provider and transport tests.
+func Source(token string) tokenauth.Source {
+	return staticSource(token)
+}
+
+func (s staticSource) Token(context.Context) (string, error) {
+	return string(s), nil
+}
+
+func (staticSource) Invalidate(string) {}
+
+func (staticSource) Descriptor() tokenauth.Descriptor {
+	return tokenauth.Descriptor{Key: tokenauth.Key{Platform: "test", Host: "test"}}
+}


### PR DESCRIPTION
Tests copied complete startup settings and static token sources across many files. Schema changes therefore required broad mechanical edits and obscured the inputs relevant to each scenario.

This change moves those defaults into shared test helpers, table-drives matching Forgejo and Gitea configuration cases, and keeps Fleet route paths and HTTP methods in one inventory. Every existing test scenario remains, including separate execution for each provider.

The result removes 798 net lines without changing production code.
