### PR TITLE
fix: preserve inline comment drafts during context expansion

### DIFF
--- a/context/inline-review-comments.md
+++ b/context/inline-review-comments.md
@@ -21,6 +21,9 @@ published review-thread ingestion, or review controls in shared diff UI.
 - Line-number pointer and keyboard selection only change the active review
   range. The gutter utility opens the composer for that range
   (`frontend/src/lib/components/diff/DiffFile.svelte::handlePierreGutterUtility`).
+- Keep unsaved composer text above renderer-owned annotation mounts: context
+  expansion can remount the composer without changing its review range
+  (`frontend/src/lib/components/diff/DiffFile.svelte::composerBody`).
 - Public routes use provider-aware pull paths and internal draft/thread IDs.
   Provider review, thread, and comment IDs remain persistence metadata unless a
   concrete public API need is introduced

--- a/frontend/src/lib/components/diff/DiffFile.svelte
+++ b/frontend/src/lib/components/diff/DiffFile.svelte
@@ -118,6 +118,7 @@
 
   let selectedRange = $state<SelectedLineRange | null>(null);
   let composerRange = $state<DiffReviewLineRange | null>(null);
+  let composerBody = $state("");
   let suppressNextPierreSelection = false;
   const selectableLineRefs = $derived.by(() => ({
     left: selectableLines("left"),
@@ -414,6 +415,7 @@
     }
     if (composerRange && rangeKey(composerRange) !== rangeKey(normalized.range)) {
       composerRange = null;
+      composerBody = "";
     }
     selectedRange = normalized.selected;
   }
@@ -430,6 +432,7 @@
       return;
     }
     selectedRange = normalized.selected;
+    composerBody = "";
     composerRange = normalized.range;
   }
 
@@ -513,7 +516,17 @@
         })
         : mount(DiffInlineCommentComposer, {
           target,
-          props: { runtime, range: metadata.range, onclose: closeComposer },
+          props: {
+            runtime,
+            range: metadata.range,
+            body: composerBody,
+            onbodychange: (body) => {
+              if (composerRange && rangeKey(composerRange) === rangeKey(metadata.range)) {
+                composerBody = body;
+              }
+            },
+            onclose: closeComposer,
+          },
           context,
         });
   }
@@ -550,6 +563,7 @@
 
   function closeComposer(): void {
     composerRange = null;
+    composerBody = "";
     selectedRange = null;
   }
 
@@ -561,6 +575,7 @@
     if (nextKey !== reviewContextKey) {
       reviewContextKey = nextKey;
       composerRange = null;
+      composerBody = "";
       selectedRange = null;
     }
   });

--- a/frontend/src/lib/components/diff/DiffFile.test.ts
+++ b/frontend/src/lib/components/diff/DiffFile.test.ts
@@ -2210,7 +2210,7 @@ describe("DiffFile", () => {
     expect(selectedPierreLines()).toHaveLength(0);
   });
 
-  it("loads and expands hidden context from a single Pierre expander click", async () => {
+  it("loads and expands hidden context without clearing an inline composer draft", async () => {
     const oldText = Array.from({ length: 90 }, (_, index) => `shared ${index + 1}`);
     const newText = [...oldText];
     oldText[1] = "old early";
@@ -2282,7 +2282,10 @@ describe("DiffFile", () => {
         },
       ],
     });
-    const { diff } = renderDiffFile(file);
+    const { diff } = renderDiffFile(file, {
+      reviewEnabled: true,
+      diffHeadSHA: "diff-head",
+    });
     const loadFileContextPreviews = vi
       .spyOn(diff, "loadFileContextPreviews")
       .mockImplementation((_owner, _name, _number, source, callbacks: FilePreviewPairCallbacks) => {
@@ -2301,6 +2304,11 @@ describe("DiffFile", () => {
       return button!;
     });
 
+    await clickLineCommentButton(2, "right");
+    await fireEvent.input(screen.getByPlaceholderText("Leave a comment"), {
+      target: { value: "Keep this draft while expanding context." },
+    });
+
     await fireEvent.click(expandButton);
 
     await waitFor(() => {
@@ -2312,6 +2320,9 @@ describe("DiffFile", () => {
       expect(expandedLines.every((line) => line.length > 0)).toBe(true);
       expect(expandedLines.some((line) => line.includes("shared 10"))).toBe(true);
     });
+    expect((screen.getByPlaceholderText("Leave a comment") as HTMLTextAreaElement).value).toBe(
+      "Keep this draft while expanding context.",
+    );
     expect(loadFileContextPreviews).toHaveBeenCalledTimes(1);
   });
 

--- a/frontend/src/lib/components/diff/DiffInlineCommentComposer.svelte
+++ b/frontend/src/lib/components/diff/DiffInlineCommentComposer.svelte
@@ -12,13 +12,14 @@
   interface Props {
     runtime: AppRuntime;
     range: DiffReviewLineRange;
+    body?: string;
+    onbodychange?: ((body: string) => void) | undefined;
     onclose?: (() => void) | undefined;
   }
 
-  const { runtime, range, onclose }: Props = $props();
+  let { runtime, range, body = $bindable(""), onbodychange, onclose }: Props = $props();
   const { diffReviewDraft } = getStores();
 
-  let body = $state("");
   let textareaEl: HTMLTextAreaElement | undefined = $state();
   let focusExecution: AppExecution<void, never> | undefined;
   let autosizeExecution: AppExecution<void, never> | undefined;
@@ -66,12 +67,18 @@
     );
   }
 
+  function handleInput(event: Event): void {
+    onbodychange?.((event.currentTarget as HTMLTextAreaElement).value);
+    scheduleAutosizeTextarea();
+  }
+
   function submit(): void {
     const nextBody = body.trim();
     if (!nextBody) return;
     diffReviewDraft.createComment(nextBody, range, {
       onSuccess: () => {
         body = "";
+        onbodychange?.("");
         onclose?.();
       },
     });
@@ -87,7 +94,7 @@
     placeholder="Leave a comment"
     disabled={submitting}
     rows="3"
-    oninput={scheduleAutosizeTextarea}
+    oninput={handleInput}
   ></textarea>
   {#if error}
     <p class="composer-error">{error}</p>


### PR DESCRIPTION
Expanding hidden diff context no longer clears text typed into an inline review composer. The draft now lives at the stable file level, so renderer annotation remounts preserve it while range and review identity changes still clear it.

Fixes #948.

[proof video](https://github.com/user-attachments/assets/bd6f6efc-0dee-4233-8625-fe711f1e8ffd)
