### PR TITLE
fix: deliver agent prompts before hook observation

### DIFF
--- a/context/mcp-server.md
+++ b/context/mcp-server.md
@@ -69,16 +69,17 @@
   `internal/mcpserver/tools_diff.go::serializeDiffPatches`,
   `internal/mcpserver/tools_diff.go::canonicalDiffFileRef`).
 - Initial-message attempts are process-local and retain the exact normalized
-  prompt only in daemon memory. Same-daemon retries must match agent, coding
-  session, and prompt; daemon restart permits a fresh attempt
+  prompt only in daemon memory. Same-daemon retries must match the live runtime
+  target and prompt; daemon restart permits a fresh attempt
   (`internal/server/workspaceapi/initial_message.go::initialMessageAttempt`).
-- Initial input requires exact live hook identity, LF or printable Unicode, and
-  tracked bracketed paste for multiline text. If safe paste mode is not observed
-  yet, release the no-write reservation and retry only that typed condition on
-  the same runtime until the handoff deadline. Terminal writes honor the handoff
-  context and do not hold the session lock while waiting. Other proven no-write
-  rejection releases its reservation; a timed-out write that may have started
-  remains uncertain
+- Initial input requires an exact live agent runtime and matching target, LF or
+  printable Unicode, and tracked bracketed paste for multiline text. Hook
+  observation is not a submission precondition. If safe paste mode is not
+  observed yet, release the no-write reservation and retry only that typed
+  condition on the same runtime until the handoff deadline. Terminal writes
+  honor the handoff context and do not hold the session lock while waiting.
+  Other proven no-write rejection releases its reservation; a timed-out write
+  that may have started remains uncertain
   (`internal/workspace/localruntime/manager.go::Manager.SubmitInitialMessage`,
   `internal/server/workspaceapi/initial_message.go::Handler.SubmitInitialMessageService`).
 - Shutdown contract: stop MCP admission, wait the bounded grace period, cancel
@@ -90,13 +91,20 @@
   (`internal/server/workspaceapi/routes_handlers.go::Handler.CreatePullWorkspace`,
   `internal/server/workspaceapi/routes_handlers.go::Handler.CreateIssueWorkspaceService`).
 - MCP can create or reuse a pull-request, issue, or ad-hoc workspace and launch
-  one new agent runtime with one initial message. Ambiguous mutations are never
-  retried or cleaned up. The exact `workspaceAlreadyExists` pull-workspace
-  conflict receives one authoritative pull read and reuses the concurrent
-  winner; only initial-message status receives a bounded,
-  cancellation-independent read
+  one new agent runtime with one initial message. It submits that message before
+  waiting for the runtime's matching hook session. A resume names the existing
+  workspace and runtime, repeats the same target and prompt through the
+  runtime-scoped duplicate guard, and never launches another agent. Ambiguous
+  workspace or runtime mutations are never retried or cleaned up. The exact
+  `workspaceAlreadyExists` pull-workspace conflict receives one authoritative
+  pull read and reuses the concurrent winner; only initial-message status
+  receives a bounded, cancellation-independent read
   (`internal/mcpserver/tools_agent_spawn.go::Server.resolveOrCreatePRWorkspace`,
   `internal/mcpserver/tools_agent_spawn.go::Server.recoverInitialMessageStatus`).
+- Agent-session inspection returns live agent runtimes separately from
+  hook-authoritative sessions. `hook_observed=false` distinguishes a launched
+  runtime awaiting its first hook from a workspace with no agent runtime
+  (`internal/mcpserver/tools_agent.go::Server.listWorkspaceAgentSessions`).
 - Handoff success and failure evidence uses `stage` plus
   `initial_message.state`; never add a separate `message_delivered` output or
   error detail (`internal/mcpserver/tools_agent_spawn.go::spawnWorkspaceWithAgentOutput`).

--- a/docs/kenn-forge-mcp.md
+++ b/docs/kenn-forge-mcp.md
@@ -109,14 +109,21 @@ call `kenn_forge_spawn_workspace_with_agent` with one source:
 - a provider-aware pull request or issue; or
 - a provider-aware repository with an optional ad-hoc branch.
 
-The tool creates or reuses a workspace, launches a new agent runtime, waits for
-its live hook session, and submits one initial message. It does not clean up a
-workspace or runtime after a later failure. The response uses `stage` and
-`initial_message.state` as the authoritative handoff evidence.
+The tool creates or reuses a workspace, launches a new agent runtime, submits
+one initial message, and then waits for the resulting live hook session. It does
+not clean up a workspace or runtime after a later failure. The response uses
+`stage` and `initial_message.state` as the authoritative handoff evidence.
 
-Use `kenn_forge_list_workspace_agent_sessions` to inspect fresh coding sessions
-joined to live agent runtimes. Historical sessions and arbitrary terminal bytes
-are outside the MCP surface.
+If prompt submission or hook observation times out after the response includes
+a workspace ID and runtime session key, call the same tool with `resume` instead
+of `source`. Pass those two IDs with the same `agent_target` and normalized
+`initial_message`. Resume targets the existing runtime and does not launch a
+second agent.
+
+Use `kenn_forge_list_workspace_agent_sessions` to inspect live agent runtimes
+and fresh coding sessions. A runtime with `hook_observed=false` has launched but
+has not reported its first hook. Historical sessions and arbitrary terminal
+bytes are outside the MCP surface.
 
 ## Troubleshooting
 

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -352,8 +352,6 @@ components:
           format: uri
           readOnly: true
           type: string
-        agent:
-          type: string
         delivered_at:
           format: date-time
           type: string
@@ -363,13 +361,12 @@ components:
         reserved_at:
           format: date-time
           type: string
-        session_id:
-          type: string
         state:
           type: string
+        target_key:
+          type: string
       required:
-        - agent
-        - session_id
+        - target_key
         - state
         - message_bytes
         - reserved_at
@@ -7328,15 +7325,12 @@ components:
           format: uri
           readOnly: true
           type: string
-        agent:
-          type: string
         message:
           type: string
-        session_id:
+        target_key:
           type: string
       required:
-        - agent
-        - session_id
+        - target_key
         - message
       type: object
     SyncStatus:

--- a/frontend/src/lib/api/generated/schema.ts
+++ b/frontend/src/lib/api/generated/schema.ts
@@ -4814,15 +4814,14 @@ export interface components {
              * @example /api/v1/schemas/AgentInitialMessageStatusResponse.json
              */
             readonly $schema?: string;
-            agent: string;
             /** Format: date-time */
             delivered_at?: string;
             /** Format: int64 */
             message_bytes: number;
             /** Format: date-time */
             reserved_at: string;
-            session_id: string;
             state: string;
+            target_key: string;
         };
         ApplyReviewSuggestionHostInputBody: {
             /**
@@ -7952,9 +7951,8 @@ export interface components {
              * @example /api/v1/schemas/SubmitInitialMessageInputBody.json
              */
             readonly $schema?: string;
-            agent: string;
             message: string;
-            session_id: string;
+            target_key: string;
         };
         SyncStatus: {
             /**

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1245,12 +1245,11 @@ type AgentInitialMessageStatusResponse struct {
 	//
 	// Example: /api/v1/schemas/AgentInitialMessageStatusResponse.json
 	Schema       *string    `json:"$schema,omitempty"`
-	Agent        string     `json:"agent"`
 	DeliveredAt  *time.Time `json:"delivered_at,omitempty"`
 	MessageBytes int64      `json:"message_bytes"`
 	ReservedAt   time.Time  `json:"reserved_at"`
-	SessionId    string     `json:"session_id"`
 	State        string     `json:"state"`
+	TargetKey    string     `json:"target_key"`
 }
 
 // ApplyReviewSuggestionHostInputBody defines model for ApplyReviewSuggestionHostInputBody.
@@ -4414,9 +4413,8 @@ type SubmitInitialMessageInputBody struct {
 	//
 	// Example: /api/v1/schemas/SubmitInitialMessageInputBody.json
 	Schema    *string `json:"$schema,omitempty"`
-	Agent     string  `json:"agent"`
 	Message   string  `json:"message"`
-	SessionId string  `json:"session_id"`
+	TargetKey string  `json:"target_key"`
 }
 
 // SyncStatus defines model for SyncStatus.

--- a/internal/mcpserver/backend.go
+++ b/internal/mcpserver/backend.go
@@ -294,6 +294,7 @@ type Workspace struct {
 type RuntimeSession struct {
 	Key       string
 	TargetKey string
+	Kind      string
 	Status    string
 	CreatedAt time.Time
 }
@@ -305,8 +306,7 @@ type WorkspaceRuntime struct {
 type InitialMessageRequest struct {
 	WorkspaceID       string
 	RuntimeSessionKey string
-	Agent             string
-	SessionID         string
+	TargetKey         string
 	Message           string
 }
 

--- a/internal/mcpserver/e2e_test.go
+++ b/internal/mcpserver/e2e_test.go
@@ -297,7 +297,7 @@ esac
 		LegacyClaim *bool `json:"message_delivered"`
 	}
 	require.NoError(json.Unmarshal(data, &spawn))
-	assert.Equal("message_delivered", spawn.Stage)
+	assert.Equal("coding_session_observed", spawn.Stage)
 	assert.Equal(workspace.ID, spawn.Workspace.ID)
 	assert.Equal(runtimeSession.SessionKey, spawn.Runtime.SessionKey)
 	require.NotNil(spawn.Initial)

--- a/internal/mcpserver/guidance.md
+++ b/internal/mcpserver/guidance.md
@@ -52,7 +52,10 @@ Handoff flow:
 1. Call kenn_forge_list_agent_targets and select an available coding agent.
 2. Call kenn_forge_spawn_workspace_with_agent once with the selected source,
    target, and initial message.
-3. Do not retry an ambiguous workspace, runtime, or message mutation. The tool
-   performs same-daemon status lookup when an initial-message response is lost.
-4. Report every returned workspace, runtime, and coding-session identifier.
+3. Do not retry an ambiguous workspace or runtime mutation. If prompt delivery
+   or hook observation times out after a runtime identifier is returned, call
+   the tool with resume, the returned workspace and runtime identifiers, and
+   the same target and initial message. Resume never launches another runtime.
+4. Report every returned workspace, runtime, prompt-delivery, and coding-session
+   identifier or state.
 ```

--- a/internal/mcpserver/tools_agent.go
+++ b/internal/mcpserver/tools_agent.go
@@ -44,7 +44,16 @@ type workspaceAgentSessionRow struct {
 }
 
 type listWorkspaceAgentSessionsOutput struct {
+	Runtimes []workspaceAgentRuntimeRow `json:"runtimes"`
 	Sessions []workspaceAgentSessionRow `json:"sessions"`
+}
+
+type workspaceAgentRuntimeRow struct {
+	RuntimeSessionKey string `json:"runtime_session_key"`
+	TargetKey         string `json:"target_key"`
+	Status            string `json:"status"`
+	CreatedAt         string `json:"created_at"`
+	HookObserved      bool   `json:"hook_observed"`
 }
 
 func (s *Server) registerAgentTools() {
@@ -55,13 +64,14 @@ func (s *Server) registerAgentTools() {
 	}, wrapTool(s.listAgentTargets))
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name: "kenn_forge_list_workspace_agent_sessions",
-		Description: "List fresh hook-authoritative coding sessions joined to live agent runtimes for one workspace. " +
-			"This is a live projection, not session history.",
+		Description: "List live agent runtimes and their fresh hook-authoritative coding sessions for one workspace. " +
+			"A runtime with hook_observed=false has launched but has not reported its first hook. This is a live projection, not session history.",
 	}, wrapTool(s.listWorkspaceAgentSessions))
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name: "kenn_forge_spawn_workspace_with_agent",
-		Description: "Create or reuse a workspace, launch one configured coding agent, observe its hook session, " +
-			"and submit exactly one initial message. Partial resources are never cleaned up automatically.",
+		Description: "Create or reuse a workspace, launch one configured coding agent, submit exactly one initial message, " +
+			"and observe the resulting hook session. Resume can continue an existing runtime without launching another agent. " +
+			"Partial resources are never cleaned up automatically.",
 	}, wrapTool(s.spawnWorkspaceWithAgent))
 }
 
@@ -105,15 +115,22 @@ func (s *Server) listWorkspaceAgentSessions(
 	in listWorkspaceAgentSessionsInput,
 ) (listWorkspaceAgentSessionsOutput, error) {
 	workspaceID := strings.TrimSpace(in.WorkspaceID)
+	runtime, err := s.backend.GetWorkspaceRuntime(ctx, workspaceID)
+	if err != nil {
+		return listWorkspaceAgentSessionsOutput{}, err
+	}
 	sessions, err := s.backend.ListWorkspaceAgentSessions(ctx, workspaceID)
 	if err != nil {
 		return listWorkspaceAgentSessionsOutput{}, err
 	}
 	slices.SortFunc(sessions, compareWorkspaceAgentSessions)
 	out := listWorkspaceAgentSessionsOutput{
+		Runtimes: make([]workspaceAgentRuntimeRow, 0),
 		Sessions: make([]workspaceAgentSessionRow, 0, len(sessions)),
 	}
+	observedRuntimeKeys := make(map[string]struct{}, len(sessions))
 	for _, session := range sessions {
+		observedRuntimeKeys[session.RuntimeSessionKey] = struct{}{}
 		row := workspaceAgentSessionRow{
 			Agent:             session.Agent,
 			SessionID:         session.SessionID,
@@ -135,6 +152,25 @@ func (s *Server) listWorkspaceAgentSessions(
 		}
 		out.Sessions = append(out.Sessions, row)
 	}
+	for _, session := range runtime.Sessions {
+		if session.Kind != "agent" || (session.Status != "starting" && session.Status != "running") {
+			continue
+		}
+		_, hookObserved := observedRuntimeKeys[session.Key]
+		out.Runtimes = append(out.Runtimes, workspaceAgentRuntimeRow{
+			RuntimeSessionKey: session.Key,
+			TargetKey:         session.TargetKey,
+			Status:            session.Status,
+			CreatedAt:         formatMCPTime(session.CreatedAt),
+			HookObserved:      hookObserved,
+		})
+	}
+	slices.SortFunc(out.Runtimes, func(a, b workspaceAgentRuntimeRow) int {
+		if order := strings.Compare(a.CreatedAt, b.CreatedAt); order != 0 {
+			return order
+		}
+		return strings.Compare(a.RuntimeSessionKey, b.RuntimeSessionKey)
+	})
 	return out, nil
 }
 

--- a/internal/mcpserver/tools_agent_spawn.go
+++ b/internal/mcpserver/tools_agent_spawn.go
@@ -34,10 +34,16 @@ type adHocWorkspaceSource struct {
 }
 
 type spawnWorkspaceWithAgentInput struct {
-	Source         workspaceSourceInput `json:"source"`
-	AgentTarget    string               `json:"agent_target"`
-	InitialMessage string               `json:"initial_message"`
-	Timeout        string               `json:"timeout,omitempty"`
+	Source         *workspaceSourceInput `json:"source,omitempty"`
+	Resume         *agentHandoffResume   `json:"resume,omitempty"`
+	AgentTarget    string                `json:"agent_target"`
+	InitialMessage string                `json:"initial_message"`
+	Timeout        string                `json:"timeout,omitempty"`
+}
+
+type agentHandoffResume struct {
+	WorkspaceID       string `json:"workspace_id"`
+	RuntimeSessionKey string `json:"runtime_session_key"`
 }
 
 type spawnedWorkspace struct {
@@ -54,12 +60,12 @@ type spawnedRuntime struct {
 }
 
 type spawnWorkspaceWithAgentOutput struct {
-	Stage          string                   `json:"stage"`
-	Source         workspaceSourceInput     `json:"source"`
-	Workspace      spawnedWorkspace         `json:"workspace"`
-	Runtime        spawnedRuntime           `json:"runtime"`
-	CodingSession  workspaceAgentSessionRow `json:"coding_session"`
-	InitialMessage *agentInitialMessageRow  `json:"initial_message,omitempty"`
+	Stage          string                    `json:"stage"`
+	Source         *workspaceSourceInput     `json:"source,omitempty"`
+	Workspace      spawnedWorkspace          `json:"workspace"`
+	Runtime        spawnedRuntime            `json:"runtime"`
+	CodingSession  *workspaceAgentSessionRow `json:"coding_session,omitempty"`
+	InitialMessage *agentInitialMessageRow   `json:"initial_message,omitempty"`
 }
 
 func (s *Server) spawnWorkspaceWithAgent(
@@ -75,66 +81,20 @@ func (s *Server) spawnWorkspaceWithAgent(
 	defer cancel()
 
 	out := spawnWorkspaceWithAgentOutput{Source: in.Source}
-	targets, err := s.listAgentTargets(ctx, listAgentTargetsInput{})
+	workspace, runtime, err := s.prepareAgentHandoff(ctx, in, &out)
 	if err != nil {
-		return out, handoffFailure(ctx, err, out, "", "")
+		return out, err
 	}
-	target, ok := findAgentTarget(targets.Targets, in.AgentTarget)
-	if !ok {
-		return spawnWorkspaceWithAgentOutput{}, fmt.Errorf(
-			"agent_target %q is not a supported coding-agent target", in.AgentTarget,
-		)
-	}
-	if !target.Available {
-		return spawnWorkspaceWithAgentOutput{}, fmt.Errorf(
-			"agent_target %q is unavailable: %s", in.AgentTarget, target.DisabledReason,
-		)
-	}
-
-	workspace, reused, err := s.resolveOrCreateWorkspace(ctx, in.Source)
-	if err != nil {
-		return out, handoffFailure(ctx, err, out, "", "workspace_created")
-	}
-	if in.Source.AdHoc != nil && in.Source.AdHoc.Branch == "" {
-		out.Source.AdHoc.Branch = workspace.GitHeadRef
-	}
-	out.Stage = "workspace_created"
-	out.Workspace = spawnedWorkspace{ID: workspace.ID, Status: workspace.Status, Reused: reused}
-
-	workspace, err = s.waitForWorkspaceReady(ctx, workspace.ID)
-	out.Workspace.Status = workspace.Status
-	if err != nil {
-		return out, handoffFailure(ctx, err, out, "workspace_created", "workspace_ready")
-	}
-	out.Stage = "workspace_ready"
-	out.Workspace.Status = workspace.Status
-
-	runtime, err := s.backend.LaunchWorkspaceRuntime(ctx, workspace.ID, in.AgentTarget)
-	if err != nil {
-		return out, handoffFailure(ctx, err, out, "workspace_ready", "runtime_launched")
-	}
-	out.Stage = "runtime_launched"
-	out.Runtime = spawnedRuntime{
-		SessionKey: runtime.Key,
-		TargetKey:  runtime.TargetKey,
-		Status:     runtime.Status,
-		CreatedAt:  formatMCPTime(runtime.CreatedAt),
-	}
-
-	codingSession, err := s.waitForCodingSession(ctx, workspace.ID, runtime.Key)
-	if err != nil {
-		return out, handoffFailure(ctx, err, out, "runtime_launched", "coding_session_observed")
-	}
-	out.Stage = "coding_session_observed"
-	out.CodingSession = codingSession
 
 	messageStatus, err := s.submitInitialAgentMessage(
-		ctx, workspace.ID, runtime.Key, codingSession, in.InitialMessage,
+		ctx, workspace.ID, runtime.Key, in.AgentTarget, in.InitialMessage,
 	)
-	if err != nil {
-		return out, handoffFailure(ctx, err, out, "coding_session_observed", "message_delivered")
+	if messageStatus.State != "" {
+		out.InitialMessage = &messageStatus
 	}
-	out.InitialMessage = &messageStatus
+	if err != nil {
+		return out, handoffFailure(ctx, err, out, "runtime_launched", "message_delivered")
+	}
 	if messageStatus.State != "delivered" {
 		stateErr := &Error{
 			Kind:      "agent_handoff_failed",
@@ -143,10 +103,19 @@ func (s *Server) spawnWorkspaceWithAgent(
 			Details:   map[string]any{"initial_message_state": messageStatus.State},
 		}
 		return out, handoffFailure(
-			ctx, stateErr, out, "coding_session_observed", "message_delivered",
+			ctx, stateErr, out, "runtime_launched", "message_delivered",
 		)
 	}
 	out.Stage = "message_delivered"
+
+	codingSession, err := s.waitForCodingSession(
+		ctx, workspace.ID, runtime.Key, runtime.TargetKey,
+	)
+	if err != nil {
+		return out, handoffFailure(ctx, err, out, "message_delivered", "coding_session_observed")
+	}
+	out.Stage = "coding_session_observed"
+	out.CodingSession = &codingSession
 	return out, nil
 }
 
@@ -173,6 +142,20 @@ func validateSpawnWorkspaceInput(
 		return in, 0, err
 	}
 	in.InitialMessage = message
+	if (in.Source == nil) == (in.Resume == nil) {
+		return in, 0, fmt.Errorf("provide exactly one of source or resume")
+	}
+	if in.Resume != nil {
+		in.Resume.WorkspaceID = strings.TrimSpace(in.Resume.WorkspaceID)
+		in.Resume.RuntimeSessionKey = strings.TrimSpace(in.Resume.RuntimeSessionKey)
+		if in.Resume.WorkspaceID == "" {
+			return in, 0, fmt.Errorf("resume.workspace_id is required")
+		}
+		if in.Resume.RuntimeSessionKey == "" {
+			return in, 0, fmt.Errorf("resume.runtime_session_key is required")
+		}
+		return in, timeout, nil
+	}
 	in.Source.Type = strings.ToLower(strings.TrimSpace(in.Source.Type))
 	switch in.Source.Type {
 	case "item":
@@ -198,6 +181,122 @@ func validateSpawnWorkspaceInput(
 		return in, 0, fmt.Errorf("source.type must be item or adhoc")
 	}
 	return in, timeout, nil
+}
+
+func (s *Server) prepareAgentHandoff(
+	ctx context.Context,
+	in spawnWorkspaceWithAgentInput,
+	out *spawnWorkspaceWithAgentOutput,
+) (Workspace, RuntimeSession, error) {
+	if in.Resume != nil {
+		return s.resumeAgentHandoff(ctx, in, out)
+	}
+	targets, err := s.listAgentTargets(ctx, listAgentTargetsInput{})
+	if err != nil {
+		return Workspace{}, RuntimeSession{}, handoffFailure(ctx, err, *out, "", "")
+	}
+	target, ok := findAgentTarget(targets.Targets, in.AgentTarget)
+	if !ok {
+		return Workspace{}, RuntimeSession{}, fmt.Errorf(
+			"agent_target %q is not a supported coding-agent target", in.AgentTarget,
+		)
+	}
+	if !target.Available {
+		return Workspace{}, RuntimeSession{}, fmt.Errorf(
+			"agent_target %q is unavailable: %s", in.AgentTarget, target.DisabledReason,
+		)
+	}
+
+	workspace, reused, err := s.resolveOrCreateWorkspace(ctx, *in.Source)
+	if err != nil {
+		return Workspace{}, RuntimeSession{}, handoffFailure(
+			ctx, err, *out, "", "workspace_created",
+		)
+	}
+	if in.Source.AdHoc != nil && in.Source.AdHoc.Branch == "" {
+		out.Source.AdHoc.Branch = workspace.GitHeadRef
+	}
+	out.Stage = "workspace_created"
+	out.Workspace = spawnedWorkspace{ID: workspace.ID, Status: workspace.Status, Reused: reused}
+
+	workspace, err = s.waitForWorkspaceReady(ctx, workspace.ID)
+	out.Workspace.Status = workspace.Status
+	if err != nil {
+		return workspace, RuntimeSession{}, handoffFailure(
+			ctx, err, *out, "workspace_created", "workspace_ready",
+		)
+	}
+	out.Stage = "workspace_ready"
+
+	runtime, err := s.backend.LaunchWorkspaceRuntime(ctx, workspace.ID, in.AgentTarget)
+	if err != nil {
+		return workspace, RuntimeSession{}, handoffFailure(
+			ctx, err, *out, "workspace_ready", "runtime_launched",
+		)
+	}
+	out.Stage = "runtime_launched"
+	out.Runtime = spawnedRuntimeFrom(runtime)
+	return workspace, runtime, nil
+}
+
+func (s *Server) resumeAgentHandoff(
+	ctx context.Context,
+	in spawnWorkspaceWithAgentInput,
+	out *spawnWorkspaceWithAgentOutput,
+) (Workspace, RuntimeSession, error) {
+	workspace, err := s.backend.GetWorkspace(ctx, in.Resume.WorkspaceID)
+	if err != nil {
+		return Workspace{}, RuntimeSession{}, handoffFailure(
+			ctx, err, *out, "", "workspace_ready",
+		)
+	}
+	out.Workspace = spawnedWorkspace{ID: workspace.ID, Status: workspace.Status, Reused: true}
+	if workspace.Status != "ready" {
+		return workspace, RuntimeSession{}, handoffFailure(
+			ctx, fmt.Errorf("workspace is not ready: %s", workspace.Status), *out, "", "workspace_ready",
+		)
+	}
+	out.Stage = "workspace_ready"
+
+	runtimeState, err := s.backend.GetWorkspaceRuntime(ctx, workspace.ID)
+	if err != nil {
+		return workspace, RuntimeSession{}, handoffFailure(
+			ctx, err, *out, "workspace_ready", "runtime_launched",
+		)
+	}
+	for _, runtime := range runtimeState.Sessions {
+		if runtime.Key != in.Resume.RuntimeSessionKey {
+			continue
+		}
+		out.Runtime = spawnedRuntimeFrom(runtime)
+		if runtime.TargetKey != in.AgentTarget {
+			return workspace, runtime, handoffFailure(
+				ctx, fmt.Errorf("agent_target does not match the existing runtime"),
+				*out, "workspace_ready", "runtime_launched",
+			)
+		}
+		if runtime.Kind != "agent" || (runtime.Status != "starting" && runtime.Status != "running") {
+			return workspace, runtime, handoffFailure(
+				ctx, fmt.Errorf("agent runtime is not live"), *out,
+				"workspace_ready", "runtime_launched",
+			)
+		}
+		out.Stage = "runtime_launched"
+		return workspace, runtime, nil
+	}
+	return workspace, RuntimeSession{}, handoffFailure(
+		ctx, fmt.Errorf("agent runtime was not found"), *out,
+		"workspace_ready", "runtime_launched",
+	)
+}
+
+func spawnedRuntimeFrom(runtime RuntimeSession) spawnedRuntime {
+	return spawnedRuntime{
+		SessionKey: runtime.Key,
+		TargetKey:  runtime.TargetKey,
+		Status:     runtime.Status,
+		CreatedAt:  formatMCPTime(runtime.CreatedAt),
+	}
 }
 
 func normalizeSpawnItem(item itemRefInput) (itemRefInput, error) {
@@ -426,6 +525,7 @@ func (s *Server) waitForCodingSession(
 	ctx context.Context,
 	workspaceID string,
 	runtimeSessionKey string,
+	targetKey string,
 ) (workspaceAgentSessionRow, error) {
 	for {
 		response, err := s.listWorkspaceAgentSessions(
@@ -435,7 +535,8 @@ func (s *Server) waitForCodingSession(
 			return workspaceAgentSessionRow{}, err
 		}
 		for _, session := range response.Sessions {
-			if session.RuntimeSessionKey == runtimeSessionKey {
+			if session.RuntimeSessionKey == runtimeSessionKey &&
+				session.TargetKey == targetKey && session.Agent == targetKey {
 				return session, nil
 			}
 		}
@@ -488,22 +589,22 @@ func (s *Server) submitInitialAgentMessage(
 	ctx context.Context,
 	workspaceID string,
 	runtimeSessionKey string,
-	session workspaceAgentSessionRow,
+	targetKey string,
 	message string,
 ) (agentInitialMessageRow, error) {
 	var messageStatus InitialMessageStatus
 	for {
 		status, err := s.backend.SubmitInitialMessage(ctx, InitialMessageRequest{
 			WorkspaceID: workspaceID, RuntimeSessionKey: runtimeSessionKey,
-			Agent: session.Agent, SessionID: session.SessionID, Message: message,
+			TargetKey: targetKey, Message: message,
 		})
+		messageStatus = status
 		if err == nil {
-			messageStatus = status
 			break
 		}
 		var backendErr *Error
 		if !errors.As(err, &backendErr) || backendErr == nil {
-			return agentInitialMessageRow{}, err
+			return initialMessageStatusRow(messageStatus), err
 		}
 		if backendErr.Code == ErrorCodeInitialMessageInputModeNotReady &&
 			backendErr.Retryable && !backendErr.Ambiguous {
@@ -513,23 +614,28 @@ func (s *Server) submitInitialAgentMessage(
 			continue
 		}
 		if !backendErr.Ambiguous {
-			return agentInitialMessageRow{}, err
+			return initialMessageStatusRow(messageStatus), err
 		}
-		messageStatus, err = s.recoverInitialMessageStatus(
+		recoveredStatus, recoveryErr := s.recoverInitialMessageStatus(
 			ctx, workspaceID, runtimeSessionKey, backendErr,
 		)
-		if err != nil {
-			return agentInitialMessageRow{}, err
+		if recoveryErr != nil {
+			return initialMessageStatusRow(messageStatus), recoveryErr
 		}
+		messageStatus = recoveredStatus
 		break
 	}
+	return initialMessageStatusRow(messageStatus), nil
+}
+
+func initialMessageStatusRow(messageStatus InitialMessageStatus) agentInitialMessageRow {
 	row := agentInitialMessageRow{
 		State: messageStatus.State, MessageBytes: messageStatus.MessageBytes,
 	}
 	if messageStatus.DeliveredAt != nil {
 		row.DeliveredAt = formatMCPTime(*messageStatus.DeliveredAt)
 	}
-	return row, nil
+	return row
 }
 
 func (s *Server) recoverInitialMessageStatus(
@@ -615,7 +721,7 @@ func handoffFailure(
 		result.Details["runtime_session_key"] = state.Runtime.SessionKey
 		result.Details["target_key"] = state.Runtime.TargetKey
 	}
-	if state.CodingSession.SessionID != "" {
+	if state.CodingSession != nil {
 		result.Details["agent"] = state.CodingSession.Agent
 		result.Details["session_id"] = state.CodingSession.SessionID
 	}

--- a/internal/mcpserver/tools_agent_spawn_test.go
+++ b/internal/mcpserver/tools_agent_spawn_test.go
@@ -33,8 +33,7 @@ func TestSpawnWorkspaceWithAgentCallsDirectServicesAndUsesAuthoritativeEvidence(
 	backend.submitInitialMessageFn = func(_ context.Context, req InitialMessageRequest) (InitialMessageStatus, error) {
 		assert.Equal(InitialMessageRequest{
 			WorkspaceID: "ws-new", RuntimeSessionKey: "runtime-new",
-			Agent: "codex", SessionID: "coding-new",
-			Message: "review this\nthen implement",
+			TargetKey: "codex", Message: "review this\nthen implement",
 		}, req)
 		deliveredAt := time.Date(2026, 8, 7, 15, 0, 2, 0, time.UTC)
 		return InitialMessageStatus{State: "delivered", MessageBytes: 26, DeliveredAt: &deliveredAt}, nil
@@ -42,7 +41,7 @@ func TestSpawnWorkspaceWithAgentCallsDirectServicesAndUsesAuthoritativeEvidence(
 	s := newMCPTestServer(t, backend)
 
 	out, err := s.spawnWorkspaceWithAgent(t.Context(), spawnWorkspaceWithAgentInput{
-		Source: workspaceSourceInput{Type: "item", Item: &itemRefInput{
+		Source: &workspaceSourceInput{Type: "item", Item: &itemRefInput{
 			Type: "pr", Provider: "github", PlatformHost: "github.com",
 			PlatformRepoID: "repo-acme-widget",
 			Owner:          "acme", Name: "widget", Number: 42,
@@ -51,15 +50,150 @@ func TestSpawnWorkspaceWithAgentCallsDirectServicesAndUsesAuthoritativeEvidence(
 	})
 
 	require.NoError(err)
-	assert.Equal("message_delivered", out.Stage)
+	assert.Equal("coding_session_observed", out.Stage)
 	assert.Equal("delivered", out.InitialMessage.State)
 	assert.Equal("ws-new", out.Workspace.ID)
 	assert.False(out.Workspace.Reused)
 	assert.Equal("runtime-new", out.Runtime.SessionKey)
+	require.NotNil(out.CodingSession)
 	assert.Equal("coding-new", out.CodingSession.SessionID)
 	raw, err := json.Marshal(out)
 	require.NoError(err)
 	assert.NotContains(string(raw), `"message_delivered":`)
+}
+
+func TestSpawnWorkspaceWithAgentSubmitsPromptBeforeHookObservation(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	backend := successfulSpawnBackend("ws-prompt-first", "runtime-prompt-first", "coding-prompt-first")
+	promptSubmitted := false
+	backend.listWorkspaceAgentSessionsFn = func(context.Context, string) ([]WorkspaceAgentSession, error) {
+		if !promptSubmitted {
+			return nil, nil
+		}
+		return []WorkspaceAgentSession{{
+			Agent: "codex", SessionID: "coding-prompt-first",
+			RuntimeSessionKey: "runtime-prompt-first", TargetKey: "codex",
+			State: "working", UpdatedAt: time.Now().UTC(),
+		}}, nil
+	}
+	backend.submitInitialMessageFn = func(_ context.Context, req InitialMessageRequest) (InitialMessageStatus, error) {
+		assert.Equal("codex", req.TargetKey)
+		promptSubmitted = true
+		return InitialMessageStatus{State: "delivered", MessageBytes: 5}, nil
+	}
+	s := newMCPTestServer(t, backend)
+
+	out, err := s.spawnWorkspaceWithAgent(t.Context(), prSpawnInput("start"))
+
+	require.NoError(err)
+	assert.True(promptSubmitted)
+	assert.Equal("coding_session_observed", out.Stage)
+	require.NotNil(out.CodingSession)
+	assert.Equal("coding-prompt-first", out.CodingSession.SessionID)
+}
+
+func TestSpawnWorkspaceWithAgentResumesExistingRuntimeAfterHookTimeout(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	backend := successfulSpawnBackend("ws-resume", "runtime-resume", "coding-resume")
+	launches := 0
+	deliveries := 0
+	submissions := 0
+	hookVisible := false
+	backend.launchWorkspaceRuntimeFn = func(context.Context, string, string) (RuntimeSession, error) {
+		launches++
+		return RuntimeSession{
+			Key: "runtime-resume", TargetKey: "codex", Kind: "agent", Status: "running",
+			CreatedAt: time.Date(2026, 8, 7, 15, 0, 0, 0, time.UTC),
+		}, nil
+	}
+	backend.submitInitialMessageFn = func(context.Context, InitialMessageRequest) (InitialMessageStatus, error) {
+		submissions++
+		if deliveries == 0 {
+			deliveries++
+		}
+		return InitialMessageStatus{State: "delivered", MessageBytes: 5}, nil
+	}
+	backend.listWorkspaceAgentSessionsFn = func(context.Context, string) ([]WorkspaceAgentSession, error) {
+		if !hookVisible {
+			return nil, nil
+		}
+		return []WorkspaceAgentSession{{
+			Agent: "codex", SessionID: "coding-resume",
+			RuntimeSessionKey: "runtime-resume", TargetKey: "codex",
+			State: "working", UpdatedAt: time.Now().UTC(),
+		}}, nil
+	}
+	s := newMCPTestServer(t, backend)
+	first := prSpawnInput("start")
+	first.Timeout = "20ms"
+
+	_, err := s.spawnWorkspaceWithAgent(t.Context(), first)
+	var timeoutErr *Error
+	require.ErrorAs(err, &timeoutErr)
+	assert.Equal("message_delivered", timeoutErr.Details["last_completed_stage"])
+	assert.Equal("coding_session_observed", timeoutErr.Details["failed_stage"])
+	assert.Equal("delivered", timeoutErr.Details["initial_message_state"])
+
+	hookVisible = true
+	out, err := s.spawnWorkspaceWithAgent(t.Context(), spawnWorkspaceWithAgentInput{
+		Resume: &agentHandoffResume{
+			WorkspaceID: "ws-resume", RuntimeSessionKey: "runtime-resume",
+		},
+		AgentTarget: "codex", InitialMessage: "start", Timeout: "2s",
+	})
+
+	require.NoError(err)
+	assert.Equal("coding_session_observed", out.Stage)
+	assert.Equal(1, launches)
+	assert.Equal(2, submissions)
+	assert.Equal(1, deliveries)
+}
+
+func TestSpawnWorkspaceWithAgentResumesPromptSubmissionOnExistingRuntime(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	backend := successfulSpawnBackend("ws-submit-resume", "runtime-submit-resume", "coding-submit-resume")
+	launches := 0
+	inputReady := false
+	backend.launchWorkspaceRuntimeFn = func(context.Context, string, string) (RuntimeSession, error) {
+		launches++
+		return RuntimeSession{
+			Key: "runtime-submit-resume", TargetKey: "codex", Kind: "agent", Status: "running",
+			CreatedAt: time.Date(2026, 8, 7, 15, 0, 0, 0, time.UTC),
+		}, nil
+	}
+	backend.submitInitialMessageFn = func(context.Context, InitialMessageRequest) (InitialMessageStatus, error) {
+		if !inputReady {
+			return InitialMessageStatus{}, &Error{
+				Kind: "unavailable", Code: ErrorCodeInitialMessageInputModeNotReady,
+				Message: "agent terminal input mode is not ready", Retryable: true,
+			}
+		}
+		return InitialMessageStatus{State: "delivered", MessageBytes: 5}, nil
+	}
+	s := newMCPTestServer(t, backend)
+	first := prSpawnInput("start")
+	first.Timeout = "20ms"
+
+	_, err := s.spawnWorkspaceWithAgent(t.Context(), first)
+	var timeoutErr *Error
+	require.ErrorAs(err, &timeoutErr)
+	assert.Equal("runtime_launched", timeoutErr.Details["last_completed_stage"])
+	assert.Equal("message_delivered", timeoutErr.Details["failed_stage"])
+
+	inputReady = true
+	out, err := s.spawnWorkspaceWithAgent(t.Context(), spawnWorkspaceWithAgentInput{
+		Resume: &agentHandoffResume{
+			WorkspaceID: "ws-submit-resume", RuntimeSessionKey: "runtime-submit-resume",
+		},
+		AgentTarget: "codex", InitialMessage: "start", Timeout: "2s",
+	})
+
+	require.NoError(err)
+	assert.Equal("coding_session_observed", out.Stage)
+	assert.Equal(1, launches)
 }
 
 func TestSpawnWorkspaceWithAgentReusesWorkspaceAndLaunchesFreshRuntime(t *testing.T) {
@@ -168,7 +302,7 @@ func TestSpawnWorkspaceWithAgentCreatesIssueAndAdHocWorkspaces(t *testing.T) {
 		s := newMCPTestServer(t, backend)
 
 		out, err := s.spawnWorkspaceWithAgent(t.Context(), spawnWorkspaceWithAgentInput{
-			Source: workspaceSourceInput{Type: "item", Item: &itemRefInput{
+			Source: &workspaceSourceInput{Type: "item", Item: &itemRefInput{
 				Type: "issue", Provider: "github", PlatformRepoID: "repo-acme-widget",
 				Owner: "acme", Name: "widget", Number: 7,
 			}},
@@ -191,7 +325,7 @@ func TestSpawnWorkspaceWithAgentCreatesIssueAndAdHocWorkspaces(t *testing.T) {
 		s := newMCPTestServer(t, backend)
 
 		out, err := s.spawnWorkspaceWithAgent(t.Context(), spawnWorkspaceWithAgentInput{
-			Source: workspaceSourceInput{Type: "adhoc", AdHoc: &adHocWorkspaceSource{
+			Source: &workspaceSourceInput{Type: "adhoc", AdHoc: &adHocWorkspaceSource{
 				Repo: repoFilterInput{
 					Provider: "github", PlatformRepoID: "repo-acme-widget",
 					Owner: "acme", Name: "widget",
@@ -223,7 +357,7 @@ func TestSpawnWorkspaceWithAgentRetriesMultilineMessageUntilInputModeIsReady(t *
 	out, err := s.spawnWorkspaceWithAgent(t.Context(), prSpawnInput("first\nsecond"))
 
 	require.NoError(t, err)
-	assert.Equal("message_delivered", out.Stage)
+	assert.Equal("coding_session_observed", out.Stage)
 	assert.Equal("delivered", out.InitialMessage.State)
 	assert.Equal(3, messagePosts)
 }
@@ -249,7 +383,7 @@ func TestSpawnWorkspaceWithAgentRecoversAmbiguousMessageFromSameBackend(t *testi
 	out, err := s.spawnWorkspaceWithAgent(t.Context(), prSpawnInput("start"))
 
 	require.NoError(t, err)
-	assert.Equal("message_delivered", out.Stage)
+	assert.Equal("coding_session_observed", out.Stage)
 	assert.Equal("delivered", out.InitialMessage.State)
 	assert.Equal(1, messagePosts)
 	assert.Equal(1, statusReads)
@@ -276,14 +410,16 @@ func TestSpawnWorkspaceWithAgentKeepsUncertainRecoveryAmbiguous(t *testing.T) {
 	assert := assert.New(t)
 	backend := successfulSpawnBackend("ws-recovery", "runtime-recovery", "coding-recovery")
 	backend.submitInitialMessageFn = func(context.Context, InitialMessageRequest) (InitialMessageStatus, error) {
-		return InitialMessageStatus{}, &Error{Kind: "internal_error", Message: "result unknown", Ambiguous: true}
+		return InitialMessageStatus{State: "uncertain", MessageBytes: 5}, &Error{
+			Kind: "internal_error", Message: "result unknown", Ambiguous: true,
+		}
 	}
 	backend.getInitialMessageFn = func(context.Context, string, string) (InitialMessageStatus, error) {
 		return InitialMessageStatus{State: "uncertain", MessageBytes: 5}, nil
 	}
 	s := newMCPTestServer(t, backend)
 
-	_, err := s.spawnWorkspaceWithAgent(t.Context(), prSpawnInput("start"))
+	out, err := s.spawnWorkspaceWithAgent(t.Context(), prSpawnInput("start"))
 
 	var backendErr *Error
 	require.ErrorAs(t, err, &backendErr)
@@ -291,6 +427,8 @@ func TestSpawnWorkspaceWithAgentKeepsUncertainRecoveryAmbiguous(t *testing.T) {
 	assert.Equal("uncertain", backendErr.Details["initial_message_state"])
 	assert.Equal("message_delivered", backendErr.Details["failed_stage"])
 	assert.NotContains(backendErr.Details, "message_delivered")
+	require.NotNil(t, out.InitialMessage)
+	assert.Equal("uncertain", out.InitialMessage.State)
 }
 
 func TestSpawnWorkspaceWithAgentReportsRuntimeExitBeforeHookSession(t *testing.T) {
@@ -305,7 +443,7 @@ func TestSpawnWorkspaceWithAgentReportsRuntimeExitBeforeHookSession(t *testing.T
 	messagePosts := 0
 	backend.submitInitialMessageFn = func(context.Context, InitialMessageRequest) (InitialMessageStatus, error) {
 		messagePosts++
-		return InitialMessageStatus{}, nil
+		return InitialMessageStatus{State: "delivered", MessageBytes: 5}, nil
 	}
 	s := newMCPTestServer(t, backend)
 
@@ -315,7 +453,7 @@ func TestSpawnWorkspaceWithAgentReportsRuntimeExitBeforeHookSession(t *testing.T
 	require.ErrorAs(t, err, &backendErr)
 	assert.Equal("coding_session_observed", backendErr.Details["failed_stage"])
 	assert.Contains(backendErr.Message, "runtime exited")
-	assert.Equal(0, messagePosts)
+	assert.Equal(1, messagePosts)
 }
 
 func TestSpawnWorkspaceWithAgentRejectsInvalidInputBeforeBackendCalls(t *testing.T) {
@@ -328,7 +466,7 @@ func TestSpawnWorkspaceWithAgentRejectsInvalidInputBeforeBackendCalls(t *testing
 	inputs := []spawnWorkspaceWithAgentInput{
 		{AgentTarget: "codex", InitialMessage: "start", Timeout: "16m"},
 		{
-			Source: workspaceSourceInput{Type: "item", Item: &itemRefInput{
+			Source: &workspaceSourceInput{Type: "item", Item: &itemRefInput{
 				Type: "pr", Provider: "github", PlatformRepoID: "repo-acme-widget",
 				Owner: "acme", Name: "widget", Number: 42,
 			}},
@@ -363,7 +501,7 @@ func successfulSpawnBackend(workspaceID, runtimeKey, codingSessionID string) *fa
 			return RuntimeSession{}, errors.New("unexpected runtime launch")
 		}
 		return RuntimeSession{
-			Key: runtimeKey, TargetKey: "codex", Status: "running",
+			Key: runtimeKey, TargetKey: "codex", Kind: "agent", Status: "running",
 			CreatedAt: time.Date(2026, 8, 7, 15, 0, 0, 0, time.UTC),
 		}, nil
 	}
@@ -375,7 +513,9 @@ func successfulSpawnBackend(workspaceID, runtimeKey, codingSessionID string) *fa
 		}}, nil
 	}
 	backend.getWorkspaceRuntimeFn = func(context.Context, string) (WorkspaceRuntime, error) {
-		return WorkspaceRuntime{Sessions: []RuntimeSession{{Key: runtimeKey, Status: "running"}}}, nil
+		return WorkspaceRuntime{Sessions: []RuntimeSession{{
+			Key: runtimeKey, TargetKey: "codex", Kind: "agent", Status: "running",
+		}}}, nil
 	}
 	backend.submitInitialMessageFn = func(_ context.Context, req InitialMessageRequest) (InitialMessageStatus, error) {
 		return InitialMessageStatus{State: "delivered", MessageBytes: len(req.Message)}, nil
@@ -385,7 +525,7 @@ func successfulSpawnBackend(workspaceID, runtimeKey, codingSessionID string) *fa
 
 func prSpawnInput(message string) spawnWorkspaceWithAgentInput {
 	return spawnWorkspaceWithAgentInput{
-		Source: workspaceSourceInput{Type: "item", Item: &itemRefInput{
+		Source: &workspaceSourceInput{Type: "item", Item: &itemRefInput{
 			Type: "pr", Provider: "github", PlatformRepoID: "repo-acme-widget",
 			Owner: "acme", Name: "widget", Number: 42,
 		}},

--- a/internal/mcpserver/tools_agent_test.go
+++ b/internal/mcpserver/tools_agent_test.go
@@ -61,6 +61,18 @@ func TestListWorkspaceAgentSessionsMapsLiveProjectionDeterministically(t *testin
 			},
 		}, nil
 	}}
+	backend.getWorkspaceRuntimeFn = func(context.Context, string) (WorkspaceRuntime, error) {
+		return WorkspaceRuntime{Sessions: []RuntimeSession{
+			{
+				Key: "runtime-b", TargetKey: "codex", Kind: "agent", Status: "running",
+				CreatedAt: time.Date(2026, 8, 7, 13, 0, 0, 0, time.UTC),
+			},
+			{
+				Key: "runtime-a", TargetKey: "claude", Kind: "agent", Status: "running",
+				CreatedAt: time.Date(2026, 8, 7, 14, 0, 0, 0, time.UTC),
+			},
+		}}, nil
+	}
 	s := newMCPTestServer(t, backend)
 
 	out, err := s.listWorkspaceAgentSessions(
@@ -75,4 +87,37 @@ func TestListWorkspaceAgentSessionsMapsLiveProjectionDeterministically(t *testin
 	assert.Equal("delivered", out.Sessions[0].InitialMessage.State)
 	assert.Equal("2026-08-07T14:59:01Z", out.Sessions[0].InitialMessage.DeliveredAt)
 	assert.Equal("codex", out.Sessions[1].Agent)
+	require.Len(out.Runtimes, 2)
+	assert.True(out.Runtimes[0].HookObserved)
+	assert.True(out.Runtimes[1].HookObserved)
+}
+
+func TestListWorkspaceAgentSessionsShowsRuntimeBeforeFirstHook(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	backend := &fakeBackend{
+		getWorkspaceRuntimeFn: func(context.Context, string) (WorkspaceRuntime, error) {
+			return WorkspaceRuntime{Sessions: []RuntimeSession{
+				{
+					Key: "runtime-waiting", TargetKey: "codex", Kind: "agent", Status: "running",
+					CreatedAt: time.Date(2026, 8, 7, 15, 0, 0, 0, time.UTC),
+				},
+				{Key: "shell", TargetKey: "shell", Kind: "shell", Status: "running"},
+			}}, nil
+		},
+		listWorkspaceAgentSessionsFn: func(context.Context, string) ([]WorkspaceAgentSession, error) {
+			return nil, nil
+		},
+	}
+	s := newMCPTestServer(t, backend)
+
+	out, err := s.listWorkspaceAgentSessions(
+		t.Context(), listWorkspaceAgentSessionsInput{WorkspaceID: "ws-1"},
+	)
+
+	require.NoError(err)
+	require.Len(out.Runtimes, 1)
+	assert.Equal("runtime-waiting", out.Runtimes[0].RuntimeSessionKey)
+	assert.False(out.Runtimes[0].HookObserved)
+	assert.Empty(out.Sessions)
 }

--- a/internal/server/mcp_backend.go
+++ b/internal/server/mcp_backend.go
@@ -548,7 +548,7 @@ func (b mcpBackend) LaunchWorkspaceRuntime(
 	}
 	return mcpserver.RuntimeSession{
 		Key: session.Key, TargetKey: session.TargetKey,
-		Status: string(session.Status), CreatedAt: session.CreatedAt,
+		Kind: string(session.Kind), Status: string(session.Status), CreatedAt: session.CreatedAt,
 	}, nil
 }
 
@@ -563,7 +563,7 @@ func (b mcpBackend) GetWorkspaceRuntime(
 	for _, session := range result.Sessions {
 		out.Sessions = append(out.Sessions, mcpserver.RuntimeSession{
 			Key: session.Key, TargetKey: session.TargetKey,
-			Status: string(session.Status), CreatedAt: session.CreatedAt,
+			Kind: string(session.Kind), Status: string(session.Status), CreatedAt: session.CreatedAt,
 		})
 	}
 	return out, nil
@@ -574,7 +574,7 @@ func (b mcpBackend) SubmitInitialMessage(
 ) (mcpserver.InitialMessageStatus, error) {
 	result, err := b.server.workspaceAPI.SubmitInitialMessageService(ctx, workspaceapi.InitialMessageRequest{
 		WorkspaceID: req.WorkspaceID, RuntimeSessionKey: req.RuntimeSessionKey,
-		Agent: req.Agent, SessionID: req.SessionID, Message: req.Message,
+		TargetKey: req.TargetKey, Message: req.Message,
 	})
 	status := *mcpInitialMessage(result)
 	if errors.Is(err, workspaceapi.ErrInitialMessageInputModeNotReady) {

--- a/internal/server/mcp_backend_test.go
+++ b/internal/server/mcp_backend_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.kenn.io/forge/internal/agentactivity"
 	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/mcpserver"
 	"go.kenn.io/forge/internal/server/httpapi"
@@ -97,19 +96,14 @@ func TestMCPBackendTranslatesInactivePasteModeToRetryableError(t *testing.T) {
 	t.Cleanup(runtime.Shutdown)
 	session, err := runtime.Launch(ctx, workspaceID, worktree, "codex")
 	require.NoError(err)
-	activity := agentactivity.NewStore(t.TempDir())
-	require.NoError(activity.HandleEvent("codex", agentactivity.HookEvent{
-		SessionID: "coding-session", CWD: worktree,
-		HookEventName: "UserPromptSubmit",
-	}, session.Key))
 	srv := &Server{workspaceAPI: workspaceapi.New(workspaceapi.Deps{
 		DB: database, Workspaces: workspace.NewManager(database, t.TempDir()),
-		Runtime: runtime, AgentActivity: activity,
+		Runtime: runtime,
 	})}
 
 	_, err = srv.MCPBackend().SubmitInitialMessage(ctx, mcpserver.InitialMessageRequest{
 		WorkspaceID: workspaceID, RuntimeSessionKey: session.Key,
-		Agent: "codex", SessionID: "coding-session", Message: "first\nsecond",
+		TargetKey: "codex", Message: "first\nsecond",
 	})
 
 	var backendErr *mcpserver.Error

--- a/internal/server/workspaceapi/agent_sessions.go
+++ b/internal/server/workspaceapi/agent_sessions.go
@@ -17,8 +17,7 @@ type listWorkspaceAgentSessionsInput struct {
 }
 
 type agentInitialMessageStatusResponse struct {
-	Agent        string     `json:"agent"`
-	SessionID    string     `json:"session_id"`
+	TargetKey    string     `json:"target_key"`
 	State        string     `json:"state"`
 	MessageBytes int        `json:"message_bytes"`
 	ReservedAt   time.Time  `json:"reserved_at"`
@@ -110,7 +109,7 @@ func (s *Handler) ListWorkspaceAgentSessionsService(
 		}
 		if attempt, found := s.initialMessageAttempt(
 			summary.ID, report.RuntimeSessionKey,
-		); found && attempt.Agent == string(agent) && attempt.SessionID == report.SessionID {
+		); found && attempt.TargetKey == live.TargetKey && report.Agent == live.TargetKey {
 			message := initialMessageAttemptResult(attempt)
 			result.InitialMessage = &message
 		}
@@ -133,7 +132,7 @@ func (s *Handler) ListWorkspaceAgentSessionsService(
 
 func initialMessageAttemptResult(attempt initialMessageAttempt) InitialMessageResult {
 	result := InitialMessageResult{
-		Agent: attempt.Agent, SessionID: attempt.SessionID, State: attempt.State,
+		TargetKey: attempt.TargetKey, State: attempt.State,
 		MessageBytes: len(attempt.Message), ReservedAt: attempt.ReservedAt.UTC(),
 	}
 	if attempt.DeliveredAt != nil {
@@ -145,7 +144,7 @@ func initialMessageAttemptResult(attempt initialMessageAttempt) InitialMessageRe
 
 func initialMessageResultResponse(result InitialMessageResult) *agentInitialMessageStatusResponse {
 	return &agentInitialMessageStatusResponse{
-		Agent: result.Agent, SessionID: result.SessionID, State: result.State,
+		TargetKey: result.TargetKey, State: result.State,
 		MessageBytes: result.MessageBytes, ReservedAt: result.ReservedAt,
 		DeliveredAt: result.DeliveredAt,
 	}

--- a/internal/server/workspaceapi/agent_sessions_test.go
+++ b/internal/server/workspaceapi/agent_sessions_test.go
@@ -110,7 +110,7 @@ func TestListWorkspaceAgentSessionsProjectsOnlySupportedLiveAgentReports(t *test
 	})
 	_, reserved := handler.reserveInitialMessageAttempt(
 		workspaceID, agentRuntime.Key,
-		initialMessageAttempt{Agent: "codex", SessionID: "shared-session", Message: "review this!"},
+		initialMessageAttempt{TargetKey: "codex", Message: "review this!"},
 	)
 	require.True(reserved)
 	handler.finishInitialMessageAttempt(workspaceID, agentRuntime.Key, initialMessageDelivered)

--- a/internal/server/workspaceapi/initial_message.go
+++ b/internal/server/workspaceapi/initial_message.go
@@ -11,7 +11,6 @@ import (
 
 	"go.kenn.io/forge/internal/server/httpapi"
 	"go.kenn.io/forge/internal/workspace/localruntime"
-	"go.kenn.io/kit/agenthook"
 )
 
 const maxInitialAgentMessageBytes = 64 << 10
@@ -33,8 +32,7 @@ type initialMessageKey struct {
 // is retained only so retries against this daemon can be compared without
 // exposing prompt content through the API. Daemon restart clears all attempts.
 type initialMessageAttempt struct {
-	Agent       string
-	SessionID   string
+	TargetKey   string
 	Message     string
 	State       string
 	ReservedAt  time.Time
@@ -50,8 +48,7 @@ type submitInitialMessageInput struct {
 	ID         string `path:"id"`
 	SessionKey string `path:"session_key"`
 	Body       struct {
-		Agent     string `json:"agent"`
-		SessionID string `json:"session_id"`
+		TargetKey string `json:"target_key"`
 		Message   string `json:"message"`
 	}
 }
@@ -98,8 +95,7 @@ func (s *Handler) submitInitialMessage(
 ) (*initialMessageOutput, error) {
 	result, err := s.SubmitInitialMessageService(ctx, InitialMessageRequest{
 		WorkspaceID: input.ID, RuntimeSessionKey: input.SessionKey,
-		Agent: input.Body.Agent, SessionID: input.Body.SessionID,
-		Message: input.Body.Message,
+		TargetKey: input.Body.TargetKey, Message: input.Body.Message,
 	})
 	if errors.Is(err, ErrInitialMessageInputModeNotReady) {
 		return nil, httpapi.Validation("body.message", err.Error())
@@ -125,22 +121,18 @@ func (s *Handler) GetInitialMessageService(
 func (s *Handler) SubmitInitialMessageService(
 	ctx context.Context, req InitialMessageRequest,
 ) (InitialMessageResult, error) {
-	if s.workspaces == nil || s.runtime == nil || s.agentActivity == nil {
+	if s.workspaces == nil || s.runtime == nil {
 		return InitialMessageResult{}, httpapi.ServiceUnavailable("initial message delivery not configured")
 	}
-	agent, err := agenthook.ParseAgent(req.Agent)
-	if err != nil {
-		return InitialMessageResult{}, httpapi.Validation("body.agent", err.Error())
-	}
-	sessionID := strings.TrimSpace(req.SessionID)
-	if sessionID == "" {
-		return InitialMessageResult{}, httpapi.Validation("body.session_id", "session_id is required")
+	targetKey := strings.ToLower(strings.TrimSpace(req.TargetKey))
+	if targetKey == "" {
+		return InitialMessageResult{}, httpapi.Validation("body.target_key", "target_key is required")
 	}
 	message, _, err := normalizeInitialAgentMessage(req.Message)
 	if err != nil {
 		return InitialMessageResult{}, httpapi.Validation("body.message", err.Error())
 	}
-	proposed := initialMessageAttempt{Agent: string(agent), SessionID: sessionID, Message: message}
+	proposed := initialMessageAttempt{TargetKey: targetKey, Message: message}
 	if existing, ok := s.initialMessageAttempt(req.WorkspaceID, req.RuntimeSessionKey); ok {
 		return existingInitialMessageAttemptResult(existing, proposed)
 	}
@@ -153,33 +145,24 @@ func (s *Handler) SubmitInitialMessageService(
 			httpapi.CodeWorkspaceNotFound, "workspace not found", nil,
 		)
 	}
-	live := false
+	liveTarget := ""
 	for _, runtimeSession := range s.runtime.ListSessions(req.WorkspaceID) {
 		if runtimeSession.Key == req.RuntimeSessionKey &&
 			runtimeSession.Kind == localruntime.LaunchTargetAgent &&
 			(runtimeSession.Status == localruntime.SessionStatusStarting ||
 				runtimeSession.Status == localruntime.SessionStatusRunning) {
-			live = true
+			liveTarget = strings.ToLower(strings.TrimSpace(runtimeSession.TargetKey))
 			break
 		}
 	}
-	if !live {
+	if liveTarget == "" {
 		return InitialMessageResult{}, httpapi.Conflict(
 			httpapi.CodeConflict, "agent runtime session is not live", nil,
 		)
 	}
-	matchedReport := false
-	for _, report := range s.agentActivity.LiveReportsForWorkspace(
-		summary.WorktreePath, []string{req.RuntimeSessionKey},
-	) {
-		if report.Agent == string(agent) && report.SessionID == sessionID {
-			matchedReport = true
-			break
-		}
-	}
-	if !matchedReport {
+	if liveTarget != targetKey {
 		return InitialMessageResult{}, httpapi.Conflict(
-			httpapi.CodeConflict, "coding session does not match the live agent runtime", nil,
+			httpapi.CodeConflict, "target_key does not match the live agent runtime", nil,
 		)
 	}
 	attempt, reserved := s.reserveInitialMessageAttempt(req.WorkspaceID, req.RuntimeSessionKey, proposed)
@@ -223,8 +206,7 @@ func existingInitialMessageAttemptResult(
 	existing initialMessageAttempt,
 	proposed initialMessageAttempt,
 ) (InitialMessageResult, error) {
-	if existing.Agent != proposed.Agent ||
-		existing.SessionID != proposed.SessionID ||
+	if existing.TargetKey != proposed.TargetKey ||
 		existing.Message != proposed.Message {
 		return initialMessageAttemptConflict(existing)
 	}
@@ -238,8 +220,7 @@ func initialMessageAttemptConflict(
 		httpapi.CodeConflict,
 		"an initial message attempt already exists for this runtime session",
 		map[string]any{
-			"agent":         existing.Agent,
-			"session_id":    existing.SessionID,
+			"target_key":    existing.TargetKey,
 			"message_bytes": len(existing.Message),
 			"state":         existing.State,
 		},
@@ -292,7 +273,7 @@ func (s *Handler) releaseInitialMessageAttempt(
 	}
 	existing, ok := s.initialMessages[key]
 	if ok && existing.State == initialMessagePending &&
-		existing.Agent == proposed.Agent && existing.SessionID == proposed.SessionID &&
+		existing.TargetKey == proposed.TargetKey &&
 		existing.Message == proposed.Message {
 		delete(s.initialMessages, key)
 	}

--- a/internal/server/workspaceapi/initial_message_test.go
+++ b/internal/server/workspaceapi/initial_message_test.go
@@ -71,7 +71,7 @@ func TestInitialMessageSubmitFailureReleasesPreWriteAttempt(t *testing.T) {
 		return time.Date(2026, 8, 18, 17, 0, 0, 0, time.UTC)
 	}})
 	proposed := initialMessageAttempt{
-		Agent: "codex", SessionID: "coding-session", Message: "review this",
+		TargetKey: "codex", Message: "review this",
 	}
 	_, reserved := handler.reserveInitialMessageAttempt("ws-1", "runtime-1", proposed)
 	require.True(reserved)
@@ -96,7 +96,7 @@ func TestInitialMessageInactivePasteModeReturnsRetryableServiceSignal(t *testing
 		return time.Date(2026, 8, 18, 17, 0, 0, 0, time.UTC)
 	}})
 	proposed := initialMessageAttempt{
-		Agent: "codex", SessionID: "coding-session", Message: "first\nsecond",
+		TargetKey: "codex", Message: "first\nsecond",
 	}
 	_, reserved := handler.reserveInitialMessageAttempt("ws-1", "runtime-1", proposed)
 	require.True(reserved)
@@ -157,10 +157,10 @@ func TestSubmitInitialMessageServiceReturnsDeliveredStateAndRoutesShareAttempt(t
 	handler.Register(api)
 	endpoint := "/api/v1/workspaces/" + workspaceID +
 		"/runtime/sessions/" + session.Key + "/initial-message"
-	postContext := func(requestContext context.Context, target, agent, codingSession, message string) *httptest.ResponseRecorder {
+	postContext := func(requestContext context.Context, target, targetKey, message string) *httptest.ResponseRecorder {
 		t.Helper()
 		body, marshalErr := json.Marshal(map[string]string{
-			"agent": agent, "session_id": codingSession, "message": message,
+			"target_key": targetKey, "message": message,
 		})
 		require.NoError(marshalErr)
 		request := httptest.NewRequest(http.MethodPost, target, bytes.NewReader(body)).WithContext(requestContext)
@@ -169,9 +169,9 @@ func TestSubmitInitialMessageServiceReturnsDeliveredStateAndRoutesShareAttempt(t
 		mux.ServeHTTP(recorder, request)
 		return recorder
 	}
-	post := func(target, agent, codingSession, message string) *httptest.ResponseRecorder {
+	post := func(target, targetKey, message string) *httptest.ResponseRecorder {
 		t.Helper()
-		return postContext(ctx, target, agent, codingSession, message)
+		return postContext(ctx, target, targetKey, message)
 	}
 
 	requestContext, cancelRequest := context.WithCancel(ctx)
@@ -183,7 +183,7 @@ func TestSubmitInitialMessageServiceReturnsDeliveredStateAndRoutesShareAttempt(t
 			requestContext,
 			InitialMessageRequest{
 				WorkspaceID: workspaceID, RuntimeSessionKey: session.Key,
-				Agent: "CoDeX", SessionID: "coding-session", Message: "review this",
+				TargetKey: "CoDeX", Message: "review this",
 			},
 		)
 		if errors.Is(submitErr, ErrInitialMessageInputModeNotReady) {
@@ -198,29 +198,27 @@ func TestSubmitInitialMessageServiceReturnsDeliveredStateAndRoutesShareAttempt(t
 	require.NotNil(serviceStatus.DeliveredAt)
 	assert.Equal("\x1b[200~review this\x1b[201~\r", string(owner.pty.written()))
 
-	response := post(endpoint, "codex", "coding-session", "review this")
+	response := post(endpoint, "codex", "review this")
 	require.Equal(http.StatusOK, response.Code, response.Body.String())
 	var messageStatus struct {
-		Agent        string     `json:"agent"`
-		SessionID    string     `json:"session_id"`
+		TargetKey    string     `json:"target_key"`
 		State        string     `json:"state"`
 		MessageBytes int        `json:"message_bytes"`
 		DeliveredAt  *time.Time `json:"delivered_at"`
 	}
 	require.NoError(json.NewDecoder(response.Body).Decode(&messageStatus))
-	assert.Equal("codex", messageStatus.Agent)
-	assert.Equal("coding-session", messageStatus.SessionID)
+	assert.Equal("codex", messageStatus.TargetKey)
 	assert.Equal(initialMessageDelivered, messageStatus.State)
 	assert.Equal(11, messageStatus.MessageBytes)
 	require.NotNil(messageStatus.DeliveredAt)
 	assert.Equal(time.UTC, messageStatus.DeliveredAt.Location())
 	assert.Equal("\x1b[200~review this\x1b[201~\r", string(owner.pty.written()))
 
-	response = post(endpoint, "codex", "coding-session", "review this")
+	response = post(endpoint, "codex", "review this")
 	require.Equal(http.StatusOK, response.Code, response.Body.String())
 	assert.Equal("\x1b[200~review this\x1b[201~\r", string(owner.pty.written()))
 
-	response = post(endpoint, "codex", "coding-session", "review that")
+	response = post(endpoint, "codex", "review that")
 	require.Equal(http.StatusConflict, response.Code, response.Body.String())
 	assert.Equal("\x1b[200~review this\x1b[201~\r", string(owner.pty.written()))
 
@@ -250,7 +248,7 @@ func TestSubmitInitialMessageServiceReturnsDeliveredStateAndRoutesShareAttempt(t
 	owner.pty.setWriteError(errors.New("write failed"))
 	failedResult, err := handler.SubmitInitialMessageService(ctx, InitialMessageRequest{
 		WorkspaceID: workspaceID, RuntimeSessionKey: failingSession.Key,
-		Agent: "codex", SessionID: "coding-failure", Message: "try once",
+		TargetKey: "codex", Message: "try once",
 	})
 	require.Error(err)
 	assert.Equal(initialMessageUncertain, failedResult.State)
@@ -263,39 +261,38 @@ func TestSubmitInitialMessageServiceReturnsDeliveredStateAndRoutesShareAttempt(t
 	inactivePasteSession := launchSession("coding-multiline", true)
 	writtenBefore := owner.pty.written()
 	response = post(
-		endpointFor(inactivePasteSession.Key), "codex", "coding-multiline", "first\nsecond",
+		endpointFor(inactivePasteSession.Key), "codex", "first\nsecond",
 	)
 	require.Equal(http.StatusBadRequest, response.Code, response.Body.String())
 	assert.Equal(writtenBefore, owner.pty.written())
 	_, found = handler.initialMessageAttempt(workspaceID, inactivePasteSession.Key)
 	assert.False(found)
 
+	owner.setEmitBracketedPaste(true)
 	unreportedSession := launchSession("coding-unreported", false)
 	response = post(
-		endpointFor(unreportedSession.Key), "codex", "coding-unreported", "do not send",
+		endpointFor(unreportedSession.Key), "codex", "do not send",
 	)
-	require.Equal(http.StatusConflict, response.Code, response.Body.String())
+	require.Equal(http.StatusOK, response.Code, response.Body.String())
 	_, found = handler.initialMessageAttempt(workspaceID, unreportedSession.Key)
-	assert.False(found)
+	assert.True(found)
 
 	require.NoError(runtime.Stop(ctx, workspaceID, session.Key))
 	require.NoError(database.DeleteWorkspaceRuntimeSession(ctx, workspaceID, session.Key))
-	response = post(endpoint, "codex", "different-session", "review this")
+	response = post(endpoint, "claude", "review this")
 	require.Equal(http.StatusConflict, response.Code, response.Body.String())
 
 	getRecorder := httptest.NewRecorder()
 	mux.ServeHTTP(getRecorder, httptest.NewRequest(http.MethodGet, endpoint, nil))
 	require.Equal(http.StatusOK, getRecorder.Code, getRecorder.Body.String())
 	messageStatus = struct {
-		Agent        string     `json:"agent"`
-		SessionID    string     `json:"session_id"`
+		TargetKey    string     `json:"target_key"`
 		State        string     `json:"state"`
 		MessageBytes int        `json:"message_bytes"`
 		DeliveredAt  *time.Time `json:"delivered_at"`
 	}{}
 	require.NoError(json.NewDecoder(getRecorder.Body).Decode(&messageStatus))
-	assert.Equal("codex", messageStatus.Agent)
-	assert.Equal("coding-session", messageStatus.SessionID)
+	assert.Equal("codex", messageStatus.TargetKey)
 	assert.Equal(initialMessageDelivered, messageStatus.State)
 }
 

--- a/internal/server/workspaceapi/services.go
+++ b/internal/server/workspaceapi/services.go
@@ -59,14 +59,12 @@ type AgentSessionResult struct {
 type InitialMessageRequest struct {
 	WorkspaceID       string
 	RuntimeSessionKey string
-	Agent             string
-	SessionID         string
+	TargetKey         string
 	Message           string
 }
 
 type InitialMessageResult struct {
-	Agent        string
-	SessionID    string
+	TargetKey    string
 	State        string
 	MessageBytes int
 	ReservedAt   time.Time

--- a/internal/server/workspacetest/workspace_agent_activity_test.go
+++ b/internal/server/workspacetest/workspace_agent_activity_test.go
@@ -82,12 +82,13 @@ func TestWorkspaceAgentActivityFlowsThroughHTTPResponsesE2E(t *testing.T) {
 	messageResponse, err := fixture.client.HTTP.SubmitWorkspaceRuntimeSessionInitialMessageWithResponse(
 		ctx, ws.Id, launch.JSON200.Key,
 		generated.SubmitInitialMessageInputBody{
-			Agent: "codex", SessionId: "live-agent", Message: "review this",
+			TargetKey: "hook-agent", Message: "review this",
 		},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusOK, messageResponse.StatusCode(), string(messageResponse.Body))
 	require.NotNil(messageResponse.JSON200)
+	assert.Equal("hook-agent", messageResponse.JSON200.TargetKey)
 	assert.Equal("delivered", messageResponse.JSON200.State)
 	assert.Equal(int64(11), messageResponse.JSON200.MessageBytes)
 	assert.Equal(time.UTC, messageResponse.JSON200.ReservedAt.Location())
@@ -100,9 +101,7 @@ func TestWorkspaceAgentActivityFlowsThroughHTTPResponsesE2E(t *testing.T) {
 	require.NotNil(sessionsResponse.JSON200)
 	require.NotNil(sessionsResponse.JSON200.Sessions)
 	require.Len(*sessionsResponse.JSON200.Sessions, 1)
-	require.NotNil((*sessionsResponse.JSON200.Sessions)[0].InitialMessage)
-	assert.Equal("delivered", (*sessionsResponse.JSON200.Sessions)[0].InitialMessage.State)
-	assert.Equal(int64(11), (*sessionsResponse.JSON200.Sessions)[0].InitialMessage.MessageBytes)
+	assert.Nil((*sessionsResponse.JSON200.Sessions)[0].InitialMessage)
 
 	getResponse, err := fixture.client.HTTP.GetWorkspaceWithResponse(ctx, ws.Id)
 	require.NoError(err)


### PR DESCRIPTION
Agent handoffs now send the initial prompt as soon as the agent runtime is live, then wait for its matching hook session. Some coding agents do not emit their first hook until they receive input, so the previous ordering could time out while the agent waited for the prompt.

- Adds a resume path that reuses the returned workspace and runtime after prompt-input or hook-observation timeouts, without launching another agent or delivering another logical prompt.
- Exposes live agent runtimes separately from hook-backed coding sessions, including whether a hook has been observed.
- Moves the internal initial-message contract from hook session identity to the live runtime target and regenerates the API clients.
