### PR TITLE
feat(github): dedicate App capacity to archive sync

### DIFF
--- a/cmd/kenn-forge-github-app/create.go
+++ b/cmd/kenn-forge-github-app/create.go
@@ -32,6 +32,7 @@ func runCreate(args []string, env *appEnv) error {
 	host := fs.String("host", "", "GitHub host (default github.com)")
 	org := fs.String("org", "", "create the app under this organization instead of your user")
 	name := fs.String("name", "", "app name (default kenn-forge-<random>)")
+	role := fs.String("role", config.GitHubAppRoleSync, "Forge workload for this App: sync or archive")
 	homepage := fs.String("homepage", "", "app homepage URL shown on its public page")
 	noBrowser := fs.Bool("no-browser", false, "print URLs instead of opening a browser")
 	timeout := fs.Duration("timeout", 10*time.Minute, "how long to wait for each browser step")
@@ -44,6 +45,10 @@ func runCreate(args []string, env *appEnv) error {
 	if err != nil {
 		return err
 	}
+	appRole := strings.ToLower(strings.TrimSpace(*role))
+	if appRole != config.GitHubAppRoleSync && appRole != config.GitHubAppRoleArchive {
+		return fmt.Errorf("--role must be %q or %q", config.GitHubAppRoleSync, config.GitHubAppRoleArchive)
+	}
 
 	if err := config.EnsureDefault(env.configPath); err != nil {
 		return fmt.Errorf("ensuring kenn-forge config exists: %w", err)
@@ -53,6 +58,13 @@ func runCreate(args []string, env *appEnv) error {
 		return err
 	}
 	for _, existing := range cfg.GitHubAppsForHost(h) {
+		existingRole := strings.ToLower(strings.TrimSpace(existing.Role))
+		if existingRole == "" {
+			existingRole = config.GitHubAppRoleSync
+		}
+		if existingRole != appRole {
+			continue
+		}
 		if *org != "" && strings.EqualFold(existing.Owner, *org) {
 			return fmt.Errorf(
 				"a github app for host %q and owner %q already exists (app id %d, slug %q); "+
@@ -108,6 +120,7 @@ func runCreate(args []string, env *appEnv) error {
 	}
 	app := config.GitHubAppConfig{
 		Host:           h,
+		Role:           appRole,
 		AppID:          creds.ID,
 		Slug:           creds.Slug,
 		Owner:          creds.Owner.Login,

--- a/cmd/kenn-forge-github-app/create.go
+++ b/cmd/kenn-forge-github-app/create.go
@@ -616,12 +616,12 @@ func (env *appEnv) refreshAppMetadata(
 	return app, nil
 }
 
-// verifySelectedInstallationCoverage checks an "Only select
-// repositories" installation against the configured repos it is
-// supposed to serve, by listing what an installation token can
-// actually reach. Glob repo patterns cannot be verified repo-by-repo
-// and are rejected outright: they expand to an open-ended set only an
-// "All repositories" install can satisfy.
+// verifySelectedInstallationCoverage lists what an "Only select
+// repositories" installation token can reach. Sync Apps must cover every
+// configured repository for their account; archive Apps record their
+// reachable set and use normal routes for repositories outside it. Glob repo
+// patterns are therefore rejected only for sync Apps because they expand to
+// an open-ended set.
 func (env *appEnv) verifySelectedInstallationCoverage(
 	ctx context.Context,
 	cfg *config.Config,
@@ -642,7 +642,7 @@ func (env *appEnv) verifySelectedInstallationCoverage(
 		return nil, fmt.Errorf("verifying selected-repository installation: %w", err)
 	}
 	missing := missingSelectedRepos(cfg, app.Host, picked.Account.Login, names)
-	if len(missing) > 0 {
+	if app.Role != config.GitHubAppRoleArchive && len(missing) > 0 {
 		return nil, fmt.Errorf(
 			"the app was installed on %q with \"Only select repositories\", but the "+
 				"installation cannot reach %s; not recording it in config. Edit the "+

--- a/cmd/kenn-forge-github-app/e2e_test.go
+++ b/cmd/kenn-forge-github-app/e2e_test.go
@@ -732,6 +732,38 @@ func TestInstallAcceptsSelectedInstallCoveringConfiguredRepos(t *testing.T) {
 	assert.Equal([]string{"kenn-io/kenn-forge"}, cfg.GitHubApps[0].SelectedRepos)
 }
 
+func TestInstallAllowsPartialSelectedArchiveCoverage(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	fake := githubapptest.NewFake()
+	t.Cleanup(fake.Close)
+	configPath := writeTestConfig(t)
+
+	env, _ := newTestEnv(t, fake, configPath)
+	env.openBrowser = scriptBrowser(t, fake, "kenn-io")
+	require.NoError(runCLI([]string{
+		"create", "--role", "archive", "--name", "kenn-forge-archive", "--timeout", "10s",
+	}, env))
+
+	env, _ = newTestEnv(t, fake, configPath)
+	require.NoError(runCLI([]string{"uninstall", "--yes"}, env))
+
+	env, _ = newTestEnv(t, fake, configPath)
+	env.openBrowser = scriptBrowserWithInstall(t, fake, func(appID int64) error {
+		_, err := fake.InstallSelected(appID, "kenn-io", "kenn-io/other-repo")
+		return err
+	})
+	require.NoError(runCLI([]string{"install", "--timeout", "10s"}, env))
+
+	cfg, err := config.Load(configPath)
+	require.NoError(err)
+	require.Len(cfg.GitHubApps, 1)
+	assert := assert.New(t)
+	assert.Equal(config.GitHubAppRoleArchive, cfg.GitHubApps[0].Role)
+	assert.NotZero(cfg.GitHubApps[0].InstallationID)
+	assert.Equal([]string{"kenn-io/other-repo"}, cfg.GitHubApps[0].SelectedRepos)
+}
+
 func TestInstallRefreshesStaleSelectedRepoSnapshot(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)

--- a/cmd/kenn-forge-github-app/list.go
+++ b/cmd/kenn-forge-github-app/list.go
@@ -104,10 +104,11 @@ func runList(args []string, env *appEnv) error {
 
 // fillLiveStatus queries GitHub for the app's current installation
 // and, when installed, the rate budget of a freshly minted token.
-// Installations limited to selected repositories are checked against
-// the configured repos: a manually edited or restored config can
-// carry an installation the CLI never verified, and surfacing the gap
-// here beats discovering it as sync-time 404s.
+// Sync installations limited to selected repositories are checked against
+// the configured repos: a manually edited or restored config can carry an
+// installation the CLI never verified, and surfacing the gap here beats
+// discovering it as sync-time 404s. Archive installations intentionally allow
+// partial coverage and use normal routes elsewhere.
 func (env *appEnv) fillLiveStatus(
 	ctx context.Context, cfg *config.Config, app config.GitHubAppConfig, status *appStatus,
 ) error {
@@ -147,13 +148,15 @@ func (env *appEnv) fillLiveStatus(
 		if err != nil {
 			return err
 		}
-		if missing := missingSelectedRepos(
-			cfg, app.Host, install.Account.Login, accessible,
-		); len(missing) > 0 {
-			return fmt.Errorf(
-				"installation does not cover %s; edit its repository access on GitHub",
-				strings.Join(missing, ", "),
-			)
+		if app.Role != config.GitHubAppRoleArchive {
+			if missing := missingSelectedRepos(
+				cfg, app.Host, install.Account.Login, accessible,
+			); len(missing) > 0 {
+				return fmt.Errorf(
+					"installation does not cover %s; edit its repository access on GitHub",
+					strings.Join(missing, ", "),
+				)
+			}
 		}
 	}
 	return nil

--- a/cmd/kenn-forge-github-app/list.go
+++ b/cmd/kenn-forge-github-app/list.go
@@ -14,6 +14,7 @@ import (
 
 type appStatus struct {
 	Host                string `json:"host"`
+	Role                string `json:"role"`
 	AppID               int64  `json:"app_id"`
 	Slug                string `json:"slug"`
 	Owner               string `json:"owner,omitempty"`
@@ -51,12 +52,16 @@ func runList(args []string, env *appEnv) error {
 	for _, app := range cfg.GitHubApps {
 		status := appStatus{
 			Host:                app.Host,
+			Role:                app.Role,
 			AppID:               app.AppID,
 			Slug:                app.Slug,
 			Owner:               app.Owner,
 			OwnerType:           app.OwnerType,
 			InstallationID:      app.InstallationID,
 			InstallationAccount: app.InstallationAccount,
+		}
+		if status.Role == "" {
+			status.Role = config.GitHubAppRoleSync
 		}
 		if err := env.fillLiveStatus(ctx, cfg, app, &status); err != nil {
 			status.Error = err.Error()
@@ -70,7 +75,7 @@ func runList(args []string, env *appEnv) error {
 		return enc.Encode(statuses)
 	}
 	w := tabwriter.NewWriter(env.stdout, 2, 4, 2, ' ', 0)
-	fmt.Fprintln(w, "HOST\tAPP ID\tSLUG\tOWNER\tINSTALLATION\tACCOUNT\tRATE (CORE)\tSTATUS")
+	fmt.Fprintln(w, "HOST\tROLE\tAPP ID\tSLUG\tOWNER\tINSTALLATION\tACCOUNT\tRATE (CORE)\tSTATUS")
 	for _, s := range statuses {
 		rate, owner, install, account := "-", "-", "-", "-"
 		if s.Owner != "" {
@@ -91,8 +96,8 @@ func runList(args []string, env *appEnv) error {
 		} else if s.InstallationID == 0 {
 			status = "not installed"
 		}
-		fmt.Fprintf(w, "%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			s.Host, s.AppID, s.Slug, owner, install, account, rate, status)
+		fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			s.Host, s.Role, s.AppID, s.Slug, owner, install, account, rate, status)
 	}
 	return w.Flush()
 }

--- a/cmd/kenn-forge-github-app/shared.go
+++ b/cmd/kenn-forge-github-app/shared.go
@@ -173,8 +173,7 @@ func removeAppFromConfig(cfg *config.Config, configPath string, app config.GitHu
 // account that a "selected repositories" installation cannot reach,
 // given the full names its token reported accessible. Repos with
 // their own credential override never resolve to the app token and
-// are exempt; glob patterns expand to an open-ended set only an "All
-// repositories" install can satisfy.
+// are exempt; callers apply the role-specific policy to the result.
 func missingSelectedRepos(
 	cfg *config.Config, host, account string, accessible []string,
 ) []string {

--- a/cmd/kenn-forge/main.go
+++ b/cmd/kenn-forge/main.go
@@ -1021,8 +1021,15 @@ func resolveStartupRepos(
 ) []ghclient.RepoRef {
 	set := ghclient.NewExpandedRepoSet()
 	for _, raw := range cfg.Repos {
+		resolveCtx := ctx
+		if raw.PlatformOrDefault() == string(platform.KindGitHub) &&
+			cfg.ResolveGitHubArchiveTokenSource(raw).Key.Host != "" {
+			// A repository with no ordinary PAT may still be discoverable
+			// through its dedicated archive App on a fresh startup.
+			resolveCtx = ghclient.WithArchiveSyncBudget(ctx)
+		}
 		_, expanded, err := ghclient.ResolveConfiguredRepoWithRegistry(
-			ctx, registry, raw,
+			resolveCtx, registry, raw,
 		)
 		if err != nil {
 			slog.Warn("resolve configured repo", "err", err)

--- a/cmd/kenn-forge/main_test.go
+++ b/cmd/kenn-forge/main_test.go
@@ -428,6 +428,41 @@ func TestResolveStartupReposExpandsConfiguredGlobs(t *testing.T) {
 	}, repos)
 }
 
+type archiveContextRepositoryReader struct {
+	mainTestRepositoryReader
+	sawArchiveContext *bool
+}
+
+func (r archiveContextRepositoryReader) GetRepository(
+	ctx context.Context, ref platform.RepoRef,
+) (platform.Repository, error) {
+	*r.sawArchiveContext = ghclient.IsArchiveSyncBudgetContext(ctx)
+	return r.mainTestRepositoryReader.GetRepository(ctx, ref)
+}
+
+func TestResolveStartupReposUsesArchiveRouteWithoutOrdinaryPAT(t *testing.T) {
+	require := require.New(t)
+	sawArchiveContext := false
+	cfg := &config.Config{
+		Repos: []config.Repo{{Owner: "acme", Name: "widget"}},
+		GitHubApps: []config.GitHubAppConfig{{
+			Host: "github.com", AppID: 2, Role: config.GitHubAppRoleArchive,
+			PrivateKeyPath: "/keys/archive.pem", InstallationID: 20,
+			InstallationAccount: "acme", RepositorySelection: "all",
+		}},
+	}
+	registry := mustProviderRegistry(t, nil, archiveContextRepositoryReader{
+		kind: platform.KindGitHub, host: "github.com",
+		sawArchiveContext: &sawArchiveContext,
+	})
+
+	repos := resolveStartupRepos(t.Context(), cfg, registry, nil, nil)
+
+	require.Len(repos, 1)
+	assert.True(t, sawArchiveContext,
+		"archive-covered startup resolution must use the archive route")
+}
+
 type getRepoFailingClient struct {
 	*testutil.FixtureClient
 }

--- a/cmd/kenn-forge/provider_startup.go
+++ b/cmd/kenn-forge/provider_startup.go
@@ -92,13 +92,16 @@ func (missingRouteTokenSource) Descriptor() tokenauth.Descriptor {
 }
 
 type githubCredentialRoute struct {
-	key            tokenauth.Key
-	source         tokenauth.Source
-	client         github.Client
-	fetcher        *github.GraphQLFetcher
-	discoveryOwner string
-	readIdentity   github.IdentityKey
-	writeIdentity  github.IdentityKey
+	key                 tokenauth.Key
+	source              tokenauth.Source
+	client              github.Client
+	fetcher             *github.GraphQLFetcher
+	discoveryOwner      string
+	readIdentity        github.IdentityKey
+	writeIdentity       github.IdentityKey
+	archiveKey          tokenauth.Key
+	archiveSource       tokenauth.Source
+	archiveReadIdentity github.IdentityKey
 }
 
 type providerStartup struct {
@@ -668,16 +671,45 @@ func buildGitHubIdentityRuntimes(
 				source, desc.Key.Host, writeIdentity.Key, resolvedWrite.token, resolver,
 			)
 		}
+		var archiveSource tokenauth.Source
+		var archiveIdentity github.IdentityKey
+		var archiveKey tokenauth.Key
+		if plan.ArchiveDescriptor.Key.Host != "" {
+			archiveSource = set.Upsert(plan.ArchiveDescriptor)
+			archiveApp, archiveOK := activeGitHubAppCandidate(
+				plan.ArchiveDescriptor, plan.GitHubOwner,
+			)
+			if archiveOK {
+				if archiveApp.InstallationID <= 0 {
+					return fmt.Errorf(
+						"resolve GitHub archive identity for %s via %s: invalid installation id %d",
+						plan.ArchiveDescriptor.Key.Scope,
+						plan.ArchiveDescriptor.SafeString(), archiveApp.InstallationID,
+					)
+				}
+				archiveIdentity = github.InstallationIdentity(
+					plan.ArchiveDescriptor.Key.Host, archiveApp.InstallationID,
+				).Key
+				archiveKey = plan.ArchiveDescriptor.Key
+				ensureGitHubIdentityRuntime(
+					database, budgetPerHour,
+					github.GitHubIdentity{Key: archiveIdentity}, startup,
+				)
+			}
+		}
 		discoveryOwner := ""
 		if hasApp && strings.HasPrefix(desc.Key.Scope, "repo:") {
 			discoveryOwner = app.InstallationAccount
 		}
 		startup.githubRoutes[desc.Key] = githubCredentialRoute{
-			key:            desc.Key,
-			source:         source,
-			discoveryOwner: discoveryOwner,
-			readIdentity:   readIdentity.Key,
-			writeIdentity:  writeIdentity.Key,
+			key:                 desc.Key,
+			source:              source,
+			discoveryOwner:      discoveryOwner,
+			readIdentity:        readIdentity.Key,
+			writeIdentity:       writeIdentity.Key,
+			archiveKey:          archiveKey,
+			archiveSource:       archiveSource,
+			archiveReadIdentity: archiveIdentity,
 		}
 	}
 	return nil
@@ -780,6 +812,36 @@ func buildGitHubRouteClients(startup *providerStartup) error {
 				startup.quotaRegistry, configured.readIdentity,
 			),
 		)
+		var archiveClient github.Client
+		var archiveFetcher *github.GraphQLFetcher
+		if configured.archiveSource != nil && configured.archiveReadIdentity.Principal != "" {
+			archiveRuntime := startup.githubIdentities[configured.archiveReadIdentity.String()]
+			if archiveRuntime == nil {
+				return fmt.Errorf("create GitHub route %s archive client: missing identity runtime", key.Scope)
+			}
+			archiveClient, err = github.NewClient(
+				configured.archiveSource, key.Host, archiveRuntime.rest,
+				archiveRuntime.budget,
+				github.WithMutationsDisabled(),
+				github.WithQuotaAccounting(
+					startup.quotaRegistry,
+					configured.archiveReadIdentity, configured.archiveReadIdentity,
+				),
+			)
+			if err != nil {
+				return fmt.Errorf("create GitHub route %s archive client: %w", key.Scope, err)
+			}
+			if setter, ok := archiveClient.(graphQLRateTrackerSetter); ok {
+				setter.SetGraphQLRateTracker(archiveRuntime.graphql)
+			}
+			archiveFetcher = github.NewGraphQLFetcher(
+				configured.archiveSource, key.Host, archiveRuntime.graphql,
+				archiveRuntime.budget,
+				github.WithGraphQLQuotaAccounting(
+					startup.quotaRegistry, configured.archiveReadIdentity,
+				),
+			)
+		}
 		var writeSnapshotClient github.Client
 		if writeRuntime != nil && configured.writeIdentity != configured.readIdentity {
 			writeSnapshotClient, err = github.NewClient(
@@ -820,6 +882,10 @@ func buildGitHubRouteClients(startup *providerStartup) error {
 			WriteSnapshotClient: writeSnapshotClient,
 			Fetcher:             fetcher, ReadIdentity: configured.readIdentity,
 			WriteIdentity: configured.writeIdentity,
+			ArchiveKey:    archiveRouteKey(configured.archiveKey, key.Host),
+			ArchiveClient: archiveClient, ArchiveFetcher: archiveFetcher,
+			ArchiveCredentialKey: archiveCredentialKey(configured.archiveSource),
+			ArchiveReadIdentity:  configured.archiveReadIdentity,
 		})
 	}
 	for host, routes := range byHost {
@@ -847,6 +913,22 @@ func githubRouteOwnerAndName(scope string) (string, string) {
 	default:
 		return "", ""
 	}
+}
+
+func archiveRouteOwnerAndName(scope string) (string, string) {
+	return githubRouteOwnerAndName(strings.TrimPrefix(scope, "archive:"))
+}
+
+func archiveRouteKey(key tokenauth.Key, host string) github.RouteKey {
+	owner, name := archiveRouteOwnerAndName(key.Scope)
+	return github.RouteKey{Host: host, Owner: owner, Name: name}
+}
+
+func archiveCredentialKey(source tokenauth.Source) string {
+	if source == nil {
+		return ""
+	}
+	return source.Descriptor().CanonicalSourceString()
 }
 
 func githubCredentialPlans(cfg *config.Config) []config.ProviderTokenSource {

--- a/cmd/kenn-forge/provider_startup.go
+++ b/cmd/kenn-forge/provider_startup.go
@@ -292,27 +292,28 @@ func providerTokenSources(
 			if resolve {
 				if _, err := archiveSrc.Token(tokenCtx); err != nil {
 					if degradeFailedHosts {
-						failedHosts[key] = struct{}{}
-						delete(providerSources, key)
+						// Archive capacity is independent of ordinary sync.
+						// Keep processing the ordinary descriptor so a broken
+						// archive App cannot take the whole host offline.
 						slog.Warn(
 							"provider archive credentials unavailable; serving cached data for it without sync",
 							"platform", archiveDesc.Key.Platform,
 							"host", archiveDesc.Key.Host,
 							"err", err,
 						)
-						continue
+					} else {
+						label := fmt.Sprintf(
+							"%s host %s archive", archiveDesc.Key.Platform,
+							archiveDesc.Key.Host,
+						)
+						if plan.GitHubOwner != "" {
+							label = fmt.Sprintf("%s owner %s", label, plan.GitHubOwner)
+						}
+						return nil, fmt.Errorf(
+							"no token for %s via %s: %w",
+							label, archiveDesc.SafeString(), err,
+						)
 					}
-					label := fmt.Sprintf(
-						"%s host %s archive", archiveDesc.Key.Platform,
-						archiveDesc.Key.Host,
-					)
-					if plan.GitHubOwner != "" {
-						label = fmt.Sprintf("%s owner %s", label, plan.GitHubOwner)
-					}
-					return nil, fmt.Errorf(
-						"no token for %s via %s: %w",
-						label, archiveDesc.SafeString(), err,
-					)
 				}
 			}
 		}
@@ -769,6 +770,24 @@ func buildGitHubIdentityRuntimes(
 		var archiveKey tokenauth.Key
 		if plan.ArchiveDescriptor.Key.Host != "" {
 			archiveSource = set.Upsert(plan.ArchiveDescriptor)
+			archiveCtx := ctx
+			if plan.GitHubOwner != "" {
+				archiveCtx = tokenauth.WithGitHubOwner(archiveCtx, plan.GitHubOwner)
+			}
+			if _, err := archiveSource.Token(archiveCtx); err != nil {
+				// Archive capacity is independent from ordinary sync. A
+				// degraded startup may keep the ordinary route while leaving
+				// this route absent until the next restart or reload.
+				slog.Warn(
+					"GitHub archive credentials unavailable; disabling archive route",
+					"host", plan.ArchiveDescriptor.Key.Host,
+					"scope", plan.ArchiveDescriptor.Key.Scope,
+					"err", err,
+				)
+				archiveSource = nil
+			}
+		}
+		if archiveSource != nil {
 			archiveApp, archiveOK := activeGitHubAppCandidate(
 				plan.ArchiveDescriptor, plan.GitHubOwner,
 			)

--- a/cmd/kenn-forge/provider_startup.go
+++ b/cmd/kenn-forge/provider_startup.go
@@ -282,13 +282,53 @@ func providerTokenSources(
 			continue
 		}
 		_, seen := providerSources[key]
+		tokenCtx := ctx
+		if plan.GitHubOwner != "" {
+			tokenCtx = tokenauth.WithGitHubOwner(tokenCtx, plan.GitHubOwner)
+		}
+		if plan.ArchiveDescriptor.Key.Host != "" {
+			archiveDesc := plan.ArchiveDescriptor
+			archiveSrc := set.Upsert(archiveDesc)
+			if resolve {
+				if _, err := archiveSrc.Token(tokenCtx); err != nil {
+					if degradeFailedHosts {
+						failedHosts[key] = struct{}{}
+						delete(providerSources, key)
+						slog.Warn(
+							"provider archive credentials unavailable; serving cached data for it without sync",
+							"platform", archiveDesc.Key.Platform,
+							"host", archiveDesc.Key.Host,
+							"err", err,
+						)
+						continue
+					}
+					label := fmt.Sprintf(
+						"%s host %s archive", archiveDesc.Key.Platform,
+						archiveDesc.Key.Host,
+					)
+					if plan.GitHubOwner != "" {
+						label = fmt.Sprintf("%s owner %s", label, plan.GitHubOwner)
+					}
+					return nil, fmt.Errorf(
+						"no token for %s via %s: %w",
+						label, archiveDesc.SafeString(), err,
+					)
+				}
+			}
+		}
 		src := set.Upsert(desc)
 		if resolve {
-			tokenCtx := ctx
-			if plan.GitHubOwner != "" {
-				tokenCtx = tokenauth.WithGitHubOwner(tokenCtx, plan.GitHubOwner)
-			}
 			if _, err := src.Token(tokenCtx); err != nil {
+				if plan.ArchiveOnly && errors.Is(err, tokenauth.ErrMissingToken) {
+					// An archive-only App is intentionally independent of the
+					// ordinary PAT chain. Keep the host provider present so its
+					// routed client can serve archive requests, while the route
+					// builder omits the unusable ordinary client.
+					if !seen {
+						providerSources[key] = src
+					}
+					continue
+				}
 				if !plan.Required && errors.Is(err, tokenauth.ErrMissingToken) {
 					continue
 				}
@@ -616,26 +656,21 @@ func buildGitHubIdentityRuntimes(
 		// failing startup. Explicit host fallbacks still fail hard.
 		bestEffort := !plan.Required && desc.Key.Scope == "" &&
 			len(requiredHosts) > 0 && !hasExplicitGitHubFallback(cfg, desc.Key.Host)
-		var source tokenauth.Source = set.Upsert(desc)
+		var source tokenauth.Source
 		app, hasApp := activeGitHubAppCandidate(desc, plan.GitHubOwner)
-		resolvedWrite, err := resolveGitHubPATIdentity(
-			ctx, resolver, desc.Key.Host, source, resolvedPATs,
-		)
-		writeIdentity := resolvedWrite.identity
-		if err != nil {
-			if errors.Is(err, tokenauth.ErrMissingToken) && hasApp {
-				writeIdentity = github.GitHubIdentity{}
-			} else if !plan.Required && errors.Is(err, tokenauth.ErrMissingToken) {
-				continue
-			} else if bestEffort {
-				slog.Warn(
-					"skipping implicit GitHub host fallback; ownerless APIs stay unrouted until it resolves",
-					"host", desc.Key.Host,
-					"source", desc.SafeString(),
-					"error", err,
-				)
-				continue
-			} else {
+		var writeIdentity, readIdentity github.GitHubIdentity
+		ordinaryUnavailable := false
+		if plan.ArchiveOnly {
+			// Archive-only routes are allowed to have no ordinary PAT. Keep
+			// building the route so the independent archive client remains
+			// available; ordinary operations fail closed through the router.
+			source = set.Upsert(desc)
+			resolvedWrite, err := resolveGitHubPATIdentity(
+				ctx, resolver, desc.Key.Host, source, resolvedPATs,
+			)
+			if err != nil && errors.Is(err, tokenauth.ErrMissingToken) {
+				ordinaryUnavailable = true
+			} else if err != nil {
 				return &providerHostStartupError{
 					platformName: desc.Key.Platform,
 					host:         desc.Key.Host,
@@ -644,31 +679,89 @@ func buildGitHubIdentityRuntimes(
 						desc.Key.Scope, desc.SafeString(), err,
 					),
 				}
+			} else {
+				writeIdentity = resolvedWrite.identity
+				if writeIdentity.Key.Principal != "" {
+					source = github.BindSourceIdentity(
+						source, desc.Key.Host, writeIdentity.Key,
+						resolvedWrite.token, resolver,
+					)
+				}
 			}
 		}
-		readIdentity := writeIdentity
-		if hasApp {
-			if app.InstallationID <= 0 {
-				return fmt.Errorf(
-					"resolve GitHub identity for %s via %s: invalid installation id %d",
-					desc.Key.Scope, desc.SafeString(), app.InstallationID,
+		if !ordinaryUnavailable {
+			if !plan.ArchiveOnly {
+				source = set.Upsert(desc)
+				resolvedWrite, err := resolveGitHubPATIdentity(
+					ctx, resolver, desc.Key.Host, source, resolvedPATs,
+				)
+				writeIdentity = resolvedWrite.identity
+				if err != nil {
+					if errors.Is(err, tokenauth.ErrMissingToken) && hasApp {
+						writeIdentity = github.GitHubIdentity{}
+					} else if !plan.Required && errors.Is(err, tokenauth.ErrMissingToken) {
+						continue
+					} else if bestEffort {
+						slog.Warn(
+							"skipping implicit GitHub host fallback; ownerless APIs stay unrouted until it resolves",
+							"host", desc.Key.Host,
+							"source", desc.SafeString(),
+							"error", err,
+						)
+						continue
+					} else {
+						return &providerHostStartupError{
+							platformName: desc.Key.Platform,
+							host:         desc.Key.Host,
+							err: fmt.Errorf(
+								"resolve GitHub identity for %s via %s: %w",
+								desc.Key.Scope, desc.SafeString(), err,
+							),
+						}
+					}
+				}
+				if writeIdentity.Key.Principal != "" {
+					source = github.BindSourceIdentity(
+						source, desc.Key.Host, writeIdentity.Key,
+						resolvedWrite.token, resolver,
+					)
+				}
+			}
+			if hasApp {
+				if app.InstallationID <= 0 {
+					return fmt.Errorf(
+						"resolve GitHub identity for %s via %s: invalid installation id %d",
+						desc.Key.Scope, desc.SafeString(), app.InstallationID,
+					)
+				}
+				readIdentity = github.InstallationIdentity(
+					desc.Key.Host, app.InstallationID,
+				)
+			} else {
+				readIdentity = writeIdentity
+			}
+			ensureGitHubIdentityRuntime(
+				database, budgetPerHour, readIdentity, startup,
+			)
+			if writeIdentity.Key.Principal != "" {
+				ensureGitHubIdentityRuntime(
+					database, budgetPerHour, writeIdentity, startup,
 				)
 			}
-			readIdentity = github.InstallationIdentity(
-				desc.Key.Host, app.InstallationID,
-			)
-		}
-		ensureGitHubIdentityRuntime(
-			database, budgetPerHour, readIdentity, startup,
-		)
-		if writeIdentity.Key.Principal != "" {
+		} else {
+			// Keep the ordinary side of the route present but unusable. The
+			// host provider and router still need a route object for archive
+			// requests; ordinary calls fail closed without borrowing the
+			// archive App's identity.
+			source = missingRouteTokenSource{
+				host:  desc.Key.Host,
+				owner: strings.TrimPrefix(desc.Key.Scope, "owner:"),
+			}
+			readIdentity = github.GitHubIdentity{
+				Key: github.HostIdentity(desc.Key.Host),
+			}
 			ensureGitHubIdentityRuntime(
-				database, budgetPerHour, writeIdentity, startup,
-			)
-		}
-		if writeIdentity.Key.Principal != "" {
-			source = github.BindSourceIdentity(
-				source, desc.Key.Host, writeIdentity.Key, resolvedWrite.token, resolver,
+				database, budgetPerHour, readIdentity, startup,
 			)
 		}
 		var archiveSource tokenauth.Source

--- a/cmd/kenn-forge/provider_startup_identity_test.go
+++ b/cmd/kenn-forge/provider_startup_identity_test.go
@@ -177,6 +177,51 @@ func TestBuildProviderStartupDoesNotRequirePATForArchiveOnlyApp(t *testing.T) {
 	assert.NotNil(startup.githubClients["github.com"])
 }
 
+func TestCollectProviderTokenSourcesDegradedKeepsOrdinaryHostWhenArchiveFails(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	t.Setenv("ORDINARY_PAT", "ordinary-token")
+	cfg := &config.Config{
+		SyncInterval: "5m", Host: "127.0.0.1", Port: 8091, BasePath: "/",
+		Activity: config.Activity{ViewMode: "flat", TimeRange: "7d"},
+		Repos:    []config.Repo{{Owner: "acme", Name: "widget"}},
+		GitHubOwnerTokens: []config.GitHubOwnerTokenConfig{{
+			Host: "github.com", Owner: "acme", TokenEnv: "ORDINARY_PAT",
+		}},
+		GitHubApps: []config.GitHubAppConfig{{
+			Host: "github.com", AppID: 2, Role: config.GitHubAppRoleArchive,
+			PrivateKeyPath: "/keys/archive.pem", InstallationID: 20,
+			InstallationAccount: "acme", RepositorySelection: "all",
+		}},
+	}
+	require.NoError(cfg.Validate())
+	set := tokenauth.NewSourceSet(tokenauth.Options{
+		GitHubApp: func(context.Context, tokenauth.Candidate) (string, time.Time, error) {
+			return "", time.Time{}, errors.New("archive App unavailable")
+		},
+	})
+	sources, err := collectProviderTokenSourcesDegraded(t.Context(), cfg, set)
+	require.NoError(err)
+	require.Contains(sources, providerHostKey("github", "github.com"))
+	_, err = sources[providerHostKey("github", "github.com")].Token(t.Context())
+	require.NoError(err)
+	startup, err := buildProviderStartupOrDegraded(
+		t.Context(), dbtest.Open(t), cfg, set, sources,
+		defaultProviderFactories(), tokenGitHubIdentityResolver{
+			"ordinary-token": {Key: github.IdentityKey{
+				Host: "github.com", Principal: "user:7",
+			}},
+		},
+	)
+	require.NoError(err)
+	assert.Len(startup.registry.Providers(), 1)
+	route := startup.githubRoutes[tokenauth.Key{
+		Platform: "github", Host: "github.com", Scope: "owner:acme",
+	}]
+	assert.Empty(route.archiveReadIdentity.Principal,
+		"a failed archive credential must disable only its archive route")
+}
+
 func TestBuildProviderStartupRetainsVerifiedPATForExactRoutes(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/cmd/kenn-forge/provider_startup_identity_test.go
+++ b/cmd/kenn-forge/provider_startup_identity_test.go
@@ -94,6 +94,51 @@ func TestRegisterProviderTokenSourcesDefersGitHubAppMinting(t *testing.T) {
 	require.Zero(mints.Load(), "provider construction must remain lazy")
 }
 
+func TestBuildProviderStartupAddsDedicatedArchiveGitHubRoute(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	database := dbtest.Open(t)
+	cfg := &config.Config{
+		SyncInterval: "5m", Host: "127.0.0.1", Port: 8091, BasePath: "/",
+		Activity: config.Activity{ViewMode: "flat", TimeRange: "7d"},
+		Repos:    []config.Repo{{Owner: "acme", Name: "widget"}},
+		GitHubApps: []config.GitHubAppConfig{
+			{
+				Host: "github.com", AppID: 1, PrivateKeyPath: "/keys/sync.pem",
+				InstallationID: 10, InstallationAccount: "acme",
+				RepositorySelection: "all",
+			},
+			{
+				Host: "github.com", AppID: 2, Role: config.GitHubAppRoleArchive,
+				PrivateKeyPath: "/keys/archive.pem", InstallationID: 20,
+				InstallationAccount: "acme", RepositorySelection: "all",
+			},
+		},
+	}
+	require.NoError(cfg.Validate())
+	set := tokenauth.NewSourceSet(tokenauth.Options{
+		GitHubApp: func(context.Context, tokenauth.Candidate) (string, time.Time, error) {
+			return "app-token", time.Now().Add(time.Hour), nil
+		},
+	})
+	sources, err := registerProviderTokenSources(cfg, set)
+	require.NoError(err)
+	startup, err := buildProviderStartup(
+		t.Context(), database, cfg, set, sources, defaultProviderFactories(),
+		fakeGitHubIdentityResolver{},
+	)
+	require.NoError(err)
+	route := startup.githubRoutes[tokenauth.Key{
+		Platform: "github", Host: "github.com", Scope: "owner:acme",
+	}]
+	assert.Equal("installation:10", route.readIdentity.Principal)
+	assert.Equal("installation:20", route.archiveReadIdentity.Principal)
+	assert.NotNil(route.archiveSource)
+	routes := startup.githubRouters["github.com"].Routes()
+	require.Len(routes, 1)
+	assert.NotNil(routes[0].ArchiveClient)
+}
+
 func TestBuildProviderStartupRetainsVerifiedPATForExactRoutes(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/cmd/kenn-forge/provider_startup_identity_test.go
+++ b/cmd/kenn-forge/provider_startup_identity_test.go
@@ -139,6 +139,44 @@ func TestBuildProviderStartupAddsDedicatedArchiveGitHubRoute(t *testing.T) {
 	assert.NotNil(routes[0].ArchiveClient)
 }
 
+func TestBuildProviderStartupDoesNotRequirePATForArchiveOnlyApp(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	cfg := &config.Config{
+		SyncInterval: "5m", Host: "127.0.0.1", Port: 8091, BasePath: "/",
+		Activity: config.Activity{ViewMode: "flat", TimeRange: "7d"},
+		Repos:    []config.Repo{{Owner: "acme", Name: "widget"}},
+		GitHubApps: []config.GitHubAppConfig{{
+			Host: "github.com", AppID: 2, Role: config.GitHubAppRoleArchive,
+			PrivateKeyPath: "/keys/archive.pem", InstallationID: 20,
+			InstallationAccount: "acme", RepositorySelection: "all",
+		}},
+	}
+	require.NoError(cfg.Validate())
+	set := tokenauth.NewSourceSet(tokenauth.Options{
+		GitHubCLI: func(context.Context, string) (string, error) {
+			return "", tokenauth.ErrMissingToken
+		},
+		GitHubApp: func(context.Context, tokenauth.Candidate) (string, time.Time, error) {
+			return "archive-token", time.Now().Add(time.Hour), nil
+		},
+	})
+	sources, err := collectProviderTokenSources(t.Context(), cfg, set)
+	require.NoError(err)
+	startup, err := buildProviderStartup(
+		t.Context(), dbtest.Open(t), cfg, set, sources,
+		defaultProviderFactories(), fakeGitHubIdentityResolver{},
+	)
+	require.NoError(err)
+	route := startup.githubRoutes[tokenauth.Key{
+		Platform: "github", Host: "github.com", Scope: "owner:acme",
+	}]
+	assert.Equal("installation:20", route.archiveReadIdentity.Principal)
+	assert.Equal("github.com", route.readIdentity.Host)
+	assert.Empty(route.writeIdentity.Principal)
+	assert.NotNil(startup.githubClients["github.com"])
+}
+
 func TestBuildProviderStartupRetainsVerifiedPATForExactRoutes(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -119,6 +119,7 @@ the installed commands through `/hooks` once.
 
 ```sh
 kenn-forge-github-app create
+kenn-forge-github-app create --role archive
 kenn-forge-github-app list
 kenn-forge-github-app install
 kenn-forge-github-app uninstall
@@ -126,6 +127,7 @@ kenn-forge-github-app delete
 kenn-forge-github-app open
 ```
 
-Use this companion CLI when sync reads should use GitHub App installation
-tokens. Comments, reviews, state changes, and merges still use the user PAT
-chain.
+Use this companion CLI when sync or archive reads should use GitHub App
+installation tokens. `--role archive` creates a separate installation route
+for historical archive work. Comments, reviews, state changes, and merges
+still use the user PAT chain.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -119,6 +119,20 @@ kenn-forge-github-app install
 kenn-forge-github-app list
 ```
 
+For a busy historical archive, create a second App with its own installation
+budget:
+
+```sh
+kenn-forge-github-app create --role archive
+kenn-forge-github-app install --app-id <archive-app-id>
+```
+
+The archive App must be installed on the same repository account. Archive
+reads use it only for repositories it covers; ordinary sync and mutations keep
+using the normal App/PAT routes. The two Apps must be distinct GitHub Apps.
+The role is also visible in `kenn-forge-github-app list` and can be set
+explicitly as `role = "archive"` in `[[github_apps]]`.
+
 The CLI writes `[[github_apps]]` entries. Mutations still use a user PAT.
 After changing selected repository access on GitHub, run
 `kenn-forge-github-app install` again and restart kenn-forge.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -73,6 +73,12 @@ kenn-forge-github-app install
 kenn-forge-github-app list
 ```
 
+If ordinary sync is healthy but historical archive work is competing for the
+same installation budget, add a separate App with
+`kenn-forge-github-app create --role archive`, install it on the repository
+account, and restart kenn-forge. `kenn-forge-github-app list` shows each App's
+role and independent rate-limit state.
+
 Mutating actions still use the user credential chain so comments, approvals, and
 merges are attributed to you. Multiple PAT entries issued to the same GitHub
 user do not create additional capacity: they share one rate limit and one

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2743,12 +2743,24 @@ func (c *Config) ProviderTokenSources() []ProviderTokenSource {
 					Owner: owner, Name: name,
 				}
 				desc := c.ResolveGitHubRepoTokenSource(repo)
+				archiveDesc := c.ResolveGitHubArchiveTokenSource(repo)
+				if githubAppRole(app) == GitHubAppRoleArchive &&
+					archiveDesc.Key.Host == "" {
+					continue
+				}
+				if strings.HasPrefix(archiveDesc.Key.Scope, "archive:repo:") &&
+					!strings.HasPrefix(desc.Key.Scope, "repo:") {
+					desc.Key.Scope = strings.TrimPrefix(archiveDesc.Key.Scope, "archive:")
+				}
 				if _, ok := seen[desc.Key]; ok {
 					continue
 				}
 				seen[desc.Key] = struct{}{}
 				out = append(out, ProviderTokenSource{
-					Descriptor: desc, Required: true, GitHubOwner: owner,
+					Descriptor:        desc,
+					ArchiveDescriptor: archiveDesc,
+					Required:          true,
+					GitHubOwner:       owner,
 				})
 			}
 			continue
@@ -2759,14 +2771,19 @@ func (c *Config) ProviderTokenSources() []ProviderTokenSource {
 			Owner:        app.InstallationAccount,
 		}
 		desc := c.ResolveGitHubRepoTokenSource(repo)
+		archiveDesc := c.ResolveGitHubArchiveTokenSource(repo)
+		if githubAppRole(app) == GitHubAppRoleArchive && archiveDesc.Key.Host == "" {
+			continue
+		}
 		if _, ok := seen[desc.Key]; ok {
 			continue
 		}
 		seen[desc.Key] = struct{}{}
 		out = append(out, ProviderTokenSource{
-			Descriptor:  desc,
-			Required:    true,
-			GitHubOwner: app.InstallationAccount,
+			Descriptor:        desc,
+			ArchiveDescriptor: archiveDesc,
+			Required:          true,
+			GitHubOwner:       app.InstallationAccount,
 		})
 	}
 	for _, ownerToken := range c.GitHubOwnerTokens {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1982,6 +1982,7 @@ func (c *Config) validateGitHubOwnerTokens() error {
 func (c *Config) validateGitHubApps() error {
 	seenOwners := make(map[string]struct{}, len(c.GitHubApps))
 	seenInstallations := make(map[string]struct{}, len(c.GitHubApps))
+	seenInstallationIdentities := make(map[string]string, len(c.GitHubApps))
 	for i := range c.GitHubApps {
 		app := &c.GitHubApps[i]
 		app.Host = strings.TrimSpace(app.Host)
@@ -2065,6 +2066,18 @@ func (c *Config) validateGitHubApps() error {
 				)
 			}
 			seenInstallations[installKey] = struct{}{}
+			identityKey := host + "\x00" + strconv.FormatInt(app.AppID, 10) +
+				"\x00" + strconv.FormatInt(app.InstallationID, 10) +
+				"\x00" + strings.ToLower(app.InstallationAccount)
+			if previousRole, ok := seenInstallationIdentities[identityKey]; ok &&
+				previousRole != app.Role {
+				return fmt.Errorf(
+					"config: github_apps[%d]: installation for host %q, app id %d, and account %q cannot be configured for both %q and %q roles",
+					i, host, app.AppID, app.InstallationAccount,
+					previousRole, app.Role,
+				)
+			}
+			seenInstallationIdentities[identityKey] = app.Role
 		}
 	}
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,23 @@ const (
 	maxSSEBufferSize                       = 16384
 )
 
+func githubAppRole(app GitHubAppConfig) string {
+	role := strings.ToLower(strings.TrimSpace(app.Role))
+	if role == "" {
+		return GitHubAppRoleSync
+	}
+	return role
+}
+
+const (
+	// GitHubAppRoleSync is the default GitHub App role for ordinary sync and
+	// user-facing reads.
+	GitHubAppRoleSync = "sync"
+	// GitHubAppRoleArchive reserves an installation for historical archive
+	// work. Archive requests use this App's independent GitHub quota.
+	GitHubAppRoleArchive = "archive"
+)
+
 const (
 	// IssueWorkspaceBranchStyleSlug appends a slug derived from the
 	// issue title onto kenn-forge/issue-<n>, producing recognizable
@@ -218,15 +235,18 @@ type GitHubOwnerTokenConfig struct {
 // private key carry their own rate-limit budget, taking sync traffic
 // off the host's PAT.
 //
-// Scope decision: one app per GitHub host with one recorded
-// installation, and one active credential chain per host. An
-// installation token only reaches repos the installation covers. "All
-// repositories" installations build owner routes; "Only select repositories"
-// installations build exact routes for the recorded selected set, while
-// uncovered repos fall through to the owner or host PAT chain. An entry without
-// an installation_id is dormant and the PAT chain stays in effect.
+// Scope decision: one sync app and one archive app may serve each GitHub host
+// and installation account. An installation token only reaches repos the
+// installation covers. "All repositories" installations build owner routes;
+// "Only select repositories" installations build exact routes for the recorded
+// selected set, while uncovered repos fall through to the owner or host PAT
+// chain. An entry without an installation_id is dormant and the PAT chain
+// stays in effect.
 type GitHubAppConfig struct {
-	Host                string `toml:"host" json:"host"`
+	Host string `toml:"host" json:"host"`
+	// Role selects which Forge workload uses this App. Empty values retain
+	// the normal sync role for backwards-compatible configuration files.
+	Role                string `toml:"role,omitempty" json:"role,omitempty"`
 	AppID               int64  `toml:"app_id" json:"app_id"`
 	Slug                string `toml:"slug,omitempty" json:"slug,omitempty"`
 	Owner               string `toml:"owner,omitempty" json:"owner,omitempty"`
@@ -1965,6 +1985,16 @@ func (c *Config) validateGitHubApps() error {
 	for i := range c.GitHubApps {
 		app := &c.GitHubApps[i]
 		app.Host = strings.TrimSpace(app.Host)
+		app.Role = strings.ToLower(strings.TrimSpace(app.Role))
+		if app.Role == "" {
+			app.Role = GitHubAppRoleSync
+		}
+		if app.Role != GitHubAppRoleSync && app.Role != GitHubAppRoleArchive {
+			return fmt.Errorf(
+				"config: github_apps[%d]: role must be %q or %q (got %q)",
+				i, GitHubAppRoleSync, GitHubAppRoleArchive, app.Role,
+			)
+		}
 		app.Slug = strings.TrimSpace(app.Slug)
 		app.Owner = strings.TrimSpace(app.Owner)
 		app.PrivateKeyPath = strings.TrimSpace(app.PrivateKeyPath)
@@ -2014,7 +2044,7 @@ func (c *Config) validateGitHubApps() error {
 		if owner == "" {
 			owner = fmt.Sprintf("app:%d", app.AppID)
 		}
-		ownerKey := host + "\x00" + owner
+		ownerKey := host + "\x00" + app.Role + "\x00" + owner
 		if _, ok := seenOwners[ownerKey]; ok {
 			label := app.Owner
 			if label == "" {
@@ -2027,7 +2057,7 @@ func (c *Config) validateGitHubApps() error {
 		}
 		seenOwners[ownerKey] = struct{}{}
 		if app.InstallationAccount != "" {
-			installKey := host + "\x00" + strings.ToLower(app.InstallationAccount)
+			installKey := host + "\x00" + app.Role + "\x00" + strings.ToLower(app.InstallationAccount)
 			if _, ok := seenInstallations[installKey]; ok {
 				return fmt.Errorf(
 					"config: github_apps[%d]: duplicate github app installation for host %q and account %q",
@@ -2362,6 +2392,7 @@ func (c *Config) globServedBySelectedApp(repo Repo) bool {
 	for _, app := range c.GitHubAppsForHost(host) {
 		if app.AppID <= 0 || app.InstallationID <= 0 ||
 			app.PrivateKeyPath == "" ||
+			githubAppRole(app) != GitHubAppRoleSync ||
 			!strings.EqualFold(app.InstallationAccount, repo.Owner) ||
 			!strings.EqualFold(strings.TrimSpace(app.RepositorySelection), "selected") {
 			continue
@@ -2495,12 +2526,72 @@ func (c *Config) ResolveGitHubRepoTokenSource(r Repo) tokenauth.Descriptor {
 	return desc
 }
 
+// ResolveGitHubArchiveTokenSource builds the optional, App-only credential
+// route for archive reads of one GitHub repository. It deliberately has no
+// PAT or gh fallback: when configured, archive work either uses the dedicated
+// installation budget or fails closed instead of spending ordinary capacity.
+func (c *Config) ResolveGitHubArchiveTokenSource(r Repo) tokenauth.Descriptor {
+	if c == nil || r.PlatformOrDefault() != defaultPlatform {
+		return tokenauth.Descriptor{}
+	}
+	host := r.PlatformHostOrDefault()
+	app, covered := c.gitHubArchiveAppForRepo(host, r.Owner, r.Name)
+	if !covered {
+		return tokenauth.Descriptor{}
+	}
+	exact := strings.EqualFold(app.RepositorySelection, "selected")
+	desc := tokenauth.Descriptor{Key: tokenauth.Key{
+		Platform: defaultPlatform,
+		Host:     host,
+		Scope:    "archive:" + githubCredentialScope(r.Owner, r.Name, exact),
+	}}
+	desc.Candidates = append(desc.Candidates, tokenauth.Candidate{
+		Kind:                tokenauth.SourceKindGitHubApp,
+		Host:                host,
+		FilePath:            app.PrivateKeyPath,
+		AppID:               app.AppID,
+		InstallationID:      app.InstallationID,
+		InstallationAccount: app.InstallationAccount,
+	})
+	return desc
+}
+
 func (c *Config) gitHubAppForRepo(
 	host, owner, name string,
 ) (GitHubAppConfig, bool) {
 	for _, app := range c.GitHubAppsForHost(host) {
 		if app.AppID <= 0 || app.InstallationID <= 0 ||
 			app.PrivateKeyPath == "" ||
+			githubAppRole(app) != GitHubAppRoleSync ||
+			!strings.EqualFold(app.InstallationAccount, owner) {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(app.RepositorySelection)) {
+		case "all":
+			return app, true
+		case "selected":
+			fullName := strings.ToLower(strings.TrimSpace(owner)) + "/" +
+				strings.ToLower(strings.TrimSpace(name))
+			if strings.TrimSpace(name) == "" {
+				continue
+			}
+			for _, selected := range app.SelectedRepos {
+				if strings.EqualFold(strings.TrimSpace(selected), fullName) {
+					return app, true
+				}
+			}
+		}
+	}
+	return GitHubAppConfig{}, false
+}
+
+func (c *Config) gitHubArchiveAppForRepo(
+	host, owner, name string,
+) (GitHubAppConfig, bool) {
+	for _, app := range c.GitHubAppsForHost(host) {
+		if app.AppID <= 0 || app.InstallationID <= 0 ||
+			app.PrivateKeyPath == "" ||
+			githubAppRole(app) != GitHubAppRoleArchive ||
 			!strings.EqualFold(app.InstallationAccount, owner) {
 			continue
 		}
@@ -2571,9 +2662,10 @@ func (c *Config) appendGitHubDefaultCandidates(
 }
 
 type ProviderTokenSource struct {
-	Descriptor  tokenauth.Descriptor
-	Required    bool
-	GitHubOwner string
+	Descriptor        tokenauth.Descriptor
+	ArchiveDescriptor tokenauth.Descriptor
+	Required          bool
+	GitHubOwner       string
 }
 
 func (c *Config) ProviderTokenSources() []ProviderTokenSource {
@@ -2601,9 +2693,20 @@ func (c *Config) ProviderTokenSources() []ProviderTokenSource {
 		})
 	}
 	for _, repo := range c.Repos {
+		desc := c.ResolveRepoTokenSource(repo)
+		archiveDesc := c.ResolveGitHubArchiveTokenSource(repo)
+		// A selected archive installation is repository-exact. Keep the
+		// ordinary route exact too, so several selected archive repositories
+		// cannot collapse onto one owner route while startup builds the paired
+		// archive routes.
+		if strings.HasPrefix(archiveDesc.Key.Scope, "archive:repo:") &&
+			!strings.HasPrefix(desc.Key.Scope, "repo:") {
+			desc.Key.Scope = strings.TrimPrefix(archiveDesc.Key.Scope, "archive:")
+		}
 		plan := ProviderTokenSource{
-			Descriptor: c.ResolveRepoTokenSource(repo),
-			Required:   !c.globServedBySelectedApp(repo),
+			Descriptor:        desc,
+			ArchiveDescriptor: archiveDesc,
+			Required:          !c.globServedBySelectedApp(repo),
 		}
 		if repo.PlatformOrDefault() == defaultPlatform {
 			plan.GitHubOwner = repo.Owner

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2678,7 +2678,12 @@ type ProviderTokenSource struct {
 	Descriptor        tokenauth.Descriptor
 	ArchiveDescriptor tokenauth.Descriptor
 	Required          bool
-	GitHubOwner       string
+	// ArchiveOnly marks a route whose ordinary credential chain is not
+	// required for archive work. The startup path still registers the ordinary
+	// source so the host provider exists, but it must not make an absent PAT
+	// disable the independent archive App route.
+	ArchiveOnly bool
+	GitHubOwner string
 }
 
 func (c *Config) ProviderTokenSources() []ProviderTokenSource {
@@ -2720,6 +2725,7 @@ func (c *Config) ProviderTokenSources() []ProviderTokenSource {
 			Descriptor:        desc,
 			ArchiveDescriptor: archiveDesc,
 			Required:          !c.globServedBySelectedApp(repo),
+			ArchiveOnly:       archiveDesc.Key.Host != "" && !desc.HasActiveGitHubApp(),
 		}
 		if repo.PlatformOrDefault() == defaultPlatform {
 			plan.GitHubOwner = repo.Owner
@@ -2773,6 +2779,7 @@ func (c *Config) ProviderTokenSources() []ProviderTokenSource {
 					Descriptor:        desc,
 					ArchiveDescriptor: archiveDesc,
 					Required:          true,
+					ArchiveOnly:       archiveDesc.Key.Host != "" && !desc.HasActiveGitHubApp(),
 					GitHubOwner:       owner,
 				})
 			}
@@ -2796,6 +2803,7 @@ func (c *Config) ProviderTokenSources() []ProviderTokenSource {
 			Descriptor:        desc,
 			ArchiveDescriptor: archiveDesc,
 			Required:          true,
+			ArchiveOnly:       archiveDesc.Key.Host != "" && !desc.HasActiveGitHubApp(),
 			GitHubOwner:       app.InstallationAccount,
 		})
 	}

--- a/internal/config/github_app_config_test.go
+++ b/internal/config/github_app_config_test.go
@@ -615,6 +615,40 @@ selected_repos = ["kenn-io/one", "kenn-io/two"]
 	assert.ElementsMatch(t, []string{"repo:kenn-io/one", "repo:kenn-io/two"}, keys)
 }
 
+func TestProviderTokenSourcesExpandSelectedArchiveReposForGlob(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	cfg, err := Load(writeConfig(t, `
+[[repos]]
+owner = "acme"
+name = "widget-*"
+
+[[github_apps]]
+app_id = 2
+role = "archive"
+private_key_path = "archive.pem"
+installation_id = 20
+installation_account = "acme"
+repository_selection = "selected"
+selected_repos = ["acme/widget-a"]
+`))
+	require.NoError(err)
+
+	var selected *ProviderTokenSource
+	plans := cfg.ProviderTokenSources()
+	for i := range plans {
+		if plans[i].Descriptor.Key.Scope == "repo:acme/widget-a" {
+			selected = &plans[i]
+			break
+		}
+	}
+	require.NotNil(selected)
+	assert.False(selected.Descriptor.HasActiveGitHubApp())
+	assert.Equal("archive:repo:acme/widget-a", selected.ArchiveDescriptor.Key.Scope)
+	require.Len(selected.ArchiveDescriptor.Candidates, 1)
+	assert.Equal(int64(2), selected.ArchiveDescriptor.Candidates[0].AppID)
+}
+
 func TestFallbackTokenSourceExcludesAccountScopedGitHubApps(t *testing.T) {
 	cfg, err := Load(writeConfig(t, `
 github_token_env = "MY_PAT"

--- a/internal/config/github_app_config_test.go
+++ b/internal/config/github_app_config_test.go
@@ -39,6 +39,7 @@ func TestLoadGitHubApps(t *testing.T) {
 	assert.Equal("kenn-forge-abc", app.Slug)
 	assert.Equal(int64(99), app.InstallationID)
 	assert.Equal("kenn-io", app.InstallationAccount)
+	assert.Equal(GitHubAppRoleSync, app.Role)
 	// Relative key paths resolve against the config directory, like
 	// token_file does, so the CLI can write portable entries.
 	assert.Equal(
@@ -126,10 +127,40 @@ private_key_path = "b.pem"
 `,
 			wantErr: `duplicate github app for host "github.com" and owner "KENN-IO"`,
 		},
+		{
+			name: "same owner may have one app per role",
+			toml: `
+[[github_apps]]
+app_id = 1
+owner = "app-owner"
+role = "sync"
+private_key_path = "sync.pem"
+
+[[github_apps]]
+app_id = 2
+owner = "app-owner"
+role = "archive"
+private_key_path = "archive.pem"
+`,
+		},
+		{
+			name: "invalid role",
+			toml: `
+[[github_apps]]
+app_id = 1
+role = "background"
+private_key_path = "key.pem"
+`,
+			wantErr: `role must be "sync" or "archive"`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := Load(writeConfig(t, tt.toml))
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
 			require.Error(t, err)
 			assert.ErrorContains(t, err, tt.wantErr)
 		})
@@ -518,6 +549,70 @@ repository_selection = "all"
 	assert.Equal("kenn-io", app.InstallationAccount)
 	assert.True(filepath.IsAbs(app.FilePath), "key path %q", app.FilePath)
 	assert.Equal("MY_PAT", desc.Candidates[1].EnvName)
+}
+
+func TestResolveGitHubArchiveTokenSourceIsolatedFromSyncApp(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	cfg, err := Load(writeConfig(t, `
+[[repos]]
+owner = "kenn-io"
+name = "kenn-forge"
+
+[[github_apps]]
+app_id = 1
+private_key_path = "sync.pem"
+installation_id = 10
+installation_account = "kenn-io"
+repository_selection = "all"
+
+[[github_apps]]
+app_id = 2
+role = "archive"
+private_key_path = "archive.pem"
+installation_id = 20
+installation_account = "kenn-io"
+repository_selection = "all"
+`))
+	require.NoError(err)
+	repo := cfg.Repos[0]
+	syncDesc := cfg.ResolveGitHubRepoTokenSource(repo)
+	archiveDesc := cfg.ResolveGitHubArchiveTokenSource(repo)
+	assert.True(syncDesc.HasActiveGitHubApp())
+	assert.Equal("archive:owner:kenn-io", archiveDesc.Key.Scope)
+	assert.NotEqual(archiveDesc.Key, syncDesc.Key)
+	require.Len(archiveDesc.Candidates, 1)
+	assert.Equal(int64(2), archiveDesc.Candidates[0].AppID)
+	assert.Equal(int64(20), archiveDesc.Candidates[0].InstallationID)
+}
+
+func TestProviderTokenSourcesKeepSelectedArchiveReposExact(t *testing.T) {
+	cfg, err := Load(writeConfig(t, `
+[[repos]]
+owner = "kenn-io"
+name = "one"
+
+[[repos]]
+owner = "kenn-io"
+name = "two"
+
+[[github_apps]]
+app_id = 2
+role = "archive"
+private_key_path = "archive.pem"
+installation_id = 20
+installation_account = "kenn-io"
+repository_selection = "selected"
+selected_repos = ["kenn-io/one", "kenn-io/two"]
+`))
+	require.NoError(t, err)
+	var keys []string
+	for _, plan := range cfg.ProviderTokenSources() {
+		if plan.ArchiveDescriptor.Key.Host != "" {
+			keys = append(keys, plan.Descriptor.Key.Scope)
+		}
+	}
+	assert.ElementsMatch(t, []string{"repo:kenn-io/one", "repo:kenn-io/two"}, keys)
 }
 
 func TestFallbackTokenSourceExcludesAccountScopedGitHubApps(t *testing.T) {

--- a/internal/config/github_app_config_test.go
+++ b/internal/config/github_app_config_test.go
@@ -144,6 +144,29 @@ private_key_path = "archive.pem"
 `,
 		},
 		{
+			name: "same installation cannot have both roles",
+			toml: `
+[[github_apps]]
+app_id = 1
+owner = "sync-owner"
+role = "sync"
+private_key_path = "sync.pem"
+installation_id = 10
+installation_account = "acme"
+repository_selection = "all"
+
+[[github_apps]]
+app_id = 1
+owner = "archive-owner"
+role = "archive"
+private_key_path = "archive.pem"
+installation_id = 10
+installation_account = "ACME"
+repository_selection = "all"
+`,
+			wantErr: `cannot be configured for both "sync" and "archive" roles`,
+		},
+		{
 			name: "invalid role",
 			toml: `
 [[github_apps]]

--- a/internal/github/auth_router.go
+++ b/internal/github/auth_router.go
@@ -290,17 +290,49 @@ func (r *HostRouter) routeForRepoMode(owner, name string, archive bool) (*Route,
 		return r.RouteForRepo(owner, name)
 	}
 	if r != nil {
-		if route := r.archiveRepos[repoRouteMapKey(owner, name)]; route != nil {
+		if route := r.archiveRepos[repoRouteMapKey(owner, name)]; routeArchiveCovers(route, owner, name) {
 			return route, nil
 		}
-		if route := r.archiveOwners[ownerRouteMapKey(owner)]; route != nil {
+		if route := r.archiveOwners[ownerRouteMapKey(owner)]; routeArchiveCovers(route, owner, name) {
 			return route, nil
 		}
-		if r.archiveFallback != nil {
+		if routeArchiveCovers(r.archiveFallback, owner, name) {
 			return r.archiveFallback, nil
 		}
 	}
-	return r.RouteForRepo(owner, name)
+	// A normal route may be selected through a repository credential alias
+	// after GitHub transfers the repository to another owner. Its archive App
+	// route is scoped to the old owner/repository and must not follow that
+	// alias unless the archive key still covers the resolved identity.
+	route, err := r.RouteForRepo(owner, name)
+	if err != nil || routeArchiveCovers(route, owner, name) {
+		return route, err
+	}
+	return withoutArchiveRoute(route), err
+}
+
+func routeArchiveCovers(route *Route, owner, name string) bool {
+	if route == nil || route.ArchiveClient == nil {
+		return false
+	}
+	key := route.ArchiveKey
+	if key.Owner != "" && !strings.EqualFold(key.Owner, owner) {
+		return false
+	}
+	return key.Name == "" || strings.EqualFold(key.Name, name)
+}
+
+func withoutArchiveRoute(route *Route) *Route {
+	if route == nil {
+		return nil
+	}
+	copy := *route
+	copy.ArchiveKey = RouteKey{}
+	copy.ArchiveClient = nil
+	copy.ArchiveFetcher = nil
+	copy.ArchiveCredentialKey = ""
+	copy.ArchiveReadIdentity = IdentityKey{}
+	return &copy
 }
 
 func (r *HostRouter) WriteIdentityForRepo(owner, name string) (IdentityKey, error) {

--- a/internal/github/auth_router.go
+++ b/internal/github/auth_router.go
@@ -290,10 +290,10 @@ func (r *HostRouter) routeForRepoMode(owner, name string, archive bool) (*Route,
 		return r.RouteForRepo(owner, name)
 	}
 	if r != nil {
-		if route := r.archiveRepos[repoRouteMapKey(owner, name)]; routeArchiveCovers(route, owner, name) {
+		if route := r.archiveRepos[repoRouteMapKey(owner, name)]; route != nil && routeArchiveCovers(route, owner, name) {
 			return route, nil
 		}
-		if route := r.archiveOwners[ownerRouteMapKey(owner)]; routeArchiveCovers(route, owner, name) {
+		if route := r.archiveOwners[ownerRouteMapKey(owner)]; route != nil && routeArchiveCovers(route, owner, name) {
 			return route, nil
 		}
 		if routeArchiveCovers(r.archiveFallback, owner, name) {

--- a/internal/github/auth_router.go
+++ b/internal/github/auth_router.go
@@ -296,8 +296,8 @@ func (r *HostRouter) routeForRepoMode(owner, name string, archive bool) (*Route,
 		if route := r.archiveRepos[repoRouteMapKey(owner, name)]; route != nil {
 			return route, nil
 		}
-		if r.archiveOwners[ownerRouteMapKey(owner)] != nil {
-			return r.archiveOwners[ownerRouteMapKey(owner)], nil
+		if route := r.archiveOwners[ownerRouteMapKey(owner)]; route != nil {
+			return route, nil
 		}
 		if r.archiveFallback != nil {
 			return r.archiveFallback, nil

--- a/internal/github/auth_router.go
+++ b/internal/github/auth_router.go
@@ -217,6 +217,21 @@ func (r *HostRouter) RouteForOwner(owner string) (*Route, error) {
 	return nil, &MissingRouteError{Host: "github.com", Owner: owner}
 }
 
+func (r *HostRouter) routeForOwnerContext(
+	ctx context.Context, owner string,
+) (*Route, error) {
+	if IsArchiveSyncBudgetContext(ctx) && r != nil {
+		if route := r.archiveOwners[ownerRouteMapKey(owner)]; route != nil &&
+			routeArchiveCovers(route, owner, "") {
+			return route, nil
+		}
+		if routeArchiveCovers(r.archiveFallback, owner, "") {
+			return r.archiveFallback, nil
+		}
+	}
+	return r.RouteForOwner(owner)
+}
+
 func (r *HostRouter) RouteForRepo(owner, name string) (*Route, error) {
 	if r != nil {
 		if route := r.repos[repoRouteMapKey(owner, name)]; route != nil {
@@ -546,10 +561,13 @@ func (c *RoutedClient) fallbackClient() (Client, error) {
 	return route.Client, nil
 }
 
-func (c *RoutedClient) routeForOwner(owner string) (Client, error) {
-	route, err := c.routes.RouteForOwner(owner)
+func (c *RoutedClient) routeForOwnerContext(ctx context.Context, owner string) (Client, error) {
+	route, err := c.routes.routeForOwnerContext(ctx, owner)
 	if err != nil {
 		return nil, err
+	}
+	if IsArchiveSyncBudgetContext(ctx) && route.ArchiveClient != nil {
+		return route.ArchiveClient, nil
 	}
 	if route.Client == nil {
 		return nil, fmt.Errorf("GitHub route for %s on %s has no client", owner, c.routes.host)
@@ -567,10 +585,10 @@ func (c *RoutedClient) listRepositoriesByOwnerAcrossRoutes(
 	ctx context.Context, owner string,
 ) ([]*gh.Repository, error) {
 	var discovery Client
-	if c != nil && c.routes != nil {
+	if !IsArchiveSyncBudgetContext(ctx) && c != nil && c.routes != nil {
 		discovery = c.routes.discoveryOwners[ownerRouteMapKey(owner)]
 	}
-	routed, routeErr := c.routeForOwner(owner)
+	routed, routeErr := c.routeForOwnerContext(ctx, owner)
 	if routeErr != nil {
 		var missing *MissingRouteError
 		if errors.As(routeErr, &missing) && discovery != nil {

--- a/internal/github/auth_router.go
+++ b/internal/github/auth_router.go
@@ -165,22 +165,19 @@ func NewHostRouter(host string, routes ...*Route) (*HostRouter, error) {
 			}
 			switch {
 			case strings.TrimSpace(archiveKey.Owner) == "":
-				if router.archiveFallback != nil {
-					return nil, fmt.Errorf("duplicate GitHub archive fallback route for %s", router.host)
+				if router.archiveFallback == nil {
+					router.archiveFallback = route
 				}
-				router.archiveFallback = route
 			case strings.TrimSpace(archiveKey.Name) == "":
 				key := ownerRouteMapKey(archiveKey.Owner)
-				if router.archiveOwners[key] != nil {
-					return nil, fmt.Errorf("duplicate GitHub archive owner route for %s on %s", archiveKey.Owner, router.host)
+				if router.archiveOwners[key] == nil {
+					router.archiveOwners[key] = route
 				}
-				router.archiveOwners[key] = route
 			default:
 				key := repoRouteMapKey(archiveKey.Owner, archiveKey.Name)
-				if router.archiveRepos[key] != nil {
-					return nil, fmt.Errorf("duplicate GitHub archive repository route for %s/%s on %s", archiveKey.Owner, archiveKey.Name, router.host)
+				if router.archiveRepos[key] == nil {
+					router.archiveRepos[key] = route
 				}
-				router.archiveRepos[key] = route
 			}
 		}
 	}

--- a/internal/github/auth_router.go
+++ b/internal/github/auth_router.go
@@ -41,6 +41,14 @@ type Route struct {
 	Fetcher             *GraphQLFetcher
 	ReadIdentity        IdentityKey
 	WriteIdentity       IdentityKey
+	// ArchiveKey and ArchiveClient are optional. When present, requests
+	// carrying the archive budget marker use the dedicated App route and its
+	// independent quota instead of the ordinary sync route.
+	ArchiveKey           RouteKey
+	ArchiveClient        Client
+	ArchiveFetcher       *GraphQLFetcher
+	ArchiveCredentialKey string
+	ArchiveReadIdentity  IdentityKey
 }
 
 // MissingRouteError reports that no configured route can serve an owner. It
@@ -71,6 +79,9 @@ type HostRouter struct {
 	owners          map[string]*Route
 	repos           map[string]*Route
 	discoveryOwners map[string]Client
+	archiveFallback *Route
+	archiveOwners   map[string]*Route
+	archiveRepos    map[string]*Route
 
 	aliasMu     sync.RWMutex
 	repoAliases map[string]repoCredentialAlias
@@ -90,6 +101,8 @@ func NewHostRouter(host string, routes ...*Route) (*HostRouter, error) {
 		owners:          make(map[string]*Route),
 		repos:           make(map[string]*Route),
 		discoveryOwners: make(map[string]Client),
+		archiveOwners:   make(map[string]*Route),
+		archiveRepos:    make(map[string]*Route),
 	}
 	for _, route := range routes {
 		if route == nil {
@@ -138,6 +151,37 @@ func NewHostRouter(host string, routes ...*Route) (*HostRouter, error) {
 				return nil, fmt.Errorf("duplicate GitHub repository route for %s/%s on %s", route.Key.Owner, route.Key.Name, router.host)
 			}
 			router.repos[key] = route
+		}
+		if route.ArchiveClient != nil {
+			archiveKey := route.ArchiveKey
+			if strings.TrimSpace(archiveKey.Host) == "" {
+				archiveKey.Host = router.host
+			}
+			if normalizedPlatformHost(archiveKey.Host) != router.host {
+				return nil, fmt.Errorf(
+					"GitHub archive route host %s does not match router host %s",
+					normalizedPlatformHost(archiveKey.Host), router.host,
+				)
+			}
+			switch {
+			case strings.TrimSpace(archiveKey.Owner) == "":
+				if router.archiveFallback != nil {
+					return nil, fmt.Errorf("duplicate GitHub archive fallback route for %s", router.host)
+				}
+				router.archiveFallback = route
+			case strings.TrimSpace(archiveKey.Name) == "":
+				key := ownerRouteMapKey(archiveKey.Owner)
+				if router.archiveOwners[key] != nil {
+					return nil, fmt.Errorf("duplicate GitHub archive owner route for %s on %s", archiveKey.Owner, router.host)
+				}
+				router.archiveOwners[key] = route
+			default:
+				key := repoRouteMapKey(archiveKey.Owner, archiveKey.Name)
+				if router.archiveRepos[key] != nil {
+					return nil, fmt.Errorf("duplicate GitHub archive repository route for %s/%s on %s", archiveKey.Owner, archiveKey.Name, router.host)
+				}
+				router.archiveRepos[key] = route
+			}
 		}
 	}
 	return router, nil
@@ -215,6 +259,53 @@ func (r *HostRouter) ReadIdentityForRepo(owner, name string) (IdentityKey, error
 	return route.ReadIdentity, nil
 }
 
+// ArchiveIdentityForRepo returns the dedicated archive identity when one is
+// configured, falling back to the normal read identity otherwise.
+func (r *HostRouter) ArchiveIdentityForRepo(owner, name string) (IdentityKey, error) {
+	route, err := r.routeForRepoMode(owner, name, true)
+	if err != nil {
+		return IdentityKey{}, err
+	}
+	if route.ArchiveReadIdentity.Principal != "" {
+		return route.ArchiveReadIdentity, nil
+	}
+	return route.ReadIdentity, nil
+}
+
+// FetcherForRepo returns the GraphQL fetcher selected for a repository and
+// request context. Archive-marked requests use the archive installation's
+// fetcher when the route provides one.
+func (r *HostRouter) FetcherForRepo(
+	ctx context.Context, owner, name string,
+) (*GraphQLFetcher, error) {
+	route, err := r.routeForRepoMode(owner, name, IsArchiveSyncBudgetContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+	if IsArchiveSyncBudgetContext(ctx) && route.ArchiveFetcher != nil {
+		return route.ArchiveFetcher, nil
+	}
+	return route.Fetcher, nil
+}
+
+func (r *HostRouter) routeForRepoMode(owner, name string, archive bool) (*Route, error) {
+	if !archive {
+		return r.RouteForRepo(owner, name)
+	}
+	if r != nil {
+		if route := r.archiveRepos[repoRouteMapKey(owner, name)]; route != nil {
+			return route, nil
+		}
+		if r.archiveOwners[ownerRouteMapKey(owner)] != nil {
+			return r.archiveOwners[ownerRouteMapKey(owner)], nil
+		}
+		if r.archiveFallback != nil {
+			return r.archiveFallback, nil
+		}
+	}
+	return r.RouteForRepo(owner, name)
+}
+
 func (r *HostRouter) WriteIdentityForRepo(owner, name string) (IdentityKey, error) {
 	route, err := r.RouteForRepo(owner, name)
 	if err != nil {
@@ -287,20 +378,28 @@ func NewRoutedClient(routes *HostRouter) (*RoutedClient, error) {
 }
 
 func (c *RoutedClient) routeForRepo(owner, repo string) (Client, error) {
-	route, err := c.routes.RouteForRepo(owner, repo)
+	return c.routeForRepoContext(context.Background(), owner, repo)
+}
+
+func (c *RoutedClient) routeForRepoContext(ctx context.Context, owner, repo string) (Client, error) {
+	route, err := c.routes.routeForRepoMode(owner, repo, IsArchiveSyncBudgetContext(ctx))
 	if err != nil {
 		return nil, err
 	}
-	if route.Client == nil {
+	client := route.Client
+	if IsArchiveSyncBudgetContext(ctx) && route.ArchiveClient != nil {
+		client = route.ArchiveClient
+	}
+	if client == nil {
 		return nil, fmt.Errorf("GitHub route for %s/%s on %s has no client", owner, repo, c.routes.host)
 	}
-	return route.Client, nil
+	return client, nil
 }
 
 func (c *RoutedClient) pageClientForRepo(
-	owner, repo string, capability platform.ArchiveCapability,
+	ctx context.Context, owner, repo string, capability platform.ArchiveCapability,
 ) (pageClient, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
@@ -322,7 +421,7 @@ func (c *RoutedClient) ListInventoryIssuesPage(
 	since string,
 ) ([]*gh.Issue, string, bool, error) {
 	paged, err := c.pageClientForRepo(
-		owner, repo, platform.ArchiveCapabilityHistoricalIssues,
+		ctx, owner, repo, platform.ArchiveCapabilityHistoricalIssues,
 	)
 	if err != nil {
 		return nil, "", false, err
@@ -338,7 +437,7 @@ func (c *RoutedClient) ListInventoryPullRequestsPage(
 	page int,
 ) ([]*gh.PullRequest, bool, error) {
 	paged, err := c.pageClientForRepo(
-		owner, repo, platform.ArchiveCapabilityHistoricalMergeRequests,
+		ctx, owner, repo, platform.ArchiveCapabilityHistoricalMergeRequests,
 	)
 	if err != nil {
 		return nil, false, err
@@ -355,7 +454,7 @@ func (c *RoutedClient) GetMarkdownImage(
 	ctx context.Context,
 	owner, repo, sourceURL string,
 ) (platform.MarkdownImage, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return platform.MarkdownImage{}, err
 	}
@@ -377,7 +476,7 @@ func (c *RoutedClient) ListOpenPullRequestsWithNativeStackHints(
 	ctx context.Context,
 	owner, repo string,
 ) ([]*gh.PullRequest, map[int]*NativeStackHint, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -394,7 +493,7 @@ func (c *RoutedClient) ListNativeStacksPage(
 	owner, repo string,
 	page int,
 ) (NativeStackPage, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return NativeStackPage{}, err
 	}
@@ -503,7 +602,7 @@ func mergeRepositoryLists(lists ...[]*gh.Repository) []*gh.Repository {
 func (c *RoutedClient) AuthenticatedViewerLoginForRepo(
 	ctx context.Context, owner, name string,
 ) (string, error) {
-	client, err := c.routeForRepo(owner, name)
+	client, err := c.routeForRepoContext(ctx, owner, name)
 	if err != nil {
 		return "", err
 	}
@@ -553,7 +652,7 @@ func (c *RoutedClient) AuthenticatedViewerCacheKey() string {
 func (c *RoutedClient) GetNotificationThreadForRepo(
 	ctx context.Context, owner, name, threadID string,
 ) (NotificationThread, error) {
-	client, err := c.routeForRepo(owner, name)
+	client, err := c.routeForRepoContext(ctx, owner, name)
 	if err != nil {
 		return NotificationThread{}, err
 	}
@@ -617,7 +716,7 @@ func (c *RoutedClient) GetUser(ctx context.Context, login string) (*gh.User, err
 func (c *RoutedClient) GetUserForRepo(
 	ctx context.Context, owner, repo, login string,
 ) (*gh.User, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
@@ -628,7 +727,7 @@ func (c *RoutedClient) ListNotifications(ctx context.Context, opts NotificationL
 	var client Client
 	var err error
 	if opts.RepoOwner != "" && opts.RepoName != "" {
-		client, err = c.routeForRepo(opts.RepoOwner, opts.RepoName)
+		client, err = c.routeForRepoContext(ctx, opts.RepoOwner, opts.RepoName)
 	} else {
 		client, err = c.fallbackClient()
 	}
@@ -641,7 +740,7 @@ func (c *RoutedClient) ListNotifications(ctx context.Context, opts NotificationL
 func (c *RoutedClient) MarkNotificationThreadReadForRepo(
 	ctx context.Context, owner, name, threadID string,
 ) error {
-	client, err := c.routeForRepo(owner, name)
+	client, err := c.routeForRepoContext(ctx, owner, name)
 	if err != nil {
 		return err
 	}
@@ -657,14 +756,14 @@ func (c *RoutedClient) MarkNotificationThreadRead(ctx context.Context, threadID 
 }
 
 func (c *RoutedClient) ListOpenPullRequests(ctx context.Context, owner, repo string) ([]*gh.PullRequest, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.ListOpenPullRequests(ctx, owner, repo)
 }
 func (c *RoutedClient) GetPullRequest(ctx context.Context, owner, repo string, number int) (*gh.PullRequest, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
@@ -674,231 +773,231 @@ func (c *RoutedClient) ListRepositoriesByOwner(ctx context.Context, owner string
 	return c.listRepositoriesByOwnerAcrossRoutes(ctx, owner)
 }
 func (c *RoutedClient) ListReleases(ctx context.Context, owner, repo string, perPage int) ([]*gh.RepositoryRelease, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.ListReleases(ctx, owner, repo, perPage)
 }
 func (c *RoutedClient) ListTags(ctx context.Context, owner, repo string, perPage int) ([]*gh.RepositoryTag, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.ListTags(ctx, owner, repo, perPage)
 }
 func (c *RoutedClient) ListOpenIssues(ctx context.Context, owner, repo string) ([]*gh.Issue, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.ListOpenIssues(ctx, owner, repo)
 }
 func (c *RoutedClient) GetIssue(ctx context.Context, owner, repo string, number int) (*gh.Issue, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.GetIssue(ctx, owner, repo, number)
 }
 func (c *RoutedClient) CreateIssue(ctx context.Context, owner, repo, title, body string) (*gh.Issue, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.CreateIssue(ctx, owner, repo, title, body)
 }
 func (c *RoutedClient) ListIssueComments(ctx context.Context, owner, repo string, number int) ([]*gh.IssueComment, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.ListIssueComments(ctx, owner, repo, number)
 }
 func (c *RoutedClient) ListIssueCommentsIfChanged(ctx context.Context, owner, repo string, number int) ([]*gh.IssueComment, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.ListIssueCommentsIfChanged(ctx, owner, repo, number)
 }
 func (c *RoutedClient) ListReviews(ctx context.Context, owner, repo string, number int) ([]*gh.PullRequestReview, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.ListReviews(ctx, owner, repo, number)
 }
 func (c *RoutedClient) ListPullRequestReviewThreads(ctx context.Context, owner, repo string, number int) ([]PullRequestReviewThread, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.ListPullRequestReviewThreads(ctx, owner, repo, number)
 }
 func (c *RoutedClient) ListCommits(ctx context.Context, owner, repo string, number int) ([]*gh.RepositoryCommit, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.ListCommits(ctx, owner, repo, number)
 }
 func (c *RoutedClient) ListPullRequestTimelineEvents(ctx context.Context, owner, repo string, number int) ([]PullRequestTimelineEvent, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.ListPullRequestTimelineEvents(ctx, owner, repo, number)
 }
 func (c *RoutedClient) ListForcePushEvents(ctx context.Context, owner, repo string, number int) ([]ForcePushEvent, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.ListForcePushEvents(ctx, owner, repo, number)
 }
 func (c *RoutedClient) GetCombinedStatus(ctx context.Context, owner, repo, ref string) (*gh.CombinedStatus, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.GetCombinedStatus(ctx, owner, repo, ref)
 }
 func (c *RoutedClient) ListCheckRunsForRef(ctx context.Context, owner, repo, ref string) ([]*gh.CheckRun, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.ListCheckRunsForRef(ctx, owner, repo, ref)
 }
 func (c *RoutedClient) ListWorkflowRunsForHeadSHA(ctx context.Context, owner, repo, sha string) ([]*gh.WorkflowRun, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.ListWorkflowRunsForHeadSHA(ctx, owner, repo, sha)
 }
 func (c *RoutedClient) ApproveWorkflowRun(ctx context.Context, owner, repo string, runID int64) error {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return err
 	}
 	return client.ApproveWorkflowRun(ctx, owner, repo, runID)
 }
 func (c *RoutedClient) CreateIssueComment(ctx context.Context, owner, repo string, number int, body string) (*gh.IssueComment, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.CreateIssueComment(ctx, owner, repo, number, body)
 }
 func (c *RoutedClient) EditIssueComment(ctx context.Context, owner, repo string, commentID int64, body string) (*gh.IssueComment, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.EditIssueComment(ctx, owner, repo, commentID, body)
 }
 func (c *RoutedClient) DeleteIssueComment(ctx context.Context, owner, repo string, commentID int64) error {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return err
 	}
 	return client.DeleteIssueComment(ctx, owner, repo, commentID)
 }
 func (c *RoutedClient) CreatePullRequestReviewCommentReply(ctx context.Context, owner, repo string, number int, body string, commentID int64) (*gh.PullRequestComment, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.CreatePullRequestReviewCommentReply(ctx, owner, repo, number, body, commentID)
 }
 func (c *RoutedClient) GetRepository(ctx context.Context, owner, repo string) (*gh.Repository, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.GetRepository(ctx, owner, repo)
 }
 func (c *RoutedClient) CreateReview(ctx context.Context, owner, repo string, number int, event, body string) (*gh.PullRequestReview, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.CreateReview(ctx, owner, repo, number, event, body)
 }
 func (c *RoutedClient) CreateReviewWithComments(ctx context.Context, owner, repo string, number int, event, body, commitID string, comments []*gh.DraftReviewComment) (*gh.PullRequestReview, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.CreateReviewWithComments(ctx, owner, repo, number, event, body, commitID, comments)
 }
 func (c *RoutedClient) ApplyReviewSuggestions(ctx context.Context, owner, repo string, number int, input platform.ApplyReviewSuggestionsInput) (*platform.AppliedReviewSuggestions, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.ApplyReviewSuggestions(ctx, owner, repo, number, input)
 }
 func (c *RoutedClient) DismissReview(ctx context.Context, owner, repo string, number int, reviewID int64, message string) (*gh.PullRequestReview, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.DismissReview(ctx, owner, repo, number, reviewID, message)
 }
 func (c *RoutedClient) MarkPullRequestReadyForReview(ctx context.Context, owner, repo string, number int) (*gh.PullRequest, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.MarkPullRequestReadyForReview(ctx, owner, repo, number)
 }
 func (c *RoutedClient) ConvertPullRequestToDraft(ctx context.Context, owner, repo string, number int) (*gh.PullRequest, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.ConvertPullRequestToDraft(ctx, owner, repo, number)
 }
 func (c *RoutedClient) MergePullRequest(ctx context.Context, owner, repo string, number int, title, message, method, expectedSHA string) (*gh.PullRequestMergeResult, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.MergePullRequest(ctx, owner, repo, number, title, message, method, expectedSHA)
 }
 func (c *RoutedClient) EditPullRequest(ctx context.Context, owner, repo string, number int, opts EditPullRequestOpts) (*gh.PullRequest, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.EditPullRequest(ctx, owner, repo, number, opts)
 }
 func (c *RoutedClient) EditIssue(ctx context.Context, owner, repo string, number int, state string) (*gh.Issue, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.EditIssue(ctx, owner, repo, number, state)
 }
 func (c *RoutedClient) EditIssueContent(ctx context.Context, owner, repo string, number int, title, body *string) (*gh.Issue, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
 	return client.EditIssueContent(ctx, owner, repo, number, title, body)
 }
 func (c *RoutedClient) ListPullRequestsPage(ctx context.Context, owner, repo, state string, page int) ([]*gh.PullRequest, bool, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, false, err
 	}
 	return client.ListPullRequestsPage(ctx, owner, repo, state, page)
 }
 func (c *RoutedClient) ListIssuesPage(ctx context.Context, owner, repo, state string, page int) ([]*gh.Issue, bool, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, false, err
 	}
@@ -912,7 +1011,7 @@ func (c *RoutedClient) InvalidateListETagsForRepo(owner, repo string, endpoints 
 }
 
 func (c *RoutedClient) ListRepoLabels(ctx context.Context, owner, repo string) ([]*gh.Label, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
@@ -924,7 +1023,7 @@ func (c *RoutedClient) ListRepoLabels(ctx context.Context, owner, repo string) (
 }
 
 func (c *RoutedClient) ReplaceIssueLabels(ctx context.Context, owner, repo string, number int, names []string) ([]*gh.Label, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
@@ -936,7 +1035,7 @@ func (c *RoutedClient) ReplaceIssueLabels(ctx context.Context, owner, repo strin
 }
 
 func (c *RoutedClient) ReplaceIssueAssignees(ctx context.Context, owner, repo string, number int, usernames []string) (*gh.Issue, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
@@ -948,7 +1047,7 @@ func (c *RoutedClient) ReplaceIssueAssignees(ctx context.Context, owner, repo st
 }
 
 func (c *RoutedClient) RequestPullRequestReviewers(ctx context.Context, owner, repo string, number int, usernames []string) (*gh.PullRequest, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}
@@ -960,7 +1059,7 @@ func (c *RoutedClient) RequestPullRequestReviewers(ctx context.Context, owner, r
 }
 
 func (c *RoutedClient) RemovePullRequestReviewers(ctx context.Context, owner, repo string, number int, usernames []string) error {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return err
 	}
@@ -972,7 +1071,7 @@ func (c *RoutedClient) RemovePullRequestReviewers(ctx context.Context, owner, re
 }
 
 func (c *RoutedClient) GetPullRequestIfChanged(ctx context.Context, owner, repo string, number int, etag string) (*gh.PullRequest, string, bool, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, "", false, err
 	}
@@ -985,7 +1084,7 @@ func (c *RoutedClient) GetPullRequestIfChanged(ctx context.Context, owner, repo 
 }
 
 func (c *RoutedClient) GetIssueIfChanged(ctx context.Context, owner, repo string, number int, etag string) (*gh.Issue, string, bool, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, "", false, err
 	}
@@ -998,7 +1097,7 @@ func (c *RoutedClient) GetIssueIfChanged(ctx context.Context, owner, repo string
 }
 
 func (c *RoutedClient) ListIssueTimelineEvents(ctx context.Context, owner, repo string, number int) ([]PullRequestTimelineEvent, error) {
-	client, err := c.routeForRepo(owner, repo)
+	client, err := c.routeForRepoContext(ctx, owner, repo)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/github/auth_router_test.go
+++ b/internal/github/auth_router_test.go
@@ -737,6 +737,34 @@ func TestRoutedClientUsesDedicatedArchiveRoute(t *testing.T) {
 	)
 }
 
+func TestNewHostRouterDeduplicatesSharedArchiveRoutes(t *testing.T) {
+	require := require.New(t)
+	archive := &routeRecordingClient{marker: "archive"}
+	router, err := NewHostRouter(
+		"github.com",
+		&Route{
+			Key:           RouteKey{Host: "github.com", Owner: "acme"},
+			Client:        &routeRecordingClient{marker: "owner"},
+			ArchiveKey:    RouteKey{Host: "github.com", Owner: "acme"},
+			ArchiveClient: archive,
+		},
+		&Route{
+			Key:           RouteKey{Host: "github.com", Owner: "acme", Name: "widget"},
+			Client:        &routeRecordingClient{marker: "repo"},
+			ArchiveKey:    RouteKey{Host: "github.com", Owner: "acme"},
+			ArchiveClient: archive,
+		},
+	)
+	require.NoError(err)
+	routed, err := NewRoutedClient(router)
+	require.NoError(err)
+	_, err = routed.GetRepository(
+		WithArchiveSyncBudget(t.Context()), "acme", "widget",
+	)
+	require.NoError(err)
+	require.Len(archive.calls, 1)
+}
+
 func mustArchiveIdentity(t *testing.T, router *HostRouter, owner, name string) IdentityKey {
 	t.Helper()
 	require := require.New(t)

--- a/internal/github/auth_router_test.go
+++ b/internal/github/auth_router_test.go
@@ -1433,6 +1433,33 @@ func TestHostRouterRepoCredentialAliasFollowsRename(t *testing.T) {
 	assert.Equal("widget-bot", identity.Principal)
 }
 
+func TestHostRouterArchiveAliasFallsBackWhenArchiveAppLosesCoverage(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	normal := &routeRecordingClient{marker: "normal"}
+	archive := &routeRecordingClient{marker: "archive"}
+	router, err := NewHostRouter("github.com",
+		&Route{
+			Key:           RouteKey{Host: "github.com", Owner: "acme", Name: "widget"},
+			Client:        normal,
+			ArchiveKey:    RouteKey{Host: "github.com", Owner: "acme", Name: "widget"},
+			ArchiveClient: archive,
+		},
+	)
+	require.NoError(err)
+	router.RegisterRepoCredentialAlias("acme", "gadget",
+		RouteKey{Host: "github.com", Owner: "acme", Name: "widget"}, "R_1")
+	routed, err := NewRoutedClient(router)
+	require.NoError(err)
+	_, err = routed.GetRepository(
+		WithArchiveSyncBudget(t.Context()), "acme", "gadget",
+	)
+	require.NoError(err)
+	assert.Equal([]string{"get:acme/gadget"}, normal.calls)
+	assert.Empty(archive.calls,
+		"an archive route scoped to the old repository must not follow its alias")
+}
+
 func TestRegisterConfiguredRepoCredentialAliasesRoutesRenamedRepo(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/github/auth_router_test.go
+++ b/internal/github/auth_router_test.go
@@ -737,6 +737,30 @@ func TestRoutedClientUsesDedicatedArchiveRoute(t *testing.T) {
 	)
 }
 
+func TestRoutedClientUsesDedicatedArchiveRouteForOwnerDiscovery(t *testing.T) {
+	require := require.New(t)
+	normal := &routeRecordingClient{marker: "normal"}
+	archive := &routeRecordingClient{marker: "archive"}
+	router, err := NewHostRouter("github.com", &Route{
+		Key:           RouteKey{Host: "github.com", Owner: "acme"},
+		Client:        normal,
+		ArchiveKey:    RouteKey{Host: "github.com", Owner: "acme"},
+		ArchiveClient: archive,
+	})
+	require.NoError(err)
+	routed, err := NewRoutedClient(router)
+	require.NoError(err)
+
+	repos, err := routed.ListRepositoriesByOwner(
+		WithArchiveSyncBudget(t.Context()), "acme",
+	)
+	require.NoError(err)
+	require.Len(repos, 1)
+	assert.Equal(t, "archive", repos[0].GetName())
+	assert.Empty(t, normal.calls,
+		"archive owner discovery must not spend the ordinary route")
+}
+
 func TestNewHostRouterDeduplicatesSharedArchiveRoutes(t *testing.T) {
 	require := require.New(t)
 	archive := &routeRecordingClient{marker: "archive"}

--- a/internal/github/auth_router_test.go
+++ b/internal/github/auth_router_test.go
@@ -709,6 +709,42 @@ func TestRoutedClientPreservesAndRoutesArchiveInventory(t *testing.T) {
 	)
 }
 
+func TestRoutedClientUsesDedicatedArchiveRoute(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	normal := &routeRecordingClient{marker: "normal"}
+	archive := &routeRecordingClient{marker: "archive"}
+	router, err := NewHostRouter("github.com", &Route{
+		Key: RouteKey{Host: "github.com", Owner: "acme"}, Client: normal,
+		Fetcher:       &GraphQLFetcher{},
+		ArchiveKey:    RouteKey{Host: "github.com", Owner: "acme"},
+		ArchiveClient: archive, ArchiveFetcher: &GraphQLFetcher{},
+		ArchiveReadIdentity: IdentityKey{Host: "github.com", Principal: "installation:2"},
+	})
+	require.NoError(err)
+	routed, err := NewRoutedClient(router)
+	require.NoError(err)
+	_, err = routed.GetRepository(t.Context(), "acme", "widget")
+	require.NoError(err)
+	_, err = routed.GetRepository(WithArchiveSyncBudget(t.Context()), "acme", "widget")
+	require.NoError(err)
+	assert.Equal([]string{"get:acme/widget"}, normal.calls)
+	assert.Equal([]string{"get:acme/widget"}, archive.calls)
+
+	assert.Equal(
+		IdentityKey{Host: "github.com", Principal: "installation:2"},
+		mustArchiveIdentity(t, router, "acme", "widget"),
+	)
+}
+
+func mustArchiveIdentity(t *testing.T, router *HostRouter, owner, name string) IdentityKey {
+	t.Helper()
+	require := require.New(t)
+	identity, err := router.ArchiveIdentityForRepo(owner, name)
+	require.NoError(err)
+	return identity
+}
+
 func TestRoutedClientWithoutFallbackRejectsOwnerlessAPIs(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -1325,17 +1325,19 @@ func (s *Syncer) Admit(
 		retryAt := now.Add(time.Second)
 		return archive.AdmissionResult{RetryAt: &retryAt, Detail: "normal sync is active"}, nil
 	}
-	key, err := s.bucketKeyForRepo(RepoRef{
+	keyRepo := RepoRef{
 		Platform:       ref.Platform,
 		PlatformHost:   ref.Host,
 		Owner:          ref.Owner,
 		Name:           ref.Name,
 		RepoPath:       ref.RepoPath,
 		PlatformRepoID: ref.PlatformID,
-	}, false)
+	}
+	identity, err := s.archiveIdentityForRepo(keyRepo)
 	if err != nil {
 		return archive.AdmissionResult{}, err
 	}
+	key := RateBucketKey(string(repoPlatform(keyRepo)), identity.Host, identity.Principal)
 	if s.higherPriorityProviderWorkActive(key, archive.PriorityFullArchive) {
 		probe.abandon()
 		retryAt := now.Add(time.Second)
@@ -1345,7 +1347,7 @@ func (s *Syncer) Admit(
 	var providerResetAt *time.Time
 	var providerPacingWindow *QuotaPacingWindow
 	var providerResources []QuotaResource
-	identity, identityErr := s.identityForRepo(repo, false)
+	identity, identityErr := s.archiveIdentityForRepo(repo)
 	if ref.Platform == platform.KindGitHub && s.quotaRegistry != nil && identityErr == nil {
 		providerResources = []QuotaResource{QuotaResourceREST, QuotaResourceGraphQL}
 		pacingWindow, pacingKnown := s.quotaRegistry.PacingWindow(identity, providerResources)
@@ -3700,14 +3702,18 @@ func (s *Syncer) SetGitHubRouters(routers map[string]*HostRouter) {
 // fetcherFor returns the GitHub GraphQL fetcher selected for a repository's
 // credential route, or the host fallback fetcher when no router is configured.
 func (s *Syncer) fetcherFor(repo RepoRef) *GraphQLFetcher {
+	return s.fetcherForContext(context.Background(), repo)
+}
+
+func (s *Syncer) fetcherForContext(ctx context.Context, repo RepoRef) *GraphQLFetcher {
 	if repoPlatform(repo) != platform.KindGitHub {
 		return nil
 	}
 	host := repoHost(repo)
 	if router := s.routers[host]; router != nil {
-		route, err := router.RouteForRepo(repo.Owner, repo.Name)
+		fetcher, err := router.FetcherForRepo(ctx, repo.Owner, repo.Name)
 		if err == nil {
-			return route.Fetcher
+			return fetcher
 		}
 		return nil
 	}
@@ -3867,6 +3873,18 @@ func (s *Syncer) identityForRepo(repo RepoRef, write bool) (IdentityKey, error) 
 		return router.WriteIdentityForRepo(repo.Owner, repo.Name)
 	}
 	return router.ReadIdentityForRepo(repo.Owner, repo.Name)
+}
+
+func (s *Syncer) archiveIdentityForRepo(repo RepoRef) (IdentityKey, error) {
+	if repoPlatform(repo) != platform.KindGitHub {
+		return HostIdentity(repoHost(repo)), nil
+	}
+	host := repoHost(repo)
+	router := s.routers[host]
+	if router == nil {
+		return HostIdentity(host), nil
+	}
+	return router.ArchiveIdentityForRepo(repo.Owner, repo.Name)
 }
 
 func (s *Syncer) bucketKeyForRepo(repo RepoRef, write bool) (string, error) {
@@ -5392,6 +5410,7 @@ func (s *Syncer) GQLRateTrackers() map[string]*RateTracker {
 	for _, router := range s.routers {
 		for _, route := range router.Routes() {
 			add(route.Fetcher)
+			add(route.ArchiveFetcher)
 		}
 	}
 	return result
@@ -5437,6 +5456,19 @@ func (s *Syncer) refreshRateLimitSnapshots(ctx context.Context) map[string]struc
 				fetcher: route.Fetcher, owner: route.Key.Owner,
 				credential: route.CredentialKey,
 			})
+			if route.ArchiveReadIdentity.Principal != "" {
+				archiveBucket := RateBucketKey(
+					string(platform.KindGitHub), route.ArchiveReadIdentity.Host,
+					route.ArchiveReadIdentity.Principal,
+				)
+				candidates[archiveBucket] = append(candidates[archiveBucket], snapshotCandidate{
+					client:     route.ArchiveClient,
+					tracker:    s.rateTrackers[archiveBucket],
+					fetcher:    route.ArchiveFetcher,
+					owner:      route.ArchiveKey.Owner,
+					credential: route.ArchiveCredentialKey,
+				})
+			}
 			if route.WriteIdentity.Principal != "" && route.WriteIdentity != route.ReadIdentity {
 				writeBucket := RateBucketKey(
 					string(platform.KindGitHub), route.WriteIdentity.Host,
@@ -7893,7 +7925,7 @@ func (s *Syncer) indexSyncRepo(
 			// the list phase updates timestamps and the detail drain
 			// conditionally fetches individual stale PRs.
 			graphQLDone := false
-			if fetcher := s.fetcherFor(repo); fetcher != nil &&
+			if fetcher := s.fetcherForContext(ctx, repo); fetcher != nil &&
 				s.shouldUseBulkGraphQLForMRs(ctx, repo, repoID, len(openMRs)) {
 				if s.graphQLReadAllowed(ctx, repo, fetcher) {
 					result, gqlErr := fetcher.FetchRepoPRs(
@@ -8047,7 +8079,7 @@ func (s *Syncer) indexSyncRepo(
 			}
 		} else {
 			graphQLIssuesDone := false
-			if fetcher := s.fetcherFor(repo); fetcher != nil &&
+			if fetcher := s.fetcherForContext(ctx, repo); fetcher != nil &&
 				s.shouldUseBulkGraphQLForIssues(ctx, repo, repoID, len(openIssues)+len(ghIssues)) {
 				if s.graphQLReadAllowed(ctx, repo, fetcher) {
 					issueResult, gqlErr := fetcher.FetchRepoIssues(
@@ -10141,7 +10173,7 @@ func (s *Syncer) markUnchangedMRDetailFetched(
 		}
 		return calls, err
 	}
-	if fetcher := s.fetcherFor(repo); fetcher != nil && s.graphQLReadAllowed(ctx, repo, fetcher) {
+	if fetcher := s.fetcherForContext(ctx, repo); fetcher != nil && s.graphQLReadAllowed(ctx, repo, fetcher) {
 		threadCalls, err := s.syncProviderMRReviewThreads(
 			ctx, repo, existing.ID, number, existing.SnapshotRevision, true,
 		)
@@ -11252,7 +11284,7 @@ func (s *Syncer) currentPRCommentVisibility(
 	repo RepoRef,
 	number int,
 ) (map[int64]CommentVisibility, bool) {
-	fetcher := s.fetcherFor(repo)
+	fetcher := s.fetcherForContext(ctx, repo)
 	if fetcher == nil || !s.graphQLReadAllowed(ctx, repo, fetcher) {
 		return nil, false
 	}
@@ -11275,7 +11307,7 @@ func (s *Syncer) currentIssueCommentVisibility(
 	repo RepoRef,
 	number int,
 ) (map[int64]CommentVisibility, bool) {
-	fetcher := s.fetcherFor(repo)
+	fetcher := s.fetcherForContext(ctx, repo)
 	if fetcher == nil || !s.graphQLReadAllowed(ctx, repo, fetcher) {
 		return nil, false
 	}

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -3861,6 +3861,12 @@ func repoHost(repo RepoRef) string {
 }
 
 func (s *Syncer) identityForRepo(repo RepoRef, write bool) (IdentityKey, error) {
+	return s.identityForRepoContext(context.Background(), repo, write)
+}
+
+func (s *Syncer) identityForRepoContext(
+	ctx context.Context, repo RepoRef, write bool,
+) (IdentityKey, error) {
 	if repoPlatform(repo) != platform.KindGitHub {
 		return HostIdentity(repoHost(repo)), nil
 	}
@@ -3868,6 +3874,9 @@ func (s *Syncer) identityForRepo(repo RepoRef, write bool) (IdentityKey, error) 
 	router := s.routers[host]
 	if router == nil {
 		return HostIdentity(host), nil
+	}
+	if IsArchiveSyncBudgetContext(ctx) && !write {
+		return router.ArchiveIdentityForRepo(repo.Owner, repo.Name)
 	}
 	if write {
 		return router.WriteIdentityForRepo(repo.Owner, repo.Name)
@@ -3888,7 +3897,13 @@ func (s *Syncer) archiveIdentityForRepo(repo RepoRef) (IdentityKey, error) {
 }
 
 func (s *Syncer) bucketKeyForRepo(repo RepoRef, write bool) (string, error) {
-	identity, err := s.identityForRepo(repo, write)
+	return s.bucketKeyForRepoContext(context.Background(), repo, write)
+}
+
+func (s *Syncer) bucketKeyForRepoContext(
+	ctx context.Context, repo RepoRef, write bool,
+) (string, error) {
+	identity, err := s.identityForRepoContext(ctx, repo, write)
 	if err != nil {
 		return "", err
 	}
@@ -4740,10 +4755,21 @@ func (s *Syncer) backgroundReserveExhausted(
 func (s *Syncer) reserveVerdictFor(
 	repo RepoRef, resource QuotaResource, writeIdentity, background bool,
 ) reserveVerdict {
+	return s.reserveVerdictForContext(
+		context.Background(), repo, resource, writeIdentity, background,
+	)
+}
+
+func (s *Syncer) reserveVerdictForContext(
+	ctx context.Context,
+	repo RepoRef,
+	resource QuotaResource,
+	writeIdentity, background bool,
+) reserveVerdict {
 	if repoPlatform(repo) != platform.KindGitHub || s.quotaRegistry == nil {
 		return reserveVerdict{}
 	}
-	bucket, err := s.bucketKeyForRepo(repo, writeIdentity)
+	bucket, err := s.bucketKeyForRepoContext(ctx, repo, writeIdentity)
 	if err != nil {
 		return reserveVerdict{}
 	}
@@ -4756,7 +4782,7 @@ func (s *Syncer) reserveVerdictFor(
 		return cached
 	}
 	availability := s.evaluateBackgroundReserve(
-		repo, resource, writeIdentity, background,
+		ctx, repo, resource, writeIdentity, background,
 	)
 	verdict := reserveVerdict{
 		exhausted: availability.Exhausted,
@@ -4806,9 +4832,10 @@ func (s *Syncer) nowUTC() time.Time {
 
 // evaluateBackgroundReserve is the single reserve computation the cache wraps.
 func (s *Syncer) evaluateBackgroundReserve(
+	ctx context.Context,
 	repo RepoRef, resource QuotaResource, writeIdentity, background bool,
 ) QuotaAvailability {
-	identity, err := s.identityForRepo(repo, writeIdentity)
+	identity, err := s.identityForRepoContext(ctx, repo, writeIdentity)
 	if err != nil {
 		return QuotaAvailability{Allowed: true}
 	}
@@ -4822,7 +4849,7 @@ func (s *Syncer) evaluateBackgroundReserve(
 	if availability.Known {
 		return availability
 	}
-	return s.persistedReserve(repo, resource, writeIdentity, reserve, availability)
+	return s.persistedReserve(ctx, repo, resource, writeIdentity, reserve, availability)
 }
 
 // persistedReserve answers from the SQLite-backed rate tracker when the
@@ -4832,17 +4859,18 @@ func (s *Syncer) evaluateBackgroundReserve(
 // repopulate the registry is exactly what fails when a credential is in
 // trouble.
 func (s *Syncer) persistedReserve(
+	ctx context.Context,
 	repo RepoRef,
 	resource QuotaResource,
 	writeIdentity bool,
 	reserve int,
 	unobserved QuotaAvailability,
 ) QuotaAvailability {
-	bucket, err := s.bucketKeyForRepo(repo, writeIdentity)
+	bucket, err := s.bucketKeyForRepoContext(ctx, repo, writeIdentity)
 	if err != nil {
 		return unobserved
 	}
-	tracker := s.reserveTracker(repo, bucket, resource, writeIdentity)
+	tracker := s.reserveTracker(ctx, repo, bucket, resource, writeIdentity)
 	if tracker == nil || !tracker.Known() {
 		return unobserved
 	}
@@ -4859,6 +4887,7 @@ func (s *Syncer) persistedReserve(
 }
 
 func (s *Syncer) reserveTracker(
+	ctx context.Context,
 	repo RepoRef, bucket string, resource QuotaResource, writeIdentity bool,
 ) *RateTracker {
 	if resource == QuotaResourceGraphQL {
@@ -4867,7 +4896,11 @@ func (s *Syncer) reserveTracker(
 		}
 		// GraphQL trackers hang off the route's fetcher rather than a
 		// syncer-level map.
-		return s.fetcherFor(repo).RateTracker()
+		fetcher := s.fetcherForContext(ctx, repo)
+		if fetcher == nil {
+			return nil
+		}
+		return fetcher.RateTracker()
 	}
 	if writeIdentity {
 		if tracker := s.writeRateTrackers[bucket]; tracker != nil {
@@ -4941,7 +4974,8 @@ func (s *Syncer) advanceNextSync(
 func (s *Syncer) graphQLReadAllowed(
 	ctx context.Context, repo RepoRef, fetcher *GraphQLFetcher,
 ) bool {
-	verdict := s.reserveVerdictFor(
+	verdict := s.reserveVerdictForContext(
+		ctx,
 		repo, QuotaResourceGraphQL, false, IsSyncBudgetContext(ctx),
 	)
 	// A known credential pool answers on its own. Falling through to the

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -22260,6 +22260,46 @@ func TestGraphQLReadAllowedIsolatesCredentialGraphQLPools(t *testing.T) {
 		"healthy user credential must not inherit the App pool's exhaustion")
 }
 
+func TestGraphQLReadAllowedUsesArchiveCredentialPool(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	repo := RepoRef{Owner: "acme", Name: "widget", PlatformHost: "github.com"}
+	normalIdentity := IdentityKey{Host: "github.com", Principal: "user:7"}
+	archiveIdentity := IdentityKey{Host: "github.com", Principal: "installation:20"}
+	client := &credentialRateLimitSnapshotMockClient{mockClient: &mockClient{}}
+	router, err := NewHostRouter("github.com", &Route{
+		Key: RouteKey{Host: "github.com", Owner: "acme"}, Client: client,
+		ReadIdentity:  normalIdentity,
+		ArchiveKey:    RouteKey{Host: "github.com", Owner: "acme"},
+		ArchiveClient: client, ArchiveFetcher: &GraphQLFetcher{},
+		ArchiveReadIdentity: archiveIdentity,
+	})
+	require.NoError(err)
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, d, nil, []RepoRef{repo},
+		time.Minute, nil, nil,
+	)
+	syncer.SetGitHubRouters(map[string]*HostRouter{"github.com": router})
+	registry := NewQuotaRegistry()
+	reset := time.Now().UTC().Add(time.Hour)
+	registry.UpdateSnapshot(normalIdentity, QuotaResourceGraphQL, Rate{
+		Limit: 5000, Remaining: 0, Reset: reset,
+	})
+	registry.UpdateSnapshot(archiveIdentity, QuotaResourceGraphQL, Rate{
+		Limit: 5000, Remaining: 4000, Reset: reset,
+	})
+	syncer.SetQuotaRegistry(registry)
+	fetcher := &GraphQLFetcher{}
+
+	assert.False(syncer.graphQLReadAllowed(
+		WithSyncBudget(t.Context()), repo, fetcher,
+	), "ordinary GraphQL must honor the exhausted ordinary pool")
+	assert.True(syncer.graphQLReadAllowed(
+		WithArchiveSyncBudget(t.Context()), repo, fetcher,
+	), "archive GraphQL must use the healthy archive pool")
+}
+
 // Bulk GraphQL is an optional optimization with a REST fallback, so a
 // credential whose GraphQL pool is exhausted must keep syncing over REST
 // instead of being held out of background scheduling entirely.

--- a/internal/server/config_reload.go
+++ b/internal/server/config_reload.go
@@ -60,6 +60,10 @@ type startupConfigSnapshot struct {
 	// bounded client pool and re-resolving authenticated identity. Token values
 	// may still rotate underneath an unchanged env/file descriptor.
 	GitHubCredentialRoutes []tokenauth.Descriptor
+	// GitHubArchiveCredentialRoutes records the dedicated archive client routes
+	// built at startup. Archive clients and their quota trackers are also
+	// startup-bound, so archive App changes require a restart.
+	GitHubArchiveCredentialRoutes []tokenauth.Descriptor
 	// GitHubAppSplitHosts lists hosts whose effective credential chain
 	// resolves sync reads through a GitHub App installation token.
 	// Split topology is startup-bound: write rate trackers and the
@@ -100,6 +104,7 @@ func snapshotStartupConfig(cfg *config.Config) startupConfigSnapshot {
 		TrustReverseProxy:               cfg.TrustReverseProxy,
 		ProviderHosts:                   startupProviderHosts(cfg),
 		GitHubCredentialRoutes:          githubCredentialRoutes(cfg),
+		GitHubArchiveCredentialRoutes:   githubArchiveCredentialRoutes(cfg),
 		GitHubAppSplitHosts:             githubAppSplitHosts(cfg),
 		RoborevEndpoint:                 cfg.RoborevEndpoint(),
 	}
@@ -178,6 +183,32 @@ func githubCredentialRoutes(cfg *config.Config) []tokenauth.Descriptor {
 		}
 		seen[key] = struct{}{}
 		routes = append(routes, plan.Descriptor)
+	}
+	slices.SortFunc(routes, func(a, b tokenauth.Descriptor) int {
+		if cmp := strings.Compare(a.Key.Host, b.Key.Host); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(a.Key.Scope, b.Key.Scope)
+	})
+	return routes
+}
+
+func githubArchiveCredentialRoutes(cfg *config.Config) []tokenauth.Descriptor {
+	if cfg == nil {
+		return nil
+	}
+	seen := make(map[tokenauth.Key]struct{})
+	var routes []tokenauth.Descriptor
+	for _, plan := range cfg.ProviderTokenSources() {
+		key := plan.ArchiveDescriptor.Key
+		if key.Platform != string(platform.KindGitHub) || key.Scope == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		routes = append(routes, plan.ArchiveDescriptor)
 	}
 	slices.SortFunc(routes, func(a, b tokenauth.Descriptor) int {
 		if cmp := strings.Compare(a.Key.Host, b.Key.Host); cmp != 0 {

--- a/internal/server/config_reload.go
+++ b/internal/server/config_reload.go
@@ -448,7 +448,7 @@ func (s *Server) applyConfigChange(ctx context.Context) configChangedEvent {
 	if s.syncer != nil {
 		previous = s.syncer.TrackedRepos()
 	}
-	resolved, skipped := s.resolveReposForReload(ctx, newCfg.Repos, previous)
+	resolved, skipped := s.resolveReposForReload(ctx, newCfg, previous)
 	if len(skipped) > 0 {
 		slog.Info(
 			"config reload: skipping repos for unknown platform hosts",
@@ -664,6 +664,11 @@ func (s *Server) validateReloadProviderTokenSources(
 			continue
 		}
 		desc := plan.Descriptor
+		if plan.ArchiveOnly {
+			// Archive-only routes deliberately have no ordinary PAT. Their
+			// required credential is the independent archive App source.
+			desc = plan.ArchiveDescriptor
+		}
 		if s.syncer != nil {
 			registry := s.syncer.Registry()
 			if registry == nil {
@@ -735,7 +740,7 @@ func cloneReloadedConfig(in *config.Config) config.Config {
 // display string for logging.
 func (s *Server) resolveReposForReload(
 	ctx context.Context,
-	repos []config.Repo,
+	cfg *config.Config,
 	previous []ghclient.RepoRef,
 ) ([]ghclient.RepoRef, []string) {
 	if s.syncer == nil {
@@ -744,7 +749,7 @@ func (s *Server) resolveReposForReload(
 	set := ghclient.NewExpandedRepoSet()
 	skipped := make([]string, 0)
 
-	for _, raw := range repos {
+	for _, raw := range cfg.Repos {
 		host := raw.PlatformHostOrDefault()
 		kind := platform.Kind(raw.PlatformOrDefault())
 		if _, err := s.syncer.RepositoryReader(kind, host); err != nil {
@@ -759,8 +764,13 @@ func (s *Server) resolveReposForReload(
 			))
 			continue
 		}
+		resolveCtx := ctx
+		if kind == platform.KindGitHub &&
+			cfg.ResolveGitHubArchiveTokenSource(raw).Key.Host != "" {
+			resolveCtx = ghclient.WithArchiveSyncBudget(ctx)
+		}
 		_, expanded, err := ghclient.ResolveConfiguredRepoWithRegistry(
-			ctx, s.syncer.SyncRegistry(), raw,
+			resolveCtx, s.syncer.SyncRegistry(), raw,
 		)
 		if err != nil {
 			// Network failure or transient API error: fall back to a

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -2281,6 +2281,25 @@ func TestRestartRequiredForMCPConfig(t *testing.T) {
 	}))
 }
 
+func TestRestartRequiredForGitHubArchiveRoutes(t *testing.T) {
+	assert := assert.New(t)
+	base := &config.Config{
+		Repos: []config.Repo{{Owner: "acme", Name: "widget"}},
+		GitHubApps: []config.GitHubAppConfig{{
+			Host: "github.com", Role: "archive", AppID: 1,
+			PrivateKeyPath: "archive.pem", InstallationID: 2,
+			InstallationAccount: "acme", RepositorySelection: "all",
+		}},
+	}
+	snap := snapshotStartupConfig(base)
+	assert.False(snap.restartRequiredFor(base))
+
+	changed := *base
+	changed.GitHubApps = slices.Clone(base.GitHubApps)
+	changed.GitHubApps[0].InstallationID = 3
+	assert.True(snap.restartRequiredFor(&changed))
+}
+
 func TestRestartRequiredForRoborevEndpointButNotManagedCloneInit(t *testing.T) {
 	assert := assert.New(t)
 	base := &config.Config{Roborev: config.Roborev{

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -1418,6 +1418,39 @@ selected_repos = ["acme/widget-one", "acme/widget-two"]
 	assert.Equal(t, "acme", minted[0].InstallationAccount)
 }
 
+func TestValidateReloadProviderSourcesUsesArchiveDescriptorForArchiveOnlyRoute(t *testing.T) {
+	require := require.New(t)
+	cfg := &config.Config{
+		SyncInterval: "5m",
+		Host:         "127.0.0.1",
+		Port:         8091,
+		BasePath:     "/",
+		Activity:     config.Activity{ViewMode: "flat", TimeRange: "7d"},
+		Repos:        []config.Repo{{Owner: "acme", Name: "widget"}},
+		GitHubApps: []config.GitHubAppConfig{{
+			Host: "github.com", AppID: 2, Role: config.GitHubAppRoleArchive,
+			PrivateKeyPath: "/keys/archive.pem", InstallationID: 20,
+			InstallationAccount: "acme", RepositorySelection: "all",
+		}},
+	}
+	require.NoError(cfg.Validate())
+	set := tokenauth.NewSourceSet(tokenauth.Options{
+		GitHubApp: func(_ context.Context, candidate tokenauth.Candidate) (string, time.Time, error) {
+			if candidate.AppID != 2 {
+				return "", time.Time{}, errors.New("unexpected App")
+			}
+			return "archive-token", time.Now().Add(time.Hour), nil
+		},
+	})
+	for _, plan := range cfg.ProviderTokenSources() {
+		if plan.ArchiveOnly {
+			set.Upsert(plan.ArchiveDescriptor)
+		}
+	}
+	srv := &Server{tokenSources: set}
+	require.NoError(srv.validateReloadProviderTokenSources(t.Context(), cfg))
+}
+
 // newReloadServerWithTokenSources mirrors startup: one source per
 // provider token plan, registered in a SourceSet the server reloads
 // against.


### PR DESCRIPTION
Historical archive work currently competes with ordinary sync for the same
GitHub App installation budget. A busy archive run can consume the available
headroom and delay normal repository updates.

This adds an explicit GitHub App role for archive work. Operators can create a
second App with `kenn-forge-github-app create --role archive` and install it on
the repository account. Archive-marked requests then use that installation's
REST and GraphQL clients, rate trackers, quota accounting, and admission
budget. Ordinary sync and mutations keep their existing App/PAT routes.

Selected-repository archive installations remain repository-exact. Repositories
outside the archive installation continue through the normal route, while
all-repository installations provide an owner-scoped archive route. Existing
configuration files default to the `sync` role and remain valid.

Review focus:

- The archive route is selected only for archive-budget contexts.
- Archive and ordinary GitHub identities have independent quota and tracker
  state.
- App role validation permits one sync and one archive App per host/account,
  while rejecting duplicate routes within a role.
