### PR TITLE
Support explicit base URLs for self-hosted Gitea

### DIFF
--- a/cmd/kenn-forge/main.go
+++ b/cmd/kenn-forge/main.go
@@ -673,6 +673,7 @@ func run(opts serve.Options) error {
 	cloneMgr := gitclone.New(
 		filepath.Join(cfg.DataDir, "clones"), &startup,
 	)
+	configureCloneTransportPolicy(cloneMgr, cfg)
 
 	syncer = ghclient.NewSyncerWithRegistry(
 		startup.registry, database, cloneMgr, nil,
@@ -1010,6 +1011,19 @@ func profilerSrvDone(srv *profiler.Server) <-chan error {
 		return nil
 	}
 	return srv.Done()
+}
+
+func configureCloneTransportPolicy(clones *gitclone.Manager, cfg *config.Config) {
+	if clones == nil || cfg == nil {
+		return
+	}
+	for _, configured := range cfg.Platforms {
+		if configured.AllowInsecure {
+			clones.SetAllowInsecureHTTP(
+				configured.Type, configured.Host, true,
+			)
+		}
+	}
 }
 
 func resolveStartupRepos(

--- a/cmd/kenn-forge/main_test.go
+++ b/cmd/kenn-forge/main_test.go
@@ -23,6 +23,7 @@ import (
 	"go.kenn.io/forge/internal/cli/serve"
 	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/gitclone"
 	ghclient "go.kenn.io/forge/internal/github"
 	"go.kenn.io/forge/internal/platform"
 	"go.kenn.io/forge/internal/server"
@@ -705,6 +706,27 @@ func TestDefaultProviderFactoriesRegisterForgejoAndGitea(t *testing.T) {
 	assert.Contains(factories, string(platform.KindGitea))
 }
 
+func TestConfigureCloneTransportPolicyUsesExactProviderIdentity(t *testing.T) {
+	clones := gitclone.New(t.TempDir(), nil)
+	configureCloneTransportPolicy(clones, &config.Config{
+		Platforms: []config.PlatformConfig{
+			{
+				Type:          "gitea",
+				Host:          "gitea.example.test:3000",
+				AllowInsecure: true,
+			},
+			{
+				Type: "gitea",
+				Host: "secure-gitea.example.test",
+			},
+		},
+	})
+
+	assert.True(t, clones.AllowsInsecureHTTP("gitea", "gitea.example.test:3000"))
+	assert.False(t, clones.AllowsInsecureHTTP("forgejo", "gitea.example.test:3000"))
+	assert.False(t, clones.AllowsInsecureHTTP("gitea", "secure-gitea.example.test"))
+}
+
 func TestBuildProviderStartupKeepsForgeProviderHostsDistinct(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -736,7 +758,16 @@ func TestBuildProviderStartupKeepsForgeProviderHostsDistinct(t *testing.T) {
 	set := tokenauth.NewSourceSet(tokenauth.Options{})
 	startup, err := buildProviderStartup(
 		t.Context(), database,
-		&config.Config{SyncBudgetPerHour: 200},
+		&config.Config{
+			SyncBudgetPerHour: 200,
+			Platforms: []config.PlatformConfig{{
+				Type:          string(platform.KindGitea),
+				Host:          "gitea.example.com",
+				BaseURL:       "http://gitea-api.example.com:3000",
+				AllowInsecure: true,
+				TokenEnv:      "GITEA_TEST_TOKEN",
+			}},
+		},
 		set,
 		map[string]tokenauth.Source{
 			providerHostKey(string(platform.KindForgejo), "codeberg.org"): mainTestTokenSource(
@@ -759,6 +790,8 @@ func TestBuildProviderStartupKeepsForgeProviderHostsDistinct(t *testing.T) {
 	require.NoError(err)
 	assert.Equal("codeberg-token", forgejoFactoryToken)
 	assert.Equal("gitea.example.com", giteaCalls[0].host)
+	assert.Equal("http://gitea-api.example.com:3000", giteaCalls[0].baseURL)
+	assert.True(giteaCalls[0].allowInsecure)
 	giteaFactoryToken, err := giteaCalls[0].tokenSource.Token(t.Context())
 	require.NoError(err)
 	assert.Equal("gitea-token", giteaFactoryToken)

--- a/cmd/kenn-forge/provider_startup.go
+++ b/cmd/kenn-forge/provider_startup.go
@@ -21,6 +21,8 @@ type providerFactory func(providerFactoryInput) (providerFactoryOutput, error)
 
 type providerFactoryInput struct {
 	host          string
+	baseURL       string
+	allowInsecure bool
 	tokenSource   tokenauth.Source
 	rateTracker   *github.RateTracker
 	budget        *github.SyncBudget
@@ -225,6 +227,7 @@ func defaultProviderFactories() map[string]providerFactory {
 		string(platform.KindGitea): func(input providerFactoryInput) (providerFactoryOutput, error) {
 			client, err := giteaclient.NewClient(
 				input.host, input.tokenSource,
+				giteaclient.WithBaseURL(input.baseURL, input.allowInsecure),
 				giteaclient.WithRateTracker(input.rateTracker),
 				giteaclient.WithSyncBudget(input.budget),
 			)
@@ -511,8 +514,11 @@ func buildProviderStartup(
 		if !ok {
 			return providerStartup{}, fmt.Errorf("unsupported platform %q", platformName)
 		}
+		transportConfig := providerTransportConfig(cfg, platformName, host)
 		built, err := factory(providerFactoryInput{
 			host:          host,
+			baseURL:       transportConfig.BaseURL,
+			allowInsecure: transportConfig.AllowInsecure,
 			tokenSource:   tokenSource,
 			rateTracker:   startup.rateTrackers[rateKey],
 			budget:        startup.budgets[rateKey],
@@ -614,6 +620,17 @@ func buildProviderStartup(
 		)
 	}
 	return startup, nil
+}
+
+func providerTransportConfig(
+	cfg *config.Config, platformName, host string,
+) config.PlatformConfig {
+	for _, configured := range cfg.Platforms {
+		if configured.Type == platformName && configured.Host == host {
+			return configured
+		}
+	}
+	return config.PlatformConfig{}
 }
 
 func buildGitHubIdentityRuntimes(

--- a/cmd/kenn-forge/provider_startup_test.go
+++ b/cmd/kenn-forge/provider_startup_test.go
@@ -48,3 +48,44 @@ func TestDefaultProviderFactoryPassesGitLabSharedSyncBudget(t *testing.T) {
 	require.NoError(err)
 	assert.Equal(1, budget.Spent())
 }
+
+func TestDefaultProviderFactoryUsesGiteaExplicitBaseURL(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("token factory-token", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.EscapedPath() {
+		case "/api/v1/version":
+			_, _ = w.Write([]byte(`{"version":"1.26.0"}`))
+		case "/api/v1/repos/owner/repo":
+			_, _ = w.Write([]byte(`{
+				"id":42,"name":"repo","full_name":"owner/repo",
+				"clone_url":"http://gitea.test/owner/repo.git",
+				"owner":{"login":"owner"}
+			}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	factory := defaultProviderFactories()[string(platform.KindGitea)]
+	built, err := factory(providerFactoryInput{
+		host:          "gitea.test",
+		baseURL:       server.URL,
+		allowInsecure: true,
+		tokenSource: mainTestTokenSource(
+			t, string(platform.KindGitea), "gitea.test", "GITEA_FACTORY_TOKEN", "factory-token",
+		),
+	})
+	require.NoError(err)
+	reader, ok := built.provider.(platform.RepositoryReader)
+	require.True(ok)
+
+	repo, err := reader.GetRepository(t.Context(), platform.RepoRef{
+		Platform: platform.KindGitea, Host: "gitea.test", Owner: "owner", Name: "repo",
+	})
+	require.NoError(err)
+	assert.Equal("http://gitea.test/owner/repo.git", repo.CloneURL)
+}

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -18,6 +18,7 @@ combining repository-owned history
 - `platform` is the provider kind named in the canonical provider list in
   `CLAUDE.md`.
 - `platform_host` is the normalized host for that provider. Preserve ports.
+- Gitea `base_url` changes API transport only; `platform_host` remains identity, and repository reads plus every authenticated Git path reject mismatched or unacknowledged plain-HTTP clone URLs (`internal/platform/gitea/client.go::validateRepositoryCloneURL`, `internal/gitclone/clone.go::validateRemoteTransport`).
 - `owner` and `name` are provider-canonical display/config fields.
 - `repo_path` carries the full provider path when `owner/name` is not enough.
 - `platform_repo_id` / provider external IDs are stable provider identities;

--- a/context/repository-source-browser.md
+++ b/context/repository-source-browser.md
@@ -47,6 +47,10 @@ coherence, file history, previews, or refresh behavior.
   general clone hot path is not coupled to the tag namespace
   (`internal/server/repobrowserapi/refresh.go::Handler.RunRefreshLoop`,
   `internal/gitclone/repo_browser.go::Manager.fetchRepoBrowserTags`).
+- Initial, refreshed, adopted, and registered browser clones validate both the
+  advertised URL and any persisted origin against the exact provider-host
+  cleartext policy before authenticated Git runs
+  (`internal/gitclone/repo_browser.go::Manager.validateRepoBrowserRemote`).
 - A missing clone may finish its single-flight initial fetch after the opening
   caller cancels; later callers share that bounded work rather than starting
   competing clones (`internal/gitclone/repo_browser.go::Manager.ensureRepoBrowserCloneLocal`).

--- a/context/server-runtime.md
+++ b/context/server-runtime.md
@@ -26,6 +26,10 @@ and the root event stream.
   host drop only that host while healthy hosts keep syncing; unattributable
   failures degrade to no provider sync. Dropped hosts serve cached data until a
   later restart (`cmd/kenn-forge/provider_startup.go::buildProviderStartupOrDegraded`).
+- Provider API origins and cleartext acknowledgements are startup-bound. Config
+  reload reports `restart_required` when either changes instead of claiming the
+  boot-time client and clone policy were updated
+  (`internal/server/config_reload.go::startupPlatformTransports`).
 
 ## Startup Lock
 

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -30,6 +30,10 @@ embedder protocol for arbitrary host state.
 - Managed clones keep `core.bare=true` in shared config and override it per
   linked worktree; repository tools use the shared value to identify this layout
   (`internal/workspace/manager.go::configureBareLinkedWorktree`).
+- Managed clones and existing local base checkouts use the same exact
+  provider-host cleartext acknowledgement when validating their origin; local
+  bases do not silently weaken or ignore the configured transport policy
+  (`internal/workspace/manager.go::ValidateWorktreeBasePath`).
 
 ## Endpoint Intent
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,25 @@ repo_path = "group/subgroup/project"
 Repository identity includes `platform`, `platform_host`, `owner`, and `name`.
 Keep `repo_path` when the provider uses nested namespaces or canonical casing.
 
+### Self-hosted Gitea transport
+
+Gitea uses `https://<host>` by default. Set an explicit API URL when a trusted
+private deployment serves Gitea over HTTP:
+
+```toml
+[[platforms]]
+type = "gitea"
+host = "gitea.example.test:3000"
+base_url = "http://gitea.example.test:3000"
+allow_insecure = true
+token_env = "GITEA_PRIVATE_TOKEN"
+```
+
+`host` remains the repository identity and must match Gitea's advertised clone
+URLs. `allow_insecure` acknowledges that API and Git credentials can travel
+without TLS. kenn-forge rejects plain-HTTP or mismatched clone URLs before
+using them.
+
 To hide a repository from lists and pickers without removing it, open the gear
 menu on its Settings row and choose "Hide from UI". Syncing continues and
 direct links keep working; choose "Show in UI" to bring it back. Hiding

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -215,10 +215,12 @@ type DocFolder struct {
 }
 
 type PlatformConfig struct {
-	Type      string `toml:"type" json:"type"`
-	Host      string `toml:"host" json:"host"`
-	TokenEnv  string `toml:"token_env,omitempty" json:"token_env,omitempty"`
-	TokenFile string `toml:"token_file,omitempty" json:"token_file,omitempty"`
+	Type          string `toml:"type" json:"type"`
+	Host          string `toml:"host" json:"host"`
+	BaseURL       string `toml:"base_url,omitempty" json:"base_url,omitempty"`
+	AllowInsecure bool   `toml:"allow_insecure,omitempty" json:"allow_insecure,omitempty"`
+	TokenEnv      string `toml:"token_env,omitempty" json:"token_env,omitempty"`
+	TokenFile     string `toml:"token_file,omitempty" json:"token_file,omitempty"`
 }
 
 // GitHubOwnerTokenConfig maps one exact GitHub resource owner to a PAT
@@ -1459,6 +1461,9 @@ func (c *Config) validate() error {
 		}
 		p.TokenEnv = strings.TrimSpace(p.TokenEnv)
 		p.TokenFile = strings.TrimSpace(p.TokenFile)
+		if err := normalizePlatformTransport(p); err != nil {
+			return fmt.Errorf("config: platforms[%d]: %w", i, err)
+		}
 	}
 	if err := c.validatePlatforms(); err != nil {
 		return err
@@ -1778,6 +1783,41 @@ func (c *Config) validate() error {
 		)
 	}
 
+	return nil
+}
+
+func normalizePlatformTransport(p *PlatformConfig) error {
+	p.BaseURL = strings.TrimSpace(p.BaseURL)
+	if p.Type != string(platformpkg.KindGitea) {
+		if p.BaseURL != "" || p.AllowInsecure {
+			return fmt.Errorf("base_url and allow_insecure are supported only for gitea")
+		}
+		return nil
+	}
+	if p.BaseURL == "" {
+		return nil
+	}
+	u, err := url.Parse(p.BaseURL)
+	if err != nil || u.Scheme == "" || u.Host == "" || u.Hostname() == "" {
+		return fmt.Errorf("base_url must be an absolute http(s) URL")
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("base_url scheme must be http or https")
+	}
+	if u.User != nil {
+		return fmt.Errorf("base_url must not include user info")
+	}
+	if u.RawQuery != "" || u.ForceQuery {
+		return fmt.Errorf("base_url must not include a query string")
+	}
+	if u.Fragment != "" {
+		return fmt.Errorf("base_url must not include a fragment")
+	}
+	if u.Scheme == "http" && !p.AllowInsecure {
+		return fmt.Errorf("base_url uses plain HTTP; set allow_insecure = true to acknowledge that API tokens will be sent without TLS")
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	p.BaseURL = u.String()
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1703,6 +1703,8 @@ base_url = "https://api.example.test"
 }
 
 func TestSaveRoundTripGiteaExplicitBaseURL(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
 	path := filepath.Join(t.TempDir(), "config.toml")
 	cfg := &Config{
 		SyncInterval:        defaultSyncInterval,
@@ -1719,12 +1721,12 @@ func TestSaveRoundTripGiteaExplicitBaseURL(t *testing.T) {
 		}},
 	}
 
-	require.NoError(t, cfg.Save(path))
+	require.NoError(cfg.Save(path))
 	reloaded, err := Load(path)
-	require.NoError(t, err)
-	require.Len(t, reloaded.Platforms, 1)
-	assert.Equal(t, "http://gitea.example.test:3000", reloaded.Platforms[0].BaseURL)
-	assert.True(t, reloaded.Platforms[0].AllowInsecure)
+	require.NoError(err)
+	require.Len(reloaded.Platforms, 1)
+	assert.Equal("http://gitea.example.test:3000", reloaded.Platforms[0].BaseURL)
+	assert.True(reloaded.Platforms[0].AllowInsecure)
 }
 
 func TestLoadForgejoDefaultHostUsesDefaultTokenEnv(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1633,6 +1633,100 @@ name = %q
 	}
 }
 
+func TestLoadGiteaExplicitBaseURL(t *testing.T) {
+	path := writeConfig(t, `
+[[platforms]]
+type = "gitea"
+host = "gitea.example.test:3000"
+base_url = "http://gitea-api.example.test:3000/root/"
+allow_insecure = true
+token_env = "GITEA_PRIVATE_TOKEN"
+`)
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	require.Len(t, cfg.Platforms, 1)
+	assert.Equal(t, PlatformConfig{
+		Type:          "gitea",
+		Host:          "gitea.example.test:3000",
+		BaseURL:       "http://gitea-api.example.test:3000/root",
+		AllowInsecure: true,
+		TokenEnv:      "GITEA_PRIVATE_TOKEN",
+	}, cfg.Platforms[0])
+}
+
+func TestLoadRejectsInvalidGiteaExplicitBaseURL(t *testing.T) {
+	tests := []struct {
+		name          string
+		baseURL       string
+		allowInsecure bool
+		want          string
+	}{
+		{name: "relative", baseURL: "gitea.example.test:3000", want: "absolute http(s) URL"},
+		{name: "unsupported scheme", baseURL: "ssh://gitea.example.test", want: "scheme must be http or https"},
+		{name: "missing host", baseURL: "https:///api", want: "absolute http(s) URL"},
+		{name: "user info", baseURL: "https://user@gitea.example.test", want: "must not include user info"},
+		{name: "query", baseURL: "https://gitea.example.test?x=1", want: "must not include a query string"},
+		{name: "empty query", baseURL: "https://gitea.example.test?", want: "must not include a query string"},
+		{name: "fragment", baseURL: "https://gitea.example.test#api", want: "must not include a fragment"},
+		{name: "http without acknowledgement", baseURL: "http://gitea.example.test", want: "set allow_insecure = true"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeConfig(t, fmt.Sprintf(`
+[[platforms]]
+type = "gitea"
+host = "gitea.example.test"
+base_url = %q
+allow_insecure = %t
+`, tt.baseURL, tt.allowInsecure))
+
+			_, err := Load(path)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+func TestLoadRejectsGiteaTransportFieldsForOtherProviders(t *testing.T) {
+	path := writeConfig(t, `
+[[platforms]]
+type = "forgejo"
+host = "forgejo.example.test"
+base_url = "https://api.example.test"
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "supported only for gitea")
+}
+
+func TestSaveRoundTripGiteaExplicitBaseURL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	cfg := &Config{
+		SyncInterval:        defaultSyncInterval,
+		GitHubTokenEnv:      defaultGitHubTokenEnv,
+		DefaultPlatformHost: defaultPlatformHost,
+		Host:                defaultHost,
+		Port:                defaultPort,
+		Platforms: []PlatformConfig{{
+			Type:          "gitea",
+			Host:          "gitea.example.test:3000",
+			BaseURL:       "http://gitea.example.test:3000/",
+			AllowInsecure: true,
+			TokenEnv:      "GITEA_PRIVATE_TOKEN",
+		}},
+	}
+
+	require.NoError(t, cfg.Save(path))
+	reloaded, err := Load(path)
+	require.NoError(t, err)
+	require.Len(t, reloaded.Platforms, 1)
+	assert.Equal(t, "http://gitea.example.test:3000", reloaded.Platforms[0].BaseURL)
+	assert.True(t, reloaded.Platforms[0].AllowInsecure)
+}
+
 func TestLoadForgejoDefaultHostUsesDefaultTokenEnv(t *testing.T) {
 	path := writeConfig(t, `
 [[repos]]

--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"io/fs"
 	"log/slog"
+	"net"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -73,6 +75,8 @@ type Manager struct {
 	ancestryVisitBudget  int
 	repoBrowserBarrierMu sync.Mutex
 	repoBrowserBarriers  map[string]*repoBrowserBarrier
+	transportPolicyMu    sync.RWMutex
+	allowInsecureHTTP    map[string]struct{}
 
 	// Deterministic synchronization and failure-injection hooks for
 	// repository-browser concurrency tests and clone cleanup tests. Tests set
@@ -126,7 +130,36 @@ func New(baseDir string, routes RouteResolver) *Manager {
 		ensureFlights:       make(map[string]*ensureCloneFlight),
 		repoBrowserRepos:    make(map[string]RepoBrowserRepoRef),
 		repoBrowserBarriers: make(map[string]*repoBrowserBarrier),
+		allowInsecureHTTP:   make(map[string]struct{}),
 	}
+}
+
+// SetAllowInsecureHTTP records the explicit, host-scoped acknowledgement
+// required before authenticated Git may use plain HTTP.
+func (m *Manager) SetAllowInsecureHTTP(platform, host string, allowed bool) {
+	key := insecureHTTPPolicyKey(platform, host)
+	m.transportPolicyMu.Lock()
+	defer m.transportPolicyMu.Unlock()
+	if allowed {
+		m.allowInsecureHTTP[key] = struct{}{}
+		return
+	}
+	delete(m.allowInsecureHTTP, key)
+}
+
+// AllowsInsecureHTTP reports whether plain HTTP was explicitly acknowledged
+// for one provider identity. Loopback HTTP is handled separately.
+func (m *Manager) AllowsInsecureHTTP(platform, host string) bool {
+	key := insecureHTTPPolicyKey(platform, host)
+	m.transportPolicyMu.RLock()
+	defer m.transportPolicyMu.RUnlock()
+	_, ok := m.allowInsecureHTTP[key]
+	return ok
+}
+
+func insecureHTTPPolicyKey(platform, host string) string {
+	return strings.ToLower(strings.TrimSpace(platform)) + "\x00" +
+		strings.ToLower(strings.TrimSpace(host))
 }
 
 // ClonePath returns the filesystem path for a repo's bare clone.
@@ -301,6 +334,9 @@ func (m *Manager) ensureCloneInNamespaceValidated(
 	if err := validateRemoteURLIdentity(host, owner, name, remoteURL); err != nil {
 		return err
 	}
+	if err := m.validateRemoteTransport(platform, host, remoteURL); err != nil {
+		return err
+	}
 	clonePath, err := m.ClonePathInNamespace(namespace, host, owner, name)
 	if err != nil {
 		return err
@@ -357,6 +393,28 @@ func (m *Manager) ensureCloneInNamespaceValidated(
 		}
 	}
 	return nil
+}
+
+func (m *Manager) validateRemoteTransport(platform, host, remoteURL string) error {
+	u, err := url.Parse(strings.TrimSpace(remoteURL))
+	if err != nil || !strings.EqualFold(u.Scheme, "http") {
+		return nil
+	}
+	if m.AllowsInsecureHTTP(platform, host) {
+		return nil
+	}
+	hostname := strings.Trim(strings.ToLower(u.Hostname()), "[]")
+	if !strings.EqualFold(strings.TrimSpace(platform), "gitea") && hostname == "localhost" {
+		return nil
+	}
+	if ip := net.ParseIP(hostname); !strings.EqualFold(strings.TrimSpace(platform), "gitea") &&
+		ip != nil && ip.IsLoopback() {
+		return nil
+	}
+	return fmt.Errorf(
+		"plain HTTP clone transport for %s host %q requires allow_insecure = true",
+		strings.ToLower(strings.TrimSpace(platform)), host,
+	)
 }
 
 func validateEnsureCloneCaller(

--- a/internal/gitclone/clone_security_test.go
+++ b/internal/gitclone/clone_security_test.go
@@ -195,20 +195,21 @@ func TestEnsureCloneValidatesRemoteURLRepoPerCaller(t *testing.T) {
 }
 
 func TestValidateRemoteTransportRequiresHostScopedHTTPAcknowledgement(t *testing.T) {
+	require := require.New(t)
 	mgr := New(t.TempDir(), nil)
 	remote := "http://gitea.example.test:3000/acme/widget.git"
 
 	err := mgr.validateRemoteTransport(
 		"gitea", "gitea.example.test:3000", remote,
 	)
-	require.Error(t, err)
+	require.Error(err)
 	assert.Contains(t, err.Error(), "allow_insecure = true")
 
 	mgr.SetAllowInsecureHTTP("gitea", "gitea.example.test:3000", true)
-	require.NoError(t, mgr.validateRemoteTransport(
+	require.NoError(mgr.validateRemoteTransport(
 		"gitea", "gitea.example.test:3000", remote,
 	))
-	require.Error(t, mgr.validateRemoteTransport(
+	require.Error(mgr.validateRemoteTransport(
 		"forgejo", "gitea.example.test:3000", remote,
 	))
 }

--- a/internal/gitclone/clone_security_test.go
+++ b/internal/gitclone/clone_security_test.go
@@ -193,3 +193,31 @@ func TestEnsureCloneValidatesRemoteURLRepoPerCaller(t *testing.T) {
 	assert.Contains(err.Error(), "other/widget")
 	assert.Contains(err.Error(), "acme/widget")
 }
+
+func TestValidateRemoteTransportRequiresHostScopedHTTPAcknowledgement(t *testing.T) {
+	mgr := New(t.TempDir(), nil)
+	remote := "http://gitea.example.test:3000/acme/widget.git"
+
+	err := mgr.validateRemoteTransport(
+		"gitea", "gitea.example.test:3000", remote,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "allow_insecure = true")
+
+	mgr.SetAllowInsecureHTTP("gitea", "gitea.example.test:3000", true)
+	require.NoError(t, mgr.validateRemoteTransport(
+		"gitea", "gitea.example.test:3000", remote,
+	))
+	require.Error(t, mgr.validateRemoteTransport(
+		"forgejo", "gitea.example.test:3000", remote,
+	))
+}
+
+func TestValidateRemoteTransportAllowsLoopbackHTTPWithoutPlatformPolicy(t *testing.T) {
+	mgr := New(t.TempDir(), nil)
+
+	require.NoError(t, mgr.validateRemoteTransport(
+		"github", "127.0.0.1:3000",
+		"http://127.0.0.1:3000/acme/widget.git",
+	))
+}

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -946,7 +946,7 @@ func (m *Manager) AdoptLegacyClones(ctx context.Context, repo RepoBrowserRepoRef
 	if strings.TrimSpace(repo.ProviderRepoID) == "" {
 		return errors.New("adopt legacy clones requires a stable provider repository id")
 	}
-	if err := validateRemoteURLIdentity(repo.Host, repo.Owner, repo.Name, repo.RemoteURL); err != nil {
+	if err := m.validateRepoBrowserRemote(repo, repo.RemoteURL); err != nil {
 		return err
 	}
 
@@ -1216,7 +1216,7 @@ func (m *Manager) refreshRepoBrowserClone(
 		return errors.New("repo browser fenced refresh requires guarded publication")
 	}
 	namespace := repoBrowserCloneNamespace(repo)
-	if err := validateRemoteURLIdentity(repo.Host, repo.Owner, repo.Name, repo.RemoteURL); err != nil {
+	if err := m.validateRepoBrowserRemote(repo, repo.RemoteURL); err != nil {
 		return err
 	}
 	dir, err := m.ClonePathInNamespace(namespace, repo.Host, repo.Owner, repo.Name)
@@ -1375,9 +1375,7 @@ func (m *Manager) prepareRepoBrowserStaging(
 		return fail(err)
 	}
 	if out, err := m.git(ctx, published, "config", "--get", "remote.origin.url"); err == nil {
-		if err := validateRemoteURLIdentity(
-			repo.Host, repo.Owner, repo.Name, strings.TrimSpace(string(out)),
-		); err != nil {
+		if err := m.validateRepoBrowserRemote(repo, strings.TrimSpace(string(out))); err != nil {
 			return fail(err)
 		}
 	}
@@ -1526,7 +1524,7 @@ func (m *Manager) RegisterExistingRepoBrowserClone(ctx context.Context, repo Rep
 		m.evictStaleRepoBrowserRegistration(repo, err)
 		return false, err
 	}
-	if err := validateRemoteURLIdentity(repo.Host, repo.Owner, repo.Name, repo.RemoteURL); err != nil {
+	if err := m.validateRepoBrowserRemote(repo, repo.RemoteURL); err != nil {
 		return false, err
 	}
 	dir, err := m.repoBrowserClonePath(repo)
@@ -1544,7 +1542,7 @@ func (m *Manager) RegisterExistingRepoBrowserClone(ctx context.Context, repo Rep
 		return false, err
 	}
 	if out, err := m.git(ctx, dir, "config", "--get", "remote.origin.url"); err == nil {
-		if err := validateRemoteURLIdentity(repo.Host, repo.Owner, repo.Name, strings.TrimSpace(string(out))); err != nil {
+		if err := m.validateRepoBrowserRemote(repo, strings.TrimSpace(string(out))); err != nil {
 			return false, err
 		}
 	}
@@ -1562,7 +1560,7 @@ func (m *Manager) ensureRepoBrowserCloneLocal(ctx context.Context, repo RepoBrow
 		return err
 	}
 	namespace := repoBrowserCloneNamespace(repo)
-	if err := validateRemoteURLIdentity(repo.Host, repo.Owner, repo.Name, repo.RemoteURL); err != nil {
+	if err := m.validateRepoBrowserRemote(repo, repo.RemoteURL); err != nil {
 		return err
 	}
 	dir, err := m.ClonePathInNamespace(namespace, repo.Host, repo.Owner, repo.Name)
@@ -1581,7 +1579,7 @@ func (m *Manager) ensureRepoBrowserCloneLocal(ctx context.Context, repo RepoBrow
 		return err
 	}
 	if out, err := m.git(ctx, dir, "config", "--get", "remote.origin.url"); err == nil {
-		if err := validateRemoteURLIdentity(repo.Host, repo.Owner, repo.Name, strings.TrimSpace(string(out))); err != nil {
+		if err := m.validateRepoBrowserRemote(repo, strings.TrimSpace(string(out))); err != nil {
 			unlock()
 			return err
 		}
@@ -1661,6 +1659,13 @@ func (m *Manager) fetchRepoBrowserTags(
 		return fmt.Errorf("git fetch repo browser tags: %w", err)
 	}
 	return nil
+}
+
+func (m *Manager) validateRepoBrowserRemote(repo RepoBrowserRepoRef, remoteURL string) error {
+	if err := validateRemoteURLIdentity(repo.Host, repo.Owner, repo.Name, remoteURL); err != nil {
+		return err
+	}
+	return m.validateRemoteTransport(repo.Provider, repo.Host, remoteURL)
 }
 
 func repoBrowserCloneNamespace(repo RepoBrowserRepoRef) string {

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -120,6 +122,44 @@ func TestEnsureRepoBrowserCloneDoesNotFetchTagsForExistingClone(t *testing.T) {
 	require.NoError(err)
 	assert.False(truncated)
 	assert.NotContains(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "v1.0.0", SHA: mainSHA})
+}
+
+func TestRefreshRepoBrowserCloneRequiresGiteaHTTPAcknowledgement(t *testing.T) {
+	require := require.New(t)
+	root := t.TempDir()
+	remote := filepath.Join(root, "acme", "widgets.git")
+	require.NoError(os.MkdirAll(filepath.Dir(remote), 0o755))
+	commitTestRun(t, root, "git", "init", "--bare", "--initial-branch=main", remote)
+
+	work := filepath.Join(root, "work")
+	commitTestRun(t, root, "git", "clone", remote, work)
+	commitTestRun(t, work, "git", "config", "user.email", "maintainer@example.test")
+	commitTestRun(t, work, "git", "config", "user.name", "Maintainer")
+	require.NoError(os.WriteFile(filepath.Join(work, "README.md"), []byte("# Widgets\n"), 0o644))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "-m", "initial")
+	commitTestRun(t, work, "git", "push", "origin", "main")
+	commitTestRun(t, remote, "git", "update-server-info")
+
+	server := httptest.NewServer(http.FileServer(http.Dir(root)))
+	t.Cleanup(server.Close)
+	host := strings.TrimPrefix(server.URL, "http://")
+	repo := RepoBrowserRepoRef{
+		Provider:  "gitea",
+		Host:      host,
+		Owner:     "acme",
+		Name:      "widgets",
+		RepoPath:  "acme/widgets",
+		RemoteURL: server.URL + "/acme/widgets.git",
+	}
+	mgr := New(filepath.Join(root, "clones"), nil)
+
+	err := mgr.RefreshRepoBrowserClone(t.Context(), repo)
+	require.Error(err)
+	require.Contains(err.Error(), "allow_insecure = true")
+
+	mgr.SetAllowInsecureHTTP("gitea", host, true)
+	require.NoError(mgr.RefreshRepoBrowserClone(t.Context(), repo))
 }
 
 func TestRefreshRepoBrowserClonesRefreshesRegisteredRepos(t *testing.T) {

--- a/internal/github/syncertest/gitealike_report_test.go
+++ b/internal/github/syncertest/gitealike_report_test.go
@@ -45,7 +45,7 @@ func TestGiteaLikeProviderMergeMetricsReachArchiveReport(t *testing.T) {
 			newClient: func(host string, source tokenauth.Source, baseURL string) (platform.MergeRequestReader, error) {
 				return gitea.NewClient(
 					host, source,
-					gitea.WithBaseURLForTesting(baseURL),
+					gitea.WithBaseURL(baseURL, true),
 					gitea.WithServerVersionForTesting("1.26.0"),
 				)
 			},

--- a/internal/platform/gitea/adapter_contract_test.go
+++ b/internal/platform/gitea/adapter_contract_test.go
@@ -25,7 +25,7 @@ func TestGiteaLikeAdapterContract(t *testing.T) {
 			options gitealiketest.ClientOptions,
 		) gitealiketest.TestClient {
 			clientOptions := []ClientOption{
-				WithBaseURLForTesting(baseURL),
+				WithBaseURL(baseURL, true),
 				WithServerVersionForTesting(testGiteaServerVersion),
 			}
 			if options.ForegroundTimeout > 0 {

--- a/internal/platform/gitea/client.go
+++ b/internal/platform/gitea/client.go
@@ -2,7 +2,9 @@ package gitea
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -12,6 +14,7 @@ import (
 	"go.kenn.io/forge/internal/platform/gitealike"
 	"go.kenn.io/forge/internal/ratelimit"
 	"go.kenn.io/forge/internal/tokenauth"
+	gitremote "go.kenn.io/kit/git/remote"
 )
 
 const minimumReviewThreadVersion = ">= 1.24.6"
@@ -24,6 +27,7 @@ type clientOptions struct {
 	rateTracker       *ratelimit.RateTracker
 	budget            *ghsync.SyncBudget
 	serverVersion     string
+	allowInsecureHTTP bool
 }
 
 type provider = gitealike.Provider
@@ -36,11 +40,17 @@ type Client struct {
 	api               *giteasdk.Client
 	foregroundTimeout time.Duration
 	readReviewThreads bool
+	allowInsecureHTTP bool
 }
 
-func WithBaseURLForTesting(baseURL string) ClientOption {
+// WithBaseURL configures the API transport independently from the provider
+// host, which remains the stable identity and credential-routing key.
+func WithBaseURL(baseURL string, allowInsecure bool) ClientOption {
 	return func(opts *clientOptions) {
-		opts.baseURL = strings.TrimRight(baseURL, "/")
+		if strings.TrimSpace(baseURL) != "" {
+			opts.baseURL = baseURL
+		}
+		opts.allowInsecureHTTP = allowInsecure
 	}
 }
 
@@ -76,6 +86,11 @@ func NewClient(host string, source tokenauth.Source, options ...ClientOption) (*
 	for _, option := range options {
 		option(&opts)
 	}
+	baseURL, err := validateBaseURL(opts.baseURL, opts.allowInsecureHTTP)
+	if err != nil {
+		return nil, err
+	}
+	opts.baseURL = baseURL
 
 	clientOptions := []giteasdk.ClientOption{
 		giteasdk.SetUserAgent("kenn-forge"),
@@ -136,7 +151,92 @@ func NewClient(host string, source tokenauth.Source, options ...ClientOption) (*
 		provider:          gitealike.NewProvider(platform.KindGitea, host, transport, gitealike.WithReadActions(), gitealike.WithMutations()),
 		foregroundTimeout: opts.foregroundTimeout,
 		readReviewThreads: readReviewThreads,
+		allowInsecureHTTP: opts.allowInsecureHTTP,
 	}, nil
+}
+
+func validateBaseURL(raw string, allowInsecure bool) (string, error) {
+	raw = strings.TrimSpace(raw)
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" || u.Hostname() == "" {
+		return "", fmt.Errorf("gitea base URL must be an absolute http(s) URL")
+	}
+	u.Scheme = strings.ToLower(u.Scheme)
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("gitea base URL scheme must be http or https")
+	}
+	if u.User != nil {
+		return "", fmt.Errorf("gitea base URL must not include user info")
+	}
+	if u.RawQuery != "" || u.ForceQuery {
+		return "", fmt.Errorf("gitea base URL must not include a query string")
+	}
+	if u.Fragment != "" {
+		return "", fmt.Errorf("gitea base URL must not include a fragment")
+	}
+	if u.Scheme == "http" && !allowInsecure {
+		return "", fmt.Errorf("gitea base URL uses plain HTTP without an explicit insecure transport acknowledgement")
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String(), nil
+}
+
+func (c *Client) GetRepository(
+	ctx context.Context,
+	ref platform.RepoRef,
+) (platform.Repository, error) {
+	repo, err := c.provider.GetRepository(ctx, ref)
+	if err != nil {
+		return platform.Repository{}, err
+	}
+	if err := c.validateRepositoryCloneURL(repo); err != nil {
+		return platform.Repository{}, err
+	}
+	return repo, nil
+}
+
+func (c *Client) ListRepositories(
+	ctx context.Context,
+	owner string,
+	opts platform.RepositoryListOptions,
+) ([]platform.Repository, error) {
+	repos, err := c.provider.ListRepositories(ctx, owner, opts)
+	if err != nil {
+		return nil, err
+	}
+	for _, repo := range repos {
+		if err := c.validateRepositoryCloneURL(repo); err != nil {
+			return nil, err
+		}
+	}
+	return repos, nil
+}
+
+func (c *Client) validateRepositoryCloneURL(repo platform.Repository) error {
+	raw := strings.TrimSpace(repo.CloneURL)
+	if raw == "" {
+		return nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("gitea repository %q advertised a clone URL that is not absolute HTTP(S)", repo.Ref.DisplayName())
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("gitea repository %q advertised unsupported clone URL scheme %q", repo.Ref.DisplayName(), scheme)
+	}
+	if u.User != nil || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" {
+		return fmt.Errorf("gitea repository %q advertised a clone URL with credentials, query, or fragment", repo.Ref.DisplayName())
+	}
+	if err := gitremote.ValidateRemoteIdentity(gitremote.Identity{
+		Host: c.host, Owner: repo.Ref.Owner, Name: repo.Ref.Name,
+	}, raw); err != nil {
+		return fmt.Errorf("gitea repository %q clone transport is incompatible with configured platform identity: %w", repo.Ref.DisplayName(), err)
+	}
+	if scheme == "http" && !c.allowInsecureHTTP {
+		return fmt.Errorf("gitea repository %q advertised a plain HTTP clone URL; set allow_insecure = true for platform %q only if sending credentials without TLS is intended", repo.Ref.DisplayName(), c.host)
+	}
+	return nil
 }
 
 func (c *Client) Platform() platform.Kind {

--- a/internal/platform/gitea/client_test.go
+++ b/internal/platform/gitea/client_test.go
@@ -54,7 +54,7 @@ func TestClientReviewThreadCapabilitiesUseValidatedVersionFloor(t *testing.T) {
 			client, err := NewClient(
 				"gitea.test",
 				testTokenSource("token"),
-				WithBaseURLForTesting(server.URL),
+				WithBaseURL(server.URL, true),
 				WithServerVersionForTesting(tt.version),
 			)
 			require.NoError(err)
@@ -87,12 +87,128 @@ func TestClientDiscoversVersionAtTestingBaseURL(t *testing.T) {
 	client, err := NewClient(
 		"gitea.test",
 		testTokenSource("token"),
-		WithBaseURLForTesting(server.URL),
+		WithBaseURL(server.URL, true),
 	)
 	require.NoError(err)
 	assert.True(versionRequested)
 	assert.True(client.Capabilities().ReadReviewThreads)
 	assert.True(client.Capabilities().Archive.InlineReviewComments)
+}
+
+func TestClientDefaultsToHTTPSForConfiguredHost(t *testing.T) {
+	client, err := NewClient(
+		"gitea.test:3000",
+		testTokenSource("token"),
+		WithServerVersionForTesting(testGiteaServerVersion),
+	)
+	Require.NoError(t, err)
+	assert.Equal(t, "https://gitea.test:3000", client.baseURL)
+}
+
+func TestClientUsesExplicitHTTPBaseURLAndScopesTokenToItsOrigin(t *testing.T) {
+	assert := assert.New(t)
+	require := Require.New(t)
+	var apiAuthorization string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiAuthorization = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":42,"name":"repo","full_name":"owner/repo",
+			"clone_url":"http://gitea.test/owner/repo.git",
+			"owner":{"login":"owner"}
+		}`))
+	}))
+	defer server.Close()
+	offOriginAuthorization := ""
+	offOrigin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		offOriginAuthorization = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer offOrigin.Close()
+
+	client, err := NewClient(
+		"gitea.test", testTokenSource("gitea-token"),
+		WithBaseURL(server.URL+"/", true),
+		WithServerVersionForTesting(testGiteaServerVersion),
+	)
+	require.NoError(err)
+	assert.Equal(server.URL, client.baseURL)
+
+	repo, err := client.GetRepository(t.Context(), platform.RepoRef{
+		Platform: platform.KindGitea, Host: "gitea.test", Owner: "owner", Name: "repo",
+	})
+	require.NoError(err)
+	assert.Equal("http://gitea.test/owner/repo.git", repo.CloneURL)
+	assert.Equal("token gitea-token", apiAuthorization)
+
+	_, err = client.transport.httpClient.Get(offOrigin.URL)
+	require.Error(err)
+	assert.Contains(err.Error(), "refusing to attach auth")
+	assert.Empty(offOriginAuthorization)
+}
+
+func TestClientRejectsUnsafeExplicitBaseURL(t *testing.T) {
+	tests := []struct {
+		name          string
+		baseURL       string
+		allowInsecure bool
+		want          string
+	}{
+		{name: "relative", baseURL: "gitea.test", want: "absolute http(s) URL"},
+		{name: "userinfo", baseURL: "https://user@gitea.test", want: "must not include user info"},
+		{name: "query", baseURL: "https://gitea.test?x=1", want: "must not include a query string"},
+		{name: "fragment", baseURL: "https://gitea.test#api", want: "must not include a fragment"},
+		{name: "unacknowledged http", baseURL: "http://gitea.test", want: "without an explicit insecure"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewClient(
+				"gitea.test", testTokenSource("token"),
+				WithBaseURL(tt.baseURL, tt.allowInsecure),
+				WithServerVersionForTesting(testGiteaServerVersion),
+			)
+			Require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+func TestClientRejectsIncompatibleAdvertisedCloneTransport(t *testing.T) {
+	tests := []struct {
+		name          string
+		cloneURL      string
+		allowInsecure bool
+		want          string
+	}{
+		{
+			name:     "different stable host",
+			cloneURL: "https://proxy.test/owner/repo.git",
+			want:     "incompatible with configured platform identity",
+		},
+		{
+			name:     "unacknowledged plain HTTP",
+			cloneURL: "http://gitea.test/owner/repo.git",
+			want:     "set allow_insecure = true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewClient(
+				"gitea.test", testTokenSource("token"),
+				WithServerVersionForTesting(testGiteaServerVersion),
+			)
+			Require.NoError(t, err)
+			client.allowInsecureHTTP = tt.allowInsecure
+			err = client.validateRepositoryCloneURL(platform.Repository{
+				Ref:      platform.RepoRef{Owner: "owner", Name: "repo"},
+				CloneURL: tt.cloneURL,
+			})
+			Require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
 }
 
 func TestClientReadsGiteaActionsChecks(t *testing.T) {
@@ -127,7 +243,7 @@ func TestClientReadsGiteaActionsChecks(t *testing.T) {
 
 	client, err := NewClient(
 		"gitea.test", testTokenSource("gitea-token"),
-		WithBaseURLForTesting(server.URL), WithServerVersionForTesting(testGiteaServerVersion),
+		WithBaseURL(server.URL, true), WithServerVersionForTesting(testGiteaServerVersion),
 	)
 	require.NoError(err)
 	checks, err := client.ListCIChecks(context.Background(), platform.RepoRef{Owner: "owner", Name: "repo"}, "abc")
@@ -184,7 +300,7 @@ func TestClientReadsTimelineAssignmentAndTitleEvents(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := NewClient("gitea.test", testTokenSource("gitea-token"), WithBaseURLForTesting(server.URL), WithServerVersionForTesting(testGiteaServerVersion))
+	client, err := NewClient("gitea.test", testTokenSource("gitea-token"), WithBaseURL(server.URL, true), WithServerVersionForTesting(testGiteaServerVersion))
 	require.NoError(err)
 	ref := platform.RepoRef{Host: "gitea.test", Owner: "owner", Name: "repo", RepoPath: "owner/repo"}
 
@@ -297,7 +413,7 @@ func TestClientRequestChangesSubmitsReview(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := NewClient("gitea.test", testTokenSource("gitea-token"), WithBaseURLForTesting(server.URL), WithServerVersionForTesting(testGiteaServerVersion))
+	client, err := NewClient("gitea.test", testTokenSource("gitea-token"), WithBaseURL(server.URL, true), WithServerVersionForTesting(testGiteaServerVersion))
 	require.NoError(err)
 	require.NoError(client.RequestChanges(
 		context.Background(), platform.RepoRef{Owner: "owner", Name: "repo"},

--- a/internal/platform/gitea/diff_review_test.go
+++ b/internal/platform/gitea/diff_review_test.go
@@ -68,7 +68,7 @@ func TestListMergeRequestReviewThreadsReadsBeyondTenthReviewPage(t *testing.T) {
 	}))
 	defer server.Close()
 	client, err := NewClient(
-		"gitea.test", testTokenSource("token"), WithBaseURLForTesting(server.URL),
+		"gitea.test", testTokenSource("token"), WithBaseURL(server.URL, true),
 		WithServerVersionForTesting(testGiteaServerVersion),
 	)
 	require.NoError(err)
@@ -140,7 +140,7 @@ func TestListMergeRequestReviewThreadsReadsEveryReviewPageAndComment(t *testing.
 	}))
 	defer server.Close()
 
-	client, err := NewClient("gitea.test", testTokenSource("token"), WithBaseURLForTesting(server.URL), WithServerVersionForTesting(testGiteaServerVersion))
+	client, err := NewClient("gitea.test", testTokenSource("token"), WithBaseURL(server.URL, true), WithServerVersionForTesting(testGiteaServerVersion))
 	require.NoError(err)
 	threads, err := client.ListMergeRequestReviewThreads(t.Context(), platform.RepoRef{
 		Platform: platform.KindGitea, Host: "gitea.test", Owner: "acme", Name: "widgets",
@@ -194,7 +194,7 @@ func TestListMergeRequestReviewThreadsRejectsPartialDataset(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := NewClient("gitea.test", testTokenSource("token"), WithBaseURLForTesting(server.URL), WithServerVersionForTesting(testGiteaServerVersion))
+	client, err := NewClient("gitea.test", testTokenSource("token"), WithBaseURL(server.URL, true), WithServerVersionForTesting(testGiteaServerVersion))
 	require.NoError(err)
 	threads, err := client.ListMergeRequestReviewThreads(t.Context(), platform.RepoRef{
 		Owner: "acme", Name: "widgets",
@@ -215,7 +215,7 @@ func TestListMergeRequestReviewThreadsMapsAuthenticationErrors(t *testing.T) {
 
 			client, err := NewClient(
 				"gitea.test", testTokenSource("token"),
-				WithBaseURLForTesting(server.URL),
+				WithBaseURL(server.URL, true),
 				WithServerVersionForTesting(testGiteaServerVersion),
 			)
 			require.NoError(err)
@@ -256,7 +256,7 @@ func TestListMergeRequestReviewThreadsReadsEveryLargeDatasetReview(t *testing.T)
 
 	client, err := NewClient(
 		"gitea.test", testTokenSource("token"),
-		WithBaseURLForTesting(server.URL),
+		WithBaseURL(server.URL, true),
 		WithServerVersionForTesting(testGiteaServerVersion),
 	)
 	require.NoError(err)
@@ -293,7 +293,7 @@ func TestListMergeRequestReviewThreadsReadsEveryLargeDatasetComment(t *testing.T
 
 	client, err := NewClient(
 		"gitea.test", testTokenSource("token"),
-		WithBaseURLForTesting(server.URL),
+		WithBaseURL(server.URL, true),
 		WithServerVersionForTesting(testGiteaServerVersion),
 	)
 	require.NoError(err)
@@ -337,7 +337,7 @@ func TestListMergeRequestReviewThreadsRejectsReviewPageCycleBeforeFanout(t *test
 
 	client, err := NewClient(
 		"gitea.test", testTokenSource("token"),
-		WithBaseURLForTesting(server.URL),
+		WithBaseURL(server.URL, true),
 		WithServerVersionForTesting(testGiteaServerVersion),
 	)
 	require.NoError(err)
@@ -374,7 +374,7 @@ func TestListMergeRequestReviewThreadsRejectsDatasetBeyondArchiveAttemptAllowanc
 	budget := ghsync.NewSyncBudget(20)
 	client, err := NewClient(
 		"gitea.test", testTokenSource("token"),
-		WithBaseURLForTesting(server.URL),
+		WithBaseURL(server.URL, true),
 		WithServerVersionForTesting(testGiteaServerVersion),
 		WithSyncBudget(budget),
 	)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -8791,7 +8791,7 @@ func TestAPIGiteaDisabledIssueCooldownPersistsThroughHTTPAndSQLite(t *testing.T)
 			_, _ = io.WriteString(w, `{
 				"id":101,"name":"kettle","full_name":"tea/kettle",
 				"html_url":"https://gitea.test/tea/kettle",
-				"clone_url":"https://gitea.test/tea/kettle.git",
+				"clone_url":"http://gitea.test/tea/kettle.git",
 				"default_branch":"main","owner":{"login":"tea"},
 				"has_issues":false,"has_pull_requests":true,
 				"created_at":"2026-07-22T12:00:00Z",
@@ -8825,7 +8825,7 @@ func TestAPIGiteaDisabledIssueCooldownPersistsThroughHTTPAndSQLite(t *testing.T)
 	provider, err := giteaplatform.NewClient(
 		"gitea.test",
 		testTokenSource("token"),
-		giteaplatform.WithBaseURLForTesting(providerServer.URL),
+		giteaplatform.WithBaseURL(providerServer.URL, true),
 		giteaplatform.WithServerVersionForTesting("1.26.0"),
 	)
 	require.NoError(err)
@@ -8858,6 +8858,7 @@ func TestAPIGiteaDisabledIssueCooldownPersistsThroughHTTPAndSQLite(t *testing.T)
 	require.NoError(err)
 	require.NotNil(repo)
 	assert.Empty(repo.LastSyncError)
+	assert.Equal("http://gitea.test/tea/kettle.git", repo.CloneURL)
 	stored, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, 7)
 	require.NoError(err)
 	require.NotNil(stored)
@@ -19761,7 +19762,7 @@ func TestAPIGitealikeHTTPMergeabilityPersistsThroughServer(t *testing.T) {
 				return giteaplatform.NewClient(
 					host,
 					testTokenSource(token),
-					giteaplatform.WithBaseURLForTesting(baseURL),
+					giteaplatform.WithBaseURL(baseURL, true),
 					giteaplatform.WithServerVersionForTesting("1.26.0"),
 				)
 			},

--- a/internal/server/config_reload.go
+++ b/internal/server/config_reload.go
@@ -55,6 +55,7 @@ type startupConfigSnapshot struct {
 	AllowedHosts                    []config.HostKey
 	TrustReverseProxy               bool
 	ProviderHosts                   []tokenauth.Key
+	PlatformTransports              []startupPlatformTransport
 	// GitHubCredentialRoutes records the scoped client routes built at startup.
 	// Adding, removing, or changing a route descriptor requires rebuilding the
 	// bounded client pool and re-resolving authenticated identity. Token values
@@ -84,6 +85,13 @@ type startupConfigSnapshot struct {
 	SSHPeers        []config.FleetSSHPeer
 }
 
+type startupPlatformTransport struct {
+	Platform      string
+	Host          string
+	BaseURL       string
+	AllowInsecure bool
+}
+
 func snapshotStartupConfig(cfg *config.Config) startupConfigSnapshot {
 	if cfg == nil {
 		return startupConfigSnapshot{}
@@ -103,6 +111,7 @@ func snapshotStartupConfig(cfg *config.Config) startupConfigSnapshot {
 		AllowedHosts:                    startupAllowedHosts(cfg),
 		TrustReverseProxy:               cfg.TrustReverseProxy,
 		ProviderHosts:                   startupProviderHosts(cfg),
+		PlatformTransports:              startupPlatformTransports(cfg),
 		GitHubCredentialRoutes:          githubCredentialRoutes(cfg),
 		GitHubArchiveCredentialRoutes:   githubArchiveCredentialRoutes(cfg),
 		GitHubAppSplitHosts:             githubAppSplitHosts(cfg),
@@ -121,6 +130,28 @@ func snapshotStartupConfig(cfg *config.Config) startupConfigSnapshot {
 	snap.RequireAuth = cfg.API.RequireAuth
 	snap.SSHPeers = slices.Clone(cfg.Fleet.SSHPeers)
 	return snap
+}
+
+func startupPlatformTransports(cfg *config.Config) []startupPlatformTransport {
+	if cfg == nil {
+		return nil
+	}
+	transports := make([]startupPlatformTransport, 0, len(cfg.Platforms))
+	for _, configured := range cfg.Platforms {
+		transports = append(transports, startupPlatformTransport{
+			Platform:      configured.Type,
+			Host:          configured.Host,
+			BaseURL:       configured.BaseURL,
+			AllowInsecure: configured.AllowInsecure,
+		})
+	}
+	slices.SortFunc(transports, func(a, b startupPlatformTransport) int {
+		if cmp := strings.Compare(a.Platform, b.Platform); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(a.Host, b.Host)
+	})
+	return transports
 }
 
 func startupAllowedHosts(cfg *config.Config) []config.HostKey {

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -2333,6 +2333,31 @@ func TestRestartRequiredForGitHubArchiveRoutes(t *testing.T) {
 	assert.True(snap.restartRequiredFor(&changed))
 }
 
+func TestRestartRequiredForPlatformTransportChange(t *testing.T) {
+	require := require.New(t)
+	base := func() *config.Config {
+		return &config.Config{Platforms: []config.PlatformConfig{
+			{
+				Type:          "gitea",
+				Host:          "gitea.example.test:3000",
+				BaseURL:       "http://gitea.example.test:3000",
+				AllowInsecure: true,
+			},
+		}}
+	}
+	snapshot := snapshotStartupConfig(base())
+
+	require.False(snapshot.restartRequiredFor(base()))
+
+	baseURLChanged := base()
+	baseURLChanged.Platforms[0].BaseURL = "https://gitea.example.test:3000"
+	require.True(snapshot.restartRequiredFor(baseURLChanged))
+
+	allowInsecureChanged := base()
+	allowInsecureChanged.Platforms[0].AllowInsecure = false
+	require.True(snapshot.restartRequiredFor(allowInsecureChanged))
+}
+
 func TestRestartRequiredForRoborevEndpointButNotManagedCloneInit(t *testing.T) {
 	assert := assert.New(t)
 	base := &config.Config{Roborev: config.Roborev{

--- a/internal/server/e2etest/labels_provider_test.go
+++ b/internal/server/e2etest/labels_provider_test.go
@@ -632,7 +632,7 @@ func gitealikeLabelVariants() []gitealikeLabelVariant {
 				client, err := gitea.NewClient(
 					platform.DefaultGiteaHost,
 					staticTokenSource("token"),
-					gitea.WithBaseURLForTesting(upstreamURL),
+					gitea.WithBaseURL(upstreamURL, true),
 					gitea.WithServerVersionForTesting("1.26.0"),
 				)
 				require.NoError(t, err)

--- a/internal/server/e2etest/token_rotation_test.go
+++ b/internal/server/e2etest/token_rotation_test.go
@@ -662,7 +662,7 @@ func TestSharedHostCloneAuthFollowsSurvivingProviderTokenE2E(t *testing.T) {
 	require.NoError(err)
 	giteaClient, err := platformgitea.NewClient(
 		"code.example.com", giteaSource,
-		platformgitea.WithBaseURLForTesting(forgeAPI.URL),
+		platformgitea.WithBaseURL(forgeAPI.URL, true),
 		platformgitea.WithServerVersionForTesting("1.26.0"),
 	)
 	require.NoError(err)

--- a/internal/server/gitealike_container_e2e_test.go
+++ b/internal/server/gitealike_container_e2e_test.go
@@ -143,7 +143,7 @@ func TestGiteaContainerSync(t *testing.T) {
 	client, err := platformgitea.NewClient(
 		manifest.Host,
 		testTokenSource(manifest.Token),
-		platformgitea.WithBaseURLForTesting(manifest.BaseURL),
+		platformgitea.WithBaseURL(manifest.BaseURL, true),
 		platformgitea.WithForegroundTimeoutForTesting(time.Minute),
 		platformgitea.WithRateTracker(tracker),
 		platformgitea.WithSyncBudget(budget),

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -1329,9 +1329,12 @@ func (s *Server) updateConfiguredRepoWorktreeBasePath(
 
 	worktreeBasePath := strings.TrimSpace(rawPath)
 	if worktreeBasePath != "" {
+		allowInsecureHTTP := s.clones != nil && s.clones.AllowsInsecureHTTP(
+			provider, targetRef.PlatformHostOrDefault(),
+		)
 		abs, err := workspace.ValidateWorktreeBasePath(
 			ctx, worktreeBasePath, targetRef.PlatformHostOrDefault(),
-			ref.Owner, ref.Name,
+			ref.Owner, ref.Name, allowInsecureHTTP,
 		)
 		if err != nil {
 			return nil, httpapi.Validation("body.worktree_base_path", err.Error())

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -1571,7 +1571,7 @@ func (m *Manager) reuseExistingWorkspaceWorktreeDetails(
 		}
 		return existingWorkspaceWorktreeResult{}, fmt.Errorf("inspect existing worktree: %w", err)
 	}
-	if !gitDirMatchesWorkspaceRepo(ctx, commonDir, ws) {
+	if !m.gitDirMatchesWorkspaceRepo(ctx, commonDir, ws) {
 		return existingWorkspaceWorktreeResult{}, nil
 	}
 	owned, err := gitDirOwnsLinkedWorktree(ctx, commonDir, ws.WorktreePath)
@@ -1751,6 +1751,7 @@ func (m *Manager) existingWorkspaceWorktreeProvenance(
 	}
 	if _, err := ValidateWorktreeBasePath(
 		ctx, ws.WorktreePath, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+		m.allowsInsecureHTTP(ws.Platform, ws.PlatformHost),
 	); err != nil {
 		return false, false, err
 	}
@@ -1784,7 +1785,7 @@ func (m *Manager) existingWorktreeUsesManagedClone(
 	if err != nil {
 		return false
 	}
-	return actualDir == expectedDir && gitDirMatchesWorkspaceRepo(ctx, commonDir, ws)
+	return actualDir == expectedDir && m.gitDirMatchesWorkspaceRepo(ctx, commonDir, ws)
 }
 
 func (m *Manager) refreshExistingWorkspaceWorktree(
@@ -1934,6 +1935,7 @@ func (m *Manager) workspaceSetupGitDir(
 		if strings.TrimSpace(worktreeBasePath) != "" {
 			baseDir, err := ValidateWorktreeBasePath(
 				ctx, worktreeBasePath, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+				m.allowsInsecureHTTP(ws.Platform, ws.PlatformHost),
 			)
 			return baseDir, err == nil, err
 		}
@@ -2000,7 +2002,10 @@ func (m *Manager) localWorktreeBaseDir(
 	if !ok || raw == "" {
 		return "", false, nil
 	}
-	abs, err := ValidateWorktreeBasePath(ctx, raw, platformHost, owner, name)
+	abs, err := ValidateWorktreeBasePath(
+		ctx, raw, platformHost, owner, name,
+		m.allowsInsecureHTTP(platform, platformHost),
+	)
 	if err != nil {
 		return "", false, err
 	}
@@ -2019,6 +2024,7 @@ func (m *Manager) localWorktreeBaseLockRoot(path string) string {
 // worktree whose origin remote matches the tracked repository identity.
 func ValidateWorktreeBasePath(
 	ctx context.Context, path, platformHost, owner, name string,
+	allowInsecureHTTP bool,
 ) (string, error) {
 	abs, err := filepath.Abs(strings.TrimSpace(path))
 	if err != nil {
@@ -2056,11 +2062,15 @@ func ValidateWorktreeBasePath(
 		return "", err
 	}
 	if err := validateOriginRemoteURLs(
-		ctx, abs, platformHost, owner, name,
+		ctx, abs, platformHost, owner, name, allowInsecureHTTP,
 	); err != nil {
 		return "", err
 	}
 	return abs, nil
+}
+
+func (m *Manager) allowsInsecureHTTP(platform, platformHost string) bool {
+	return m.clones != nil && m.clones.AllowsInsecureHTTP(platform, platformHost)
 }
 
 func (m *Manager) workspaceRepo(
@@ -2155,6 +2165,7 @@ func localGitConfigKeyMayExecute(key string) bool {
 
 func validateOriginRemoteURLs(
 	ctx context.Context, dir, platformHost, owner, name string,
+	allowInsecureHTTP bool,
 ) error {
 	remoteURLs, err := gitConfigValues(ctx, dir, "remote.origin.url")
 	if err != nil {
@@ -2165,7 +2176,7 @@ func validateOriginRemoteURLs(
 	}
 	for _, remoteURL := range remoteURLs {
 		if err := validateOriginRemoteURL(
-			remoteURL, platformHost, owner, name,
+			remoteURL, platformHost, owner, name, allowInsecureHTTP,
 		); err != nil {
 			return err
 		}
@@ -2175,6 +2186,7 @@ func validateOriginRemoteURLs(
 
 func validateOriginRemoteURL(
 	remoteURL, platformHost, owner, name string,
+	allowInsecureHTTP bool,
 ) error {
 	if gitremote.RemoteHost(remoteURL) == "" ||
 		gitremote.RemoteRepoPath(remoteURL) == "" {
@@ -2182,7 +2194,7 @@ func validateOriginRemoteURL(
 			"origin remote must include a forge host and repository path",
 		)
 	}
-	if !originRemoteSchemeAllowed(remoteURL) {
+	if !originRemoteSchemeAllowed(remoteURL, allowInsecureHTTP) {
 		// Never include the raw remote URL: it can embed credentials
 		// (http://oauth2:token@host/...) and this error is persisted as
 		// workspace error state and returned through the API.
@@ -2211,7 +2223,7 @@ func remoteURLScheme(remoteURL string) string {
 	return strings.ToLower(scheme)
 }
 
-func originRemoteSchemeAllowed(remoteURL string) bool {
+func originRemoteSchemeAllowed(remoteURL string, allowInsecureHTTP bool) bool {
 	if !strings.Contains(remoteURL, "://") {
 		return true
 	}
@@ -2223,7 +2235,7 @@ func originRemoteSchemeAllowed(remoteURL string) bool {
 	case "", "https", "ssh":
 		return true
 	case "http":
-		return hostIsLoopback(parsed.Host)
+		return allowInsecureHTTP || hostIsLoopback(parsed.Host)
 	default:
 		return false
 	}
@@ -3787,11 +3799,12 @@ func pathContains(parent, child string) bool {
 			!strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
 }
 
-func gitDirMatchesWorkspaceRepo(
+func (m *Manager) gitDirMatchesWorkspaceRepo(
 	ctx context.Context, dir string, ws *Workspace,
 ) bool {
 	return validateOriginRemoteURLs(
 		ctx, dir, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+		m.allowsInsecureHTTP(ws.Platform, ws.PlatformHost),
 	) == nil
 }
 

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -2327,8 +2327,7 @@ func TestValidateWorktreeBasePathRejectsLocalRemotes(t *testing.T) {
 			)
 
 			got, err := ValidateWorktreeBasePath(
-				t.Context(), localRepo, "github.com", "acme", "widget",
-			)
+				t.Context(), localRepo, "github.com", "acme", "widget", false)
 
 			require.Empty(got)
 			require.Error(err)
@@ -2377,8 +2376,7 @@ func TestValidateWorktreeBasePathRejectsExecutableLocalConfig(t *testing.T) {
 			runWorkspaceTestGit(t, localRepo, "config", tt.key, tt.value)
 
 			got, err := ValidateWorktreeBasePath(
-				t.Context(), localRepo, "github.com", "acme", "widget",
-			)
+				t.Context(), localRepo, "github.com", "acme", "widget", false)
 
 			require.Empty(got)
 			require.Error(err)
@@ -2404,8 +2402,7 @@ func TestValidateWorktreeBasePathAcceptsConfiguredHooksPath(t *testing.T) {
 	require.NoError(os.WriteFile(hookPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
 
 	got, err := ValidateWorktreeBasePath(
-		t.Context(), localRepo, "github.com", "acme", "widget",
-	)
+		t.Context(), localRepo, "github.com", "acme", "widget", false)
 
 	require.NoError(err)
 	canonicalLocalRepo, err := filepath.EvalSymlinks(localRepo)
@@ -2446,8 +2443,7 @@ func TestValidateWorktreeBasePathRejectsUnsafeOriginSchemes(t *testing.T) {
 			)
 
 			got, err := ValidateWorktreeBasePath(
-				t.Context(), localRepo, "github.com", "acme", "widget",
-			)
+				t.Context(), localRepo, "github.com", "acme", "widget", false)
 
 			require.Empty(got)
 			require.Error(err)
@@ -2476,7 +2472,25 @@ func TestValidateWorktreeBasePathAcceptsLoopbackHTTPOrigin(t *testing.T) {
 	)
 
 	got, err := ValidateWorktreeBasePath(
-		t.Context(), localRepo, "127.0.0.1", "acme", "widget",
+		t.Context(), localRepo, "127.0.0.1", "acme", "widget", false)
+
+	require.NoError(err)
+	canonicalLocalRepo, err := filepath.EvalSymlinks(localRepo)
+	require.NoError(err)
+	require.Equal(canonicalLocalRepo, got)
+}
+
+func TestValidateWorktreeBasePathAcceptsExplicitlyAllowedHTTPOrigin(t *testing.T) {
+	require := require.New(t)
+
+	localRepo := setupLocalWorktreeBaseForWorkspaceGitTest(t, "feature/thing")
+	runWorkspaceTestGit(
+		t, localRepo, "remote", "set-url", "origin",
+		"http://gitea.example.test:3000/acme/widget.git",
+	)
+
+	got, err := ValidateWorktreeBasePath(
+		t.Context(), localRepo, "gitea.example.test:3000", "acme", "widget", true,
 	)
 
 	require.NoError(err)
@@ -2495,8 +2509,7 @@ func TestValidateWorktreeBasePathAcceptsSCPStyleSSHOrigin(t *testing.T) {
 	)
 
 	got, err := ValidateWorktreeBasePath(
-		t.Context(), localRepo, "github.com", "acme", "widget",
-	)
+		t.Context(), localRepo, "github.com", "acme", "widget", false)
 
 	require.NoError(err)
 	canonicalLocalRepo, err := filepath.EvalSymlinks(localRepo)
@@ -2533,8 +2546,7 @@ func TestValidateWorktreeBasePathCanonicalizesSymlinkPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := ValidateWorktreeBasePath(
-				t.Context(), tt.path, "github.com", "acme", "widget",
-			)
+				t.Context(), tt.path, "github.com", "acme", "widget", false)
 
 			require.NoError(err)
 			assert.Equal(canonicalLocalRepo, got)
@@ -2553,8 +2565,7 @@ func TestValidateWorktreeBasePathRejectsAdditionalOriginURLs(t *testing.T) {
 	)
 
 	got, err := ValidateWorktreeBasePath(
-		t.Context(), localRepo, "github.com", "acme", "widget",
-	)
+		t.Context(), localRepo, "github.com", "acme", "widget", false)
 
 	require.Empty(got)
 	require.Error(err)
@@ -2577,8 +2588,7 @@ func TestValidateWorktreeBasePathRejectsUnsafeOriginFetchRefspec(t *testing.T) {
 	)
 
 	got, err := ValidateWorktreeBasePath(
-		t.Context(), localRepo, "github.com", "acme", "widget",
-	)
+		t.Context(), localRepo, "github.com", "acme", "widget", false)
 
 	require.Empty(got)
 	require.Error(err)
@@ -2601,8 +2611,7 @@ func TestValidateWorktreeBasePathAcceptsSingleBranchOriginFetchRefspec(t *testin
 	)
 
 	got, err := ValidateWorktreeBasePath(
-		t.Context(), localRepo, "github.com", "acme", "widget",
-	)
+		t.Context(), localRepo, "github.com", "acme", "widget", false)
 
 	require.NoError(err)
 	canonicalLocalRepo, err := filepath.EvalSymlinks(localRepo)
@@ -2623,8 +2632,7 @@ func TestValidateWorktreeBasePathRejectsBareRepositories(t *testing.T) {
 	)
 
 	got, err := ValidateWorktreeBasePath(
-		t.Context(), bareRepo, "github.com", "acme", "widget",
-	)
+		t.Context(), bareRepo, "github.com", "acme", "widget", false)
 
 	require.Empty(got)
 	require.Error(err)
@@ -2643,8 +2651,7 @@ func TestValidateWorktreeBasePathRejectsExecutableWorktreeConfig(t *testing.T) {
 	)
 
 	got, err := ValidateWorktreeBasePath(
-		t.Context(), localRepo, "github.com", "acme", "widget",
-	)
+		t.Context(), localRepo, "github.com", "acme", "widget", false)
 
 	require.Empty(got)
 	require.Error(err)
@@ -2735,6 +2742,54 @@ func TestCreateIssueUsesProviderCloneURLForNamespacedManagedClone(t *testing.T) 
 			t, cloneDir, "config", "--get", "remote.origin.url",
 		))),
 	)
+}
+
+func TestCreateIssueClonesExplicitlyAllowedGiteaHTTPRemote(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	_, _, platformHost := setupHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/thing",
+	)
+	cloneURL := "http://" + platformHost + "/acme/widget.git"
+
+	repoID, err := d.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:       "gitea",
+		PlatformHost:   platformHost,
+		PlatformRepoID: "repo-gitea-widget",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+	require.NoError(d.UpdateRepoProviderMetadata(
+		ctx, repoID, db.RepoProviderMetadata{
+			CloneURL:      cloneURL,
+			DefaultBranch: "main",
+		},
+	))
+	seedIssue(t, d, repoID, 11, "Gitea issue")
+
+	clones := gitclone.New(filepath.Join(t.TempDir(), "clones"), nil)
+	clones.SetAllowInsecureHTTP("gitea", platformHost, true)
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetClones(clones)
+
+	ws, err := mgr.CreateIssue(
+		ctx, platformHost, "acme", "widget", 11,
+		CreateIssueOptions{Provider: "gitea"},
+	)
+
+	require.NoError(err)
+	require.NotNil(ws)
+	cloneDir, err := clones.ClonePathInNamespace(
+		"gitea", platformHost, "acme", "widget",
+	)
+	require.NoError(err)
+	assert.DirExists(cloneDir)
+	assert.Equal(cloneURL, strings.TrimSpace(string(runWorkspaceTestGit(
+		t, cloneDir, "config", "--get", "remote.origin.url",
+	))))
 }
 
 func TestCreateUsesProviderQualifiedRepo(t *testing.T) {


### PR DESCRIPTION
Allows a Gitea platform to set a validated `base_url` while keeping `host` as the repository and credential identity. Plain HTTP requires `allow_insecure = true`; the existing `https://<host>` default is unchanged.

The transport setting flows through provider startup, API requests, provider-reported clone URLs, repository browser clones, managed workspaces, and configured worktree bases. Config reloads flag transport changes as restart-required because the clients and clone policy are built at startup.

Authored by @salmonumbrella.

Closes #896
