### PR TITLE
feat: choose recent workspace agent by default

### DIFF
--- a/context/mcp-server.md
+++ b/context/mcp-server.md
@@ -105,6 +105,9 @@
   hook-authoritative sessions. `hook_observed=false` distinguishes a launched
   runtime awaiting its first hook from a workspace with no agent runtime
   (`internal/mcpserver/tools_agent.go::Server.listWorkspaceAgentSessions`).
+- An omitted MCP agent target selects the most-used available workspace agent
+  from the prior 14 days; ties prefer recent use, then key, and empty history
+  falls back to configured order (`internal/mcpserver/tools_agent_spawn.go::Server.defaultAgentTarget`).
 - Handoff success and failure evidence uses `stage` plus
   `initial_message.state`; never add a separate `message_delivered` output or
   error detail (`internal/mcpserver/tools_agent_spawn.go::spawnWorkspaceWithAgentOutput`).

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -362,6 +362,9 @@ refresh and persist head-repository classification while preparing generated
 context, but classification does not authorize or block the launch
 (`internal/server/workspaceapi/routes_handlers.go::Handler.launchWorkspaceRuntimeSession`,
 `internal/workspace/agent_context.go::Manager.PrepareAgentLaunchContext`).
+Each recorded workspace agent runtime contributes one durable launch event per
+session; runtime cleanup never erases this preference history
+(`internal/db/workspace_agent_usage.go::DB.RecordWorkspaceRuntimeSession`).
 Agent settings use the `agents` and `launch_targets` fields from `GET /settings`;
 the shared create split control consumes agent targets from the hydrated store
 (`frontend/src/lib/components/workspace/WorkspaceCreateSplitButton.svelte::agentTargets`).

--- a/internal/db/migrations/000053_workspace_agent_launches.down.sql
+++ b/internal/db/migrations/000053_workspace_agent_launches.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS forge_workspace_agent_launches_created_at_idx;
+DROP TABLE IF EXISTS forge_workspace_agent_launches;

--- a/internal/db/migrations/000053_workspace_agent_launches.up.sql
+++ b/internal/db/migrations/000053_workspace_agent_launches.up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE forge_workspace_agent_launches (
+    session_key TEXT PRIMARY KEY,
+    target_key  TEXT NOT NULL,
+    created_at  DATETIME NOT NULL
+);
+
+CREATE INDEX forge_workspace_agent_launches_created_at_idx
+    ON forge_workspace_agent_launches(created_at);

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -5462,31 +5462,9 @@ func (d *DB) UpsertWorkspaceRuntimeSession(
 	ctx context.Context,
 	session *WorkspaceRuntimeSession,
 ) error {
-	createdAt := canonicalUTCTime(session.CreatedAt)
-	if createdAt.IsZero() {
-		createdAt = time.Now().UTC()
-	}
-	_, err := d.execContext(ctx, `
-		INSERT INTO forge_workspace_runtime_sessions
-		    (workspace_id, session_key, target_key, label, kind, display_region, scope,
-		     tmux_session, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(workspace_id, session_key) DO UPDATE SET
-		    target_key = excluded.target_key,
-		    label = excluded.label,
-		    kind = excluded.kind,
-		    display_region = excluded.display_region,
-		    scope = excluded.scope,
-		    tmux_session = excluded.tmux_session,
-		    created_at = excluded.created_at`,
-		session.WorkspaceID, session.SessionKey, session.TargetKey,
-		session.Label, session.Kind, session.DisplayRegion, session.Scope,
-		session.TmuxSession, createdAt,
-	)
-	if err != nil {
-		return fmt.Errorf("upsert workspace runtime session: %w", err)
-	}
-	return nil
+	return d.Tx(ctx, func(tx *sql.Tx) error {
+		return upsertWorkspaceRuntimeSession(ctx, tx, session)
+	})
 }
 
 // ListWorkspaceRuntimeSessions returns stored runtime sessions for a workspace

--- a/internal/db/workspace_agent_usage.go
+++ b/internal/db/workspace_agent_usage.go
@@ -1,0 +1,117 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type workspaceRuntimeSessionExecer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+func upsertWorkspaceRuntimeSession(
+	ctx context.Context,
+	execer workspaceRuntimeSessionExecer,
+	session *WorkspaceRuntimeSession,
+) error {
+	createdAt := canonicalUTCTime(session.CreatedAt)
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	_, err := execer.ExecContext(ctx, `
+		INSERT INTO forge_workspace_runtime_sessions
+		    (workspace_id, session_key, target_key, label, kind, display_region, scope,
+		     tmux_session, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(workspace_id, session_key) DO UPDATE SET
+		    target_key = excluded.target_key,
+		    label = excluded.label,
+		    kind = excluded.kind,
+		    display_region = excluded.display_region,
+		    scope = excluded.scope,
+		    tmux_session = excluded.tmux_session,
+		    created_at = excluded.created_at`,
+		session.WorkspaceID, session.SessionKey, session.TargetKey,
+		session.Label, session.Kind, session.DisplayRegion, session.Scope,
+		session.TmuxSession, createdAt,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert workspace runtime session: %w", err)
+	}
+	return nil
+}
+
+// RecordWorkspaceRuntimeSession stores a runtime session and records each
+// agent launch once, independently of the live session's later cleanup.
+func (d *DB) RecordWorkspaceRuntimeSession(
+	ctx context.Context,
+	session *WorkspaceRuntimeSession,
+) error {
+	return d.Tx(ctx, func(tx *sql.Tx) error {
+		if err := upsertWorkspaceRuntimeSession(ctx, tx, session); err != nil {
+			return err
+		}
+		if session.Kind != "agent" {
+			return nil
+		}
+		createdAt := canonicalUTCTime(session.CreatedAt)
+		if createdAt.IsZero() {
+			createdAt = time.Now().UTC()
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO forge_workspace_agent_launches
+			    (session_key, target_key, created_at)
+			VALUES (?, ?, ?)
+			ON CONFLICT(session_key) DO NOTHING`,
+			session.SessionKey, session.TargetKey, createdAt,
+		); err != nil {
+			return fmt.Errorf("record workspace agent launch: %w", err)
+		}
+		return nil
+	})
+}
+
+// PreferredWorkspaceAgentTarget returns the most frequently launched allowed
+// agent target since the supplied time. Recency and target key break ties.
+func (d *DB) PreferredWorkspaceAgentTarget(
+	ctx context.Context,
+	since time.Time,
+	targetKeys []string,
+) (string, bool, error) {
+	allowed := make(map[string]struct{}, len(targetKeys))
+	for _, key := range targetKeys {
+		if key = strings.TrimSpace(key); key != "" {
+			allowed[key] = struct{}{}
+		}
+	}
+	if len(allowed) == 0 {
+		return "", false, nil
+	}
+
+	rows, err := d.ro.QueryContext(ctx, `
+		SELECT target_key
+		FROM forge_workspace_agent_launches
+		WHERE created_at >= ?
+		GROUP BY target_key
+		ORDER BY COUNT(*) DESC, MAX(created_at) DESC, target_key ASC`, since.UTC())
+	if err != nil {
+		return "", false, fmt.Errorf("rank workspace agent launches: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			return "", false, fmt.Errorf("scan workspace agent launch rank: %w", err)
+		}
+		if _, ok := allowed[key]; ok {
+			return key, true, nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return "", false, fmt.Errorf("rank workspace agent launches: %w", err)
+	}
+	return "", false, nil
+}

--- a/internal/db/workspace_agent_usage_test.go
+++ b/internal/db/workspace_agent_usage_test.go
@@ -1,0 +1,81 @@
+package db
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkspaceAgentLaunchesMigrationUpgradesV52(t *testing.T) {
+	databasePath := filepath.Join(t.TempDir(), "forge-v52.db")
+	openAtVersionForTest(t, databasePath, 52, func(*sql.DB) {})
+
+	database, err := Open(databasePath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+
+	_, found, err := database.PreferredWorkspaceAgentTarget(
+		t.Context(), time.Time{}, []string{"codex"},
+	)
+	require.NoError(t, err)
+	assert.False(t, found)
+	assertDatabaseIntegrityForTest(t, database.ReadDB())
+}
+
+func TestPreferredWorkspaceAgentTargetUsesRecentDistinctLaunches(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := openTestDB(t)
+	ctx := t.Context()
+	require.NoError(database.InsertWorkspace(ctx, &Workspace{
+		ID: "ws-agent-usage", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget",
+		ItemType: WorkspaceItemTypePullRequest, ItemNumber: 42,
+		GitHeadRef: "feature/agent-usage", WorkspaceBranch: "kenn-forge/pr-42",
+		WorktreePath: "/tmp/ws-agent-usage", TmuxSession: "ws-agent-usage",
+		Status: "ready",
+	}))
+
+	cutoff := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+	record := func(key, target string, createdAt time.Time) {
+		t.Helper()
+		require.NoError(database.RecordWorkspaceRuntimeSession(ctx, &WorkspaceRuntimeSession{
+			WorkspaceID: "ws-agent-usage", SessionKey: key,
+			TargetKey: target, Label: target, Kind: "agent", Scope: "session",
+			CreatedAt: createdAt,
+		}))
+	}
+
+	record("old-opencode", "opencode", cutoff.Add(-time.Minute))
+	record("codex-a", "codex", cutoff.Add(24*time.Hour))
+	record("codex-a", "codex", cutoff.Add(24*time.Hour))
+	record("codex-b", "codex", cutoff.Add(25*time.Hour))
+	record("claude", "claude", cutoff.Add(48*time.Hour))
+	record("gemini-a", "gemini", cutoff.Add(20*time.Hour))
+	record("gemini-b", "gemini", cutoff.Add(30*time.Hour))
+	require.NoError(database.DeleteWorkspaceRuntimeSession(ctx, "ws-agent-usage", "claude"))
+
+	target, found, err := database.PreferredWorkspaceAgentTarget(
+		ctx, cutoff, []string{"codex", "claude", "gemini"},
+	)
+	require.NoError(err)
+	assert.True(found)
+	assert.Equal("gemini", target)
+
+	target, found, err = database.PreferredWorkspaceAgentTarget(
+		ctx, cutoff, []string{"codex", "claude"},
+	)
+	require.NoError(err)
+	assert.True(found)
+	assert.Equal("codex", target)
+
+	_, found, err = database.PreferredWorkspaceAgentTarget(
+		ctx, cutoff, []string{"opencode"},
+	)
+	require.NoError(err)
+	assert.False(found)
+}

--- a/internal/mcpserver/backend.go
+++ b/internal/mcpserver/backend.go
@@ -18,6 +18,7 @@ type Backend interface {
 	ListWorkflowStates(context.Context, WorkflowQuery) (WorkflowPage, error)
 	SetWorkflowState(context.Context, ItemIdentity, WorkflowUpdate) (WorkflowMutation, error)
 	ListLaunchTargets(context.Context) ([]LaunchTarget, error)
+	PreferredWorkspaceAgentTarget(context.Context, time.Time, []string) (string, bool, error)
 	ListWorkspaceAgentSessions(context.Context, string) ([]WorkspaceAgentSession, error)
 	GetWorkspace(context.Context, string) (Workspace, error)
 	CreatePullWorkspace(context.Context, ItemIdentity, bool) (Workspace, error)

--- a/internal/mcpserver/fake_backend_test.go
+++ b/internal/mcpserver/fake_backend_test.go
@@ -20,6 +20,7 @@ type fakeBackend struct {
 	listWorkflowStatesFn         func(context.Context, WorkflowQuery) (WorkflowPage, error)
 	setWorkflowStateFn           func(context.Context, ItemIdentity, WorkflowUpdate) (WorkflowMutation, error)
 	listLaunchTargetsFn          func(context.Context) ([]LaunchTarget, error)
+	preferredWorkspaceAgentFn    func(context.Context, time.Time, []string) (string, bool, error)
 	listWorkspaceAgentSessionsFn func(context.Context, string) ([]WorkspaceAgentSession, error)
 	getWorkspaceFn               func(context.Context, string) (Workspace, error)
 	createPullWorkspaceFn        func(context.Context, ItemIdentity, bool) (Workspace, error)
@@ -106,6 +107,15 @@ func (b *fakeBackend) ListLaunchTargets(ctx context.Context) ([]LaunchTarget, er
 		return b.listLaunchTargetsFn(ctx)
 	}
 	return nil, nil
+}
+
+func (b *fakeBackend) PreferredWorkspaceAgentTarget(
+	ctx context.Context, since time.Time, targetKeys []string,
+) (string, bool, error) {
+	if b.preferredWorkspaceAgentFn != nil {
+		return b.preferredWorkspaceAgentFn(ctx, since, targetKeys)
+	}
+	return "", false, nil
 }
 
 func (b *fakeBackend) ListWorkspaceAgentSessions(ctx context.Context, workspaceID string) ([]WorkspaceAgentSession, error) {

--- a/internal/mcpserver/tools_agent.go
+++ b/internal/mcpserver/tools_agent.go
@@ -17,6 +17,7 @@ type agentTargetRow struct {
 	Source         string `json:"source"`
 	Available      bool   `json:"available"`
 	DisabledReason string `json:"disabled_reason,omitempty"`
+	configOrder    int
 }
 
 type listAgentTargetsOutput struct {
@@ -70,8 +71,9 @@ func (s *Server) registerAgentTools() {
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name: "kenn_forge_spawn_workspace_with_agent",
 		Description: "Create or reuse a workspace, launch one configured coding agent, submit exactly one initial message, " +
-			"and observe the resulting hook session. Resume can continue an existing runtime without launching another agent. " +
-			"Partial resources are never cleaned up automatically.",
+			"and observe the resulting hook session. When agent_target is omitted for a new handoff, the most used " +
+			"available agent from the previous 14 days is selected. Resume can continue an existing runtime without " +
+			"launching another agent. Partial resources are never cleaned up automatically.",
 	}, wrapTool(s.spawnWorkspaceWithAgent))
 }
 
@@ -88,7 +90,7 @@ func (s *Server) listAgentTargets(
 		supported[string(profile.Agent)] = struct{}{}
 	}
 	out := listAgentTargetsOutput{Targets: make([]agentTargetRow, 0)}
-	for _, target := range targets {
+	for index, target := range targets {
 		key := strings.ToLower(strings.TrimSpace(target.Key))
 		if target.Kind != "agent" {
 			continue
@@ -102,6 +104,7 @@ func (s *Server) listAgentTargets(
 			Source:         target.Source,
 			Available:      target.Available,
 			DisabledReason: target.DisabledReason,
+			configOrder:    index,
 		})
 	}
 	slices.SortFunc(out.Targets, func(a, b agentTargetRow) int {

--- a/internal/mcpserver/tools_agent_spawn.go
+++ b/internal/mcpserver/tools_agent_spawn.go
@@ -1,6 +1,7 @@
 package mcpserver
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -20,6 +21,7 @@ const (
 	defaultAgentHandoffPollInterval = 250 * time.Millisecond
 	messageStatusRecoveryTimeout    = 6 * time.Second
 	maxAgentInitialMessage          = 64 << 10
+	workspaceAgentPreferenceWindow  = 14 * 24 * time.Hour
 )
 
 type workspaceSourceInput struct {
@@ -36,7 +38,7 @@ type adHocWorkspaceSource struct {
 type spawnWorkspaceWithAgentInput struct {
 	Source         *workspaceSourceInput `json:"source,omitempty"`
 	Resume         *agentHandoffResume   `json:"resume,omitempty"`
-	AgentTarget    string                `json:"agent_target"`
+	AgentTarget    string                `json:"agent_target,omitempty" jsonschema:"configured coding-agent target; omit on a new handoff to use recent workspace launch history"`
 	InitialMessage string                `json:"initial_message"`
 	Timeout        string                `json:"timeout,omitempty"`
 }
@@ -87,7 +89,7 @@ func (s *Server) spawnWorkspaceWithAgent(
 	}
 
 	messageStatus, err := s.submitInitialAgentMessage(
-		ctx, workspace.ID, runtime.Key, in.AgentTarget, in.InitialMessage,
+		ctx, workspace.ID, runtime.Key, runtime.TargetKey, in.InitialMessage,
 	)
 	if messageStatus.State != "" {
 		out.InitialMessage = &messageStatus
@@ -134,9 +136,6 @@ func validateSpawnWorkspaceInput(
 		return in, 0, fmt.Errorf("timeout must not exceed 15m")
 	}
 	in.AgentTarget = strings.ToLower(strings.TrimSpace(in.AgentTarget))
-	if in.AgentTarget == "" {
-		return in, 0, fmt.Errorf("agent_target is required")
-	}
 	message, err := normalizeSpawnInitialMessage(in.InitialMessage)
 	if err != nil {
 		return in, 0, err
@@ -146,6 +145,9 @@ func validateSpawnWorkspaceInput(
 		return in, 0, fmt.Errorf("provide exactly one of source or resume")
 	}
 	if in.Resume != nil {
+		if in.AgentTarget == "" {
+			return in, 0, fmt.Errorf("agent_target is required when resume is provided")
+		}
 		in.Resume.WorkspaceID = strings.TrimSpace(in.Resume.WorkspaceID)
 		in.Resume.RuntimeSessionKey = strings.TrimSpace(in.Resume.RuntimeSessionKey)
 		if in.Resume.WorkspaceID == "" {
@@ -194,6 +196,12 @@ func (s *Server) prepareAgentHandoff(
 	targets, err := s.listAgentTargets(ctx, listAgentTargetsInput{})
 	if err != nil {
 		return Workspace{}, RuntimeSession{}, handoffFailure(ctx, err, *out, "", "")
+	}
+	if in.AgentTarget == "" {
+		in.AgentTarget, err = s.defaultAgentTarget(ctx, targets.Targets)
+		if err != nil {
+			return Workspace{}, RuntimeSession{}, handoffFailure(ctx, err, *out, "", "")
+		}
 	}
 	target, ok := findAgentTarget(targets.Targets, in.AgentTarget)
 	if !ok {
@@ -406,6 +414,37 @@ func findAgentTarget(targets []agentTargetRow, key string) (agentTargetRow, bool
 		}
 	}
 	return agentTargetRow{}, false
+}
+
+func (s *Server) defaultAgentTarget(
+	ctx context.Context,
+	targets []agentTargetRow,
+) (string, error) {
+	available := make([]agentTargetRow, 0, len(targets))
+	keys := make([]string, 0, len(targets))
+	for _, target := range targets {
+		if !target.Available {
+			continue
+		}
+		available = append(available, target)
+		keys = append(keys, target.Key)
+	}
+	if len(available) == 0 {
+		return "", fmt.Errorf("no available coding-agent targets are configured")
+	}
+	preferred, found, err := s.backend.PreferredWorkspaceAgentTarget(
+		ctx, time.Now().UTC().Add(-workspaceAgentPreferenceWindow), keys,
+	)
+	if err != nil {
+		return "", err
+	}
+	if found {
+		return preferred, nil
+	}
+	slices.SortFunc(available, func(a, b agentTargetRow) int {
+		return cmp.Compare(a.configOrder, b.configOrder)
+	})
+	return available[0].Key, nil
 }
 
 func (s *Server) resolveOrCreateWorkspace(

--- a/internal/mcpserver/tools_agent_spawn_test.go
+++ b/internal/mcpserver/tools_agent_spawn_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -214,6 +215,84 @@ func TestSpawnWorkspaceWithAgentReusesWorkspaceAndLaunchesFreshRuntime(t *testin
 	require.NoError(t, err)
 	assert.True(t, out.Workspace.Reused)
 	assert.Equal(t, "runtime-fresh", out.Runtime.SessionKey)
+}
+
+func TestSpawnWorkspaceWithAgentDefaultsToMostUsedRecentAgent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	backend := successfulSpawnBackend("ws-default", "runtime-default", "coding-default")
+	backend.listLaunchTargetsFn = func(context.Context) ([]LaunchTarget, error) {
+		return []LaunchTarget{
+			{Key: "codex", Label: "Codex", Kind: "agent", Source: "config", Available: true},
+			{Key: "claude", Label: "Claude", Kind: "agent", Source: "config", Available: true},
+		}, nil
+	}
+	backend.preferredWorkspaceAgentFn = func(_ context.Context, since time.Time, candidates []string) (string, bool, error) {
+		assert.WithinDuration(time.Now().Add(-14*24*time.Hour), since, time.Second)
+		assert.ElementsMatch([]string{"codex", "claude"}, candidates)
+		return "claude", true, nil
+	}
+	backend.launchWorkspaceRuntimeFn = func(_ context.Context, workspaceID, target string) (RuntimeSession, error) {
+		assert.Equal("ws-default", workspaceID)
+		assert.Equal("claude", target)
+		return RuntimeSession{
+			Key: "runtime-default", TargetKey: "claude", Status: "running",
+			CreatedAt: time.Date(2026, 8, 7, 15, 0, 0, 0, time.UTC),
+		}, nil
+	}
+	backend.listWorkspaceAgentSessionsFn = func(context.Context, string) ([]WorkspaceAgentSession, error) {
+		return []WorkspaceAgentSession{{
+			Agent: "claude", SessionID: "coding-default", RuntimeSessionKey: "runtime-default",
+			TargetKey: "claude", State: "working",
+			UpdatedAt: time.Date(2026, 8, 7, 15, 0, 1, 0, time.UTC),
+		}}, nil
+	}
+	s := newMCPTestServer(t, backend)
+
+	result, err := connectMCPTestSession(t, s).CallTool(
+		t.Context(), &mcp.CallToolParams{
+			Name: "kenn_forge_spawn_workspace_with_agent",
+			Arguments: map[string]any{
+				"source": map[string]any{
+					"type": "item",
+					"item": map[string]any{
+						"type": "pr", "provider": "github",
+						"platform_repo_id": "repo-acme-widget",
+						"owner":            "acme", "name": "widget", "number": 42,
+					},
+				},
+				"initial_message": "start",
+				"timeout":         "2s",
+			},
+		},
+	)
+
+	require.NoError(err)
+	require.NotNil(result)
+	assert.False(result.IsError)
+	raw, err := json.Marshal(result.StructuredContent)
+	require.NoError(err)
+	var out spawnWorkspaceWithAgentOutput
+	require.NoError(json.Unmarshal(raw, &out))
+	assert.Equal("claude", out.Runtime.TargetKey)
+}
+
+func TestSpawnWorkspaceWithAgentFallsBackToFirstConfiguredAgent(t *testing.T) {
+	backend := successfulSpawnBackend("ws-fallback", "runtime-fallback", "coding-fallback")
+	backend.listLaunchTargetsFn = func(context.Context) ([]LaunchTarget, error) {
+		return []LaunchTarget{
+			{Key: "codex", Label: "Codex", Kind: "agent", Source: "config", Available: true},
+			{Key: "claude", Label: "Claude", Kind: "agent", Source: "config", Available: true},
+		}, nil
+	}
+	s := newMCPTestServer(t, backend)
+	input := prSpawnInput("start")
+	input.AgentTarget = ""
+
+	out, err := s.spawnWorkspaceWithAgent(t.Context(), input)
+
+	require.NoError(t, err)
+	assert.Equal(t, "codex", out.Runtime.TargetKey)
 }
 
 func TestSpawnWorkspaceWithAgentReusesPRWorkspaceCreatedConcurrently(t *testing.T) {

--- a/internal/server/mcp_backend.go
+++ b/internal/server/mcp_backend.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"net/http"
 	"strings"
+	"time"
 
 	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/gitclone"
@@ -550,6 +551,18 @@ func (b mcpBackend) LaunchWorkspaceRuntime(
 		Key: session.Key, TargetKey: session.TargetKey,
 		Kind: string(session.Kind), Status: string(session.Status), CreatedAt: session.CreatedAt,
 	}, nil
+}
+
+func (b mcpBackend) PreferredWorkspaceAgentTarget(
+	ctx context.Context, since time.Time, targetKeys []string,
+) (string, bool, error) {
+	target, found, err := b.server.workspaceAPI.PreferredWorkspaceAgentTargetService(
+		ctx, since, targetKeys,
+	)
+	if err != nil {
+		return "", false, mcpBackendError(err)
+	}
+	return target, found, nil
 }
 
 func (b mcpBackend) GetWorkspaceRuntime(

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -2336,6 +2336,12 @@ func (s *Handler) LaunchWorkspaceRuntimeService(
 	return s.launchWorkspaceRuntimeService(ctx, workspaceID, targetKey, "")
 }
 
+func (s *Handler) PreferredWorkspaceAgentTargetService(
+	ctx context.Context, since time.Time, targetKeys []string,
+) (string, bool, error) {
+	return s.workspaces.PreferredWorkspaceAgentTarget(ctx, since, targetKeys)
+}
+
 func (s *Handler) launchWorkspaceRuntimeService(
 	ctx context.Context, workspaceID, targetKey, displayRegion string,
 ) (localruntime.SessionInfo, error) {

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -4333,7 +4333,15 @@ func (m *Manager) RecordRuntimeSession(
 	if session.SessionKey == "" {
 		return nil
 	}
-	return m.db.UpsertWorkspaceRuntimeSession(ctx, &session)
+	return m.db.RecordWorkspaceRuntimeSession(ctx, &session)
+}
+
+func (m *Manager) PreferredWorkspaceAgentTarget(
+	ctx context.Context,
+	since time.Time,
+	targetKeys []string,
+) (string, bool, error) {
+	return m.db.PreferredWorkspaceAgentTarget(ctx, since, targetKeys)
 }
 
 func (m *Manager) UpdateRuntimeSessionLabel(


### PR DESCRIPTION
MCP callers can now start a workspace without choosing a coding agent. Forge uses the maintainer's recent workspace launch history to pick the default while still honoring explicit choices.

- Ranks available agents by use over the previous 14 days, with deterministic tie-breaks and configured-order fallback.
- Keeps preference history after runtime sessions exit.
- Preserves existing validation for explicit agent targets.

<sup>generated by a clanker</sup>
