### PR TITLE
fix: keep the active-pane focus ring visible on every edge

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -374,8 +374,12 @@ Keyboard handlers must have one clear owner for each key press.
   moves focus or changes the active pane. Mark actual focus with a subtle inset
   border without replacing control focus styling. Paint that marker as part of
   the pane itself, below descendants; a high-z generated overlay cuts through
-  popovers trapped in descendant stacking contexts
-  (`frontend/src/lib/components/shared/TabbedPanelTree.svelte`).
+  popovers trapped in descendant stacking contexts. Because it paints below
+  descendants, the leaf must reserve the marker's pixels: a constant 1px leaf
+  padding keeps every child inside the content box while the inset shadow
+  paints in the outer ring of the padding box, so opaque children (tab strip,
+  diff surfaces, terminal canvases) can never cover it and no z-index is
+  involved (`frontend/src/lib/components/shared/TabbedPanelTree.svelte`).
   A dedicated Files route keeps global diff shortcuts only while no pane or
   external dock has live focus; this fallback never paints active-pane styling
   (`frontend/src/lib/views/PRListView.svelte::diffKeyboardActive`).

--- a/frontend/src/lib/components/shared/TabbedPanelTree.svelte
+++ b/frontend/src/lib/components/shared/TabbedPanelTree.svelte
@@ -922,6 +922,13 @@
     overflow: hidden;
     border: var(--chrome-border-width) solid var(--border-default);
     border-top: 0;
+    /* The focus ring below is an inset shadow, which clips to the padding box.
+       This constant padding reserves that ring as pixels no descendant can
+       reach: children lay out in the content box, so the opaque tab strip,
+       scrolled diff surfaces, and terminal canvases cannot cover the ring,
+       while the shadow itself stays in the leaf's background layer, under
+       every popover, with no z-index involved. */
+    padding: var(--chrome-border-width);
     background: var(--bg-surface);
   }
 

--- a/frontend/tests/e2e-full/issue-list.spec.ts
+++ b/frontend/tests/e2e-full/issue-list.spec.ts
@@ -419,8 +419,11 @@ test.describe("issue list view", () => {
       const scrollportWidth = await scroller.evaluate((el) => el.clientWidth);
       const scrollportCenter = detailBox.x + scrollportWidth / 2;
       const headerCenter = headerBox.x + headerBox.width / 2;
-      // Allow small slack for sub-pixel layout differences.
-      expect(Math.abs(detailBox.x + detailBox.width - (areaBox.x + areaBox.width))).toBeLessThan(2);
+      // Pane chrome allowance: leaf border plus the 1px ring the leaf
+      // reserves for the pane focus marker (see TabbedPanelTree), plus
+      // sub-pixel slack. Anything larger means the scroller shrank to the
+      // centered content column instead of spanning the pane.
+      expect(Math.abs(detailBox.x + detailBox.width - (areaBox.x + areaBox.width))).toBeLessThan(3);
       expect(Math.abs(headerCenter - scrollportCenter)).toBeLessThan(2);
       expect(headerBox.width).toBeLessThanOrEqual(800);
     }

--- a/frontend/tests/e2e-full/pull-list.spec.ts
+++ b/frontend/tests/e2e-full/pull-list.spec.ts
@@ -199,7 +199,11 @@ test.describe("PR list view", () => {
       const scrollportWidth = await scroller.evaluate((el) => el.clientWidth);
       const scrollportCenter = detailBox.x + scrollportWidth / 2;
       const headerCenter = headerBox.x + headerBox.width / 2;
-      expect(Math.abs(detailBox.x + detailBox.width - (areaBox.x + areaBox.width))).toBeLessThan(2);
+      // Pane chrome allowance: leaf border plus the 1px ring the leaf
+      // reserves for the pane focus marker (see TabbedPanelTree), plus
+      // sub-pixel slack. Anything larger means the scroller shrank to the
+      // centered content column instead of spanning the pane.
+      expect(Math.abs(detailBox.x + detailBox.width - (areaBox.x + areaBox.width))).toBeLessThan(3);
       expect(Math.abs(headerCenter - scrollportCenter)).toBeLessThan(2);
       expect(headerBox.width).toBeLessThanOrEqual(800);
     }

--- a/frontend/tests/e2e/pr-detail-panes.spec.ts
+++ b/frontend/tests/e2e/pr-detail-panes.spec.ts
@@ -322,6 +322,38 @@ test("routes page keys by focus while wheel input remains focus-neutral", async 
   expect(filesPaneChrome.tabAccentContent).toBe("none");
   expect(filesPaneChrome.toolbarZIndex).toBe("auto");
 
+  // The focus marker is an inset shadow, which paints beneath descendants. It
+  // stays visible only because the leaf reserves the outer 1px of its padding
+  // box: every child must lay out strictly inside that ring, even while the
+  // scrolled diff surface presses against the pane edges.
+  const ringClearance = await filesLeaf.evaluate((leaf) => {
+    const rect = leaf.getBoundingClientRect();
+    const style = getComputedStyle(leaf);
+    const inner = {
+      left: rect.left + parseFloat(style.borderLeftWidth) + 1,
+      top: rect.top + parseFloat(style.borderTopWidth) + 1,
+      right: rect.right - parseFloat(style.borderRightWidth) - 1,
+      bottom: rect.bottom - parseFloat(style.borderBottomWidth) - 1,
+    };
+    const epsilon = 0.01;
+    return [...leaf.children].map((child) => {
+      const box = child.getBoundingClientRect();
+      return {
+        className: child.className,
+        insideRing:
+          box.width === 0 ||
+          box.height === 0 ||
+          (box.left >= inner.left - epsilon &&
+            box.top >= inner.top - epsilon &&
+            box.right <= inner.right + epsilon &&
+            box.bottom <= inner.bottom + epsilon),
+      };
+    });
+  });
+  for (const child of ringClearance) {
+    expect(child.insideRing, `${child.className} must not cover the focus ring`).toBe(true);
+  }
+
   const afterFocus = await diffArea.evaluate((area) => Math.round(area.scrollTop));
   await page.keyboard.press("PageDown");
   await expect.poll(async () => diffArea.evaluate((area) => Math.round(area.scrollTop))).toBeGreaterThan(afterFocus);

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -3774,7 +3774,9 @@ test.describe("sidebar toggle behavior", () => {
     expect(workflowPanelMetrics).toEqual({
       handleWidth: 4,
       homeToPanelRight: 0,
-      homeToSplitter: 1,
+      // Leaf border plus the 1px ring the leaf reserves for the pane focus
+      // marker (see TabbedPanelTree); pane content sits inside both.
+      homeToSplitter: 2,
       panelOverflowY: "hidden",
     });
     // PR button should be active

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -2709,6 +2709,37 @@ test.describe("workspace launch home", () => {
     expect(activeBorder.overlayContent).toBe("none");
     expect(activeBorder.insetShadow).toContain("inset");
 
+    // The inset focus shadow paints beneath descendants, and a hosted terminal
+    // fills its pane with opaque layers. The marker survives only because the
+    // leaf reserves the outer 1px of its padding box, so no child may reach it.
+    const ringClearance = await codexLeaf.evaluate((leaf) => {
+      const rect = leaf.getBoundingClientRect();
+      const style = getComputedStyle(leaf);
+      const inner = {
+        left: rect.left + parseFloat(style.borderLeftWidth) + 1,
+        top: rect.top + parseFloat(style.borderTopWidth) + 1,
+        right: rect.right - parseFloat(style.borderRightWidth) - 1,
+        bottom: rect.bottom - parseFloat(style.borderBottomWidth) - 1,
+      };
+      const epsilon = 0.01;
+      return [...leaf.children].map((child) => {
+        const box = child.getBoundingClientRect();
+        return {
+          className: child.className,
+          insideRing:
+            box.width === 0 ||
+            box.height === 0 ||
+            (box.left >= inner.left - epsilon &&
+              box.top >= inner.top - epsilon &&
+              box.right <= inner.right + epsilon &&
+              box.bottom <= inner.bottom + epsilon),
+        };
+      });
+    });
+    for (const child of ringClearance) {
+      expect(child.insideRing, `${child.className} must not cover the focus ring`).toBe(true);
+    }
+
     await reviewerLeaf.getByRole("tab", { name: /^Reviewer/ }).focus();
     await expect(reviewerLeaf).toHaveClass(/input-active/);
     await expect(codexLeaf).not.toHaveClass(/input-active/);


### PR DESCRIPTION
The active-pane focus ring was being erased by the pane's own content: the tab strip covered its top stroke, scrolled diff content covered its bottom stroke, and terminal panes showed no focus highlight at all, since the terminal canvas covers the whole pane. #971 moved the marker from a high z-index overlay (which cut through popovers) to an inset box shadow, but inset shadows paint beneath descendants, so the marker only survived where content happened not to reach.

The pane leaf now reserves the ring's pixels instead of fighting for them: a constant 1px padding keeps every child inside the content box, while the inset shadow paints in the outer ring of the padding box. No descendant can reach those pixels, popovers still paint above the ring (it stays in the leaf's background layer, no z-index anywhere), and the padding is constant so focusing a pane never shifts layout. Verified live against the real app: full ring on detail and terminal panes, label picker painting cleanly over it.

The e2e specs now assert the reserved geometry itself — every child of an active leaf must lay out strictly inside the ring. The previous computed-style checks kept passing while the marker was invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
