### PR TITLE
fix: give issue-backed workspace bubbles a blue state color

### DIFF
--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -839,7 +839,7 @@
       return "kata";
     }
     if (ws.item_type === "issue") {
-      return ws.mr_state === "closed" ? "closed" : "open";
+      return ws.mr_state === "closed" ? "closed" : "issue";
     }
     if (ws.mr_is_draft) return "draft";
     if (ws.mr_state === "merged") return "merged";
@@ -2298,6 +2298,13 @@
      * than as a muted/neutral pill indistinguishable from other states. */
     --bubble-bg: color-mix(in srgb, var(--accent-amber) 70%, #ffffff);
     --bubble-fg: color-mix(in srgb, var(--accent-amber) 25%, var(--bubble-ink));
+  }
+
+  /* Open issues use blue instead of the open/green PR treatment so an
+   * issue-backed workspace is distinguishable from a PR-backed one. */
+  .item-bubble.issue {
+    --bubble-bg: color-mix(in srgb, var(--accent-blue) 70%, #ffffff);
+    --bubble-fg: color-mix(in srgb, var(--accent-blue) 25%, var(--bubble-ink));
   }
 
   .item-bubble.kata {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -1732,6 +1732,51 @@ describe("WorkspaceListSidebar", () => {
     expect(openBubble?.classList.contains("draft")).toBe(false);
   });
 
+  it("gives an issue-backed workspace bubble the issue state class, not open", async () => {
+    // An open issue-backed workspace must not reuse the open/green PR
+    // treatment; the blue issue styling tells it apart from PR-backed
+    // rows at a glance.
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [
+          workspaceFixture({
+            id: "ws-issue",
+            provider: "github",
+            platformHost: "github.com",
+            owner: "kenn-io",
+            name: "kenn-forge",
+            number: 968,
+            title: "Keep local base branches in sync",
+            itemType: "issue",
+          }),
+          workspaceFixture({
+            id: "ws-pr",
+            provider: "github",
+            platformHost: "github.com",
+            owner: "kenn-io",
+            name: "kenn-forge",
+            number: 242,
+            title: "Ready for review PR",
+          }),
+        ],
+      },
+    });
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-issue" },
+    });
+    await screen.findByText("Keep local base branches in sync");
+
+    const bubbles = Array.from(container.querySelectorAll(".item-bubble"));
+    const issueBubble = bubbles.find((b) => b.textContent?.trim() === "#968");
+    const prBubble = bubbles.find((b) => b.textContent?.trim() === "#242");
+
+    expect(issueBubble?.classList.contains("issue")).toBe(true);
+    expect(issueBubble?.classList.contains("open")).toBe(false);
+    expect(prBubble?.classList.contains("open")).toBe(true);
+    expect(prBubble?.classList.contains("issue")).toBe(false);
+  });
+
   it("omits provider item actions in the Kata workspace context menu", async () => {
     mockGet.mockResolvedValue({
       data: { workspaces: [kataWorkspaceFixture()] },


### PR DESCRIPTION
In the workspace list sidebar, a workspace created from an open issue showed the same green number bubble as an open pull request, so issue work and PR work were indistinguishable at a glance.

- Open issue-backed workspace bubbles now use the blue treatment already used for Kata task bubbles.
- Closed issues keep the red closed state; PR bubble states (open, draft, merged, closed) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sup>generated by a clanker</sup>
