### PR TITLE
fix: show sidebar title popovers only for truncated rows

### DIFF
--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -222,9 +222,12 @@ Use it inside left sidebar headers and collapsed strips. Pass a specific label s
 
 ### SidebarTitlePopover
 
-Use `SidebarTitlePopover` on truncated pull-request and issue sidebar rows so the full
-title and formatted repository remain readable; pull requests add the full head branch
-on its own line (`frontend/src/lib/components/sidebar/SidebarTitlePopover.svelte`).
+Use `SidebarTitlePopover` on pull-request, issue, and workspace sidebar rows so the full
+title and formatted repository remain readable; pull-request and workspace rows add the
+full head branch on its own line. The required `truncationSelector` prop names the row
+elements whose ellipsis truncation the popover reveals; it opens only while one of those
+is actually truncated, measured at show time
+(`frontend/src/lib/components/sidebar/SidebarTitlePopover.svelte`).
 
 ### GroupedSidebarSection
 

--- a/frontend/src/lib/components/sidebar/IssueItem.svelte
+++ b/frontend/src/lib/components/sidebar/IssueItem.svelte
@@ -108,7 +108,7 @@
     </span>
   </div>
 </button>
-<SidebarTitlePopover target={el} title={issue.Title} repository={repoLabel} />
+<SidebarTitlePopover target={el} title={issue.Title} repository={repoLabel} truncationSelector=".title-text" />
 
 <style>
   .issue-item {

--- a/frontend/src/lib/components/sidebar/IssueItem.test.ts
+++ b/frontend/src/lib/components/sidebar/IssueItem.test.ts
@@ -26,6 +26,13 @@ const mkIssue = (overrides: Record<string, unknown>): Issue =>
     ...overrides,
   }) as unknown as Issue;
 
+// jsdom reports zero layout widths, so tests choose whether the title is
+// ellipsis-truncated by stubbing the measurements the popover gate reads.
+function setElementWidths(el: Element, widths: { scrollWidth: number; clientWidth: number }): void {
+  Object.defineProperty(el, "scrollWidth", { configurable: true, value: widths.scrollWidth });
+  Object.defineProperty(el, "clientWidth", { configurable: true, value: widths.clientWidth });
+}
+
 function renderItem(issue: Issue, useWorkspaceActivityForRecency = false): void {
   render(IssueItem, {
     props: {
@@ -138,9 +145,10 @@ describe("IssueItem", () => {
     expect(screen.getByText("Closed")).toBeTruthy();
   });
 
-  it("shows the full title while the row has keyboard focus", async () => {
+  it("shows the full title while the row has keyboard focus and the title is truncated", async () => {
     renderItem(mkIssue({ Title: "An issue title too long for the sidebar" }));
     const row = screen.getByRole("button", { name: /An issue title too long for the sidebar/i });
+    setElementWidths(row.querySelector(".title-text")!, { scrollWidth: 320, clientWidth: 160 });
 
     await fireEvent.focusIn(row);
     const tooltip = screen.getByRole("tooltip");
@@ -151,6 +159,15 @@ describe("IssueItem", () => {
     expect(row.getAttribute("aria-describedby")).toBe(tooltip.id);
 
     await fireEvent.focusOut(row);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("shows no focus popover when the title fits the row", async () => {
+    renderItem(mkIssue({ Title: "Short issue" }));
+    const row = screen.getByRole("button", { name: /Short issue/i });
+    setElementWidths(row.querySelector(".title-text")!, { scrollWidth: 160, clientWidth: 160 });
+
+    await fireEvent.focusIn(row);
     expect(screen.queryByRole("tooltip")).toBeNull();
   });
 });

--- a/frontend/src/lib/components/sidebar/PullItem.svelte
+++ b/frontend/src/lib/components/sidebar/PullItem.svelte
@@ -276,7 +276,7 @@
     </span>
   </div>
 </button>
-<SidebarTitlePopover target={el} title={pr.Title} repository={repoLabel} branch={pr.HeadBranch} />
+<SidebarTitlePopover target={el} title={pr.Title} repository={repoLabel} branch={pr.HeadBranch} truncationSelector=".title-text" />
 
 <style>
   .pull-item {

--- a/frontend/src/lib/components/sidebar/PullItem.test.ts
+++ b/frontend/src/lib/components/sidebar/PullItem.test.ts
@@ -35,6 +35,13 @@ const mkPR = (overrides: Record<string, unknown>): PullRequest =>
     ...overrides,
   }) as unknown as PullRequest;
 
+// jsdom reports zero layout widths, so tests choose whether the title is
+// ellipsis-truncated by stubbing the measurements the popover gate reads.
+function setElementWidths(el: Element, widths: { scrollWidth: number; clientWidth: number }): void {
+  Object.defineProperty(el, "scrollWidth", { configurable: true, value: widths.scrollWidth });
+  Object.defineProperty(el, "clientWidth", { configurable: true, value: widths.clientWidth });
+}
+
 function renderItem(pr: PullRequest, useWorkspaceActivityForRecency = false): void {
   render(PullItem, {
     props: {
@@ -418,7 +425,7 @@ describe("PullItem compact layout", () => {
     expect(document.querySelector(".meta-left .meta-text")?.textContent).toBe("alice");
   });
 
-  it("shows the full title after sustained row hover", async () => {
+  it("shows the full title after sustained row hover when the title is truncated", async () => {
     vi.useFakeTimers();
     try {
       renderItem(
@@ -428,6 +435,7 @@ describe("PullItem compact layout", () => {
         }),
       );
       const row = screen.getByRole("button", { name: /A pull request title too long for the sidebar/i });
+      setElementWidths(row.querySelector(".title-text")!, { scrollWidth: 320, clientWidth: 160 });
 
       await fireEvent.mouseEnter(row);
       await vi.advanceTimersByTimeAsync(599);
@@ -443,6 +451,21 @@ describe("PullItem compact layout", () => {
       expect(row.contains(tooltip)).toBe(false);
 
       await fireEvent.mouseLeave(row);
+      expect(screen.queryByRole("tooltip")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("shows no hover popover when the title fits the row", async () => {
+    vi.useFakeTimers();
+    try {
+      renderItem(mkPR({ Title: "Short title" }));
+      const row = screen.getByRole("button", { name: /Short title/i });
+      setElementWidths(row.querySelector(".title-text")!, { scrollWidth: 160, clientWidth: 160 });
+
+      await fireEvent.mouseEnter(row);
+      await vi.advanceTimersByTimeAsync(1000);
       expect(screen.queryByRole("tooltip")).toBeNull();
     } finally {
       vi.useRealTimers();

--- a/frontend/src/lib/components/sidebar/SidebarTitlePopover.svelte
+++ b/frontend/src/lib/components/sidebar/SidebarTitlePopover.svelte
@@ -7,9 +7,13 @@
     title: string;
     repository: string;
     branch?: string | undefined;
+    // Selector for the row elements whose ellipsis truncation this popover
+    // reveals. The popover only opens while at least one match is actually
+    // truncated, so untruncated rows never grow a redundant tooltip.
+    truncationSelector: string;
   }
 
-  let { target, title, repository, branch = undefined }: Props = $props();
+  let { target, title, repository, branch = undefined, truncationSelector }: Props = $props();
 
   const tooltipId = $props.id();
   // kit-ui-check-ignore: kit Tooltip neither portals to body nor describes the focused row button
@@ -44,11 +48,21 @@
     side = top < target.getBoundingClientRect().top ? "top" : "bottom";
   }
 
+  // Measured at show time (not mount) so resizes since render are honored.
+  function hasTruncatedText(): boolean {
+    if (!target) return false;
+    for (const el of target.querySelectorAll(truncationSelector)) {
+      if (el.scrollWidth > el.clientWidth) return true;
+    }
+    return false;
+  }
+
   function showAfterDelay(): void {
     clearTimer();
     if (open) return;
     timer = setTimeout(() => {
       timer = undefined;
+      if (!hasTruncatedText()) return;
       open = true;
       void position();
     }, hoverDelayMs);
@@ -56,7 +70,7 @@
 
   function showNow(): void {
     clearTimer();
-    if (open) return;
+    if (open || !hasTruncatedText()) return;
     open = true;
     void position();
   }

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -31,6 +31,7 @@
   import type { components } from "../../api/generated/schema.js";
   import { DiffStats, FilterDropdown, ScrollBox, SidebarToggle } from "@kenn-io/kit-ui";
   import GroupedSidebarSection from "../shared/GroupedSidebarSection.svelte";
+  import SidebarTitlePopover from "../sidebar/SidebarTitlePopover.svelte";
   import type { WorkspaceItemIdentity } from "../../workspace-inline.js";
   import {
     createRepoLabelFormatter,
@@ -164,6 +165,9 @@
     action: "push" | "pull" | "reveal" | "delete";
   } | null>(null);
   let contextMenuEl = $state<HTMLDivElement | null>(null);
+  // Row elements keyed by workspaceRowKey so the snippet-rendered rows can
+  // each anchor their own truncation popover.
+  let rowEls = $state<Record<string, HTMLElement | null>>({});
   let contextMenuStyle = $state("");
   let acknowledgedDoneStates = $state.raw<Record<string, string>>(
     loadDoneAcknowledgements(),
@@ -1483,6 +1487,7 @@
           {@const agentState = agentStatePresentation(ws)}
           <div
             class={["ws-row", { selected: isSelectedWorkspace(ws) }]}
+            bind:this={rowEls[workspaceRowKey(ws)]}
             onclick={(e) => {
               // The PR/issue bubble is a focusable child button; let
               // its own click handler run without the row also
@@ -1647,6 +1652,13 @@
               </div>
             {/if}
           </div>
+          <SidebarTitlePopover
+            target={rowEls[workspaceRowKey(ws)] ?? undefined}
+            title={displayName(ws)}
+            repository={repoLabel(ws)}
+            branch={shortBranch(ws.git_head_ref)}
+            truncationSelector=".ws-name"
+          />
     {/snippet}
     {#if workspaceListStatus === "loading" && workspaces.length === 0}
       <p class="filter-empty">Loading workspaces...</p>

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -1190,6 +1190,53 @@ describe("WorkspaceListSidebar", () => {
     expect(container.querySelectorAll(".ws-row")).toHaveLength(0);
   });
 
+  it("shows a full-detail popover on row focus only while the name is truncated", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [
+          workspaceFixture({
+            id: "ws-popover",
+            provider: "github",
+            platformHost: "github.com",
+            owner: "kenn-io",
+            name: "kenn-forge",
+            number: 41,
+            title: "A workspace title too long for the sidebar rail",
+            branch: "feature/full-sidebar-popover-details",
+          }),
+        ],
+      },
+    });
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "" },
+    });
+    await waitFor(() => expect(container.querySelectorAll(".ws-row")).toHaveLength(1));
+    const row = container.querySelector<HTMLElement>(".ws-row")!;
+    const name = row.querySelector(".ws-name")!;
+
+    // jsdom reports zero layout widths, so the test chooses whether the name
+    // is ellipsis-truncated by stubbing the measurements the popover reads.
+    Object.defineProperty(name, "scrollWidth", { configurable: true, value: 180 });
+    Object.defineProperty(name, "clientWidth", { configurable: true, value: 180 });
+    await fireEvent.focusIn(row);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+    await fireEvent.focusOut(row);
+
+    Object.defineProperty(name, "scrollWidth", { configurable: true, value: 360 });
+    await fireEvent.focusIn(row);
+    const tooltip = screen.getByRole("tooltip");
+    expect(Array.from(tooltip.children, (line) => line.textContent)).toEqual([
+      "A workspace title too long for the sidebar rail",
+      "kenn-io/kenn-forge",
+      "feature/full-sidebar-popover-details",
+    ]);
+    expect(row.contains(tooltip)).toBe(false);
+
+    await fireEvent.focusOut(row);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
   it("sorts flat by creation time and drops group headers", async () => {
     mockGet.mockResolvedValue({
       data: { workspaces: sortFixtures() },


### PR DESCRIPTION
The hover popover on PR and issue sidebar rows opened for every row, repeating a title that was already fully readable. It now measures the row's title at show time and opens only when the text is actually ellipsized, on both hover and keyboard focus.

- PR and issue rows: popover only when the title is truncated.
- Workspace rows: gained the same popover (full title, repo, branch), with the same truncation gate.
- `SidebarTitlePopover` now requires a `truncationSelector` prop, so a caller cannot reintroduce an always-open tooltip.

[popover-demo.webm](https://github.com/user-attachments/assets/c4cb3a1c-3377-4085-a812-be0c7d93db66)

Truncated PR row | Truncated workspace row
--- | ---
![popover-pr-truncated.png](https://github.com/user-attachments/assets/03185982-c852-4bfe-a8a4-3411a3b80ba9) | ![popover-workspace-truncated.png](https://github.com/user-attachments/assets/11714dc5-dda7-48bd-a4be-188101c3f61a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
