### PR TITLE
fix: keep PR base branches current for review

### DIFF
--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -541,6 +541,9 @@ synthetic name and its numbered variants and may delete them during cleanup;
 any other pre-existing branch is user-owned and must keep pointing where it did.
 Ad-hoc workspaces instead reserve their final hashed branch identity before
 setup; a later external Git ref collision is an explicit setup error.
+PR worktree creation and reuse fast-forward the fetched local base branch;
+checked-out or diverged base branches stay untouched and emit a warning
+(`internal/workspace/manager.go::syncLocalBaseBranch`).
 
 ## Branch Upstream
 

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -541,8 +541,9 @@ synthetic name and its numbered variants and may delete them during cleanup;
 any other pre-existing branch is user-owned and must keep pointing where it did.
 Ad-hoc workspaces instead reserve their final hashed branch identity before
 setup; a later external Git ref collision is an explicit setup error.
-PR worktree creation and reuse fast-forward the fetched local base branch;
-checked-out or diverged base branches stay untouched and emit a warning
+PR worktree creation and reuse fast-forward the fetched local base branch while
+holding repository route identity stable; checked-out, diverged, or ref-namespace-
+blocked base branches stay untouched and emit a warning
 (`internal/workspace/manager.go::syncLocalBaseBranch`).
 
 ## Branch Upstream

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -5168,7 +5168,15 @@ func (m *Manager) syncWorkspaceBaseBranch(
 		ws.RepoOwner == "" || ws.RepoName == "" {
 		return nil
 	}
-	repo, err := m.workspaceRepo(
+	releaseReconciliation, err := m.db.LockRepositoryReconciliationRead(ctx)
+	if err != nil {
+		return fmt.Errorf("lock repository reconciliation for base branch sync: %w", err)
+	}
+	defer releaseReconciliation()
+	if err := m.verifyWorkspaceRouteUnoccupied(ctx, ws); err != nil {
+		return err
+	}
+	repo, err := m.workspaceRepoUnderReconciliationRead(
 		ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
 	)
 	if err != nil {
@@ -5248,8 +5256,39 @@ func syncLocalBaseBranch(
 				"reason", "local branch became checked out")
 			return nil
 		}
+		if !exists {
+			occupied, checkErr := localBranchRefNamespaceOccupied(ctx, dir, branch)
+			if checkErr == nil && occupied {
+				slog.Warn("workspace base branch sync skipped",
+					"workspace_id", workspaceID, "branch", branch,
+					"reason", "local branch ref namespace is occupied")
+				return nil
+			}
+		}
 		return fmt.Errorf("update local base branch %q: %w", branch, err)
 	}
+}
+
+func localBranchRefNamespaceOccupied(
+	ctx context.Context, dir, branch string,
+) (bool, error) {
+	parts := strings.Split(branch, "/")
+	for i := 1; i < len(parts); i++ {
+		_, exists, err := gitRefSHA(ctx, dir, "refs/heads/"+strings.Join(parts[:i], "/"))
+		if err != nil {
+			return false, err
+		}
+		if exists {
+			return true, nil
+		}
+	}
+	out, err := gitCombinedOutput(
+		ctx, dir, "for-each-ref", "--format=%(refname)", "refs/heads/"+branch+"/",
+	)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(out) != "", nil
 }
 
 func gitCommitIsAncestor(

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -1798,6 +1798,9 @@ func (m *Manager) refreshExistingWorkspaceWorktree(
 	); err != nil {
 		return false, err
 	}
+	if err := m.syncWorkspaceBaseBranch(ctx, commonDir, ws); err != nil {
+		return false, err
+	}
 	if ws.ItemType != db.WorkspaceItemTypePullRequest {
 		return false, nil
 	}
@@ -2346,6 +2349,9 @@ func (m *Manager) addWorktree(
 			); err != nil {
 				return err
 			}
+		}
+		if err := m.syncWorkspaceBaseBranch(ctx, cloneDir, ws); err != nil {
+			return err
 		}
 		if err := m.ensureWorkspacePathAvailable(ctx, ws); err != nil {
 			return err
@@ -5152,6 +5158,114 @@ func fetchWorkspaceBaseWithGit(
 		return err
 	}
 	return nil
+}
+
+func (m *Manager) syncWorkspaceBaseBranch(
+	ctx context.Context, dir string, ws *Workspace,
+) error {
+	if ws == nil || ws.ItemType != db.WorkspaceItemTypePullRequest ||
+		ws.Platform == "" || ws.PlatformHost == "" ||
+		ws.RepoOwner == "" || ws.RepoName == "" {
+		return nil
+	}
+	repo, err := m.workspaceRepo(
+		ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+	)
+	if err != nil {
+		return fmt.Errorf("look up workspace repo for base branch sync: %w", err)
+	}
+	if repo == nil {
+		return nil
+	}
+	mr, err := m.db.GetMergeRequestByRepoIDAndNumber(
+		ctx, repo.ID, ws.ItemNumber,
+	)
+	if err != nil {
+		return fmt.Errorf("look up workspace merge request for base branch sync: %w", err)
+	}
+	if mr == nil || strings.TrimSpace(mr.BaseBranch) == "" {
+		return nil
+	}
+	return syncLocalBaseBranch(ctx, dir, ws.ID, strings.TrimSpace(mr.BaseBranch))
+}
+
+func syncLocalBaseBranch(
+	ctx context.Context, dir, workspaceID, branch string,
+) error {
+	localRef := "refs/heads/" + branch
+	remoteRef := "refs/remotes/origin/" + branch
+	remoteSHA, exists, err := gitRefSHA(ctx, dir, remoteRef)
+	if err != nil {
+		return fmt.Errorf("inspect remote base branch %q: %w", branch, err)
+	}
+	if !exists {
+		slog.Warn("workspace base branch sync skipped",
+			"workspace_id", workspaceID, "branch", branch,
+			"reason", "remote-tracking branch is missing")
+		return nil
+	}
+	localSHA, exists, err := gitRefSHA(ctx, dir, localRef)
+	if err != nil {
+		return fmt.Errorf("inspect local base branch %q: %w", branch, err)
+	}
+	if exists {
+		if localSHA == remoteSHA {
+			return nil
+		}
+		checkedOut, err := localBranchCheckedOut(ctx, dir, branch)
+		if err != nil {
+			return fmt.Errorf("inspect base branch worktrees: %w", err)
+		}
+		if checkedOut {
+			slog.Warn("workspace base branch sync skipped",
+				"workspace_id", workspaceID, "branch", branch,
+				"reason", "local branch is checked out")
+			return nil
+		}
+		ancestor, err := gitCommitIsAncestor(ctx, dir, localSHA, remoteSHA)
+		if err != nil {
+			return fmt.Errorf("check base branch fast-forward: %w", err)
+		}
+		if !ancestor {
+			slog.Warn("workspace base branch sync skipped",
+				"workspace_id", workspaceID, "branch", branch,
+				"local_sha", localSHA, "remote_sha", remoteSHA,
+				"reason", "update is not a fast-forward")
+			return nil
+		}
+	}
+	if err := runGitWithoutHooks(
+		ctx, dir, "branch", "--force", "--", branch, remoteSHA,
+	); err == nil {
+		return nil
+	} else if ctx.Err() != nil {
+		return ctx.Err()
+	} else {
+		checkedOut, checkErr := localBranchCheckedOut(ctx, dir, branch)
+		if checkErr == nil && checkedOut {
+			slog.Warn("workspace base branch sync skipped",
+				"workspace_id", workspaceID, "branch", branch,
+				"reason", "local branch became checked out")
+			return nil
+		}
+		return fmt.Errorf("update local base branch %q: %w", branch, err)
+	}
+}
+
+func gitCommitIsAncestor(
+	ctx context.Context, dir, ancestor, descendant string,
+) (bool, error) {
+	_, err := gitCombinedOutput(
+		ctx, dir, "merge-base", "--is-ancestor", ancestor, descendant,
+	)
+	if err == nil {
+		return true, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return false, nil
+	}
+	return false, err
 }
 
 func refreshWorkspaceBaseOriginHeadWithGit(

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -2968,6 +2968,118 @@ func TestFetchWorkspaceBaseRequiresOriginHeadOnlyForIssueWorkspaces(t *testing.T
 	require.Error(fetchWorkspaceBaseWithGit(t.Context(), runGitWithoutHooks, localRepo, true))
 }
 
+func TestAddAndRefreshPRWorktreeFastForwardLocalBaseBranch(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	const branch = "feature/base-sync"
+	localRepo, remote, platformHost := setupHTTPWorktreeBaseForWorkspaceGitTest(
+		t, branch,
+	)
+	runWorkspaceTestGit(t, localRepo, "checkout", "--detach")
+	runWorkspaceTestGit(t, remote, "config", "user.email", "test@test.com")
+	runWorkspaceTestGit(t, remote, "config", "user.name", "Test")
+	firstBaseSHA := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, remote, "commit-tree", "refs/heads/main^{tree}",
+		"-p", "refs/heads/main", "-m", "advance base once",
+	)))
+	runWorkspaceTestGit(t, remote, "update-ref", "refs/heads/main", firstBaseSHA)
+	runWorkspaceTestGit(t, remote, "update-server-info")
+
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, platformHost, "acme", "widget")
+	seedMR(t, d, repoID, 968, branch)
+	mgr := NewManager(d, t.TempDir())
+	ws, err := mgr.Create(
+		t.Context(), "github", platformHost, "acme", "widget", 968,
+	)
+	require.NoError(err)
+
+	_, err = mgr.addWorktree(t.Context(), localRepo, true, ws)
+	require.NoError(err)
+	localBaseSHA := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo, "rev-parse", "refs/heads/main",
+	)))
+	assert.Equal(firstBaseSHA, localBaseSHA)
+
+	secondBaseSHA := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, remote, "commit-tree", firstBaseSHA+"^{tree}",
+		"-p", firstBaseSHA, "-m", "advance base twice",
+	)))
+	runWorkspaceTestGit(t, remote, "update-ref", "refs/heads/main", secondBaseSHA)
+	runWorkspaceTestGit(t, remote, "update-server-info")
+
+	_, err = mgr.refreshExistingWorkspaceWorktree(t.Context(), localRepo, ws)
+	require.NoError(err)
+	localBaseSHA = strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo, "rev-parse", "refs/heads/main",
+	)))
+	assert.Equal(secondBaseSHA, localBaseSHA)
+}
+
+func TestSyncLocalBaseBranchSkipsCheckedOutAndDivergedBranches(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	const branch = "main"
+	localRepo := setupLocalWorktreeBaseForWorkspaceGitTest(t, "feature/base-sync")
+	originalSHA := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo, "rev-parse", "refs/heads/main",
+	)))
+	firstRemoteSHA := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo, "commit-tree", originalSHA+"^{tree}",
+		"-p", originalSHA, "-m", "first remote base",
+	)))
+	runWorkspaceTestGit(
+		t, localRepo, "update-ref", "refs/remotes/origin/main", firstRemoteSHA,
+	)
+	runWorkspaceTestGit(t, localRepo, "checkout", "--detach")
+
+	require.NoError(syncLocalBaseBranch(
+		t.Context(), localRepo, "ws-base-sync-safety", branch,
+	))
+	assert.Equal(firstRemoteSHA, strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo, "rev-parse", "refs/heads/main",
+	))))
+
+	secondRemoteSHA := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo, "commit-tree", firstRemoteSHA+"^{tree}",
+		"-p", firstRemoteSHA, "-m", "second remote base",
+	)))
+	runWorkspaceTestGit(
+		t, localRepo, "update-ref", "refs/remotes/origin/main", secondRemoteSHA,
+	)
+	runWorkspaceTestGit(t, localRepo, "checkout", branch)
+	require.NoError(syncLocalBaseBranch(
+		t.Context(), localRepo, "ws-base-sync-safety", branch,
+	))
+	assert.Equal(firstRemoteSHA, strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo, "rev-parse", "refs/heads/main",
+	))))
+
+	runWorkspaceTestGit(t, localRepo, "checkout", "--detach")
+	divergentSHA := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo, "commit-tree", firstRemoteSHA+"^{tree}",
+		"-p", firstRemoteSHA, "-m", "divergent local base",
+	)))
+	thirdRemoteSHA := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo, "commit-tree", secondRemoteSHA+"^{tree}",
+		"-p", secondRemoteSHA, "-m", "third remote base",
+	)))
+	runWorkspaceTestGit(
+		t, localRepo, "update-ref", "refs/heads/main", divergentSHA,
+	)
+	runWorkspaceTestGit(
+		t, localRepo, "update-ref", "refs/remotes/origin/main", thirdRemoteSHA,
+	)
+	require.NoError(syncLocalBaseBranch(
+		t.Context(), localRepo, "ws-base-sync-safety", branch,
+	))
+	assert.Equal(divergentSHA, strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo, "rev-parse", "refs/heads/main",
+	))))
+}
+
 func TestFetchWorkspaceBaseConstrainsNegotiationTips(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -3080,6 +3080,78 @@ func TestSyncLocalBaseBranchSkipsCheckedOutAndDivergedBranches(t *testing.T) {
 	))))
 }
 
+func TestSyncLocalBaseBranchSkipsOccupiedRefNamespace(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	localRepo := setupLocalWorktreeBaseForWorkspaceGitTest(t, "feature/base-sync")
+	mainSHA := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo, "rev-parse", "refs/heads/main",
+	)))
+	runWorkspaceTestGit(t, localRepo, "checkout", "--detach")
+	runWorkspaceTestGit(t, localRepo, "branch", "-D", "main")
+	runWorkspaceTestGit(t, localRepo, "branch", "main/topic", mainSHA)
+
+	require.NoError(syncLocalBaseBranch(
+		t.Context(), localRepo, "ws-base-sync-namespace", "main",
+	))
+	_, mainExists, err := gitRefSHA(t.Context(), localRepo, "refs/heads/main")
+	require.NoError(err)
+	assert.False(mainExists)
+	assert.Equal(mainSHA, strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo, "rev-parse", "refs/heads/main/topic",
+	))))
+}
+
+func TestSyncWorkspaceBaseBranchRejectsReplacedRepositoryRoute(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	localRepo := setupLocalWorktreeBaseForWorkspaceGitTest(t, "feature/base-sync")
+	localMainSHA := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo, "rev-parse", "refs/heads/main",
+	)))
+	remoteMainSHA := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo, "commit-tree", localMainSHA+"^{tree}",
+		"-p", localMainSHA, "-m", "replacement base",
+	)))
+	runWorkspaceTestGit(
+		t, localRepo, "update-ref", "refs/remotes/origin/main", remoteMainSHA,
+	)
+	runWorkspaceTestGit(t, localRepo, "checkout", "--detach")
+
+	d := openTestDB(t)
+	seedRepo(t, d, "github.com", "acme", "widget")
+	replacement, _, err := d.ReconcileRepositoryObservation(
+		t.Context(), db.RepoIdentity{
+			Platform:       "github",
+			PlatformHost:   "github.com",
+			PlatformRepoID: "repo-acme-widget-replacement",
+			Owner:          "acme",
+			Name:           "widget",
+		}, time.Now().UTC(),
+	)
+	require.NoError(err)
+	require.NotNil(replacement)
+	seedMR(t, d, replacement.Repository.ID, 968, "feature/base-sync")
+	mgr := NewManager(d, t.TempDir())
+	ws := &Workspace{
+		ID:           "ws-base-sync-replaced-route",
+		Platform:     "github",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   968,
+	}
+
+	err = mgr.syncWorkspaceBaseBranch(t.Context(), localRepo, ws)
+	require.ErrorContains(err, "historical occupants")
+	assert.Equal(localMainSHA, strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo, "rev-parse", "refs/heads/main",
+	))))
+}
+
 func TestFetchWorkspaceBaseConstrainsNegotiationTips(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)


### PR DESCRIPTION
Forge now fast-forwards a pull request worktree's local base branch to its fetched remote-tracking branch during creation and reuse. This keeps review tools from reporting changes that are already merged.

Forge leaves the base branch untouched and writes a warning when another worktree has it checked out, the update is not a fast-forward, or another branch occupies the ref namespace. Setup also keeps repository route identity stable through the base-branch lookup and update, so a reassigned route cannot apply another repository's metadata to the original clone.

Closes #968
