### PR TITLE
Accept healthy Kata daemons across API schema versions

### DIFF
--- a/context/kata-mode.md
+++ b/context/kata-mode.md
@@ -65,12 +65,10 @@ in [`ui-interaction-contracts.md`](./ui-interaction-contracts.md).
 - Narrow reference, detail, and launch reads resolve the daemon from the route's
   daemon ID. Browser input never supplies daemon credentials or an ambient
   active-daemon fallback (`internal/server/kata/read_routes.go`).
-- Forge requires Kata v0.14.3 or newer with API schema `>=0.9.0 and <0.11.0`;
-  narrow reads require connected health and fail with a typed 503 otherwise
-  (`internal/server/kata/read_routes.go::Handler.kataClientForCompatibleDaemon`).
-- Surface schema guidance in the UI: upgrade Kata for old or missing schemas,
-  but upgrade Forge or select a supported Kata release for newer schemas
-  (`internal/server/kata/client.go::kataDaemonCompatibilityMessage`).
+- Successful Kata health is authoritative for availability; Forge exposes
+  `api_schema_version` only for diagnostics and never gates workflows on it.
+  Reachability and authentication failures still return a typed 503
+  (`internal/server/kata/read_routes.go::Handler.kataClientForConnectedDaemon`).
 - Reference lists expose only open tasks, including empty-query autocomplete;
   completed tasks remain reachable through exact reference and issue-UID reads
   (`internal/server/kata/read_routes.go::Handler.listKataReferences`).

--- a/docs/adr/0004-kata-ui-ownership.md
+++ b/docs/adr/0004-kata-ui-ownership.md
@@ -334,11 +334,9 @@ a legacy config alias, route redirect, fallback wrapper, or translation shim.
 - A live validation failure prevents inserting an explicit link.
 - A deleted or unreachable task retains explicit identity and can be unlinked.
 - Hydration errors are per task and produce partial results.
-- A daemon outside `@kenn-io/kata-ui`'s supported API-schema range produces a
-  typed unavailable task state; additive fields from compatible newer daemons
-  are ignored.
-- A daemon health response with no `api_schema_version` is incompatible; Forge
-  never guesses an implicit minimum version.
+- Forge uses Kata health reachability and authentication state to decide
+  availability. `api_schema_version` remains diagnostic metadata and does not
+  gate Kata-backed workflows.
 - Detail, workspace, and launch operations are pinned to the task's daemon.
 - No safe HTTP(S) browser origin means `Open in Kata` is unavailable with an
   explanation; Forge never falls back to a Unix-socket URL or configured URL

--- a/frontend/src/lib/components/kata/KataLinkDialog.svelte
+++ b/frontend/src/lib/components/kata/KataLinkDialog.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { Button, Modal, SearchInput, SelectDropdown } from "@kenn-io/kit-ui";
-  import { supportsKataAPISchema } from "@kenn-io/kata-ui/packages/kata-ui/src/index.ts";
   import { untrack } from "svelte";
 
   import type { components } from "../../api/generated/schema.js";
@@ -43,11 +42,7 @@
   );
   const daemonOptions = $derived(
     daemons.map((daemon) => {
-      const healthReason = daemon.health === "connected" ? "" : daemon.hint || `Health: ${daemon.health}`;
-      const schemaReason = supportsKataAPISchema(daemon.api_schema_version ?? "")
-        ? ""
-        : `Unsupported API schema ${daemon.api_schema_version || "unknown"}`;
-      const reason = healthReason || schemaReason;
+      const reason = daemon.health === "connected" ? "" : daemon.hint || `Health: ${daemon.health}`;
       return {
         value: daemon.id,
         label: daemon.id,
@@ -58,15 +53,11 @@
       };
     }),
   );
-  const selectedDaemonUsable = $derived(
-    selectedDaemon?.health === "connected" &&
-      supportsKataAPISchema(selectedDaemon.api_schema_version ?? ""),
-  );
+  const selectedDaemonUsable = $derived(selectedDaemon?.health === "connected");
   const selectedDaemonProblem = $derived.by(() => {
     if (!selectedDaemon || selectedDaemonUsable) return null;
     if (selectedDaemon.hint) return selectedDaemon.hint;
-    if (selectedDaemon.health !== "connected") return `Kata daemon health: ${selectedDaemon.health}.`;
-    return `Kata API schema ${selectedDaemon.api_schema_version || "unknown"} is incompatible.`;
+    return `Kata daemon health: ${selectedDaemon.health}.`;
   });
 
   function problemMessage(problem: unknown, fallback: string): string {

--- a/frontend/src/lib/components/kata/KataLinkDialog.test.ts
+++ b/frontend/src/lib/components/kata/KataLinkDialog.test.ts
@@ -37,7 +37,7 @@ describe("KataLinkDialog", () => {
     vi.restoreAllMocks();
   });
 
-  it("uses the configured default initially and disables unhealthy or incompatible daemons", async () => {
+  it("uses the configured default initially and disables unhealthy daemons", async () => {
     const get = vi.fn().mockResolvedValue({
       data: {
         daemons: [
@@ -47,7 +47,7 @@ describe("KataLinkDialog", () => {
             health: "connected",
             auth: "none",
             default: true,
-            api_schema_version: "0.10.0",
+            api_schema_version: "0.13.0",
           },
           {
             id: "down",
@@ -55,15 +55,7 @@ describe("KataLinkDialog", () => {
             health: "unreachable",
             auth: "none",
             default: false,
-            api_schema_version: "0.10.0",
-          },
-          {
-            id: "old",
-            url: "http://old",
-            health: "connected",
-            auth: "none",
-            default: false,
-            api_schema_version: "0.8.4",
+            api_schema_version: "0.13.0",
           },
         ],
       },
@@ -73,33 +65,9 @@ describe("KataLinkDialog", () => {
     const trigger = await screen.findByRole("combobox", { name: /Kata daemon: healthy/ });
     await fireEvent.click(trigger);
     expect((screen.getByRole("option", { name: /down/ }) as HTMLButtonElement).disabled).toBe(true);
-    expect((screen.getByRole("option", { name: /old/ }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole("searchbox", { name: "Search Kata issues" }) as HTMLInputElement).disabled).toBe(false);
     expect(screen.queryByLabelText(/daemon URL/i)).toBeNull();
     expect(screen.queryByLabelText(/issue UID/i)).toBeNull();
-  });
-
-  it("explains how to recover when the selected daemon is incompatible", async () => {
-    const get = vi.fn().mockResolvedValue({
-      data: {
-        daemons: [
-          {
-            id: "old",
-            url: "http://old",
-            health: "incompatible",
-            auth: "none",
-            default: true,
-            api_schema_version: "0.7.0",
-            hint: "Kata API schema 0.7.0 is incompatible; Forge requires >=0.9.0 and <0.11.0. Upgrade Kata.",
-          },
-        ],
-      },
-    });
-    renderDialog(clientWith(get));
-
-    const alert = await screen.findByRole("alert");
-    expect(alert.textContent).toContain("Kata API schema 0.7.0 is incompatible");
-    expect(alert.textContent).toContain("Upgrade Kata");
-    expect((screen.getByRole("searchbox", { name: "Search Kata issues" }) as HTMLInputElement).disabled).toBe(true);
   });
 
   it("debounces reference search and submits the selected canonical identity", async () => {

--- a/frontend/src/lib/components/kata/KataLinksPanel.svelte
+++ b/frontend/src/lib/components/kata/KataLinksPanel.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { Button, Chip, EmptyState, Spinner } from "@kenn-io/kit-ui";
-  import { supportsKataAPISchema } from "@kenn-io/kata-ui/packages/kata-ui/src/index.ts";
   import RefreshCwIcon from "@lucide/svelte/icons/refresh-cw";
   import UnlinkIcon from "@lucide/svelte/icons/unlink";
   import { onDestroy, untrack } from "svelte";
@@ -56,9 +55,6 @@
 
   const selected = $derived(store.selected());
   const detailEnvelope = $derived(store.detail());
-  const detailCompatible = $derived(
-    detailEnvelope !== null && supportsKataAPISchema(detailEnvelope.api_schema_version ?? ""),
-  );
   const selectedWorkspaceIdentity = $derived<KataWorkspaceIdentity | null>(
     selected ? { daemonID: selected.daemon_id, issueUID: selected.issue_uid } : null,
   );
@@ -444,10 +440,6 @@
             <div class="loading"><Spinner size={14} /> Loading issue detail…</div>
           {:else if detailEnvelope === null}
             <p class="detail-message">Kata issue detail is unavailable.</p>
-          {:else if !detailCompatible}
-            <p class="detail-message">
-              Kata API schema is not supported ({detailEnvelope.api_schema_version || "version missing"}).
-            </p>
           {:else}
             {#key detailEnvelope}
               <svelte:boundary>

--- a/frontend/src/lib/components/kata/KataLinksPanel.test.ts
+++ b/frontend/src/lib/components/kata/KataLinksPanel.test.ts
@@ -281,21 +281,7 @@ describe("KataLinksPanel", () => {
     expect(post).not.toHaveBeenCalled();
   });
 
-  it.each([undefined, "0.8.9", "0.11.0"])(
-    "does not project or render incompatible schema version %s",
-    async (version) => {
-      const envelope = detail();
-      envelope.api_schema_version = version;
-      const { client } = listAndDetailClient([link({ api_schema_version: version })], envelope);
-      renderPanel(client);
-
-      expect(await screen.findByText(/Kata API schema is not supported/)).toBeTruthy();
-      expect(projectIssueDetail).not.toHaveBeenCalled();
-      expect(screen.queryByLabelText("Kata issue detail")).toBeNull();
-    },
-  );
-
-  it.each(["0.9.0", "0.10.7"])("renders supported schema version %s through Kata UI", async (version) => {
+  it.each(["0.11.0", "0.13.0"])("renders reported schema version %s through Kata UI", async (version) => {
     const { client } = listAndDetailClient([link({ api_schema_version: version })], detail(version));
     renderPanel(client);
 

--- a/frontend/src/lib/components/terminal/NewWorkspaceDialog.svelte
+++ b/frontend/src/lib/components/terminal/NewWorkspaceDialog.svelte
@@ -2,7 +2,6 @@
   import { Effect } from "effect";
   import { getStores } from "../../context.js";
   import WorkspaceCreateSplitButton from "../workspace/WorkspaceCreateSplitButton.svelte";
-  import { supportsKataAPISchema } from "@kenn-io/kata-ui/packages/kata-ui/src/index.ts";
   import {
     Button,
     SearchInput,
@@ -293,15 +292,11 @@
   const selectedDaemon = $derived(
     kataDaemons.daemons().find((daemon) => daemon.id === selectedDaemonID) ?? null,
   );
-  const selectedDaemonUsable = $derived(
-    selectedDaemon?.health === "connected" &&
-      supportsKataAPISchema(selectedDaemon.api_schema_version ?? ""),
-  );
+  const selectedDaemonUsable = $derived(selectedDaemon?.health === "connected");
   const selectedDaemonProblem = $derived.by(() => {
     if (!selectedDaemon || selectedDaemonUsable) return null;
     if (selectedDaemon.hint) return selectedDaemon.hint;
-    if (selectedDaemon.health !== "connected") return `Kata daemon health: ${selectedDaemon.health}.`;
-    return `Kata API schema ${selectedDaemon.api_schema_version || "unknown"} is incompatible.`;
+    return `Kata daemon health: ${selectedDaemon.health}.`;
   });
   const selectedKataWorkspaceIdentity = $derived<KataWorkspaceIdentity | null>(
     source === "kata_issue" && selectedKataReference && selectedDaemonID
@@ -315,11 +310,7 @@
   );
   const daemonOptions = $derived(
     kataDaemons.daemons().map((daemon) => {
-      const healthReason = daemon.health === "connected" ? "" : daemon.hint || `Health: ${daemon.health}`;
-      const schemaReason = supportsKataAPISchema(daemon.api_schema_version ?? "")
-        ? ""
-        : `Unsupported API schema ${daemon.api_schema_version || "unknown"}`;
-      const reason = healthReason || schemaReason;
+      const reason = daemon.health === "connected" ? "" : daemon.hint || `Health: ${daemon.health}`;
       return {
         value: daemon.id,
         label: daemon.id,

--- a/frontend/src/lib/components/terminal/NewWorkspaceDialog.test.ts
+++ b/frontend/src/lib/components/terminal/NewWorkspaceDialog.test.ts
@@ -320,7 +320,9 @@ describe("NewWorkspaceDialog", () => {
     await renderDialog();
 
     await fireEvent.click(screen.getByRole("button", { name: "Kata issue" }));
-    expect((await screen.findByRole("searchbox", { name: "Search Kata issues" }) as HTMLInputElement).disabled).toBe(false);
+    expect(((await screen.findByRole("searchbox", { name: "Search Kata issues" })) as HTMLInputElement).disabled).toBe(
+      false,
+    );
   });
 
   it("routes non-default hosts through the host-scoped path", async () => {

--- a/frontend/src/lib/components/terminal/NewWorkspaceDialog.test.ts
+++ b/frontend/src/lib/components/terminal/NewWorkspaceDialog.test.ts
@@ -296,7 +296,7 @@ describe("NewWorkspaceDialog", () => {
     });
   });
 
-  it("explains how to recover when the selected Kata daemon is incompatible", async () => {
+  it("accepts the current Kata API schema", async () => {
     mockGet.mockImplementation((path: string) => {
       if (path === "/repos") return Promise.resolve({ data: [repoFixture("acme", "widget")] });
       if (path === "/kata/daemons") {
@@ -304,13 +304,12 @@ describe("NewWorkspaceDialog", () => {
           data: {
             daemons: [
               {
-                id: "old",
-                url: "http://old",
-                health: "incompatible",
+                id: "current",
+                url: "http://current",
+                health: "connected",
                 auth: "none",
                 default: true,
-                api_schema_version: "0.7.0",
-                hint: "Kata API schema 0.7.0 is incompatible; Forge requires >=0.9.0 and <0.11.0. Upgrade Kata.",
+                api_schema_version: "0.13.0",
               },
             ],
           },
@@ -321,10 +320,7 @@ describe("NewWorkspaceDialog", () => {
     await renderDialog();
 
     await fireEvent.click(screen.getByRole("button", { name: "Kata issue" }));
-    const alert = await screen.findByRole("alert");
-    expect(alert.textContent).toContain("Kata API schema 0.7.0 is incompatible");
-    expect(alert.textContent).toContain("Upgrade Kata");
-    expect((screen.getByRole("searchbox", { name: "Search Kata issues" }) as HTMLInputElement).disabled).toBe(true);
+    expect((await screen.findByRole("searchbox", { name: "Search Kata issues" }) as HTMLInputElement).disabled).toBe(false);
   });
 
   it("routes non-default hosts through the host-scoped path", async () => {

--- a/internal/server/kata/client.go
+++ b/internal/server/kata/client.go
@@ -18,8 +18,6 @@ const (
 	maxKataDaemonHealthBytes  = 1 << 20
 	defaultKataReferenceLimit = 100
 	maxKataReferenceLimit     = 200
-	kataMinimumVersion        = "v0.14.3"
-	kataSupportedAPISchemas   = ">=0.9.0 and <0.11.0"
 )
 
 type kataDaemonHealth struct {
@@ -93,50 +91,7 @@ func (c *kataDaemonClient) Health(ctx context.Context) (kataDaemonHealth, error)
 			"decode Kata daemon %q health response: %w", c.daemon.ID, err,
 		)
 	}
-	state := "connected"
-	if !supportsKataAPISchema(payload.APISchemaVersion) {
-		state = "incompatible"
-	}
-	return kataDaemonHealth{State: state, APISchemaVersion: payload.APISchemaVersion}, nil
-}
-
-func supportsKataAPISchema(version string) bool {
-	parsed, ok := parseKataAPISchema(version)
-	return ok && parsed[0] == 0 && (parsed[1] == 9 || parsed[1] == 10)
-}
-
-func parseKataAPISchema(version string) ([3]int, bool) {
-	var parsed [3]int
-	parts := strings.Split(strings.TrimSpace(version), ".")
-	if len(parts) != 3 {
-		return parsed, false
-	}
-	for i, part := range parts {
-		if part == "" || strings.IndexFunc(part, func(r rune) bool { return r < '0' || r > '9' }) >= 0 {
-			return parsed, false
-		}
-		value, err := strconv.Atoi(part)
-		if err != nil {
-			return parsed, false
-		}
-		parsed[i] = value
-	}
-	return parsed, true
-}
-
-func kataDaemonCompatibilityMessage(version string) string {
-	detected := strings.TrimSpace(version)
-	if detected == "" {
-		detected = "unknown"
-	}
-	action := fmt.Sprintf(
-		"Upgrade Kata to %s or newer with a supported API schema, then restart the daemon.",
-		kataMinimumVersion,
-	)
-	if parsed, ok := parseKataAPISchema(detected); ok && (parsed[0] > 0 || parsed[1] >= 11) {
-		action = "Upgrade Forge or use a supported Kata release."
-	}
-	return fmt.Sprintf("Kata API schema %s is incompatible; Forge requires %s. %s", detected, kataSupportedAPISchemas, action)
+	return kataDaemonHealth{State: "connected", APISchemaVersion: payload.APISchemaVersion}, nil
 }
 
 func (c *kataDaemonClient) References(

--- a/internal/server/kata/client_test.go
+++ b/internal/server/kata/client_test.go
@@ -25,7 +25,7 @@ func TestKataDaemonClientHealthPreservesPathPrefixSchemaVersionAndAuthorization(
 		assert.Equal("application/json", r.Header.Get("Accept"))
 		assert.Equal("Bearer example-token", r.Header.Get("Authorization"))
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.10.4"}`))
+		_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.13.0"}`))
 	}))
 	defer upstream.Close()
 
@@ -36,7 +36,7 @@ func TestKataDaemonClientHealthPreservesPathPrefixSchemaVersionAndAuthorization(
 
 	require.NoError(t, err)
 	assert.Equal("connected", health.State)
-	assert.Equal("0.10.4", health.APISchemaVersion)
+	assert.Equal("0.13.0", health.APISchemaVersion)
 }
 
 func TestKataDaemonClientRejectsUnsafeLaunchTargets(t *testing.T) {
@@ -97,73 +97,7 @@ func TestKataDaemonClientHealthKeepsMissingSchemaVersionVisible(t *testing.T) {
 	}).Health(t.Context())
 
 	require.NoError(t, err)
-	assert.Equal(t, kataDaemonHealth{State: "incompatible"}, health)
-}
-
-func TestKataDaemonClientHealthMarksUnsupportedSchemaIncompatible(t *testing.T) {
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.7.0"}`))
-	}))
-	defer upstream.Close()
-
-	health, err := newTestKataDaemonClient(t, katacatalog.Daemon{
-		ID: "example", URL: upstream.URL,
-	}).Health(t.Context())
-
-	require.NoError(t, err)
-	assert.Equal(t, kataDaemonHealth{State: "incompatible", APISchemaVersion: "0.7.0"}, health)
-}
-
-func TestSupportsKataAPISchema(t *testing.T) {
-	t.Parallel()
-
-	tests := map[string]bool{
-		"0.9.0":  true,
-		"0.10.7": true,
-		"0.8.9":  false,
-		"0.11.0": false,
-		"":       false,
-		"0.9":    false,
-		"0.9.-1": false,
-		"0.+9.0": false,
-	}
-	for version, want := range tests {
-		t.Run(version, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, want, supportsKataAPISchema(version))
-		})
-	}
-}
-
-func TestKataDaemonCompatibilityMessagePointsToCompatibleProduct(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name        string
-		version     string
-		want        string
-		doesNotWant string
-	}{
-		{name: "missing", version: "", want: "Upgrade Kata to v0.14.3 or newer"},
-		{name: "older", version: "0.8.9", want: "Upgrade Kata to v0.14.3 or newer"},
-		{
-			name:        "newer",
-			version:     "0.11.0",
-			want:        "Upgrade Forge or use a supported Kata release",
-			doesNotWant: "Upgrade Kata to v0.14.3 or newer",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			message := kataDaemonCompatibilityMessage(tt.version)
-			assert.Contains(t, message, tt.want)
-			if tt.doesNotWant != "" {
-				assert.NotContains(t, message, tt.doesNotWant)
-			}
-		})
-	}
+	assert.Equal(t, kataDaemonHealth{State: "connected"}, health)
 }
 
 func TestKataDaemonClientReferencesPinsFiltersAndCapsLimit(t *testing.T) {

--- a/internal/server/kata/effective_links.go
+++ b/internal/server/kata/effective_links.go
@@ -234,11 +234,7 @@ func (h *Handler) hydrateKataDaemonLinks(
 	}
 	health, err := client.Health(upstreamCtx)
 	if err != nil || health.State != "connected" {
-		reason := "daemon unavailable"
-		if health.State == "incompatible" {
-			reason = kataDaemonCompatibilityMessage(health.APISchemaVersion)
-		}
-		h.appendUnavailableKataLinks(ctx, response, links, reason, health.State)
+		h.appendUnavailableKataLinks(ctx, response, links, "daemon unavailable", health.State)
 		return 0
 	}
 	issueUIDs := make([]string, 0, len(links))

--- a/internal/server/kata/effective_links_test.go
+++ b/internal/server/kata/effective_links_test.go
@@ -197,33 +197,36 @@ func TestKataEffectiveLinkHydrationReportsOneDiagnosticPerDaemonFailure(t *testi
 	assert.Equal([]kataLinkDiagnostic{{DaemonID: "primary", Reason: "daemon unavailable"}}, response.Diagnostics)
 }
 
-func TestKataEffectiveLinkHydrationExplainsIncompatibleDaemon(t *testing.T) {
+func TestKataEffectiveLinkHydrationAcceptsCurrentSchema(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	old := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !assert.Equal("/api/v1/health", r.URL.Path, "unexpected incompatible daemon request") {
+	current := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/health" {
+			_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.13.0"}`))
+			return
+		}
+		if r.URL.Path != "/api/v1/ui/references" {
 			http.NotFound(w, r)
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.7.0"}`))
+		_ = json.NewEncoder(w).Encode(map[string]any{"issues": []kataIssueReference{{
+			UID: "issue-a", ProjectUID: "project-a", QualifiedID: "project-a:issue-a",
+			Title: "Task issue-a", Status: "open",
+		}}})
 	}))
-	t.Cleanup(old.Close)
-	configureKataLinkTestDaemon(t, old.URL)
+	t.Cleanup(current.Close)
+	configureKataLinkTestDaemon(t, current.URL)
 	srv, _ := setupTestServer(t)
 	candidates := make(map[string]*kataLinkCandidate)
 	mergeKataLinkCandidate(candidates, "primary", "project-a", "issue-a", kataLinkDirect)
 
 	response := srv.hydrateKataLinkCandidates(t.Context(), candidates)
 
-	assert.Equal("unavailable", response.State)
+	assert.Equal("complete", response.State)
 	require.Len(response.Links, 1)
-	assert.Contains(response.Links[0].UnavailableReason, "Kata API schema 0.7.0 is incompatible")
-	assert.Contains(response.Links[0].UnavailableReason, "Upgrade Kata to v0.14.3 or newer")
-	assert.Equal([]kataLinkDiagnostic{{
-		DaemonID: "primary",
-		Reason:   response.Links[0].UnavailableReason,
-	}}, response.Diagnostics)
+	assert.Equal("0.13.0", response.Links[0].APISchemaVersion)
+	assert.Empty(response.Diagnostics)
 }
 
 func TestKataEffectiveLinkHydrationKeepsExistingWorkspaceWhenDaemonUnavailable(t *testing.T) {

--- a/internal/server/kata/read_routes.go
+++ b/internal/server/kata/read_routes.go
@@ -78,7 +78,7 @@ func (h *Handler) listKataReferences(
 ) (*kataReferencesOutput, error) {
 	ctx, cancel := context.WithTimeout(ctx, kataDaemonReadTimeout)
 	defer cancel()
-	client, problem := h.kataClientForCompatibleDaemon(input.DaemonID)
+	client, problem := h.kataClientForConnectedDaemon(input.DaemonID)
 	if problem != nil {
 		return nil, problem
 	}
@@ -102,7 +102,7 @@ func (h *Handler) resolveKataIssueReference(
 ) (*kataIssueReferenceResolveOutput, error) {
 	ctx, cancel := context.WithTimeout(ctx, kataDaemonReadTimeout)
 	defer cancel()
-	client, problem := h.kataClientForCompatibleDaemon(input.DaemonID)
+	client, problem := h.kataClientForConnectedDaemon(input.DaemonID)
 	if problem != nil {
 		return nil, problem
 	}
@@ -145,7 +145,7 @@ func (h *Handler) getKataLaunchTarget(
 ) (*kataLaunchTargetOutput, error) {
 	ctx, cancel := context.WithTimeout(ctx, kataDaemonReadTimeout)
 	defer cancel()
-	client, problem := h.kataClientForCompatibleDaemon(input.DaemonID)
+	client, problem := h.kataClientForConnectedDaemon(input.DaemonID)
 	if problem != nil {
 		return nil, problem
 	}
@@ -181,7 +181,7 @@ func (h *Handler) kataClientForDaemon(daemonID string) (*kataDaemonClient, *http
 	return &kataDaemonClient{daemon: daemon, client: client, baseURL: baseURL}, nil
 }
 
-func (h *Handler) kataClientForCompatibleDaemon(daemonID string) (*kataDaemonClient, *httpapi.ProblemError) {
+func (h *Handler) kataClientForConnectedDaemon(daemonID string) (*kataDaemonClient, *httpapi.ProblemError) {
 	client, problem := h.kataClientForDaemon(daemonID)
 	if problem != nil {
 		return nil, problem
@@ -197,17 +197,6 @@ func kataDaemonUnavailableProblem(daemonID string, health kataDaemonHealth) *htt
 	details := map[string]any{"daemon": daemonID}
 	if health.State != "" {
 		details["health"] = health.State
-	}
-	if health.State == "incompatible" {
-		details["reason"] = "incompatible_api_schema"
-		details["api_schema_version"] = health.APISchemaVersion
-		details["supported_api_schema"] = kataSupportedAPISchemas
-		return httpapi.NewProblem(
-			http.StatusServiceUnavailable,
-			httpapi.CodeServiceUnavailable,
-			kataDaemonCompatibilityMessage(health.APISchemaVersion),
-			details,
-		)
 	}
 	return httpapi.NewProblem(
 		http.StatusServiceUnavailable,

--- a/internal/server/kata/read_routes_test.go
+++ b/internal/server/kata/read_routes_test.go
@@ -286,17 +286,17 @@ url = "`+upstream.URL+`"
 	assert.NotContains(problem.Details, "platformHost")
 }
 
-func TestKataReferencesRouteExplainsIncompatibleDaemonBeforeNarrowRead(t *testing.T) {
+func TestKataReferencesRouteAcceptsCurrentSchema(t *testing.T) {
 	assert := assert.New(t)
 	var referenceCalls int
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path == "/api/v1/health" {
-			_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.7.0"}`))
+			_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.13.0"}`))
 			return
 		}
 		referenceCalls++
-		http.NotFound(w, r)
+		_, _ = w.Write([]byte(`{"issues":[]}`))
 	}))
 	defer upstream.Close()
 
@@ -304,21 +304,15 @@ func TestKataReferencesRouteExplainsIncompatibleDaemonBeforeNarrowRead(t *testin
 	t.Setenv("KATA_HOME", home)
 	writeKataServerCatalog(t, home, `
 [[daemon]]
-name = "old"
+name = "current"
 url = "`+upstream.URL+`"
 `)
 	srv, _ := setupTestServer(t)
 
 	rr := doJSON(t, srv, http.MethodGet,
-		"/api/v1/kata/daemons/old/references?q=task", nil)
-	require.Equal(t, http.StatusServiceUnavailable, rr.Code, rr.Body.String())
-	problem := decodeProblem(t, rr)
-	assert.Equal(httpapi.CodeServiceUnavailable, problem.Code)
-	assert.Equal("incompatible_api_schema", problem.Details["reason"])
-	assert.Equal("0.7.0", problem.Details["api_schema_version"])
-	assert.Equal(">=0.9.0 and <0.11.0", problem.Details["supported_api_schema"])
-	assert.Contains(problem.Detail, "Upgrade Kata")
-	assert.Zero(referenceCalls)
+		"/api/v1/kata/daemons/current/references?q=task", nil)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	assert.Equal(1, referenceCalls)
 }
 
 func TestKataReferencesRouteRequiresConnectedHealthBeforeNarrowRead(t *testing.T) {

--- a/internal/server/kata/routes.go
+++ b/internal/server/kata/routes.go
@@ -94,8 +94,6 @@ func (h *Handler) listKataDaemons(context.Context, *struct{}) (*listKataDaemonsO
 		hint := ""
 		if d.Local && d.URL == "" {
 			hint = "local daemon not running; run `kata daemon start`"
-		} else if health[i].State == "incompatible" {
-			hint = kataDaemonCompatibilityMessage(health[i].APISchemaVersion)
 		}
 
 		out.Daemons = append(out.Daemons, kataDaemonResponse{

--- a/internal/server/kata/routes_test.go
+++ b/internal/server/kata/routes_test.go
@@ -102,7 +102,7 @@ func TestKataDaemonsEndpointReportsHealthAndRedactsSecrets(t *testing.T) {
 		assert.Equal("/secret/path/api/v1/health", r.URL.Path)
 		assert.Equal("Bearer prod-secret", r.Header.Get("Authorization"))
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.9.0"}`))
+		_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.13.0"}`))
 	}))
 	defer connected.Close()
 	authRequired := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -139,7 +139,7 @@ url = "`+authRequired.URL+`"
 	assert.True(body.Daemons[0].Default)
 	assert.Equal("token", body.Daemons[0].Auth)
 	assert.Equal("connected", body.Daemons[0].Health)
-	assert.Equal("0.9.0", body.Daemons[0].APISchemaVersion)
+	assert.Equal("0.13.0", body.Daemons[0].APISchemaVersion)
 	assert.NotContains(body.Daemons[0].URL, "secret")
 	assert.NotContains(rr.Body.String(), "prod-secret")
 	assert.NotContains(rr.Body.String(), "token=leak")
@@ -148,32 +148,6 @@ url = "`+authRequired.URL+`"
 	assert.False(body.Daemons[1].Default)
 	assert.Equal("none", body.Daemons[1].Auth)
 	assert.Equal("auth_required", body.Daemons[1].Health)
-}
-
-func TestKataDaemonsEndpointSurfacesIncompatibleSchema(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"ok":true,"api_schema_version":"0.7.0"}`))
-	}))
-	defer upstream.Close()
-
-	home := t.TempDir()
-	t.Setenv("KATA_HOME", home)
-	writeKataServerCatalog(t, home, `
-[[daemon]]
-name = "old"
-url = "`+upstream.URL+`"
-`)
-	srv, _ := setupTestServer(t)
-
-	daemons := requestKataDaemons(t, srv)
-	require.Len(daemons, 1)
-	assert.Equal("incompatible", daemons[0].Health)
-	assert.Equal("0.7.0", daemons[0].APISchemaVersion)
-	assert.Contains(daemons[0].Hint, "Forge requires >=0.9.0 and <0.11.0")
-	assert.Contains(daemons[0].Hint, "Upgrade Kata")
 }
 
 func TestKataDaemonsEndpointRejectsUnsetTokenEnv(t *testing.T) {

--- a/internal/server/kata/workspace.go
+++ b/internal/server/kata/workspace.go
@@ -321,7 +321,7 @@ func (h *Handler) canonicalKataWorkspaceMetadata(
 	ctx context.Context,
 	requested db.WorkspaceKataMetadata,
 ) (db.WorkspaceKataMetadata, error) {
-	client, problem := h.kataClientForCompatibleDaemon(requested.DaemonID)
+	client, problem := h.kataClientForConnectedDaemon(requested.DaemonID)
 	if problem != nil {
 		return db.WorkspaceKataMetadata{}, problem
 	}


### PR DESCRIPTION
## TL;DR

Kata main reports HTTP API schema 0.13.0, but Forge only treated 0.9.x and 0.10.x as connected, so healthy current daemons became unavailable.

Successful health now controls availability. Forge keeps the reported schema version as diagnostic metadata and sends each operation's payload to the consumer that owns it.

**Files to review (17, +62 / -297):**

| File | Why |
|---|---|
| `internal/server/kata/client.go` and `read_routes.go` *(start here)* | Health classification and narrow-route availability. |
| `internal/server/kata/effective_links.go`, `routes.go`, and `workspace.go` | Consumers no longer branch on an incompatible-schema state. |
| `frontend/src/lib/components/kata/` and `frontend/src/lib/components/terminal/NewWorkspaceDialog.svelte` | UI actions trust Forge's connected health state instead of applying another schema gate. |
| Kata server and frontend tests | Current 0.13.0 daemons exercise roster, reads, links, workspaces, and detail rendering. |
| `context/kata-mode.md` and `docs/adr/0004-kata-ui-ownership.md` | The durable compatibility rule now matches runtime behavior. |

## Why

The health payload separates `api_schema_version` from the daemon build version. Treating that diagnostic value as a fixed allowlist required Forge updates for every additive Kata schema release and broke latest-to-latest compatibility when the list stopped at 0.10.x.

## How

Forge accepts any successful Kata health response as connected and preserves the reported schema version in responses. Kata UI's issue-detail projector ignores unknown JSON fields, while its existing Svelte boundary contains projection errors. Reachability, malformed health responses, and authentication failures still stop downstream requests.

## Reviewer notes

- **Compatibility model.** The change deliberately removes version prediction instead of widening the range to another short-lived upper bound.
- **Failure boundary.** Kata UI reads the canonical detail fields it owns and ignores additive response fields. No fallback parser or compatibility shim was added.
