### PR TITLE
feat: reveal full sidebar item details on hover

### DIFF
--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -220,6 +220,12 @@ Intent:
 
 Use it inside left sidebar headers and collapsed strips. Pass a specific label such as `Workspaces sidebar` when the generic `sidebar` label would be ambiguous. The resizable sidebar layout itself is kit-ui's `CollapsibleSidebar`; the container-width-driven floating overlay is requested through its `overlay` prop (hosts pass the container store's `isNarrow()` — kit's `overlayOnNarrow` media query is viewport-based, which is not the same signal).
 
+### SidebarTitlePopover
+
+Use `SidebarTitlePopover` on truncated pull-request and issue sidebar rows so the full
+title and formatted repository remain readable; pull requests add the full head branch
+on its own line (`frontend/src/lib/components/sidebar/SidebarTitlePopover.svelte`).
+
 ### GroupedSidebarSection
 
 Use `GroupedSidebarSection` for collapsible groups in PR, issue, and workspace list rails. Keep group chrome and the `--sidebar-*` surface/row-state tokens shared; domain-specific row content stays with its owner. Wrap large always-visible vertical scroll panes (list rails, diff area, pull/issue detail, activity views) in `ScrollBox` for consistent flex sizing, native vertical scrolling, and a labelled focusable region; bind `viewport` when a host needs imperative scroll logic, and note the scrolling element is the viewport, not the host's content wrapper class. Give each scroll area a concise accessible label so keyboard users can identify and scroll the region. (`frontend/src/lib/components/shared/GroupedSidebarSection.svelte`, `ScrollBox` from `@kenn-io/kit-ui` — see kit-ui's `docs/components/scroll-box.md`, `frontend/src/app.css:39`)

--- a/frontend/src/lib/components/sidebar/IssueItem.svelte
+++ b/frontend/src/lib/components/sidebar/IssueItem.svelte
@@ -6,6 +6,7 @@
   import { Chip } from "@kenn-io/kit-ui";
   import LabelRow from "../shared/LabelRow.svelte";
   import WorkspaceIndicator from "../shared/WorkspaceIndicator.svelte";
+  import SidebarTitlePopover from "./SidebarTitlePopover.svelte";
   import { repoIdentityKey } from "../../utils/repo-label.js";
   import { effectiveActivity } from "../../utils/effective-activity.js";
 
@@ -21,7 +22,7 @@
 
   const { issue, selected, showRepo, repoLabel, onclick }: Props = $props();
 
-  let el: HTMLButtonElement;
+  let el = $state<HTMLButtonElement>();
 
   $effect(() => {
     if (selected && el) {
@@ -107,6 +108,7 @@
     </span>
   </div>
 </button>
+<SidebarTitlePopover target={el} title={issue.Title} repository={repoLabel} />
 
 <style>
   .issue-item {

--- a/frontend/src/lib/components/sidebar/IssueItem.test.ts
+++ b/frontend/src/lib/components/sidebar/IssueItem.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/svelte";
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import type { Issue } from "../../api/types.js";
@@ -151,5 +151,21 @@ describe("IssueItem", () => {
     renderItem(mkIssue({ State: "closed" }));
 
     expect(screen.getByText("Closed")).toBeTruthy();
+  });
+
+  it("shows the full title while the row has keyboard focus", async () => {
+    renderItem(mkIssue({ Title: "An issue title too long for the sidebar" }));
+    const row = screen.getByRole("button", { name: /An issue title too long for the sidebar/i });
+
+    await fireEvent.focusIn(row);
+    const tooltip = screen.getByRole("tooltip");
+    expect(Array.from(tooltip.children, (line) => line.textContent)).toEqual([
+      "An issue title too long for the sidebar",
+      "acme/widgets",
+    ]);
+    expect(row.getAttribute("aria-describedby")).toBe(tooltip.id);
+
+    await fireEvent.focusOut(row);
+    expect(screen.queryByRole("tooltip")).toBeNull();
   });
 });

--- a/frontend/src/lib/components/sidebar/PullItem.svelte
+++ b/frontend/src/lib/components/sidebar/PullItem.svelte
@@ -15,6 +15,7 @@
   import OctagonXIcon from "@lucide/svelte/icons/octagon-x";
   import LabelRow from "../shared/LabelRow.svelte";
   import WorkspaceIndicator from "../shared/WorkspaceIndicator.svelte";
+  import SidebarTitlePopover from "./SidebarTitlePopover.svelte";
   import { repoIdentityKey } from "../../utils/repo-label.js";
   import { effectiveActivity } from "../../utils/effective-activity.js";
 
@@ -54,7 +55,7 @@
     );
   }
 
-  let el: HTMLButtonElement;
+  let el = $state<HTMLButtonElement>();
 
   $effect(() => {
     if (selected && el) {
@@ -275,6 +276,7 @@
     </span>
   </div>
 </button>
+<SidebarTitlePopover target={el} title={pr.Title} repository={repoLabel} branch={pr.HeadBranch} />
 
 <style>
   .pull-item {

--- a/frontend/src/lib/components/sidebar/PullItem.test.ts
+++ b/frontend/src/lib/components/sidebar/PullItem.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/svelte";
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import type { PullRequest } from "../../api/types.js";
@@ -428,5 +428,36 @@ describe("PullItem compact layout", () => {
     expect(document.querySelector(".title .title-text")?.textContent).toBe("Cache widget details");
     expect(document.querySelector(".title .item-number")?.textContent).toBe("#7");
     expect(document.querySelector(".meta-left .meta-text")?.textContent).toBe("alice");
+  });
+
+  it("shows the full title after sustained row hover", async () => {
+    vi.useFakeTimers();
+    try {
+      renderItem(
+        mkPR({
+          Title: "A pull request title too long for the sidebar",
+          HeadBranch: "feature/full-sidebar-popover-details",
+        }),
+      );
+      const row = screen.getByRole("button", { name: /A pull request title too long for the sidebar/i });
+
+      await fireEvent.mouseEnter(row);
+      await vi.advanceTimersByTimeAsync(599);
+      expect(screen.queryByRole("tooltip")).toBeNull();
+
+      await vi.advanceTimersByTimeAsync(1);
+      const tooltip = screen.getByRole("tooltip");
+      expect(Array.from(tooltip.children, (line) => line.textContent)).toEqual([
+        "A pull request title too long for the sidebar",
+        "o/n",
+        "feature/full-sidebar-popover-details",
+      ]);
+      expect(row.contains(tooltip)).toBe(false);
+
+      await fireEvent.mouseLeave(row);
+      expect(screen.queryByRole("tooltip")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/frontend/src/lib/components/sidebar/SidebarTitlePopover.svelte
+++ b/frontend/src/lib/components/sidebar/SidebarTitlePopover.svelte
@@ -1,0 +1,182 @@
+<script lang="ts">
+  import { autoReposition, floatingPopoverStyle } from "@kenn-io/kit-ui";
+  import { tick } from "svelte";
+
+  interface Props {
+    target: HTMLElement | undefined;
+    title: string;
+    repository: string;
+    branch?: string | undefined;
+  }
+
+  let { target, title, repository, branch = undefined }: Props = $props();
+
+  const tooltipId = $props.id();
+  // kit-ui-check-ignore: kit Tooltip neither portals to body nor describes the focused row button
+  const tooltipRole = "tooltip";
+  const hoverDelayMs = 600;
+
+  let open = $state(false);
+  let side = $state<"top" | "bottom">("bottom");
+  let popoverEl = $state<HTMLDivElement>();
+  let popoverStyle = $state("");
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  function clearTimer(): void {
+    if (timer === undefined) return;
+    clearTimeout(timer);
+    timer = undefined;
+  }
+
+  async function position(): Promise<void> {
+    await tick();
+    if (!target || !popoverEl) return;
+    popoverStyle = floatingPopoverStyle({
+      trigger: target.getBoundingClientRect(),
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      popoverWidth: popoverEl.offsetWidth,
+      popoverHeight: popoverEl.offsetHeight,
+      align: "start",
+      triggerGap: 6,
+    });
+    const top = Number.parseFloat(/top: (-?[0-9.]+)px/.exec(popoverStyle)?.[1] ?? "0");
+    side = top < target.getBoundingClientRect().top ? "top" : "bottom";
+  }
+
+  function showAfterDelay(): void {
+    clearTimer();
+    if (open) return;
+    timer = setTimeout(() => {
+      timer = undefined;
+      open = true;
+      void position();
+    }, hoverDelayMs);
+  }
+
+  function showNow(): void {
+    clearTimer();
+    if (open) return;
+    open = true;
+    void position();
+  }
+
+  function hide(): void {
+    clearTimer();
+    open = false;
+  }
+
+  function handleKeydown(event: KeyboardEvent): void {
+    if (event.key === "Escape") hide();
+  }
+
+  function portalToBody(node: HTMLElement): () => void {
+    document.body.appendChild(node);
+    return () => node.remove();
+  }
+
+  $effect(() => {
+    if (!target) return;
+
+    target.addEventListener("mouseenter", showAfterDelay);
+    target.addEventListener("mouseleave", hide);
+    target.addEventListener("focusin", showNow);
+    target.addEventListener("focusout", hide);
+    target.addEventListener("keydown", handleKeydown);
+
+    return () => {
+      clearTimer();
+      target.removeEventListener("mouseenter", showAfterDelay);
+      target.removeEventListener("mouseleave", hide);
+      target.removeEventListener("focusin", showNow);
+      target.removeEventListener("focusout", hide);
+      target.removeEventListener("keydown", handleKeydown);
+    };
+  });
+
+  $effect(() => {
+    if (!open || !target) return;
+    target.setAttribute("aria-describedby", tooltipId);
+    const stopRepositioning = autoReposition(
+      () => popoverEl,
+      () => void position(),
+    );
+    return () => {
+      stopRepositioning();
+      if (target.getAttribute("aria-describedby") === tooltipId) {
+        target.removeAttribute("aria-describedby");
+      }
+    };
+  });
+</script>
+
+{#if open}
+  <div
+    bind:this={popoverEl}
+    id={tooltipId}
+    class="sidebar-title-popover kit-popover-card"
+    role={tooltipRole}
+    data-side={side}
+    style={popoverStyle}
+    {@attach portalToBody}
+  >
+    <div class="sidebar-title-popover__title">{title}</div>
+    <div class="sidebar-title-popover__metadata">{repository}</div>
+    {#if branch}
+      <div class="sidebar-title-popover__metadata sidebar-title-popover__branch">{branch}</div>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .sidebar-title-popover {
+    position: fixed;
+    z-index: var(--z-tooltip);
+    width: max-content;
+    max-width: min(420px, calc(100vw - 32px));
+    padding: var(--space-4) var(--space-5);
+    display: grid;
+    gap: var(--space-2);
+    font-size: var(--font-size-sm);
+    line-height: 1.4;
+    overflow-wrap: anywhere;
+    pointer-events: none;
+  }
+
+  .sidebar-title-popover__title {
+    color: var(--text-primary);
+    font-weight: 500;
+  }
+
+  .sidebar-title-popover__metadata {
+    color: var(--text-secondary);
+    font-size: var(--font-size-xs);
+    line-height: 1.35;
+  }
+
+  .sidebar-title-popover__branch {
+    font-family: "SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", monospace;
+  }
+
+  .sidebar-title-popover::before {
+    content: "";
+    position: absolute;
+    left: 18px;
+    width: 8px;
+    height: 8px;
+    transform: rotate(45deg);
+    background: var(--bg-surface);
+  }
+
+  .sidebar-title-popover[data-side="bottom"]::before {
+    top: -5px;
+    border-top: 1px solid var(--border-default);
+    border-left: 1px solid var(--border-default);
+  }
+
+  .sidebar-title-popover[data-side="top"]::before {
+    bottom: -5px;
+    border-right: 1px solid var(--border-default);
+    border-bottom: 1px solid var(--border-default);
+  }
+</style>


### PR DESCRIPTION
Sidebar pull request and issue rows now reveal their full title and formatted repository after a brief hover or immediately on keyboard focus. Pull request popovers put the full head branch on a separate line, while repository formatting continues to honor the **Hide org name** preference.

The popover escapes sidebar clipping, repositions with the viewport, wraps long values, and closes on pointer exit, focus loss, or Escape.

![Sidebar pull request popover showing the full title, repository, and head branch](https://github.com/user-attachments/assets/7eb86c79-faa5-4ea1-ba40-b5ed7a925836)
