### PR TITLE
fix: keep workspaces tied to repository identity

### DIFF
--- a/context/db-migrations.md
+++ b/context/db-migrations.md
@@ -67,7 +67,7 @@ generations.
 
 - [ ] The migration runs from the previous schema version to the new version.
 - [ ] Existing rows are transformed before new constraints or triggers are installed.
-- [ ] Foreign-key child rows are moved or merged before parent rows are deleted.
+- [ ] Foreign-key child rows are moved or merged before parent rows are deleted, unless the product decision deletes the parent and its owned state as one unit.
 - [ ] Unique-index conflicts are handled intentionally: true duplicates are deleted, non-duplicate children are preserved.
 - [ ] `PRAGMA integrity_check` and `PRAGMA foreign_key_check` are clean on migrated test data.
 - [ ] Any real-data validation uses a copy or SQLite backup, never the live database.

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -107,9 +107,12 @@ opts into case folding (`internal/platform/metadata.go::LowercaseRepoNames`).
 URL-parsed config or provider responses.
 
 Scope repository-owned data by internal repository ID; route-facing requests
-still carry the full provider ref. Provider workspaces remain route-keyed and
-must fail closed once a route has historical occupants
-(`internal/db/queries.go::DB.workspaceRouteHasHistoricalOccupants`).
+still carry the full provider ref. New provider workspaces persist that internal
+ID, so renames follow the same repository and a replacement repository can use
+the old route without inheriting workspaces. Unresolved legacy workspaces and
+route-only Git operations still fail closed once a route has historical
+occupants (`internal/db/queries.go::DB.workspaceRouteHasHistoricalOccupants`,
+`internal/workspace/manager.go::Manager.verifyWorkspaceRepository`).
 
 ## Provider Hosts And Tokens
 

--- a/context/testing.md
+++ b/context/testing.md
@@ -374,6 +374,8 @@ concern. The main levers are:
 - replace fixed sleeps with explicit events, callbacks, readiness channels, or
   short polling loops that check immediately before waiting;
 - reuse migrated SQLite template databases for isolated non-migration tests;
+- prepare SQLite fixtures before starting a subprocess timeout and pass the file
+  to the child; process-local template caches are cold after exec (`internal/workspace/manager_test.go::TestSyncWorkspaceBaseBranchSurvivesQueuedReconciliationWriter`);
 - add `t.Parallel` only after proving the test does not touch process-global
   state, fixed external resources, shared tmux sessions, or shared database
   files.

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -14,6 +14,38 @@ embedder protocol for arbitrary host state.
 - Materialize that entry as a local Git worktree plus tmux session.
 - Let the UI reopen the same workspace from `/workspaces` or `/terminal/:id`.
 - Carry enough item metadata to render the correct sidebar behavior.
+- Persist provider workspaces by the internal repository catalog ID. Route
+  requests resolve their current occupant before lookup or creation; a rename
+  follows the same repository, while route reuse creates a separate workspace
+  identity. Migration backfills every unambiguous catalog route, including
+  route-only repositories. Provider lifecycle code retires legacy rows through
+  dirty-aware deletion and leaves failures stable for explicit user action; it
+  must neither discard uncommitted work nor resolve them through the current
+  occupant
+  (`internal/server/workspaceapi/handler.go::New`,
+  `internal/workspace/launch_spec.go::Manager.RequireWorkspaceLaunchSpec`).
+- A repository referenced by a workspace is a durable identity tombstone.
+  Provider-host purge deactivates that repository and releases its current
+  route instead of deleting it or nulling the workspace `repo_id`
+  (`internal/db/queries.go::DB.PurgeOtherHosts`).
+- Stable-identity migration keeps the newest workspace when pre-rename and
+  post-rename routes contain the same item, then deletes the older workspace
+  and its owned state instead of adding another legacy path (`internal/db/migrations/000055_workspace_repository_identity.up.sql:15`).
+- Setup verifies the stable repository ID independently of its mutable route.
+  Managed clones partition storage by that ID, and configured bases must match
+  it; route reuse must not share checkout state. Network Git work also captures
+  the route generation and fails closed if that route changes before setup
+  completes, restoring refs and retargeted origins after a rejected fetch.
+  Recovery and cleanup discover identity-scoped clones across every route
+  owned by that repository; network reuse retargets a historical origin to the
+  fenced current route
+  (`internal/workspace/manager.go::Manager.workspaceSetupGitDir`,
+  `internal/gitclone/clone.go::Manager.EnsureCloneValidated`,
+  `internal/server/settings_handlers.go::Server.worktreeBasePathForRepo`,
+  `internal/workspace/manager.go::Manager.workspaceManagedCloneCandidates`).
+- A backfilled workspace may keep a route-keyed managed clone from any current
+  or historical route that has one stable owner; route reuse excludes that path
+  (`internal/workspace/manager.go::Manager.workspaceManagedClonePaths`).
 - Keep Workspace and Projects request state below the root server composition
   boundary. The handler receives deep-copied committed config snapshots; it
   never retains the root mutable config pointer or mutex
@@ -97,6 +129,9 @@ embedder protocol for arbitrary host state.
   visibility lease. Workspace and specification creation is one transaction;
   reads never reconstruct a missing specification from provider cache tables
   (`internal/db/queries_workspace_launch_specs.go::DB.CreateWorkspaceWithLaunchSpec`).
+- Preparation inventory must close its SQLite result cursor before per-workspace
+  repository or launch-spec reads; the bounded read pool cannot nest these queries
+  (`internal/db/queries_workspace_launch_specs.go::DB.ListUnpreparedProviderWorkspacesAt`).
 - PR and issue create routes resolve that specification before persistence and
   validate its exact request, Git identity, credential route, and mutable route
   occupancy. The atomic workspace/specification commit precedes asynchronous
@@ -377,13 +412,13 @@ best-effort, while the launch-specification lifecycle path is fail-closed
 `internal/github/sync.go::reclassifyWorkspaceHeadRepoTrustUnderRepositoryReconciliationRead`,
 `internal/workspace/manager.go::WorkspaceHeadRepo`).
 
-Head-repo classification writes retry under an MR revision guard, or an
-absence-aware repository guard when the repository row is missing. Parent
-snapshot commits use the per-MR snapshot lock; repository-ID reconciliation
-holds the exclusive side of the stable barrier that every snapshot lock holds
-shared, so moving an MR cannot change its lock identity during a snapshot
-commit (`internal/db/db.go::LockMergeRequestSnapshot`,
-`internal/db/queries.go::UpdateWorkspaceMRHeadRepoForMissingRepo`).
+Head-repo classification reads and writes stay on the workspace repository ID;
+persisted provider workspaces without one fail unresolved. Parent snapshot
+commits use the per-MR snapshot lock; repository-ID reconciliation holds the
+exclusive side of the stable barrier that every snapshot lock holds shared, so
+moving an MR cannot change its lock identity during a snapshot commit
+(`internal/workspace/manager.go::Manager.RefreshWorkspaceHeadRepoSnapshot`,
+`internal/db/queries.go::UpdateWorkspaceMRHeadRepoForSnapshot`).
 Launch-spec refresh preserves the workspace's stable repository and branch
 identity while renewing hub-owned head and visibility facts. A changed
 repository identity conflicts; an expired lease followed by a hub
@@ -394,9 +429,16 @@ context can expose a branch or push target
 Branch push and pull use the workspace route returned by launch-spec
 validation, never a route captured before a lease refresh
 (`internal/workspace/branch_sync.go::Manager.validateBranchSyncLaunchSpec`).
-Workspace summaries expose provider links and head metadata only when the mutable
-route resolves to one active repository; unresolved or reused routes keep local
-workspace state but hide provider projections (`internal/db/queries.go::workspaceSummaryColumns`).
+Persisted-workspace refreshes reload by workspace ID while holding that same
+barrier through classification persistence, so repository renames cannot turn
+a known head into `unknown` (`internal/workspace/manager.go::RefreshWorkspaceHeadRepoSnapshot`).
+Head-trust refresh and generated-context rendering both recheck removed-upstream
+visibility; removed PRs contribute no provider title, URL, branch, or push target
+(`internal/workspace/agent_context.go::PrepareAgentLaunchContext`).
+Workspace summaries resolve identified repositories by stored stable ID, so
+renames retain provider projections while inactive repositories do not.
+Unresolved legacy rows require an unambiguous active route
+(`internal/db/queries.go::workspaceSummaryJoins`).
 
 Workspace creation launches an agent only after an explicit target choice on
 the create split button. The one-shot target is reactive session state keyed by

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -9062,6 +9062,9 @@ components:
           type: string
         PlatformHost:
           type: string
+        RepoID:
+          format: int64
+          type: integer
         RepoName:
           type: string
         RepoOwner:
@@ -9082,6 +9085,7 @@ components:
         - PlatformHost
         - RepoOwner
         - RepoName
+        - RepoID
         - ItemType
         - ItemNumber
         - ItemKey

--- a/frontend/src/lib/api/generated/schema.ts
+++ b/frontend/src/lib/api/generated/schema.ts
@@ -9122,6 +9122,8 @@ export interface components {
             MRHeadRepo: string | null;
             Platform: string;
             PlatformHost: string;
+            /** Format: int64 */
+            RepoID: number;
             RepoName: string;
             RepoOwner: string;
             Status: string;

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -5279,6 +5279,7 @@ type Workspace struct {
 	MRHeadRepo         *string               `json:"MRHeadRepo"`
 	Platform           string                `json:"Platform"`
 	PlatformHost       string                `json:"PlatformHost"`
+	RepoID             int64                 `json:"RepoID"`
 	RepoName           string                `json:"RepoName"`
 	RepoOwner          string                `json:"RepoOwner"`
 	Status             string                `json:"Status"`

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -387,7 +387,7 @@ func TestMigration54BackfillsWorkspaceLaunchSpecs(t *testing.T) {
 		"ws-issue":              "sourceVisibilityExpired",
 		"ws-fork":               "sourceVisibilityExpired",
 		"ws-incomplete":         "launchSpecMissing",
-		"ws-renamed":            "launchSpecMismatch",
+		"ws-renamed":            "sourceVisibilityExpired",
 		"ws-renamed-incomplete": "launchSpecMissing",
 	}, reasons)
 	assert.Equal("provider-repo-renamed", stableIDs["ws-renamed-incomplete"])
@@ -416,6 +416,152 @@ func TestMigration54DownDropsOnlyPreparationTables(t *testing.T) {
 	} {
 		assert.True(tableExistsForTest(t, raw, table), table)
 	}
+	assertDatabaseIntegrityForTest(t, raw)
+	require.NoError(raw.Close())
+}
+
+func TestWorkspaceRepositoryIdentityMigration55BackfillsOnlyUnambiguousRoutes(
+	t *testing.T,
+) {
+	require := require.New(t)
+	dbPath := filepath.Join(t.TempDir(), "workspace-repository-identity-v54.db")
+
+	openAtVersionForTest(t, dbPath, 54, func(raw *sql.DB) {
+		_, err := raw.Exec(`
+			INSERT INTO forge_repos (
+				id, platform, platform_host, platform_repo_id,
+				owner, name, repo_path, owner_key, name_key, repo_path_key,
+				lifecycle_state
+			) VALUES
+				(1, 'github', 'github.com', 'repo-safe',
+				 'acme', 'safe', 'acme/safe', 'acme', 'safe', 'acme/safe', 'active'),
+				(5, 'github', 'github.com', '',
+				 'acme', 'route-only', 'acme/route-only', 'acme', 'route-only', 'acme/route-only', 'active'),
+				(2, 'github', 'github.com', 'repo-displaced',
+				 'acme', 'reused', 'acme/reused', 'acme', 'reused', 'acme/reused', 'inactive'),
+				(3, 'github', 'github.com', 'repo-current',
+				 'acme', 'reused', 'acme/reused', 'acme', 'reused', 'acme/reused', 'active'),
+				(4, 'github', 'github.com', 'repo-renamed',
+				 'acme', 'renamed', 'acme/renamed', 'acme', 'renamed', 'acme/renamed', 'active');
+
+			INSERT INTO forge_repo_routes (
+				repo_id, platform, platform_host,
+				owner, name, repo_path, owner_key, name_key, repo_path_key,
+				is_current, first_seen_at, last_seen_at
+			) VALUES
+				(1, 'github', 'github.com',
+				 'acme', 'safe', 'acme/safe', 'acme', 'safe', 'acme/safe',
+				 1, '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z'),
+				(5, 'github', 'github.com',
+				 'acme', 'route-only', 'acme/route-only', 'acme', 'route-only', 'acme/route-only',
+				 1, '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z'),
+				(2, 'github', 'github.com',
+				 'acme', 'reused', 'acme/reused', 'acme', 'reused', 'acme/reused',
+				 0, '2026-08-01T00:00:00Z', '2026-08-02T00:00:00Z'),
+				(3, 'github', 'github.com',
+				 'acme', 'reused', 'acme/reused', 'acme', 'reused', 'acme/reused',
+				 1, '2026-08-03T00:00:00Z', '2026-08-03T00:00:00Z'),
+				(4, 'github', 'github.com',
+				 'acme', 'before-rename', 'acme/before-rename', 'acme', 'before-rename', 'acme/before-rename',
+				 0, '2026-08-01T00:00:00Z', '2026-08-02T00:00:00Z'),
+				(4, 'github', 'github.com',
+				 'acme', 'renamed', 'acme/renamed', 'acme', 'renamed', 'acme/renamed',
+				 1, '2026-08-03T00:00:00Z', '2026-08-03T00:00:00Z');
+
+			INSERT INTO forge_workspaces (
+				id, platform, platform_host, repo_owner, repo_name,
+				repo_owner_key, repo_name_key, repo_path_key,
+				item_type, item_number, item_key, git_head_ref,
+				worktree_path, tmux_session, status, created_at
+			) VALUES
+				('workspace-safe', 'github', 'github.com', 'acme', 'safe',
+				 'acme', 'safe', 'acme/safe',
+				 'pull_request', 7, '7', 'feature/safe',
+				 '/tmp/workspace-safe', 'workspace-safe', 'ready', '2026-08-01T00:00:00Z'),
+				('workspace-route-only', 'github', 'github.com', 'acme', 'route-only',
+				 'acme', 'route-only', 'acme/route-only',
+				 'pull_request', 11, '11', 'feature/route-only',
+				 '/tmp/workspace-route-only', 'workspace-route-only', 'ready', '2026-08-01T00:00:00Z'),
+				('workspace-contested', 'github', 'github.com', 'acme', 'reused',
+				 'acme', 'reused', 'acme/reused',
+				 'pull_request', 8, '8', 'feature/contested',
+				 '/tmp/workspace-contested', 'workspace-contested', 'ready', '2026-08-01T00:00:00Z'),
+				('workspace-renamed-old', 'github', 'github.com', 'acme', 'before-rename',
+				 'acme', 'before-rename', 'acme/before-rename',
+				 'pull_request', 9, '9', 'feature/old',
+				 '/tmp/workspace-renamed-old', 'workspace-renamed-old', 'ready', '2026-08-03T00:00:00Z'),
+				('workspace-renamed-new', 'github', 'github.com', 'acme', 'renamed',
+				 'acme', 'renamed', 'acme/renamed',
+				 'pull_request', 9, '9', 'feature/new',
+				 '/tmp/workspace-renamed-new', 'workspace-renamed-new', 'ready', '2026-08-03T00:00:00Z');
+
+			INSERT INTO forge_workspace_setup_events (
+				workspace_id, stage, outcome, message
+			) VALUES
+				('workspace-safe', 'setup', 'success', 'ready'),
+				('workspace-contested', 'setup', 'success', 'ready'),
+				('workspace-renamed-old', 'setup', 'success', 'ready'),
+				('workspace-renamed-new', 'setup', 'success', 'ready');
+		`)
+		require.NoError(err)
+	})
+
+	database, err := Open(dbPath)
+	require.NoError(err)
+
+	var safeRepoID sql.NullInt64
+	require.NoError(database.ReadDB().QueryRow(`
+		SELECT repo_id FROM forge_workspaces WHERE id = 'workspace-safe'
+	`).Scan(&safeRepoID))
+	require.True(safeRepoID.Valid)
+	require.Equal(int64(1), safeRepoID.Int64)
+
+	var routeOnlyRepoID sql.NullInt64
+	require.NoError(database.ReadDB().QueryRow(`
+		SELECT repo_id FROM forge_workspaces WHERE id = 'workspace-route-only'
+	`).Scan(&routeOnlyRepoID))
+	require.True(routeOnlyRepoID.Valid)
+	require.Equal(int64(5), routeOnlyRepoID.Int64)
+
+	var contestedRepoID sql.NullInt64
+	require.NoError(database.ReadDB().QueryRow(`
+		SELECT repo_id FROM forge_workspaces WHERE id = 'workspace-contested'
+	`).Scan(&contestedRepoID))
+	require.False(contestedRepoID.Valid)
+
+	var renamedRepoID int64
+	require.NoError(database.ReadDB().QueryRow(`
+		SELECT repo_id FROM forge_workspaces WHERE id = 'workspace-renamed-new'
+	`).Scan(&renamedRepoID))
+	require.Equal(int64(4), renamedRepoID)
+	var deletedDuplicateCount int
+	require.NoError(database.ReadDB().QueryRow(`
+		SELECT COUNT(*) FROM forge_workspaces WHERE id = 'workspace-renamed-old'
+	`).Scan(&deletedDuplicateCount))
+	require.Zero(deletedDuplicateCount)
+
+	var setupEventCount int
+	require.NoError(database.ReadDB().QueryRow(`
+		SELECT COUNT(*) FROM forge_workspace_setup_events
+	`).Scan(&setupEventCount))
+	require.Equal(3, setupEventCount)
+	assertDatabaseIntegrityForTest(t, database.ReadDB())
+	require.NoError(database.Close())
+
+	raw, migrator := openMigratorForTest(t, dbPath)
+	require.NoError(migrator.Migrate(54))
+	var repoIDColumnCount int
+	require.NoError(raw.QueryRow(`
+		SELECT COUNT(*)
+		FROM pragma_table_info('forge_workspaces')
+		WHERE name = 'repo_id'
+	`).Scan(&repoIDColumnCount))
+	require.Zero(repoIDColumnCount)
+	require.True(hasIndex(raw, "idx_workspaces_provider_item_key"))
+	require.NoError(raw.QueryRow(`
+		SELECT COUNT(*) FROM forge_workspace_setup_events
+	`).Scan(&setupEventCount))
+	require.Equal(3, setupEventCount)
 	assertDatabaseIntegrityForTest(t, raw)
 	require.NoError(raw.Close())
 }

--- a/internal/db/migrations/000055_workspace_repository_identity.down.sql
+++ b/internal/db/migrations/000055_workspace_repository_identity.down.sql
@@ -1,0 +1,11 @@
+-- Duplicate route-era workspaces deleted by the up migration cannot be restored.
+DROP INDEX idx_workspaces_legacy_provider_item_key;
+DROP INDEX idx_workspaces_repo_item_key;
+
+-- Recreating the route-keyed unique index will reject a downgrade when
+-- distinct repositories created the same workspace identity while sharing a
+-- route at different times. Those identities cannot be collapsed safely.
+ALTER TABLE forge_workspaces DROP COLUMN repo_id;
+
+CREATE UNIQUE INDEX idx_workspaces_provider_item_key
+    ON forge_workspaces(platform, platform_host, repo_path_key, item_type, item_key);

--- a/internal/db/migrations/000055_workspace_repository_identity.up.sql
+++ b/internal/db/migrations/000055_workspace_repository_identity.up.sql
@@ -1,0 +1,42 @@
+ALTER TABLE forge_workspaces
+    ADD COLUMN repo_id INTEGER REFERENCES forge_repos(id) ON DELETE RESTRICT;
+
+UPDATE forge_workspaces AS workspace
+SET repo_id = (
+    SELECT MIN(route.repo_id)
+    FROM forge_repo_routes AS route
+    JOIN forge_repos AS repo ON repo.id = route.repo_id
+    WHERE route.platform = workspace.platform
+      AND route.platform_host = workspace.platform_host
+      AND route.repo_path_key = workspace.repo_path_key
+    HAVING COUNT(DISTINCT route.repo_id) = 1
+);
+
+DELETE FROM forge_workspaces AS duplicate
+WHERE duplicate.repo_id IS NOT NULL
+  AND EXISTS (
+      SELECT 1
+      FROM forge_workspaces AS keeper
+      WHERE keeper.repo_id = duplicate.repo_id
+        AND keeper.item_type = duplicate.item_type
+        AND keeper.item_key = duplicate.item_key
+        AND (
+            keeper.created_at > duplicate.created_at
+            OR (
+                keeper.created_at = duplicate.created_at
+                AND keeper.rowid > duplicate.rowid
+            )
+        )
+  );
+
+DROP INDEX idx_workspaces_provider_item_key;
+
+CREATE UNIQUE INDEX idx_workspaces_repo_item_key
+    ON forge_workspaces(repo_id, item_type, item_key)
+    WHERE repo_id IS NOT NULL;
+
+CREATE UNIQUE INDEX idx_workspaces_legacy_provider_item_key
+    ON forge_workspaces(
+        platform, platform_host, repo_path_key, item_type, item_key
+    )
+    WHERE repo_id IS NULL;

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -984,9 +984,11 @@ func (d *DB) loadLabelsForIssues(ctx context.Context, ids []int64) (map[int64][]
 	return out, nil
 }
 
-// PurgeOtherHosts deletes all data for platform hosts other
-// than keepHost. Deletes in FK-dependency order so it works
-// on existing DBs where CASCADE may not be retrofitted.
+// PurgeOtherHosts deletes data for platform hosts other than keepHost. A
+// repository referenced by a workspace survives as an inactive identity
+// tombstone so purging provider data cannot detach the local checkout from its
+// stable repository identity. Deletes otherwise run in FK-dependency order so
+// this works on existing DBs where CASCADE may not be retrofitted.
 func (d *DB) PurgeOtherHosts(ctx context.Context, keepHost string) error {
 	releaseReconciliation := d.lockRepositoryReconciliationWrite()
 	defer releaseReconciliation()
@@ -1002,7 +1004,16 @@ func (d *DB) PurgeOtherHosts(ctx context.Context, keepHost string) error {
 			`DELETE FROM forge_merge_requests WHERE repo_id IN (SELECT id FROM forge_repos WHERE platform_host != ?)`,
 			`DELETE FROM forge_issue_events WHERE issue_id IN (SELECT id FROM forge_issues WHERE repo_id IN (SELECT id FROM forge_repos WHERE platform_host != ?))`,
 			`DELETE FROM forge_issues WHERE repo_id IN (SELECT id FROM forge_repos WHERE platform_host != ?)`,
-			`DELETE FROM forge_repos WHERE platform_host != ?`,
+			`UPDATE forge_repo_routes SET is_current = 0
+			 WHERE repo_id IN (
+				 SELECT id FROM forge_repos WHERE platform_host != ?
+				   AND id IN (SELECT repo_id FROM forge_workspaces WHERE repo_id IS NOT NULL)
+			 )`,
+			`UPDATE forge_repos SET lifecycle_state = 'inactive'
+			 WHERE platform_host != ?
+			   AND id IN (SELECT repo_id FROM forge_workspaces WHERE repo_id IS NOT NULL)`,
+			`DELETE FROM forge_repos WHERE platform_host != ?
+			   AND id NOT IN (SELECT repo_id FROM forge_workspaces WHERE repo_id IS NOT NULL)`,
 			`DELETE FROM forge_rate_limits WHERE platform_host != ?`,
 		}
 		for _, q := range queries {
@@ -1387,8 +1398,18 @@ func repoFromCatalogEntry(entry *RepositoryCatalogEntry, err error) (*Repo, erro
 
 // GetRepoByID returns the repo with the given ID, or nil if not found.
 func (d *DB) GetRepoByID(ctx context.Context, id int64) (*Repo, error) {
+	return d.getRepoByID(ctx, id, false)
+}
+
+// GetActiveRepoByID returns the active repo with the given ID, or nil if the
+// repo does not exist or is inactive.
+func (d *DB) GetActiveRepoByID(ctx context.Context, id int64) (*Repo, error) {
+	return d.getRepoByID(ctx, id, true)
+}
+
+func (d *DB) getRepoByID(ctx context.Context, id int64, activeOnly bool) (*Repo, error) {
 	var r Repo
-	err := d.ro.QueryRowContext(ctx,
+	query :=
 		`SELECT id, platform, platform_host, platform_repo_id,
 		        owner, name, repo_path,
 		        owner_key, name_key, repo_path_key,
@@ -1399,8 +1420,11 @@ func (d *DB) GetRepoByID(ctx context.Context, id int64) (*Repo, error) {
 		        label_catalog_synced_at, label_catalog_checked_at,
 		        label_catalog_sync_error,
 		        created_at
-		 FROM forge_repos WHERE id = ?`, id,
-	).Scan(
+		 FROM forge_repos WHERE id = ?`
+	if activeOnly {
+		query += ` AND lifecycle_state = 'active'`
+	}
+	err := d.ro.QueryRowContext(ctx, query, id).Scan(
 		&r.ID, &r.Platform, &r.PlatformHost, &r.PlatformRepoID,
 		&r.Owner, &r.Name, &r.RepoPath,
 		&r.OwnerKey, &r.NameKey, &r.RepoPathKey,
@@ -4567,26 +4591,15 @@ func (d *DB) WorkspaceRepoRouteHasHistoricalOccupants(
 func (d *DB) canonicalizeWorkspaceRepo(
 	ctx context.Context,
 	provider, platformHost, owner, name string,
-) (string, string, string, string, string, string, string, error) {
+) (string, string, string, string, string, string, string, int64, error) {
 	provider = strings.ToLower(strings.TrimSpace(provider))
 	host, ownerKey, nameKey := canonicalRepoLookupIdentifier(platformHost, owner, name)
 	pathKey := ownerKey + "/" + nameKey
-	collision, err := d.workspaceRouteHasHistoricalOccupants(
-		ctx, provider, host, pathKey,
-	)
-	if err != nil {
-		return "", "", "", "", "", "", "", err
-	}
-	if collision {
-		return "", "", "", "", "", "", "", fmt.Errorf(
-			"workspace repository route has historical occupants: %s/%s",
-			ownerKey, nameKey,
-		)
-	}
 
 	var matchedProvider, displayOwner, displayName, repoOwnerKey, repoNameKey, repoPathKey string
-	err = d.ro.QueryRowContext(ctx, `
-		SELECT platform, owner, name, owner_key, name_key, repo_path_key
+	var repoID int64
+	err := d.ro.QueryRowContext(ctx, `
+		SELECT platform, owner, name, owner_key, name_key, repo_path_key, id
 		FROM forge_repos
 		WHERE platform_host = ? AND repo_path_key = ?
 		  AND lifecycle_state = 'active'
@@ -4594,14 +4607,57 @@ func (d *DB) canonicalizeWorkspaceRepo(
 		ORDER BY CASE WHEN platform <> 'github' THEN 0 ELSE 1 END, id
 		LIMIT 1`,
 		host, pathKey, provider, provider,
-	).Scan(&matchedProvider, &displayOwner, &displayName, &repoOwnerKey, &repoNameKey, &repoPathKey)
+	).Scan(
+		&matchedProvider, &displayOwner, &displayName,
+		&repoOwnerKey, &repoNameKey, &repoPathKey, &repoID,
+	)
 	if errors.Is(err, sql.ErrNoRows) {
-		return canonicalWorkspacePlatform(provider), host, ownerKey, nameKey, ownerKey, nameKey, pathKey, nil
+		return canonicalWorkspacePlatform(provider), host, ownerKey, nameKey,
+			ownerKey, nameKey, pathKey, 0, nil
 	}
 	if err != nil {
-		return "", "", "", "", "", "", "", fmt.Errorf("lookup workspace repo identity: %w", err)
+		return "", "", "", "", "", "", "", 0,
+			fmt.Errorf("lookup workspace repo identity: %w", err)
 	}
-	return matchedProvider, host, displayOwner, displayName, repoOwnerKey, repoNameKey, repoPathKey, nil
+	return matchedProvider, host, displayOwner, displayName,
+		repoOwnerKey, repoNameKey, repoPathKey, repoID, nil
+}
+
+func (d *DB) resolveWorkspaceLookupRoute(
+	ctx context.Context,
+	provider, platformHost, owner, name string,
+) (string, string, string, int64, bool, error) {
+	_, host, _, _, ownerKey, nameKey, pathKey, repoID, err :=
+		d.canonicalizeWorkspaceRepo(ctx, provider, platformHost, owner, name)
+	if err != nil {
+		return "", "", "", 0, false, err
+	}
+	if repoID != 0 {
+		return host, ownerKey, nameKey, repoID, false, nil
+	}
+	collision, err := d.workspaceRouteHasHistoricalOccupants(
+		ctx, provider, host, pathKey,
+	)
+	if err != nil {
+		return "", "", "", 0, false, err
+	}
+	return host, ownerKey, nameKey, 0, !collision, nil
+}
+
+func workspaceRepositoryLookupPredicate(
+	provider, platformHost, owner, name string, repoID int64,
+) (string, []any) {
+	if repoID != 0 {
+		return "repo_id = ?", []any{repoID}
+	}
+	predicate := `repo_id IS NULL
+		AND platform_host = ? AND repo_owner_key = ? AND repo_name_key = ?`
+	args := []any{platformHost, owner, name}
+	if provider != "" {
+		predicate += " AND platform = ?"
+		args = append(args, provider)
+	}
+	return predicate, args
 }
 
 func workspaceItemKeyForInsert(ws *Workspace) (string, error) {
@@ -4640,11 +4696,45 @@ func workspaceKataMetadataJSON(ws *Workspace) (string, error) {
 	return string(data), nil
 }
 
-func scanWorkspace(scanner interface{ Scan(...any) error }) (*Workspace, error) {
+func (d *DB) scanWorkspace(
+	ctx context.Context,
+	scanner interface{ Scan(...any) error },
+) (*Workspace, error) {
+	ws, err := scanWorkspaceRow(scanner)
+	if err != nil {
+		return nil, err
+	}
+	return d.resolveWorkspaceRepository(ctx, ws)
+}
+
+func (d *DB) resolveWorkspaceRepository(
+	ctx context.Context, ws *Workspace,
+) (*Workspace, error) {
+	if ws.RepoID == 0 {
+		return ws, nil
+	}
+	repo, err := d.GetActiveRepoByID(ctx, ws.RepoID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve workspace repository route: %w", err)
+	}
+	if repo != nil {
+		ws.Platform = repo.Platform
+		ws.PlatformHost = repo.PlatformHost
+		ws.RepoOwner = repo.Owner
+		ws.RepoName = repo.Name
+	}
+	return ws, nil
+}
+
+func scanWorkspaceRow(
+	scanner interface{ Scan(...any) error },
+) (*Workspace, error) {
 	var ws Workspace
 	var kataMetadataJSON string
+	var repoID sql.NullInt64
 	err := scanner.Scan(
 		&ws.ID, &ws.Platform, &ws.PlatformHost, &ws.RepoOwner, &ws.RepoName,
+		&repoID,
 		&ws.ItemType, &ws.ItemNumber, &ws.ItemKey, &ws.AssociatedPRNumber,
 		&ws.GitHeadRef, &ws.MRHeadRepo, &ws.WorkspaceBranch,
 		&ws.WorktreePath, &ws.TmuxSession, &ws.TerminalBackend, &ws.Status,
@@ -4652,6 +4742,9 @@ func scanWorkspace(scanner interface{ Scan(...any) error }) (*Workspace, error) 
 	)
 	if err != nil {
 		return nil, err
+	}
+	if repoID.Valid {
+		ws.RepoID = repoID.Int64
 	}
 	if ws.ItemKey == "" && workspaceItemTypeKeysByNumber(ws.ItemType) {
 		ws.ItemKey = strconv.Itoa(ws.ItemNumber)
@@ -4694,6 +4787,7 @@ type preparedWorkspaceInsert struct {
 	repoOwnerKey     string
 	repoNameKey      string
 	repoPathKey      string
+	repoID           int64
 	itemKey          string
 	kataMetadataJSON string
 }
@@ -4706,14 +4800,38 @@ func (d *DB) prepareWorkspaceInsert(
 	}
 	var prepared preparedWorkspaceInsert
 	var err error
+	requestedRepoID := ws.RepoID
 	ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
-		prepared.repoOwnerKey, prepared.repoNameKey, prepared.repoPathKey, err =
+		prepared.repoOwnerKey, prepared.repoNameKey, prepared.repoPathKey,
+		prepared.repoID, err =
 		d.canonicalizeWorkspaceRepo(
 			ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
 		)
 	if err != nil {
 		return preparedWorkspaceInsert{}, err
 	}
+	if requestedRepoID != 0 && requestedRepoID != prepared.repoID {
+		return preparedWorkspaceInsert{}, fmt.Errorf(
+			"%w: workspace repository identity changed for route: %s/%s",
+			ErrRepositoryRouteFenceChanged,
+			ws.RepoOwner, ws.RepoName,
+		)
+	}
+	if prepared.repoID == 0 {
+		collision, err := d.workspaceRouteHasHistoricalOccupants(
+			ctx, ws.Platform, ws.PlatformHost, prepared.repoPathKey,
+		)
+		if err != nil {
+			return preparedWorkspaceInsert{}, err
+		}
+		if collision {
+			return preparedWorkspaceInsert{}, fmt.Errorf(
+				"workspace repository route has historical occupants: %s/%s",
+				prepared.repoOwnerKey, prepared.repoNameKey,
+			)
+		}
+	}
+	ws.RepoID = prepared.repoID
 	if ws.TerminalBackend == "" {
 		ws.TerminalBackend = "tmux"
 	}
@@ -4740,14 +4858,15 @@ func insertPreparedWorkspace(
 ) error {
 	_, err := executor.ExecContext(ctx, `
 		INSERT INTO forge_workspaces
-		    (id, platform, platform_host, repo_owner, repo_name,
+		    (id, platform, platform_host, repo_owner, repo_name, repo_id,
 		     repo_owner_key, repo_name_key, repo_path_key,
 		     item_type, item_number, item_key, associated_pr_number,
 		     git_head_ref, mr_head_repo, workspace_branch,
 		     worktree_path, tmux_session, terminal_backend, status,
 		     error_message, kata_metadata)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		ws.ID, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+		sql.NullInt64{Int64: prepared.repoID, Valid: prepared.repoID != 0},
 		prepared.repoOwnerKey, prepared.repoNameKey, prepared.repoPathKey,
 		ws.ItemType, ws.ItemNumber, prepared.itemKey, ws.AssociatedPRNumber,
 		ws.GitHeadRef, ws.MRHeadRepo, ws.WorkspaceBranch,
@@ -4764,8 +4883,8 @@ func insertPreparedWorkspace(
 func (d *DB) GetWorkspace(
 	ctx context.Context, id string,
 ) (*Workspace, error) {
-	ws, err := scanWorkspace(d.ro.QueryRowContext(ctx, `
-		SELECT id, platform, platform_host, repo_owner, repo_name,
+	ws, err := d.scanWorkspace(ctx, d.ro.QueryRowContext(ctx, `
+		SELECT id, platform, platform_host, repo_owner, repo_name, repo_id,
 		       item_type, item_number, item_key, associated_pr_number,
 		       git_head_ref, mr_head_repo, workspace_branch,
 		       worktree_path, tmux_session, terminal_backend, status,
@@ -4814,25 +4933,25 @@ func (d *DB) GetWorkspaceLinkedToMRForProvider(
 	mrNumber int,
 ) (*Workspace, error) {
 	provider = strings.ToLower(strings.TrimSpace(provider))
-	platformHost, owner, name = canonicalRepoLookupIdentifier(platformHost, owner, name)
-	collision, err := d.workspaceRouteHasHistoricalOccupants(
-		ctx, provider, platformHost, owner+"/"+name,
-	)
+	platformHost, owner, name, repoID, legacySafe, err :=
+		d.resolveWorkspaceLookupRoute(ctx, provider, platformHost, owner, name)
 	if err != nil {
 		return nil, err
 	}
-	if collision {
+	if repoID == 0 && !legacySafe {
 		return nil, nil
 	}
-	ws, err := scanWorkspace(d.ro.QueryRowContext(ctx, `
-		SELECT id, platform, platform_host, repo_owner, repo_name,
+	predicate, args := workspaceRepositoryLookupPredicate(
+		provider, platformHost, owner, name, repoID,
+	)
+	query := `
+		SELECT id, platform, platform_host, repo_owner, repo_name, repo_id,
 		       item_type, item_number, item_key, associated_pr_number,
 		       git_head_ref, mr_head_repo, workspace_branch,
 		       worktree_path, tmux_session, terminal_backend, status,
 		       error_message, created_at, kata_metadata
 			FROM forge_workspaces
-			WHERE platform_host = ? AND repo_owner_key = ?
-			  AND repo_name_key = ?
+			WHERE (` + predicate + `)
 			  AND (
 			    (item_type = ? AND item_number = ?)
 			    OR (
@@ -4840,21 +4959,20 @@ func (d *DB) GetWorkspaceLinkedToMRForProvider(
 			      AND associated_pr_number = ?
 			    )
 			  )
-			  AND (? = '' OR platform = ?)
 			ORDER BY CASE
 			           WHEN item_type = ? AND item_number = ? THEN 0
 			           ELSE 1
 			         END,
 			         created_at DESC,
 			         id DESC
-			LIMIT 1`,
-		platformHost, owner, name,
+			LIMIT 1`
+	args = append(args,
 		WorkspaceItemTypePullRequest, mrNumber,
 		WorkspaceItemTypeIssue, WorkspaceItemTypeKataTask, WorkspaceItemTypeAdHoc,
 		mrNumber,
-		provider, provider,
 		WorkspaceItemTypePullRequest, mrNumber,
-	))
+	)
+	ws, err := d.scanWorkspace(ctx, d.ro.QueryRowContext(ctx, query, args...))
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -4870,29 +4988,28 @@ func (d *DB) getWorkspaceByMR(
 	mrNumber int,
 ) (*Workspace, error) {
 	provider = strings.ToLower(strings.TrimSpace(provider))
-	platformHost, owner, name = canonicalRepoLookupIdentifier(platformHost, owner, name)
-	collision, err := d.workspaceRouteHasHistoricalOccupants(
-		ctx, provider, platformHost, owner+"/"+name,
-	)
+	platformHost, owner, name, repoID, legacySafe, err :=
+		d.resolveWorkspaceLookupRoute(ctx, provider, platformHost, owner, name)
 	if err != nil {
 		return nil, err
 	}
-	if collision {
+	if repoID == 0 && !legacySafe {
 		return nil, nil
 	}
-	ws, err := scanWorkspace(d.ro.QueryRowContext(ctx, `
-		SELECT id, platform, platform_host, repo_owner, repo_name,
+	predicate, lookupArgs := workspaceRepositoryLookupPredicate(
+		provider, platformHost, owner, name, repoID,
+	)
+	query := `
+		SELECT id, platform, platform_host, repo_owner, repo_name, repo_id,
 		       item_type, item_number, item_key, associated_pr_number,
 		       git_head_ref, mr_head_repo, workspace_branch,
 		       worktree_path, tmux_session, terminal_backend, status,
 		       error_message, created_at, kata_metadata
 			FROM forge_workspaces
-			WHERE platform_host = ? AND repo_owner_key = ?
-			  AND repo_name_key = ? AND item_type = ? AND item_number = ?
-			  AND (? = '' OR platform = ?)`,
-		platformHost, owner, name, WorkspaceItemTypePullRequest, mrNumber,
-		provider, provider,
-	))
+			WHERE item_type = ? AND item_number = ?
+			  AND (` + predicate + `)`
+	args := append([]any{WorkspaceItemTypePullRequest, mrNumber}, lookupArgs...)
+	ws, err := d.scanWorkspace(ctx, d.ro.QueryRowContext(ctx, query, args...))
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -4930,29 +5047,28 @@ func (d *DB) getWorkspaceByIssue(
 	issueNumber int,
 ) (*Workspace, error) {
 	provider = strings.ToLower(strings.TrimSpace(provider))
-	platformHost, owner, name = canonicalRepoLookupIdentifier(platformHost, owner, name)
-	collision, err := d.workspaceRouteHasHistoricalOccupants(
-		ctx, provider, platformHost, owner+"/"+name,
-	)
+	platformHost, owner, name, repoID, legacySafe, err :=
+		d.resolveWorkspaceLookupRoute(ctx, provider, platformHost, owner, name)
 	if err != nil {
 		return nil, err
 	}
-	if collision {
+	if repoID == 0 && !legacySafe {
 		return nil, nil
 	}
-	ws, err := scanWorkspace(d.ro.QueryRowContext(ctx, `
-		SELECT id, platform, platform_host, repo_owner, repo_name,
+	predicate, lookupArgs := workspaceRepositoryLookupPredicate(
+		provider, platformHost, owner, name, repoID,
+	)
+	query := `
+		SELECT id, platform, platform_host, repo_owner, repo_name, repo_id,
 		       item_type, item_number, item_key, associated_pr_number,
 		       git_head_ref, mr_head_repo, workspace_branch,
 		       worktree_path, tmux_session, terminal_backend, status,
 		       error_message, created_at, kata_metadata
 		FROM forge_workspaces
-		WHERE platform_host = ? AND repo_owner_key = ?
-		  AND repo_name_key = ? AND item_type = ? AND item_number = ?
-		  AND (? = '' OR platform = ?)`,
-		platformHost, owner, name, WorkspaceItemTypeIssue, issueNumber,
-		provider, provider,
-	))
+		WHERE item_type = ? AND item_number = ?
+		  AND (` + predicate + `)`
+	args := append([]any{WorkspaceItemTypeIssue, issueNumber}, lookupArgs...)
+	ws, err := d.scanWorkspace(ctx, d.ro.QueryRowContext(ctx, query, args...))
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -4972,28 +5088,28 @@ func (d *DB) GetWorkspaceByItemKeyForProvider(
 	if itemType == "" || itemKey == "" {
 		return nil, nil
 	}
-	platformHost, owner, name = canonicalRepoLookupIdentifier(platformHost, owner, name)
-	collision, err := d.workspaceRouteHasHistoricalOccupants(
-		ctx, provider, platformHost, owner+"/"+name,
-	)
+	platformHost, owner, name, repoID, legacySafe, err :=
+		d.resolveWorkspaceLookupRoute(ctx, provider, platformHost, owner, name)
 	if err != nil {
 		return nil, err
 	}
-	if collision {
+	if repoID == 0 && !legacySafe {
 		return nil, nil
 	}
-	ws, err := scanWorkspace(d.ro.QueryRowContext(ctx, `
-		SELECT id, platform, platform_host, repo_owner, repo_name,
+	predicate, lookupArgs := workspaceRepositoryLookupPredicate(
+		provider, platformHost, owner, name, repoID,
+	)
+	query := `
+		SELECT id, platform, platform_host, repo_owner, repo_name, repo_id,
 		       item_type, item_number, item_key, associated_pr_number,
 		       git_head_ref, mr_head_repo, workspace_branch,
 		       worktree_path, tmux_session, terminal_backend, status,
 		       error_message, created_at, kata_metadata
 		FROM forge_workspaces
-		WHERE platform_host = ? AND repo_owner_key = ?
-		  AND repo_name_key = ? AND item_type = ? AND item_key = ?
-		  AND (? = '' OR platform = ?)`,
-		platformHost, owner, name, itemType, itemKey, provider, provider,
-	))
+		WHERE item_type = ? AND item_key = ?
+		  AND (` + predicate + `)`
+	args := append([]any{itemType, itemKey}, lookupArgs...)
+	ws, err := d.scanWorkspace(ctx, d.ro.QueryRowContext(ctx, query, args...))
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -5015,8 +5131,8 @@ func (d *DB) GetKataWorkspaceByIssue(
 	if daemonID == "" || issueUID == "" {
 		return nil, nil
 	}
-	ws, err := scanWorkspace(d.ro.QueryRowContext(ctx, `
-		SELECT id, platform, platform_host, repo_owner, repo_name,
+	ws, err := d.scanWorkspace(ctx, d.ro.QueryRowContext(ctx, `
+		SELECT id, platform, platform_host, repo_owner, repo_name, repo_id,
 		       item_type, item_number, item_key, associated_pr_number,
 		       git_head_ref, mr_head_repo, workspace_branch,
 		       worktree_path, tmux_session, terminal_backend, status,
@@ -5043,13 +5159,20 @@ func (d *DB) ListWorkspaces(
 	ctx context.Context,
 ) ([]Workspace, error) {
 	rows, err := d.ro.QueryContext(ctx, `
-		SELECT id, platform, platform_host, repo_owner, repo_name,
-		       item_type, item_number, item_key, associated_pr_number,
-		       git_head_ref, mr_head_repo, workspace_branch,
-		       worktree_path, tmux_session, terminal_backend, status,
-		       error_message, created_at, kata_metadata
-		FROM forge_workspaces
-		ORDER BY created_at DESC`,
+		SELECT w.id,
+		       COALESCE(r.platform, w.platform),
+		       COALESCE(r.platform_host, w.platform_host),
+		       COALESCE(r.owner, w.repo_owner),
+		       COALESCE(r.name, w.repo_name),
+		       w.repo_id,
+		       w.item_type, w.item_number, w.item_key, w.associated_pr_number,
+		       w.git_head_ref, w.mr_head_repo, w.workspace_branch,
+		       w.worktree_path, w.tmux_session, w.terminal_backend, w.status,
+		       w.error_message, w.created_at, w.kata_metadata
+		FROM forge_workspaces w
+		LEFT JOIN forge_repos r
+		  ON r.id = w.repo_id AND r.lifecycle_state = 'active'
+		ORDER BY w.created_at DESC`,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("list workspaces: %w", err)
@@ -5058,7 +5181,7 @@ func (d *DB) ListWorkspaces(
 
 	var out []Workspace
 	for rows.Next() {
-		ws, err := scanWorkspace(rows)
+		ws, err := scanWorkspaceRow(rows)
 		if err != nil {
 			return nil, fmt.Errorf("scan workspace: %w", err)
 		}
@@ -5112,12 +5235,29 @@ func (d *DB) MarkReadyWorkspaceError(
 // workspace state and clears any error left by an earlier attempt. A false
 // result means another deletion is already responsible for the workspace.
 func (d *DB) BeginWorkspaceDeletion(ctx context.Context, id string) (bool, error) {
-	result, err := d.execContext(ctx, `
+	return d.beginWorkspaceDeletion(ctx, id, true)
+}
+
+// BeginWorkspaceRetirement atomically admits an automatic deletion attempt,
+// but leaves a prior deletion failure for explicit user action.
+func (d *DB) BeginWorkspaceRetirement(ctx context.Context, id string) (bool, error) {
+	return d.beginWorkspaceDeletion(ctx, id, false)
+}
+
+func (d *DB) beginWorkspaceDeletion(
+	ctx context.Context, id string, retryFailure bool,
+) (bool, error) {
+	query := `
 		UPDATE forge_workspaces
 		SET status = 'deleting', error_message = NULL
-		WHERE id = ? AND status IN ('ready', 'error', 'deletion_failed')`,
-		id,
-	)
+		WHERE id = ? AND status IN ('ready', 'error')`
+	if retryFailure {
+		query = `
+			UPDATE forge_workspaces
+			SET status = 'deleting', error_message = NULL
+			WHERE id = ? AND status IN ('ready', 'error', 'deletion_failed')`
+	}
+	result, err := d.execContext(ctx, query, id)
 	if err != nil {
 		return false, fmt.Errorf("begin workspace deletion: %w", err)
 	}
@@ -5130,7 +5270,8 @@ func (d *DB) BeginWorkspaceDeletion(ctx context.Context, id string) (bool, error
 	}
 	var status string
 	err = d.ro.QueryRowContext(ctx, `SELECT status FROM forge_workspaces WHERE id = ?`, id).Scan(&status)
-	if errors.Is(err, sql.ErrNoRows) || status == "deleting" {
+	if errors.Is(err, sql.ErrNoRows) || status == "deleting" ||
+		(!retryFailure && status == "deletion_failed") {
 		return false, nil
 	}
 	if err != nil {
@@ -5257,68 +5398,6 @@ func (d *DB) UpdateWorkspaceMRHeadRepo(
 	return nil
 }
 
-// UpdateWorkspaceMRHeadRepoForMissingRepo persists an unknown classification
-// only while the repository identity used to derive that absence is still
-// missing. A false result tells the caller to reread and retry after the
-// repository appeared concurrently.
-func (d *DB) UpdateWorkspaceMRHeadRepoForMissingRepo(
-	ctx context.Context,
-	id string,
-	identity RepoIdentity,
-	mrHeadRepo *string,
-) (bool, error) {
-	identity = canonicalRepoIdentity(identity)
-	result, err := d.execContext(ctx, `
-		UPDATE forge_workspaces
-		SET mr_head_repo = ?
-		WHERE id = ?
-		  AND NOT EXISTS (
-		      SELECT 1
-		      FROM forge_repos
-		      WHERE platform = ?
-		        AND platform_host = ?
-		        AND repo_path_key = ?
-		        AND lifecycle_state = 'active'
-		  )`,
-		mrHeadRepo,
-		id,
-		identity.Platform,
-		identity.PlatformHost,
-		identity.RepoPathKey,
-	)
-	if err != nil {
-		return false, fmt.Errorf(
-			"update workspace mr head repo for missing repo: %w", err,
-		)
-	}
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return false, fmt.Errorf(
-			"read missing-repo head classification update result: %w", err,
-		)
-	}
-	if rowsAffected > 0 {
-		return true, nil
-	}
-	var workspaceExists bool
-	if err := d.ro.QueryRowContext(
-		ctx,
-		`SELECT EXISTS(
-		    SELECT 1 FROM forge_workspaces WHERE id = ?
-		)`,
-		id,
-	).Scan(&workspaceExists); err != nil {
-		return false, fmt.Errorf(
-			"check workspace after missing-repo head classification update: %w",
-			err,
-		)
-	}
-	if !workspaceExists {
-		return false, fmt.Errorf("workspace %q not found", id)
-	}
-	return false, nil
-}
-
 // UpdateWorkspaceMRHeadRepoForSnapshot persists a classification only while
 // the merge-request revision and removed-upstream visibility that produced it
 // remain current. A false result tells the caller to reread and retry.
@@ -5335,6 +5414,7 @@ func (d *DB) UpdateWorkspaceMRHeadRepoForSnapshot(
 		UPDATE forge_workspaces
 		SET mr_head_repo = ?
 		WHERE id = ?
+		  AND repo_id = ?
 		  AND COALESCE((
 		      SELECT snapshot_revision
 		      FROM forge_merge_requests
@@ -5350,6 +5430,7 @@ func (d *DB) UpdateWorkspaceMRHeadRepoForSnapshot(
 		  ) = ?`,
 		mrHeadRepo,
 		id,
+		repoID,
 		repoID,
 		mrNumber,
 		expectedRevision,
@@ -5702,7 +5783,12 @@ func (d *DB) DeleteWorkspace(
 // workspaceSummaryColumns is the SELECT list shared by
 // ListWorkspaceSummaries and GetWorkspaceSummary.
 const workspaceSummaryColumns = `
-	w.id, w.platform, w.platform_host, w.repo_owner, w.repo_name,
+	w.id,
+	COALESCE(r.platform, w.platform),
+	COALESCE(r.platform_host, w.platform_host),
+	COALESCE(r.owner, w.repo_owner),
+	COALESCE(r.name, w.repo_name),
+	w.repo_id,
 	w.item_type, w.item_number, w.item_key, w.associated_pr_number,
 	w.git_head_ref, w.mr_head_repo, w.workspace_branch,
 	w.worktree_path, w.tmux_session, w.terminal_backend, w.status,
@@ -5764,7 +5850,8 @@ const workspaceSummaryColumns = `
 const workspaceSummaryJoins = `
 	FROM forge_workspaces w
 	LEFT JOIN forge_repo_routes rr
-	    ON rr.platform = w.platform
+	    ON w.repo_id IS NULL
+	   AND rr.platform = w.platform
 	   AND rr.platform_host = w.platform_host
 	   AND rr.owner_key = w.repo_owner_key
 	   AND rr.name_key = w.repo_name_key
@@ -5777,7 +5864,7 @@ const workspaceSummaryJoins = `
 	         AND historical.repo_id <> rr.repo_id
 	   )
 	LEFT JOIN forge_repos r
-	    ON r.id = rr.repo_id
+	    ON r.id = COALESCE(w.repo_id, rr.repo_id)
 	   AND r.lifecycle_state = 'active'
 	LEFT JOIN forge_merge_requests m
 	    ON m.repo_id = r.id
@@ -5810,10 +5897,12 @@ func scanWorkspaceSummary(
 	var s WorkspaceSummary
 	var kataMetadataJSON string
 	var itemLastActivityAt sql.NullString
+	var workspaceRepoID sql.NullInt64
 	var repoID sql.NullInt64
 	var repoPlatformID sql.NullString
 	err := scanner.Scan(
 		&s.ID, &s.Platform, &s.PlatformHost, &s.RepoOwner, &s.RepoName,
+		&workspaceRepoID,
 		&s.ItemType, &s.ItemNumber, &s.ItemKey, &s.AssociatedPRNumber,
 		&s.GitHeadRef, &s.MRHeadRepo, &s.WorkspaceBranch,
 		&s.WorktreePath, &s.TmuxSession, &s.TerminalBackend, &s.Status,
@@ -5829,6 +5918,9 @@ func scanWorkspaceSummary(
 	)
 	if err != nil {
 		return nil, err
+	}
+	if workspaceRepoID.Valid {
+		s.Workspace.RepoID = workspaceRepoID.Int64
 	}
 	if repoID.Valid {
 		s.RepoID = repoID.Int64

--- a/internal/db/queries_kata_links_test.go
+++ b/internal/db/queries_kata_links_test.go
@@ -225,9 +225,12 @@ func TestKataIssueLinksSurviveRepoRenameAndCascadeWithOwners(t *testing.T) {
 	assert.Len(repoLinks, 1)
 
 	_, err = database.WriteDB().ExecContext(t.Context(), `DELETE FROM forge_repos WHERE id = ?`, repoID)
+	require.Error(err, "a workspace keeps its stable repository identity alive")
+	assert.Equal(2, kataIssueLinkCountForTest(t, database))
+	_, err = database.WriteDB().ExecContext(t.Context(), `DELETE FROM forge_workspaces WHERE id = ?`, workspaceID)
 	require.NoError(err)
 	assert.Equal(1, kataIssueLinkCountForTest(t, database))
-	_, err = database.WriteDB().ExecContext(t.Context(), `DELETE FROM forge_workspaces WHERE id = ?`, workspaceID)
+	_, err = database.WriteDB().ExecContext(t.Context(), `DELETE FROM forge_repos WHERE id = ?`, repoID)
 	require.NoError(err)
 	assert.Zero(kataIssueLinkCountForTest(t, database))
 	assertDatabaseIntegrityForTest(t, database.ReadDB())

--- a/internal/db/queries_projects.go
+++ b/internal/db/queries_projects.go
@@ -19,10 +19,11 @@ import (
 // linked repo (a local-only directory with no parseable remote), in which case
 // PlatformIdentity is nil.
 type PlatformIdentity struct {
-	Platform string `json:"platform"`
-	Host     string `json:"platform_host"`
-	Owner    string `json:"owner"`
-	Name     string `json:"name"`
+	Platform       string `json:"platform"`
+	Host           string `json:"platform_host"`
+	PlatformRepoID string `json:"-"`
+	Owner          string `json:"owner"`
+	Name           string `json:"name"`
 }
 
 // Project is the registry record for a local repository checkout kenn-forge
@@ -128,7 +129,7 @@ func (d *DB) CreateProject(ctx context.Context, in CreateProjectInput) (*Project
 const projectSelectColumns = `p.id, p.display_name, p.local_path,
         p.default_branch, p.repository_kind, p.is_stale,
         p.created_at, p.updated_at,
-        r.platform, r.platform_host, r.owner, r.name`
+        r.platform, r.platform_host, r.platform_repo_id, r.owner, r.name`
 
 const projectFromJoin = `FROM forge_projects p
         LEFT JOIN forge_repos r ON r.id = p.repo_id`
@@ -724,13 +725,14 @@ func scanProjectFields(scanner interface{ Scan(...any) error }) (*Project, error
 		isStale      int64
 		platform     sql.NullString
 		platformHost sql.NullString
+		platformID   sql.NullString
 		repoOwner    sql.NullString
 		repoName     sql.NullString
 	)
 	err := scanner.Scan(
 		&p.ID, &p.DisplayName, &p.LocalPath,
 		&defaultBr, &repoKind, &isStale, &p.CreatedAt, &p.UpdatedAt,
-		&platform, &platformHost, &repoOwner, &repoName,
+		&platform, &platformHost, &platformID, &repoOwner, &repoName,
 	)
 	if err != nil {
 		return nil, err
@@ -745,10 +747,11 @@ func scanProjectFields(scanner interface{ Scan(...any) error }) (*Project, error
 	p.IsStale = isStale != 0
 	if platformHost.Valid {
 		p.PlatformIdentity = &PlatformIdentity{
-			Platform: platform.String,
-			Host:     platformHost.String,
-			Owner:    repoOwner.String,
-			Name:     repoName.String,
+			Platform:       platform.String,
+			Host:           platformHost.String,
+			PlatformRepoID: platformID.String,
+			Owner:          repoOwner.String,
+			Name:           repoName.String,
 		}
 	}
 	return &p, nil

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -158,6 +158,28 @@ func TestPurgeOtherHosts(t *testing.T) {
 	gheRepoID := insertTestRepoWithHost(
 		t, d, "corp", "internal", "ghes.company.com",
 	)
+	require.NoError(d.InsertWorkspace(ctx, &Workspace{
+		ID: "ws-ghe-identified", Platform: "github",
+		PlatformHost: "ghes.company.com", RepoOwner: "corp", RepoName: "internal",
+		RepoID: gheRepoID, ItemType: WorkspaceItemTypePullRequest, ItemNumber: 2,
+		GitHeadRef: "feature/two", WorkspaceBranch: "kenn-forge/pr-2",
+		WorktreePath: "/tmp/ws-ghe-identified", TmuxSession: "forge-ws-ghe-identified",
+		Status: "ready",
+	}))
+	_, err := d.WriteDB().ExecContext(ctx, `
+		INSERT INTO forge_workspaces (
+			id, platform, platform_host, repo_owner, repo_name, repo_id,
+			repo_owner_key, repo_name_key, repo_path_key,
+			item_type, item_number, item_key, git_head_ref, workspace_branch,
+			worktree_path, tmux_session, status
+		)
+		SELECT
+			'ws-ghe-legacy', platform, platform_host, repo_owner, repo_name, NULL,
+			repo_owner_key, repo_name_key, repo_path_key,
+			item_type, item_number, item_key, git_head_ref, workspace_branch,
+			'/tmp/ws-ghe-legacy', 'forge-ws-ghe-legacy', status
+		FROM forge_workspaces WHERE id = 'ws-ghe-identified'`)
+	require.NoError(err)
 
 	// Insert MRs for both hosts.
 	ghMRID := insertTestMR(
@@ -243,14 +265,25 @@ func TestPurgeOtherHosts(t *testing.T) {
 	require.NoError(err)
 	assert.True(starred)
 
-	// ghes.company.com repo should be gone.
+	// The ghes.company.com repository survives only as an inactive identity
+	// tombstone for its workspace.
 	var gheCount int
 	err = d.ReadDB().QueryRowContext(ctx,
 		`SELECT COUNT(*) FROM forge_repos
-		 WHERE platform_host = 'ghes.company.com'`,
+		 WHERE platform_host = 'ghes.company.com'
+		   AND id = ? AND lifecycle_state = 'inactive'`, gheRepoID,
 	).Scan(&gheCount)
 	require.NoError(err)
-	assert.Equal(0, gheCount)
+	assert.Equal(1, gheCount)
+	var identifiedRepoID int64
+	require.NoError(d.ReadDB().QueryRowContext(ctx, `
+		SELECT repo_id FROM forge_workspaces WHERE id = 'ws-ghe-identified'`,
+	).Scan(&identifiedRepoID))
+	assert.Equal(gheRepoID, identifiedRepoID)
+	_, err = d.WriteDB().ExecContext(ctx,
+		`DELETE FROM forge_repos WHERE id = ?`, gheRepoID,
+	)
+	require.Error(err, "workspace repository identities must not be nulled by deletion")
 
 	// ghes.company.com MR should be gone.
 	var gheMRCount int
@@ -4199,6 +4232,38 @@ func TestWorkspaceCRUD(t *testing.T) {
 	assert.Nil(noSuch)
 }
 
+func TestListWorkspacesUsesOneReadConnection(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	now := baseTime()
+
+	identity := GitHubRepoIdentity("github.com", "acme", "widget")
+	identity.PlatformRepoID = "repo-acme-widget"
+	repo, accepted, err := d.ReconcileRepositoryObservation(t.Context(), identity, now)
+	require.NoError(err)
+	require.True(accepted)
+	require.NoError(d.InsertWorkspace(t.Context(), &Workspace{
+		ID: "ws-list-one-connection", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget", RepoID: repo.Repository.ID,
+		ItemType: WorkspaceItemTypePullRequest, ItemNumber: 42,
+		WorktreePath: "/tmp/ws-list-one-connection", Status: "ready",
+	}))
+
+	renamed := GitHubRepoIdentity("github.com", "acme", "gadget")
+	renamed.PlatformRepoID = identity.PlatformRepoID
+	_, accepted, err = d.ReconcileRepositoryObservation(t.Context(), renamed, now.Add(time.Minute))
+	require.NoError(err)
+	require.True(accepted)
+
+	d.ReadDB().SetMaxOpenConns(1)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	workspaces, err := d.ListWorkspaces(ctx)
+	require.NoError(err)
+	require.Len(workspaces, 1)
+	require.Equal("gadget", workspaces[0].RepoName)
+}
+
 func TestWorkspaceDeletionLifecycle(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -4243,6 +4308,16 @@ func TestWorkspaceDeletionLifecycle(t *testing.T) {
 	require.NotNil(got.ErrorMessage)
 	assert.Equal("worktree is dirty", *got.ErrorMessage)
 
+	started, err = d.BeginWorkspaceRetirement(ctx, "ws-delete")
+	require.NoError(err)
+	assert.False(started)
+	got, err = d.GetWorkspace(ctx, "ws-delete")
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal("deletion_failed", got.Status)
+	require.NotNil(got.ErrorMessage)
+	assert.Equal("worktree is dirty", *got.ErrorMessage)
+
 	started, err = d.BeginWorkspaceDeletion(ctx, "ws-delete")
 	require.NoError(err)
 	assert.True(started)
@@ -4259,6 +4334,60 @@ func TestWorkspaceDeletionLifecycle(t *testing.T) {
 		require.NotNil(got.ErrorMessage)
 		assert.Equal("deletion interrupted by server restart", *got.ErrorMessage)
 	}
+}
+
+func TestBeginWorkspaceRetirementPreservesFailureConcurrently(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	message := "worktree is dirty"
+	require.NoError(d.InsertWorkspace(ctx, &Workspace{
+		ID:              "ws-retirement-failure",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        WorkspaceItemTypePullRequest,
+		ItemNumber:      42,
+		GitHeadRef:      "feature/delete",
+		WorkspaceBranch: "kenn-forge/pr-42",
+		WorktreePath:    "/tmp/ws-retirement-failure",
+		TmuxSession:     "kenn-forge-ws-retirement-failure",
+		Status:          "deletion_failed",
+		ErrorMessage:    &message,
+	}))
+
+	const callers = 16
+	start := make(chan struct{})
+	results := make(chan bool, callers)
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for range callers {
+		go func() {
+			defer wg.Done()
+			<-start
+			started, err := d.BeginWorkspaceRetirement(ctx, "ws-retirement-failure")
+			results <- started
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	for err := range errs {
+		require.NoError(err)
+	}
+	for started := range results {
+		require.False(started)
+	}
+	got, err := d.GetWorkspace(ctx, "ws-retirement-failure")
+	require.NoError(err)
+	require.NotNil(got)
+	require.Equal("deletion_failed", got.Status)
+	require.NotNil(got.ErrorMessage)
+	require.Equal(message, *got.ErrorMessage)
 }
 
 func TestFailInterruptedWorkspaceSetups(t *testing.T) {
@@ -4532,6 +4661,40 @@ func TestUpdateWorkspaceMRHeadRepoForSnapshotRejectsStaleRevision(t *testing.T) 
 	)
 	require.Error(err)
 	assert.Contains(err.Error(), "workspace \"missing-workspace\" not found")
+}
+
+func TestUpdateWorkspaceMRHeadRepoForSnapshotRejectsRepositoryMismatch(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	originalRepoID := insertTestRepo(t, database, "acme", "original")
+	replacementRepoID := insertTestRepo(t, database, "acme", "replacement")
+	insertTestMR(t, database, replacementRepoID, 7, "replacement pull", baseTime())
+	replacementMR, err := database.GetMergeRequestByRepoIDAndNumber(
+		t.Context(), replacementRepoID, 7,
+	)
+	require.NoError(err)
+	require.NotNil(replacementMR)
+	workspace := &Workspace{
+		ID: "ws-repository-mismatch", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "original",
+		ItemType: WorkspaceItemTypePullRequest, ItemNumber: 7,
+		WorktreePath: t.TempDir(), Status: "ready",
+	}
+	require.NoError(database.InsertWorkspace(t.Context(), workspace))
+	require.Equal(originalRepoID, workspace.RepoID)
+	forkURL := "https://github.com/contributor/replacement.git"
+
+	applied, err := database.UpdateWorkspaceMRHeadRepoForSnapshot(
+		t.Context(), workspace.ID, replacementRepoID, 7,
+		replacementMR.SnapshotRevision, false, &forkURL,
+	)
+
+	require.NoError(err)
+	require.False(applied)
+	stored, err := database.GetWorkspace(t.Context(), workspace.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	require.Nil(stored.MRHeadRepo)
 }
 
 func TestWorkspaceItemKeyDefaultsFromItemNumber(t *testing.T) {
@@ -5527,11 +5690,11 @@ func TestWorkspaceSummariesRetainWorkspaceWithoutRemovedPullMetadata(t *testing.
 	require.Nil(summaries[0].MRTitle)
 }
 
-func TestWorkspaceSummariesHideProviderMetadataForReusedRoute(t *testing.T) {
+func TestWorkspaceSummariesFollowStableRepositoryAcrossReusedRoute(t *testing.T) {
 	require := require.New(t)
 	d := openTestDB(t)
 	observedAt := baseTime()
-	reconcileCatalogRepository(
+	original := reconcileCatalogRepository(
 		t, d, "provider-original", "org-a", "project-a", observedAt,
 	)
 	associatedPR := 42
@@ -5556,15 +5719,16 @@ func TestWorkspaceSummariesHideProviderMetadataForReusedRoute(t *testing.T) {
 	summary, err := d.GetWorkspaceSummary(t.Context(), "ws-reused-route")
 	require.NoError(err)
 	require.NotNil(summary)
-	require.Zero(summary.RepoID)
-	require.False(summary.SourceItemVisible)
-	require.False(summary.AssociatedPRVisible)
+	require.Equal(original.Repository.ID, summary.RepoID)
+	require.Equal("renamed-project", summary.RepoName)
+	require.True(summary.SourceItemVisible)
+	require.True(summary.AssociatedPRVisible)
 
 	summaries, err := d.ListWorkspaceSummaries(t.Context())
 	require.NoError(err)
 	require.Len(summaries, 1)
-	require.False(summaries[0].SourceItemVisible)
-	require.False(summaries[0].AssociatedPRVisible)
+	require.True(summaries[0].SourceItemVisible)
+	require.True(summaries[0].AssociatedPRVisible)
 }
 
 func TestSetWorkspaceAssociatedPRNumberIfNull(t *testing.T) {

--- a/internal/db/queries_workspace_launch_specs.go
+++ b/internal/db/queries_workspace_launch_specs.go
@@ -58,6 +58,26 @@ func insertWorkspaceLaunchSpec(
 	return nil
 }
 
+func (d *DB) validateWorkspaceLaunchSpecRepository(
+	ctx context.Context, repoID int64, spec WorkspaceLaunchSpec,
+) error {
+	repo, err := d.GetActiveRepoByID(ctx, repoID)
+	if err != nil {
+		return fmt.Errorf("resolve workspace launch repository: %w", err)
+	}
+	if repo == nil ||
+		!strings.EqualFold(repo.Platform, spec.Repository.Provider) ||
+		!strings.EqualFold(repo.PlatformHost, spec.Repository.PlatformHost) ||
+		strings.TrimSpace(repo.PlatformRepoID) !=
+			strings.TrimSpace(spec.Repository.PlatformRepoID) {
+		return fmt.Errorf(
+			"%w: workspace launch specification repository identity changed",
+			ErrRepositoryRouteFenceChanged,
+		)
+	}
+	return nil
+}
+
 // CreateWorkspaceWithLaunchSpec inserts a provider-backed workspace and its
 // immutable launch facts in one transaction. Validation happens before either
 // row is written.
@@ -84,6 +104,11 @@ func (d *DB) CreateWorkspaceWithLaunchSpec(
 	if prepared.itemKey != spec.ItemKey {
 		return errors.New("workspace launch specification item key does not match persisted workspace key")
 	}
+	if err := d.validateWorkspaceLaunchSpecRepository(
+		ctx, prepared.repoID, spec,
+	); err != nil {
+		return err
+	}
 	tx, err := d.rw.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("create workspace with launch specification: begin: %w", err)
@@ -107,6 +132,11 @@ func (d *DB) PutWorkspaceLaunchSpec(
 	workspaceID string,
 	spec WorkspaceLaunchSpec,
 ) error {
+	release, err := d.LockRepositoryReconciliationRead(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
 	workspace, err := d.GetWorkspace(ctx, workspaceID)
 	if err != nil {
 		return err
@@ -115,6 +145,11 @@ func (d *DB) PutWorkspaceLaunchSpec(
 		return sql.ErrNoRows
 	}
 	if err := spec.ValidateWorkspace(*workspace); err != nil {
+		return err
+	}
+	if err := d.validateWorkspaceLaunchSpecRepository(
+		ctx, workspace.RepoID, spec,
+	); err != nil {
 		return err
 	}
 	return insertWorkspaceLaunchSpec(ctx, d.rw, workspaceID, spec)
@@ -136,8 +171,9 @@ func (d *DB) GetWorkspaceByLaunchSpecIdentity(
 		itemType == "" || itemKey == "" {
 		return nil, nil
 	}
-	workspace, err := scanWorkspace(d.ro.QueryRowContext(ctx, `
+	workspace, err := d.scanWorkspace(ctx, d.ro.QueryRowContext(ctx, `
 		SELECT w.id, w.platform, w.platform_host, w.repo_owner, w.repo_name,
+		       w.repo_id,
 		       w.item_type, w.item_number, w.item_key, w.associated_pr_number,
 		       w.git_head_ref, w.mr_head_repo, w.workspace_branch,
 		       w.worktree_path, w.tmux_session, w.terminal_backend, w.status,
@@ -220,6 +256,11 @@ func (d *DB) PutRefreshedWorkspaceLaunchSpec(
 	if workspace == nil {
 		return nil, sql.ErrNoRows
 	}
+	if err := d.validateWorkspaceLaunchSpecRepository(
+		ctx, workspace.RepoID, spec,
+	); err != nil {
+		return nil, err
+	}
 	current, err := d.GetWorkspaceLaunchSpec(ctx, workspaceID)
 	if err != nil {
 		return nil, err
@@ -228,12 +269,12 @@ func (d *DB) PutRefreshedWorkspaceLaunchSpec(
 	originalHost := workspace.PlatformHost
 	originalOwner := workspace.RepoOwner
 	originalName := workspace.RepoName
-	routeChanged := !strings.EqualFold(
-		canonicalWorkspacePlatform(workspace.Platform), spec.Repository.Provider,
+	routeChanged := current != nil && (!strings.EqualFold(
+		canonicalWorkspacePlatform(current.Repository.Provider), spec.Repository.Provider,
 	) ||
-		!strings.EqualFold(workspace.PlatformHost, spec.Repository.PlatformHost) ||
-		!strings.EqualFold(workspace.RepoOwner, spec.Repository.Owner) ||
-		!strings.EqualFold(workspace.RepoName, spec.Repository.Name)
+		!strings.EqualFold(current.Repository.PlatformHost, spec.Repository.PlatformHost) ||
+		!strings.EqualFold(current.Repository.Owner, spec.Repository.Owner) ||
+		!strings.EqualFold(current.Repository.Name, spec.Repository.Name))
 	if routeChanged {
 		if current == nil ||
 			current.Repository.PlatformRepoID != spec.Repository.PlatformRepoID ||
@@ -253,15 +294,17 @@ func (d *DB) PutRefreshedWorkspaceLaunchSpec(
 			!strings.EqualFold(entry.Repository.Name, spec.Repository.Name) {
 			return nil, errors.New("refreshed workspace route is not the active repository route")
 		}
-		collision, collisionErr := d.workspaceRouteHasHistoricalOccupants(
-			ctx, entry.Repository.Platform, entry.Repository.PlatformHost,
-			entry.Repository.RepoPathKey,
-		)
-		if collisionErr != nil {
-			return nil, collisionErr
-		}
-		if collision {
-			return nil, errors.New("refreshed workspace route has historical occupants")
+		if workspace.RepoID == 0 {
+			collision, collisionErr := d.workspaceRouteHasHistoricalOccupants(
+				ctx, entry.Repository.Platform, entry.Repository.PlatformHost,
+				entry.Repository.RepoPathKey,
+			)
+			if collisionErr != nil {
+				return nil, collisionErr
+			}
+			if collision {
+				return nil, errors.New("refreshed workspace route has historical occupants")
+			}
 		}
 		workspace.Platform = entry.Repository.Platform
 		workspace.PlatformHost = entry.Repository.PlatformHost
@@ -278,7 +321,16 @@ func (d *DB) PutRefreshedWorkspaceLaunchSpec(
 	}
 	defer func() { _ = tx.Rollback() }()
 	var result sql.Result
-	if routeChanged {
+	if workspace.RepoID != 0 {
+		result, err = tx.ExecContext(ctx, `
+			UPDATE forge_workspaces SET status = status
+			WHERE id = ? AND repo_id = ?`,
+			workspace.ID, workspace.RepoID,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("guard workspace repository identity: %w", err)
+		}
+	} else if routeChanged {
 		ownerKey := strings.ToLower(strings.TrimSpace(workspace.RepoOwner))
 		nameKey := strings.ToLower(strings.TrimSpace(workspace.RepoName))
 		result, err = tx.ExecContext(ctx, `
@@ -377,7 +429,7 @@ func (d *DB) ListUnpreparedProviderWorkspacesAt(
 	now time.Time,
 ) ([]UnpreparedWorkspace, error) {
 	rows, err := d.ro.QueryContext(ctx, `
-		SELECT id, platform, platform_host, repo_owner, repo_name,
+		SELECT id, platform, platform_host, repo_owner, repo_name, repo_id,
 		       item_type, item_number, item_key, associated_pr_number,
 		       git_head_ref, mr_head_repo, workspace_branch,
 		       worktree_path, tmux_session, terminal_backend, status,
@@ -389,9 +441,24 @@ func (d *DB) ListUnpreparedProviderWorkspacesAt(
 		return nil, fmt.Errorf("list provider-backed workspaces for preparation: %w", err)
 	}
 	defer rows.Close()
-	var unprepared []UnpreparedWorkspace
+	var workspaces []*Workspace
 	for rows.Next() {
-		workspace, err := scanWorkspace(rows)
+		workspace, err := scanWorkspaceRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		workspaces = append(workspaces, workspace)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("close provider-backed workspace rows: %w", err)
+	}
+
+	var unprepared []UnpreparedWorkspace
+	for _, workspace := range workspaces {
+		workspace, err := d.resolveWorkspaceRepository(ctx, workspace)
 		if err != nil {
 			return nil, err
 		}
@@ -402,12 +469,12 @@ func (d *DB) ListUnpreparedProviderWorkspacesAt(
 			reason = err.Error()
 		case spec == nil:
 			reason = "launchSpecMissing"
-		case spec.ValidateWorkspace(*workspace) != nil:
-			reason = "launchSpecMismatch"
 		case errors.Is(spec.RequireVisible(now), ErrLaunchSpecSourceHidden):
 			reason = "sourceNotVisible"
 		case errors.Is(spec.RequireVisible(now), ErrLaunchSpecRefreshRequired):
 			reason = "sourceVisibilityExpired"
+		case spec.ValidateWorkspace(*workspace) != nil:
+			reason = "launchSpecMismatch"
 		}
 		if reason != "" {
 			platformRepoID := ""
@@ -427,9 +494,6 @@ func (d *DB) ListUnpreparedProviderWorkspacesAt(
 				PlatformRepoID: platformRepoID,
 			})
 		}
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
 	}
 	return unprepared, nil
 }

--- a/internal/db/queries_workspace_launch_specs_test.go
+++ b/internal/db/queries_workspace_launch_specs_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -56,6 +57,77 @@ func TestWorkspaceAndLaunchSpecPersistAtomically(t *testing.T) {
 	storedSpec, readErr := database.GetWorkspaceLaunchSpec(t.Context(), workspace.ID)
 	require.NoError(readErr)
 	assert.Nil(storedSpec)
+}
+
+func TestListUnpreparedProviderWorkspacesUsesOneReadConnection(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	workspace, spec := workspaceLaunchFixture(t, database, "ws-unprepared-one-connection")
+	require.NoError(database.CreateWorkspaceWithLaunchSpec(
+		t.Context(), workspace, spec,
+	))
+
+	database.ReadDB().SetMaxOpenConns(1)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	unprepared, err := database.ListUnpreparedProviderWorkspacesAt(
+		ctx, spec.SourceVisibleUntil,
+	)
+
+	require.NoError(err)
+	require.Len(unprepared, 1)
+	require.Equal(workspace.ID, unprepared[0].Workspace.ID)
+	require.Equal("sourceVisibilityExpired", unprepared[0].Reason)
+}
+
+func TestCreateWorkspaceWithLaunchSpecRejectsCatalogIdentityMismatch(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	workspace, spec := workspaceLaunchFixture(t, database, "ws-catalog-mismatch")
+	spec.Repository.PlatformRepoID = "replacement-repository"
+
+	err := database.CreateWorkspaceWithLaunchSpec(t.Context(), workspace, spec)
+
+	require.ErrorIs(err, ErrRepositoryRouteFenceChanged)
+	stored, readErr := database.GetWorkspace(t.Context(), workspace.ID)
+	require.NoError(readErr)
+	require.Nil(stored)
+}
+
+func TestPutWorkspaceLaunchSpecRejectsCatalogIdentityMismatch(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	workspace, spec := workspaceLaunchFixture(t, database, "ws-put-mismatch")
+	require.NoError(database.InsertWorkspace(t.Context(), workspace))
+	spec.Repository.PlatformRepoID = "replacement-repository"
+
+	err := database.PutWorkspaceLaunchSpec(t.Context(), workspace.ID, spec)
+
+	require.ErrorIs(err, ErrRepositoryRouteFenceChanged)
+	stored, readErr := database.GetWorkspaceLaunchSpec(t.Context(), workspace.ID)
+	require.NoError(readErr)
+	require.Nil(stored)
+}
+
+func TestRefreshWorkspaceLaunchSpecRejectsSameRouteIdentityMismatch(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	workspace, spec := workspaceLaunchFixture(t, database, "ws-refresh-mismatch")
+	require.NoError(database.CreateWorkspaceWithLaunchSpec(t.Context(), workspace, spec))
+	refreshed := spec
+	refreshed.Repository.PlatformRepoID = "replacement-repository"
+	refreshed.IssuedAt = spec.IssuedAt.Add(time.Minute)
+	refreshed.SourceVisibleUntil = refreshed.IssuedAt.Add(WorkspaceLaunchSpecVisibilityLease)
+
+	_, err := database.PutRefreshedWorkspaceLaunchSpec(
+		t.Context(), workspace.ID, refreshed,
+	)
+
+	require.ErrorIs(err, ErrRepositoryRouteFenceChanged)
+	stored, readErr := database.GetWorkspaceLaunchSpec(t.Context(), workspace.ID)
+	require.NoError(readErr)
+	require.NotNil(stored)
+	require.Equal(spec.Repository.PlatformRepoID, stored.Repository.PlatformRepoID)
 }
 
 func TestWorkspaceLaunchSpecRoundTripsCanonicalUTCTimestamps(t *testing.T) {

--- a/internal/db/repository_catalog.go
+++ b/internal/db/repository_catalog.go
@@ -789,8 +789,17 @@ func historicalRouteHasOtherRepositoryTx(
 	identity RepoIdentity,
 	repoID int64,
 ) (bool, error) {
+	return repositoryRouteHasOtherRepository(ctx, tx, identity, repoID)
+}
+
+func repositoryRouteHasOtherRepository(
+	ctx context.Context,
+	queryer repositoryCatalogQueryer,
+	identity RepoIdentity,
+	repoID int64,
+) (bool, error) {
 	var reused bool
-	err := tx.QueryRowContext(ctx, `
+	err := queryer.QueryRowContext(ctx, `
 		SELECT EXISTS (
 			SELECT 1
 			FROM forge_repo_routes AS route
@@ -805,6 +814,30 @@ func historicalRouteHasOtherRepositoryTx(
 		return false, fmt.Errorf("check historical repository route reuse: %w", err)
 	}
 	return reused, nil
+}
+
+// RepositoryRouteHasOtherRepository reports whether any other stable
+// repository identity has occupied the route. Callers use this to decide whether
+// a pre-identity, route-keyed clone can be associated safely.
+func (d *DB) RepositoryRouteHasOtherRepository(
+	ctx context.Context,
+	identity RepoIdentity,
+	repoID int64,
+) (bool, error) {
+	identity = canonicalRepoIdentity(identity)
+	if repoID <= 0 {
+		return false, errors.New("repository route owner id is required")
+	}
+	if identity.Platform == "" || identity.PlatformHost == "" ||
+		identity.RepoPathKey == "" {
+		return false, errors.New("repository route identity is required")
+	}
+	release, err := d.LockRepositoryReconciliationRead(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer release()
+	return repositoryRouteHasOtherRepository(ctx, d.ro, identity, repoID)
 }
 
 // AdoptLegacyClonesIfSafe runs adopt while repoID remains the verified current

--- a/internal/db/repository_catalog_test.go
+++ b/internal/db/repository_catalog_test.go
@@ -217,12 +217,12 @@ func TestOperationalAssociationsDoNotCrossRepositoryIncarnations(t *testing.T) {
 	assert.Nil(summary.SourceTitle)
 }
 
-func TestWorkspaceRouteLookupAndCreationFailClosedAfterReplacement(t *testing.T) {
+func TestWorkspaceRouteLookupBindsCurrentRepositoryAfterReplacement(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	d := openTestDB(t)
 	firstObservedAt := baseTime()
-	reconcileCatalogRepository(
+	original := reconcileCatalogRepository(
 		t, d, "provider-old", "org-a", "project-a", firstObservedAt,
 	)
 	require.NoError(d.InsertWorkspace(t.Context(), &Workspace{
@@ -231,10 +231,14 @@ func TestWorkspaceRouteLookupAndCreationFailClosedAfterReplacement(t *testing.T)
 		ItemType: WorkspaceItemTypePullRequest, ItemNumber: 7,
 		WorktreePath: "/tmp/historical-workspace", TmuxSession: "historical-workspace",
 	}))
-	reconcileCatalogRepository(
+	current := reconcileCatalogRepository(
 		t, d, "provider-new", "org-a", "project-a",
 		firstObservedAt.Add(time.Hour),
 	)
+	originalWorkspace, err := d.GetWorkspace(t.Context(), "historical-workspace")
+	require.NoError(err)
+	require.NotNil(originalWorkspace)
+	assert.Equal(original.Repository.ID, originalWorkspace.RepoID)
 
 	byRoute, err := d.GetWorkspaceByMRForProvider(
 		t.Context(), "github", "github.com", "org-a", "project-a", 7,
@@ -250,8 +254,101 @@ func TestWorkspaceRouteLookupAndCreationFailClosedAfterReplacement(t *testing.T)
 	err = d.InsertWorkspace(t.Context(), &Workspace{
 		ID: "replacement-workspace", Platform: "github",
 		PlatformHost: "github.com", RepoOwner: "org-a", RepoName: "project-a",
-		ItemType: WorkspaceItemTypePullRequest, ItemNumber: 8,
+		ItemType: WorkspaceItemTypePullRequest, ItemNumber: 7,
 		WorktreePath: "/tmp/replacement-workspace", TmuxSession: "replacement-workspace",
+	})
+	require.NoError(err)
+	replacementWorkspace, err := d.GetWorkspace(t.Context(), "replacement-workspace")
+	require.NoError(err)
+	require.NotNil(replacementWorkspace)
+	assert.Equal(current.Repository.ID, replacementWorkspace.RepoID)
+	byRoute, err = d.GetWorkspaceByMRForProvider(
+		t.Context(), "github", "github.com", "org-a", "project-a", 7,
+	)
+	require.NoError(err)
+	require.NotNil(byRoute)
+	assert.Equal("replacement-workspace", byRoute.ID)
+}
+
+func TestInsertWorkspaceRejectsChangedExplicitRepositoryIdentity(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	originalID, _ := seedRepositoryCatalogCollision(t, d)
+
+	err := d.InsertWorkspace(t.Context(), &Workspace{
+		ID: "stale-repository-workspace", Platform: "github",
+		PlatformHost: "github.com", RepoOwner: "org-a", RepoName: "project-a",
+		RepoID:   originalID,
+		ItemType: WorkspaceItemTypePullRequest, ItemNumber: 9,
+		WorktreePath: "/tmp/stale-repository-workspace",
+		TmuxSession:  "stale-repository-workspace",
+	})
+	require.ErrorContains(err, "repository identity changed")
+	require.ErrorIs(err, ErrRepositoryRouteFenceChanged)
+}
+
+func TestInactiveWorkspaceRepositoryKeepsPersistedRoute(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	observedAt := baseTime()
+	repo := reconcileCatalogRepository(
+		t, d, "provider-retired", "org-a", "project-a", observedAt,
+	)
+	require.NoError(d.InsertWorkspace(t.Context(), &Workspace{
+		ID: "retired-workspace", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "org-a", RepoName: "project-a",
+		ItemType: WorkspaceItemTypePullRequest, ItemNumber: 7,
+		WorktreePath: "/tmp/retired-workspace", TmuxSession: "retired-workspace",
+	}))
+	_, _, err := d.ReconcileRepositoryObservation(t.Context(), RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "provider-retired", Owner: "org-a", Name: "renamed",
+	}, observedAt.Add(time.Minute))
+	require.NoError(err)
+	retired, err := d.DeactivateRepositoryObservation(
+		t.Context(), "github", "github.com", "provider-retired",
+		observedAt.Add(2*time.Minute),
+	)
+	require.NoError(err)
+	require.NotNil(retired)
+	require.Equal(repo.Repository.ID, retired.Repository.ID)
+
+	workspace, err := d.GetWorkspace(t.Context(), "retired-workspace")
+	require.NoError(err)
+	require.NotNil(workspace)
+	require.Equal("project-a", workspace.RepoName)
+
+	workspaces, err := d.ListWorkspaces(t.Context())
+	require.NoError(err)
+	require.Len(workspaces, 1)
+	require.Equal("project-a", workspaces[0].RepoName)
+
+	summary, err := d.GetWorkspaceSummary(t.Context(), "retired-workspace")
+	require.NoError(err)
+	require.NotNil(summary)
+	require.Equal("project-a", summary.RepoName)
+}
+
+func TestInsertWorkspaceWithoutActiveRepositoryRetainsHistoricalRouteFence(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	observedAt := baseTime()
+	reconcileCatalogRepository(
+		t, d, "provider-retired", "org-a", "project-a", observedAt,
+	)
+	retired, err := d.DeactivateRepositoryObservation(
+		t.Context(), "github", "github.com", "provider-retired",
+		observedAt.Add(time.Hour),
+	)
+	require.NoError(err)
+	require.NotNil(retired)
+
+	err = d.InsertWorkspace(t.Context(), &Workspace{
+		ID: "unresolved-repository-workspace", Platform: "github",
+		PlatformHost: "github.com", RepoOwner: "org-a", RepoName: "project-a",
+		ItemType: WorkspaceItemTypePullRequest, ItemNumber: 10,
+		WorktreePath: "/tmp/unresolved-repository-workspace",
+		TmuxSession:  "unresolved-repository-workspace",
 	})
 	require.ErrorContains(err, "repository route has historical occupants")
 }
@@ -455,8 +552,8 @@ func TestDeactivateRepositoryObservationIgnoresStaleAbsence(t *testing.T) {
 }
 
 // TestInsertWorkspaceWaitsForReconciliation verifies workspace creation holds
-// the reconciliation read lock, so a replacement that makes the route
-// historically ambiguous cannot interleave with the collision check.
+// the reconciliation read lock, then binds the repository that owns the route
+// after a pending replacement finishes.
 func TestInsertWorkspaceWaitsForReconciliation(t *testing.T) {
 	require := require.New(t)
 	d := openTestDB(t)
@@ -514,7 +611,16 @@ func TestInsertWorkspaceWaitsForReconciliation(t *testing.T) {
 
 	close(releaseWriter)
 	require.NoError(<-writerDone)
-	require.ErrorContains(<-insertDone, "historical occupants")
+	require.NoError(<-insertDone)
+	workspace, err := d.GetWorkspace(t.Context(), "ws-reconcile-race")
+	require.NoError(err)
+	require.NotNil(workspace)
+	current, err := d.GetRepositoryByProviderID(
+		t.Context(), "github", "github.com", "provider-2",
+	)
+	require.NoError(err)
+	require.NotNil(current)
+	require.Equal(current.Repository.ID, workspace.RepoID)
 }
 
 func TestReconcileRepositoryObservationRejectsStaleReplacement(t *testing.T) {

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -1263,6 +1263,7 @@ type Workspace struct {
 	PlatformHost       string
 	RepoOwner          string
 	RepoName           string
+	RepoID             int64
 	ItemType           string
 	ItemNumber         int
 	ItemKey            string
@@ -1412,10 +1413,11 @@ func (spec WorkspaceLaunchSpec) ValidateWorkspace(workspace Workspace) error {
 	if workspace.ID == "" {
 		return errors.New("workspace ID is required")
 	}
+	routeChanged := !strings.EqualFold(workspace.RepoOwner, spec.Repository.Owner) ||
+		!strings.EqualFold(workspace.RepoName, spec.Repository.Name)
 	if !strings.EqualFold(canonicalWorkspacePlatform(workspace.Platform), strings.TrimSpace(spec.Repository.Provider)) ||
 		!strings.EqualFold(strings.TrimSpace(workspace.PlatformHost), strings.TrimSpace(spec.Repository.PlatformHost)) ||
-		!strings.EqualFold(workspace.RepoOwner, spec.Repository.Owner) ||
-		!strings.EqualFold(workspace.RepoName, spec.Repository.Name) ||
+		(workspace.RepoID == 0 && routeChanged) ||
 		workspace.ItemType != spec.ItemType || workspace.ItemNumber != spec.ItemNumber ||
 		workspaceItemKeyForComparison(workspace) != spec.ItemKey ||
 		strings.TrimSpace(workspace.GitHeadRef) != strings.TrimSpace(spec.GitHeadRef) {

--- a/internal/db/workspace_subjects.go
+++ b/internal/db/workspace_subjects.go
@@ -88,10 +88,7 @@ func (d *DB) ListWorkspaceSubjectMetadata(
 			SELECT 1
 			FROM forge_workspaces w
 			JOIN forge_workspace_launch_specs launch ON launch.workspace_id = w.id
-			WHERE w.platform = r.platform
-			  AND w.platform_host = r.platform_host
-			  AND w.repo_owner_key = r.owner_key
-			  AND w.repo_name_key = r.name_key
+			WHERE w.repo_id = q.repo_id
 			  AND w.item_type = q.item_type
 			  AND w.item_number = q.item_number
 			  AND json_extract(launch.spec_json, '$.source_visible') = 1

--- a/internal/db/workspace_subjects_test.go
+++ b/internal/db/workspace_subjects_test.go
@@ -59,6 +59,41 @@ func TestListWorkspaceSubjectMetadataUsesLaunchSpecWithoutProviderReplica(t *tes
 	assert.Empty(got[key].Title, "provider details stay hub-owned")
 }
 
+func TestListWorkspaceSubjectMetadataUsesStableRepositoryAfterRename(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	workspace, spec := workspaceLaunchFixture(t, database, "ws-renamed-overlay")
+	require.NoError(database.CreateWorkspaceWithLaunchSpec(
+		t.Context(), workspace, spec,
+	))
+	repo, err := database.GetRepoByIdentity(
+		t.Context(), GitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	require.NotNil(repo)
+	_, accepted, err := database.ReconcileRepositoryObservation(
+		t.Context(), RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: spec.Repository.PlatformRepoID,
+			Owner:          "acme-renamed", Name: "widget-renamed",
+		}, time.Now().UTC().Add(time.Hour),
+	)
+	require.NoError(err)
+	require.True(accepted)
+	key := WorkspaceSubjectKey{
+		RepoID: repo.ID, ItemType: WorkspaceItemTypePullRequest, ItemNumber: 7,
+	}
+
+	got, err := database.ListWorkspaceSubjectMetadata(
+		t.Context(), []WorkspaceSubjectKey{key},
+	)
+
+	require.NoError(err)
+	require.Contains(got, key)
+	require.Equal("acme-renamed", got[key].RepoOwner)
+	require.Equal("widget-renamed", got[key].RepoName)
+}
+
 func TestListWorkspaceSubjectMetadataHidesOnlyRemovedUpstreamItems(t *testing.T) {
 	require := require.New(t)
 	d := openTestDB(t)

--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -104,11 +105,10 @@ type ensureCloneFlight struct {
 }
 
 // cloneValidationError marks a slot whose fetch succeeded but whose
-// starter's route validation failed, removing the fetched clone. Followers
-// distinguish it from a fetch failure so a caller whose own route still owns
-// the path can retry with a fresh, self-validated fetch. Unwrap keeps
-// errors.Is checks (for example db.ErrRepositoryRouteFenceChanged) working
-// through the marker.
+// starter's route validation failed, removing a new clone or rolling an
+// existing clone back. Followers distinguish it from a fetch failure so a
+// caller whose own route still owns the path can retry with a self-validated
+// fetch. Unwrap keeps errors.Is checks working through the marker.
 type cloneValidationError struct{ err error }
 
 func (e *cloneValidationError) Error() string { return e.err.Error() }
@@ -387,6 +387,15 @@ func (m *Manager) ensureCloneInNamespaceValidated(
 			context.WithoutCancel(ctx), ensureCloneTimeout,
 		)
 		defer cancel()
+		var previous existingCloneState
+		var existed bool
+		if validate != nil {
+			var err error
+			previous, existed, err = m.snapshotExistingClone(opCtx, clonePath)
+			if err != nil {
+				return err
+			}
+		}
 		if err := m.ensureCloneNowInNamespace(
 			opCtx, namespace, platform, host, owner, name, remoteURL,
 		); err != nil {
@@ -396,13 +405,20 @@ func (m *Manager) ensureCloneInNamespaceValidated(
 			return nil
 		}
 		// The slot starter's validation spans the whole fetch window, so a
-		// route that changed ownership during the fetch fails here and the
-		// possibly cross-repository clone is removed before any waiter can
-		// observe it.
+		// route that changed ownership during the fetch fails here. A new
+		// clone is removed; an existing clone is restored so linked worktrees
+		// keep their repository while no fetched replacement refs remain.
 		if err := validate(opCtx); err != nil {
-			if cleanupErr := m.removeCloneAside(clonePath); cleanupErr != nil {
+			cleanupCtx := context.WithoutCancel(opCtx)
+			var cleanupErr error
+			if existed {
+				cleanupErr = m.restoreExistingClone(cleanupCtx, clonePath, previous)
+			} else {
+				cleanupErr = m.removeCloneAside(clonePath)
+			}
+			if cleanupErr != nil {
 				return errors.Join(err, fmt.Errorf(
-					"remove clone after failed validation: %w", cleanupErr,
+					"clean clone after failed validation: %w", cleanupErr,
 				))
 			}
 			return &cloneValidationError{err: err}
@@ -430,6 +446,136 @@ func (m *Manager) ensureCloneInNamespaceValidated(
 		}
 	}
 	return nil
+}
+
+type cloneRefState struct {
+	objectName string
+	symref     string
+}
+
+type existingCloneState struct {
+	refs          map[string]cloneRefState
+	fetchRefspecs []string
+}
+
+func (m *Manager) snapshotExistingClone(
+	ctx context.Context, clonePath string,
+) (existingCloneState, bool, error) {
+	if _, err := os.Stat(filepath.Join(clonePath, "HEAD")); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return existingCloneState{}, false, nil
+		}
+		return existingCloneState{}, false, fmt.Errorf("inspect existing clone: %w", err)
+	}
+	refs, err := m.snapshotCloneRefs(ctx, clonePath)
+	if err != nil {
+		return existingCloneState{}, false, err
+	}
+	refspecs, err := m.cloneFetchRefspecs(ctx, clonePath)
+	if err != nil {
+		return existingCloneState{}, false, err
+	}
+	return existingCloneState{refs: refs, fetchRefspecs: refspecs}, true, nil
+}
+
+func (m *Manager) snapshotCloneRefs(
+	ctx context.Context, clonePath string,
+) (map[string]cloneRefState, error) {
+	out, err := m.git(
+		ctx, clonePath, "for-each-ref", "--format=%(refname)%09%(objectname)%09%(symref)",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot clone refs: %w", err)
+	}
+	refs := make(map[string]cloneRefState)
+	for line := range strings.SplitSeq(strings.TrimSuffix(string(out), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 3)
+		if len(parts) != 3 {
+			return nil, fmt.Errorf("snapshot clone refs: malformed ref record %q", line)
+		}
+		refs[parts[0]] = cloneRefState{objectName: parts[1], symref: parts[2]}
+	}
+	return refs, nil
+}
+
+func (m *Manager) cloneFetchRefspecs(
+	ctx context.Context, clonePath string,
+) ([]string, error) {
+	out, err := m.git(ctx, clonePath, "config", "--get-all", "remote.origin.fetch")
+	if err != nil {
+		if code, ok := gitExitCode(err); ok && code == 1 {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("snapshot clone fetch refspecs: %w", err)
+	}
+	value := strings.TrimSuffix(string(out), "\n")
+	if value == "" {
+		return nil, nil
+	}
+	return strings.Split(value, "\n"), nil
+}
+
+func (m *Manager) restoreExistingClone(
+	ctx context.Context, clonePath string, before existingCloneState,
+) error {
+	currentRefs, err := m.snapshotCloneRefs(ctx, clonePath)
+	if err != nil {
+		return err
+	}
+	var restoreErr error
+	var deleteRefs []string
+	for ref := range currentRefs {
+		if _, ok := before.refs[ref]; !ok {
+			deleteRefs = append(deleteRefs, ref)
+		}
+	}
+	slices.Sort(deleteRefs)
+	slices.Reverse(deleteRefs)
+	for _, ref := range deleteRefs {
+		_, err := m.git(ctx, clonePath, "update-ref", "--no-deref", "-d", ref)
+		restoreErr = errors.Join(restoreErr, err)
+	}
+	refs := make([]string, 0, len(before.refs))
+	for ref := range before.refs {
+		refs = append(refs, ref)
+	}
+	slices.Sort(refs)
+	for _, ref := range refs {
+		state := before.refs[ref]
+		if current, ok := currentRefs[ref]; ok && current == state {
+			continue
+		}
+		var err error
+		if state.symref != "" {
+			_, err = m.git(ctx, clonePath, "symbolic-ref", ref, state.symref)
+		} else {
+			_, err = m.git(
+				ctx, clonePath, "update-ref", "--no-deref", ref, state.objectName,
+			)
+		}
+		restoreErr = errors.Join(restoreErr, err)
+	}
+	currentRefspecs, err := m.cloneFetchRefspecs(ctx, clonePath)
+	if err != nil {
+		return errors.Join(restoreErr, err)
+	}
+	if slices.Equal(currentRefspecs, before.fetchRefspecs) {
+		return restoreErr
+	}
+	if len(currentRefspecs) > 0 {
+		_, err = m.git(ctx, clonePath, "config", "--unset-all", "remote.origin.fetch")
+		restoreErr = errors.Join(restoreErr, err)
+	}
+	for _, refspec := range before.fetchRefspecs {
+		_, err = m.git(
+			ctx, clonePath, "config", "--add", "remote.origin.fetch", refspec,
+		)
+		restoreErr = errors.Join(restoreErr, err)
+	}
+	return restoreErr
 }
 
 func (m *Manager) validateRemoteTransport(platform, host, remoteURL string) error {

--- a/internal/gitclone/clone_test.go
+++ b/internal/gitclone/clone_test.go
@@ -206,6 +206,62 @@ func TestIntegrationEnsureCloneValidatedRemovesCloneAfterRouteChange(t *testing.
 		"invalidation must not leave a renamed-aside clone behind")
 }
 
+func TestIntegrationEnsureCloneValidatedRestoresExistingCloneAfterRouteChange(
+	t *testing.T,
+) {
+	remote, work := setupTestRepo(t)
+	mgr := New(t.TempDir(), nil)
+	ctx := WithRepositoryIdentity(t.Context(), "provider-repo-a")
+	require.NoError(t, mgr.EnsureClone(
+		ctx, "github", "github.com", "acme", "widget", remote,
+	))
+	clonePath, err := mgr.ClonePathForContext(
+		ctx, "github", "github.com", "acme", "widget",
+	)
+	require.NoError(t, err)
+	originalSHABytes, err := gitcmd.New().Output(
+		t.Context(), clonePath, "rev-parse", "refs/remotes/origin/main",
+	)
+	require.NoError(t, err)
+	originalSHA := strings.TrimSpace(string(originalSHABytes))
+	worktreePath := filepath.Join(t.TempDir(), "linked-worktree")
+	run(t, clonePath, "git", "worktree", "add", "-b", "workspace-test",
+		worktreePath, "refs/remotes/origin/main")
+	run(t, clonePath, "git", "config", "--unset-all", "remote.origin.fetch")
+	run(t, clonePath, "git", "config", "--add", "remote.origin.fetch", legacyBranchRefspec)
+
+	newSHA := commitAndPush(t, work, "replacement.go", "package replacement\n", "replacement")
+	require.NotEqual(t, originalSHA, newSHA)
+	validationErr := errors.New("repository route changed")
+	var validations atomic.Int64
+	err = mgr.EnsureCloneValidated(
+		ctx, "github", "github.com", "acme", "widget", remote,
+		func(context.Context) error {
+			if validations.Add(1) == 1 {
+				return nil
+			}
+			return validationErr
+		},
+	)
+
+	require.ErrorIs(t, err, validationErr)
+	assert.DirExists(t, clonePath)
+	assert.NoDirExists(t, clonePath+".removing")
+	restoredSHABytes, err := gitcmd.New().Output(
+		t.Context(), clonePath, "rev-parse", "refs/remotes/origin/main",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, originalSHA, strings.TrimSpace(string(restoredSHABytes)))
+	worktreeSHABytes, err := gitcmd.New().Output(t.Context(), worktreePath, "rev-parse", "HEAD")
+	require.NoError(t, err)
+	assert.Equal(t, originalSHA, strings.TrimSpace(string(worktreeSHABytes)))
+	refspecBytes, err := gitcmd.New().Output(
+		t.Context(), clonePath, "config", "--get-all", "remote.origin.fetch",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, legacyBranchRefspec, strings.TrimSpace(string(refspecBytes)))
+}
+
 func TestIntegrationEnsureCloneValidatedRejectsStaleCallerBeforeUnvalidatedFetch(t *testing.T) {
 	remote, _ := setupTestRepo(t)
 	routes := &blockingRouteResolver{

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -11019,6 +11019,32 @@ func (s *Syncer) RefreshMRCIStatusOnProvider(
 	return nil, nil
 }
 
+// RefreshMRCIStatusForRepository refreshes CI only while repo still owns its
+// captured route. Delayed background work uses this entry point so route reuse
+// cannot write a replacement repository's provider response under repoID.
+func (s *Syncer) RefreshMRCIStatusForRepository(
+	ctx context.Context,
+	repo RepoRef,
+	repoID int64,
+	number int,
+	headSHA string,
+) ([]string, error) {
+	identity := platform.DBRepoIdentity(platformRepoRef(repo))
+	routeFence, found, err := s.db.CurrentRepositoryRouteFence(ctx, identity, repoID)
+	if err != nil {
+		return nil, fmt.Errorf("capture repository route for CI refresh %s/%s: %w", repo.Owner, repo.Name, err)
+	}
+	if !found {
+		return nil, nil
+	}
+	ctx = s.db.WithRepositoryRouteFence(ctx, identity, routeFence)
+	warnings, err := s.RefreshMRCIStatusOnProvider(ctx, repo, repoID, number, headSHA)
+	if errors.Is(err, db.ErrRepositoryRouteFenceChanged) {
+		return nil, nil
+	}
+	return warnings, err
+}
+
 // refreshCIStatus fetches combined status and check runs for a PR's head SHA.
 // Called on every sync cycle for open PRs, since check runs change independently
 // of the PR's updated_at field. Takes headSHA and number directly so it can be
@@ -12687,6 +12713,20 @@ func (s *Syncer) SyncMROnProvider(
 	return s.syncMRForRepo(ctx, repo, number, false, nil)
 }
 
+// SyncMRForRepository refreshes an MR only while repoID still owns repo's
+// route. It is intended for delayed work that was queued for a stable
+// repository identity rather than for an owner/name route.
+func (s *Syncer) SyncMRForRepository(
+	ctx context.Context,
+	repo RepoRef,
+	repoID int64,
+	number int,
+) error {
+	return s.syncMRForRepoResolved(
+		ctx, repo, number, false, nil, nil, nil, nil, &repoID,
+	)
+}
+
 // syncMRWithHost is the internal implementation of SyncMR.
 // When hostHint is non-empty it is used instead of resolving via
 // s.hostFor, avoiding ambiguity when the same owner/name exists on
@@ -12759,7 +12799,7 @@ func (s *Syncer) syncMRForRepo(
 	providerAttempted *bool,
 ) error {
 	return s.syncMRForRepoResolved(
-		ctx, repo, number, useConditionalPRDetail, providerAttempted, nil, nil, nil,
+		ctx, repo, number, useConditionalPRDetail, providerAttempted, nil, nil, nil, nil,
 	)
 }
 
@@ -12795,6 +12835,7 @@ func (s *Syncer) syncMRForRepoResolved(
 	resolvedRepoID *int64,
 	fetchedEvidence *mergeRequestFetchEvidence,
 	lifecyclePersisted *bool,
+	expectedRepoID *int64,
 ) error {
 	if resolvedRepoID != nil {
 		*resolvedRepoID = 0
@@ -12829,6 +12870,9 @@ func (s *Syncer) syncMRForRepoResolved(
 		return err
 	}
 	if !found {
+		return nil
+	}
+	if expectedRepoID != nil && repoID != *expectedRepoID {
 		return nil
 	}
 	if resolvedRepoID != nil {
@@ -13597,7 +13641,7 @@ func (s *Syncer) SyncArchiveItem(
 		var lifecyclePersisted bool
 		err := s.syncMRForRepoResolved(
 			ctx, repo, number, false, &providerAttempted, &resolvedRepoID, &fetchedEvidence,
-			&lifecyclePersisted,
+			&lifecyclePersisted, nil,
 		)
 		if _, onlyDiffFailed := err.(*DiffSyncError); onlyDiffFailed { //nolint:errorlint // joined hard failures must propagate
 			err = nil

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -752,6 +752,8 @@ case "$*" in
 		echo "+refs/heads/*:refs/remotes/origin/*"
 		echo "+refs/pull/*/head:refs/pull/*/head"
 		;;
+	"for-each-ref --format=%(refname)%09%(objectname)%09%(symref)")
+		;;
 	"fetch --prune --no-tags origin")
 		;;
 	"remote set-head origin -a")
@@ -6819,8 +6821,8 @@ func TestCommitMergeRequestParentSnapshotKeepsHistoryBoundDuringReconciliation(
 	reclassified, err := d.GetWorkspace(ctx, ws.ID)
 	require.NoError(err)
 	require.NotNil(reclassified)
-	assert.Equal("old-group", reclassified.RepoOwner)
-	assert.Equal("old-name", reclassified.RepoName)
+	assert.Equal("new-group", reclassified.RepoOwner)
+	assert.Equal("new-name", reclassified.RepoName)
 	require.NotNil(reclassified.MRHeadRepo)
 	assert.Equal(forkURL, *reclassified.MRHeadRepo)
 
@@ -7058,8 +7060,8 @@ func TestReclassifyWorkspaceHeadRepoTrustKeepsHistoryBoundDuringReconciliation(t
 	reclassified, err := d.GetWorkspace(ctx, ws.ID)
 	require.NoError(err)
 	require.NotNil(reclassified)
-	assert.Equal("old-group", reclassified.RepoOwner)
-	assert.Equal("old-name", reclassified.RepoName)
+	assert.Equal("new-group", reclassified.RepoOwner)
+	assert.Equal("new-name", reclassified.RepoName)
 	require.NotNil(reclassified.MRHeadRepo)
 	assert.Equal(forkURL, *reclassified.MRHeadRepo)
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -9206,8 +9206,13 @@ func seedWorkspace(
 	number int,
 ) {
 	t.Helper()
+	repoID, err := database.UpsertRepo(
+		t.Context(), verifiedGitHubRepoIdentity("github.com", owner, name),
+	)
+	require.NoError(t, err)
 	require.NoError(t, database.InsertWorkspace(t.Context(), &db.Workspace{
 		ID:              id,
+		RepoID:          repoID,
 		Platform:        "github",
 		PlatformHost:    "github.com",
 		RepoOwner:       owner,
@@ -26534,13 +26539,15 @@ func setupWorkspaceServerFixtureWithMockHostAndOptions(
 
 	bareDir := filepath.Join(dir, "clones")
 	require.NoError(t, os.MkdirAll(bareDir, 0o755))
-	bare := filepath.Join(
-		bareDir, platformHost, "acme", "widget.git",
+	clones := gitclone.New(bareDir, nil)
+	bare, err := clones.ClonePathForContext(
+		gitclone.WithRepositoryIdentity(t.Context(), "repo-acme-widget"),
+		"github", platformHost, "acme", "widget",
 	)
+	require.NoError(t, err)
 	runGit(t, dir, "clone", "--bare", remote, bare)
 	runGit(t, bare, "remote", "set-url", "origin", gitLocalRemoteURL(remote))
 
-	clones := gitclone.New(bareDir, nil)
 	worktreeDir := filepath.Join(dir, "worktrees")
 	repos := []ghclient.RepoRef{
 		{Owner: "acme", Name: "widget", PlatformHost: platformHost},
@@ -32240,22 +32247,21 @@ func TestWorkspaceCreateReusesExistingWorktreeThroughAPI(t *testing.T) {
 	}}}
 	fixture := setupWorkspaceServerFixture(t, cfg)
 	ctx := t.Context()
+	repoID := seedPROnHost(
+		t, fixture.database,
+		platformHost, "acme", "widget", prNumber,
+		withSeedPRHeadRepoCloneURL("https://"+platformHost+"/acme/widget.git"),
+	)
 	existingBranch := syntheticPRWorktreeBranchForTest(prNumber)
 	worktreePath := filepath.Join(
 		fixture.worktrees, "github", platformHost, "acme", "widget",
-		fmt.Sprintf("pr-%d", prNumber),
+		fmt.Sprintf("repo-%d", repoID), fmt.Sprintf("pr-%d", prNumber),
 	)
 	runGit(
 		t, localRepo,
 		"worktree", "add", worktreePath, "-b", existingBranch, "main",
 	)
 	wantSHA := testGitSHA(t, worktreePath, "HEAD")
-	seedPROnHost(
-		t, fixture.database,
-		platformHost, "acme", "widget", prNumber,
-		withSeedPRHeadRepoCloneURL("https://"+platformHost+"/acme/widget.git"),
-	)
-
 	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
@@ -32302,9 +32308,14 @@ func TestWorkspaceRetryReusesExistingLocalHeadBranchThroughAPI(t *testing.T) {
 	}}}
 	fixture := setupWorkspaceServerFixture(t, cfg)
 	ctx := t.Context()
+	repoID := seedPROnHost(
+		t, fixture.database,
+		platformHost, "acme", "widget", prNumber,
+		withSeedPRHeadRepoCloneURL("https://"+platformHost+"/acme/widget.git"),
+	)
 	worktreePath := filepath.Join(
 		fixture.worktrees, "github", platformHost, "acme", "widget",
-		fmt.Sprintf("pr-%d", prNumber),
+		fmt.Sprintf("repo-%d", repoID), fmt.Sprintf("pr-%d", prNumber),
 	)
 	runGit(
 		t, localRepo,
@@ -32312,12 +32323,6 @@ func TestWorkspaceRetryReusesExistingLocalHeadBranchThroughAPI(t *testing.T) {
 		"-b", "feature", "refs/remotes/origin/feature",
 	)
 	wantSHA := testGitSHA(t, worktreePath, "HEAD")
-	seedPROnHost(
-		t, fixture.database,
-		platformHost, "acme", "widget", prNumber,
-		withSeedPRHeadRepoCloneURL("https://"+platformHost+"/acme/widget.git"),
-	)
-
 	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{

--- a/internal/server/apitest/workspace_subject_identity_test.go
+++ b/internal/server/apitest/workspace_subject_identity_test.go
@@ -43,7 +43,7 @@ func TestWorkspaceReferencesUseStableRepositoryIdentityAcrossRenameAndRouteReuse
 		t, database, replacement.Repository.ID, "acme", "widget", "replacement", now.Add(2*time.Minute),
 	)
 
-	assertWorkspaceIdentitySurfaces(t, client.HTTP, "gadget", false)
+	assertWorkspaceIdentitySurfaces(t, client.HTTP, "gadget", true)
 	assertWorkspaceIdentitySurfaces(t, client.HTTP, "widget", false)
 }
 

--- a/internal/server/e2etest/token_rotation_test.go
+++ b/internal/server/e2etest/token_rotation_test.go
@@ -986,6 +986,11 @@ func waitForTokenRotationConfigEvent(
 func seedReadyRuntimeWorkspace(t *testing.T, database *db.DB, worktreePath string) {
 	t.Helper()
 	now := time.Now().UTC().Truncate(time.Second)
+	_, err := database.UpsertRepo(t.Context(), db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-acme-widget", Owner: "acme", Name: "widget",
+	})
+	require.NoError(t, err)
 	require.NoError(t, os.MkdirAll(worktreePath, 0o755))
 	runSettingsGit(t, worktreePath, "init", "--initial-branch=main")
 	runSettingsGit(t, worktreePath, "config", "user.email", "test@example.test")

--- a/internal/server/e2etest/workspace_visibility_test.go
+++ b/internal/server/e2etest/workspace_visibility_test.go
@@ -73,7 +73,7 @@ func TestWorkspaceAPIHidesRemovedAssociatedPullRequestE2E(t *testing.T) {
 	require.Equal(42, *stored.AssociatedPRNumber)
 }
 
-func TestWorkspaceAPIHidesProviderMetadataForReusedRouteE2E(t *testing.T) {
+func TestWorkspaceAPIRetainsProviderMetadataAcrossReusedRouteE2E(t *testing.T) {
 	require := require.New(t)
 	ctx := t.Context()
 	ts, database := bootFleetServer(t, nil)
@@ -129,11 +129,11 @@ func TestWorkspaceAPIHidesProviderMetadataForReusedRouteE2E(t *testing.T) {
 	pullSummary, err := database.GetWorkspaceSummary(ctx, "ws-pull")
 	require.NoError(err)
 	require.NotNil(pullSummary)
-	require.False(pullSummary.SourceItemVisible)
+	require.True(pullSummary.SourceItemVisible)
 	associatedSummary, err := database.GetWorkspaceSummary(ctx, "ws-associated")
 	require.NoError(err)
 	require.NotNil(associatedSummary)
-	require.False(associatedSummary.AssociatedPRVisible)
+	require.True(associatedSummary.AssociatedPRVisible)
 
 	client, err := apiclient.NewWithHTTPClient(ts.URL, ts.Client())
 	require.NoError(err)
@@ -147,7 +147,10 @@ func TestWorkspaceAPIHidesProviderMetadataForReusedRouteE2E(t *testing.T) {
 	for _, workspace := range *list.JSON200.Workspaces {
 		byID[workspace.Id] = workspace
 	}
-	require.Nil(byID["ws-associated"].AssociatedPrNumber)
-	require.Nil(byID["ws-pull"].MrHeadRepoKind)
-	require.Nil(byID["ws-pull"].MrTitle)
+	require.NotNil(byID["ws-associated"].AssociatedPrNumber)
+	require.Equal(int64(42), *byID["ws-associated"].AssociatedPrNumber)
+	require.NotNil(byID["ws-pull"].MrHeadRepoKind)
+	require.Equal(generated.WorkspaceResponseMrHeadRepoKindFork, *byID["ws-pull"].MrHeadRepoKind)
+	require.NotNil(byID["ws-pull"].MrTitle)
+	require.Equal("Original pull", *byID["ws-pull"].MrTitle)
 }

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -527,10 +527,12 @@ func sameConfiguredRepo(left, right config.Repo) bool {
 }
 
 func (s *Server) worktreeBasePathForRepo(
-	ctx context.Context, provider, platformHost, owner, name string,
+	ctx context.Context, repo workspace.WorktreeBaseRepository,
 ) (string, bool, error) {
 	target := config.Repo{
-		Platform: provider, PlatformHost: platformHost, Owner: owner, Name: name,
+		Platform: repo.Platform, PlatformHost: repo.PlatformHost,
+		PlatformRepoID: repo.PlatformRepoID,
+		Owner:          repo.Owner, Name: repo.Name,
 	}
 	if s.cfg != nil {
 		s.cfgMu.Lock()
@@ -567,11 +569,17 @@ func (s *Server) worktreeBasePathForRepo(
 	var matchedPath string
 	for _, project := range projects {
 		identity := project.PlatformIdentity
-		if project.IsStale || identity == nil ||
-			!strings.EqualFold(identity.Platform, provider) ||
-			!samePlatformHost(identity.Host, platformHost) ||
-			!strings.EqualFold(identity.Owner, owner) ||
-			!strings.EqualFold(identity.Name, name) {
+		if project.IsStale || identity == nil {
+			continue
+		}
+		stableMatch := strings.TrimSpace(repo.PlatformRepoID) != "" &&
+			strings.TrimSpace(identity.PlatformRepoID) == strings.TrimSpace(repo.PlatformRepoID)
+		routeMatch := strings.TrimSpace(repo.PlatformRepoID) == "" &&
+			strings.EqualFold(identity.Owner, repo.Owner) &&
+			strings.EqualFold(identity.Name, repo.Name)
+		if !strings.EqualFold(identity.Platform, repo.Platform) ||
+			!samePlatformHost(identity.Host, repo.PlatformHost) ||
+			(!stableMatch && !routeMatch) {
 			continue
 		}
 		if matchedPath != "" && matchedPath != project.LocalPath {

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -33,6 +34,7 @@ import (
 	"go.kenn.io/forge/internal/server/httpapi"
 	"go.kenn.io/forge/internal/stacks"
 	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/workspace"
 	"go.kenn.io/forge/internal/workspace/localruntime"
 )
 
@@ -3388,6 +3390,7 @@ func TestWorktreeBasePathResolverMatchesProviderIdentity(t *testing.T) {
 		{
 			Platform:         "github",
 			PlatformHost:     "forge.example.com",
+			PlatformRepoID:   "github-widget",
 			Owner:            "acme",
 			Name:             "widget",
 			WorktreeBasePath: "/tmp/github-widget",
@@ -3395,6 +3398,7 @@ func TestWorktreeBasePathResolverMatchesProviderIdentity(t *testing.T) {
 		{
 			Platform:         "gitlab",
 			PlatformHost:     "forge.example.com",
+			PlatformRepoID:   "gitlab-widget",
 			Owner:            "acme",
 			Name:             "widget",
 			WorktreeBasePath: "/tmp/gitlab-widget",
@@ -3402,12 +3406,60 @@ func TestWorktreeBasePathResolverMatchesProviderIdentity(t *testing.T) {
 	}}}
 
 	got, ok, err := srv.worktreeBasePathForRepo(
-		t.Context(), "gitlab", "forge.example.com", "acme", "widget",
+		t.Context(), workspace.WorktreeBaseRepository{
+			Platform: "gitlab", PlatformHost: "forge.example.com",
+			PlatformRepoID: "gitlab-widget", Owner: "acme", Name: "widget",
+		},
 	)
 
 	require.NoError(err)
 	require.True(ok)
 	assert.Equal("/tmp/gitlab-widget", got)
+
+	_, ok, err = srv.worktreeBasePathForRepo(
+		t.Context(), workspace.WorktreeBaseRepository{
+			Platform: "gitlab", PlatformHost: "forge.example.com",
+			PlatformRepoID: "replacement-widget", Owner: "acme", Name: "widget",
+		},
+	)
+	require.NoError(err)
+	assert.False(ok)
+}
+
+func TestWorktreeBasePathResolverMatchesRegisteredProjectIdentity(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	database := dbtest.Open(t)
+	repoID, err := database.UpsertRepo(t.Context(), db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "provider-widget", Owner: "acme", Name: "widget",
+	})
+	require.NoError(err)
+	_, err = database.CreateProject(t.Context(), db.CreateProjectInput{
+		DisplayName: "widget", LocalPath: "/work/widget",
+		RepoID: sql.NullInt64{Int64: repoID, Valid: true},
+	})
+	require.NoError(err)
+	srv := &Server{db: database}
+
+	got, ok, err := srv.worktreeBasePathForRepo(
+		t.Context(), workspace.WorktreeBaseRepository{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: "provider-widget", Owner: "acme", Name: "widget",
+		},
+	)
+	require.NoError(err)
+	require.True(ok)
+	assert.Equal("/work/widget", got)
+
+	_, ok, err = srv.worktreeBasePathForRepo(
+		t.Context(), workspace.WorktreeBaseRepository{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: "replacement-widget", Owner: "acme", Name: "widget",
+		},
+	)
+	require.NoError(err)
+	assert.False(ok)
 }
 
 func TestApplyProviderSettingsMatchesWorktreePathByStableIdentity(t *testing.T) {
@@ -4127,6 +4179,8 @@ base_url = %q
 	assert.True(spoke.cfg.Roborev.InitManagedClones)
 
 	worktreeBase := t.TempDir()
+	canonicalWorktreeBase, err := filepath.EvalSymlinks(worktreeBase)
+	require.NoError(err)
 	runGit(t, worktreeBase, "init", "--initial-branch=main")
 	runGit(t, worktreeBase, "remote", "add", "origin", "https://github.com/acme/widget.git")
 	response = doJSON(
@@ -4135,13 +4189,13 @@ base_url = %q
 		repoWorktreeBaseRequest{WorktreeBasePath: worktreeBase},
 	)
 	require.Equal(http.StatusOK, response.Code, response.Body.String())
-	assert.Equal(worktreeBase, spoke.cfg.Repos[0].WorktreeBasePath)
+	assert.Equal(canonicalWorktreeBase, spoke.cfg.Repos[0].WorktreeBasePath)
 	assert.Empty(hub.cfg.Repos[0].WorktreeBasePath)
 
 	var settings settingsResponse
 	require.NoError(json.NewDecoder(response.Body).Decode(&settings))
 	require.Len(settings.Repos, 1)
-	assert.Equal(worktreeBase, settings.Repos[0].WorktreeBasePath)
+	assert.Equal(canonicalWorktreeBase, settings.Repos[0].WorktreeBasePath)
 	assert.Equal(75, settings.Detail.InitialTimelineEntryLimit)
 	assert.True(settings.Workspaces.AutoAssignOnCreate)
 	assert.Equal(config.FleetRoleSpoke, settings.Fleet.Role)
@@ -4150,7 +4204,7 @@ base_url = %q
 	require.Equal(http.StatusOK, response.Code, response.Body.String())
 	require.NoError(json.NewDecoder(response.Body).Decode(&settings))
 	require.Len(settings.Repos, 1)
-	assert.Equal(worktreeBase, settings.Repos[0].WorktreeBasePath)
+	assert.Equal(canonicalWorktreeBase, settings.Repos[0].WorktreeBasePath)
 }
 
 func TestNodeWorktreeBaseOverrideFollowsHubRepositoryIdentity(t *testing.T) {
@@ -4195,6 +4249,8 @@ port = 8091
 		}),
 	}
 	worktreeBase := t.TempDir()
+	canonicalWorktreeBase, err := filepath.EvalSymlinks(worktreeBase)
+	require.NoError(err)
 	runGit(t, worktreeBase, "init", "--initial-branch=main")
 	runGit(t, worktreeBase, "remote", "add", "origin", "https://github.com/acme/late.git")
 
@@ -4204,7 +4260,7 @@ port = 8091
 	)
 	require.Equal(http.StatusOK, response.Code, response.Body.String())
 	require.Len(srv.cfg.Repos, 1)
-	assert.Equal(worktreeBase, srv.cfg.Repos[0].WorktreeBasePath)
+	assert.Equal(canonicalWorktreeBase, srv.cfg.Repos[0].WorktreeBasePath)
 
 	projection.Repos[0].Owner = "renamed"
 	projection.Repos[0].Name = "late-renamed"

--- a/internal/server/spoke_preparation_test.go
+++ b/internal/server/spoke_preparation_test.go
@@ -672,15 +672,6 @@ func TestSpokePreparationRefreshFollowsStableRepositoryRename(t *testing.T) {
 		IssuedAt:      now.Add(-db.WorkspaceLaunchSpecVisibilityLease - time.Minute),
 	}
 	current.SourceVisibleUntil = current.IssuedAt.Add(db.WorkspaceLaunchSpecVisibilityLease)
-	_, accepted, err := database.ReconcileRepositoryObservation(
-		t.Context(), db.RepoIdentity{
-			Platform: "github", PlatformHost: "github.com",
-			PlatformRepoID: current.Repository.PlatformRepoID,
-			Owner:          current.Repository.Owner, Name: current.Repository.Name,
-		}, current.IssuedAt,
-	)
-	require.NoError(err)
-	require.True(accepted)
 	require.NoError(database.PutWorkspaceLaunchSpec(t.Context(), workspaceID, current))
 
 	refreshed := current
@@ -689,12 +680,12 @@ func TestSpokePreparationRefreshFollowsStableRepositoryRename(t *testing.T) {
 	refreshed.Repository.CloneURL = "https://github.com/acme-renamed/widget-renamed.git"
 	refreshed.IssuedAt = now
 	refreshed.SourceVisibleUntil = now.Add(db.WorkspaceLaunchSpecVisibilityLease)
-	_, accepted, err = database.ReconcileRepositoryObservation(
+	_, accepted, err := database.ReconcileRepositoryObservation(
 		t.Context(), db.RepoIdentity{
 			Platform: "github", PlatformHost: "github.com",
 			PlatformRepoID: refreshed.Repository.PlatformRepoID,
 			Owner:          refreshed.Repository.Owner, Name: refreshed.Repository.Name,
-		}, now,
+		}, time.Now().UTC().Add(time.Second),
 	)
 	require.NoError(err)
 	require.True(accepted)

--- a/internal/server/tmux_wrapper_test.go
+++ b/internal/server/tmux_wrapper_test.go
@@ -245,9 +245,12 @@ func setupWrapperServerWithScriptAndDBAndServer(
 
 	bareDir := filepath.Join(dir, "clones")
 	require.NoError(t, os.MkdirAll(bareDir, 0o755))
-	bare := filepath.Join(
-		bareDir, "github.com", "acme", "widget.git",
+	clones := gitclone.New(bareDir, nil)
+	bare, err := clones.ClonePathForContext(
+		gitclone.WithRepositoryIdentity(t.Context(), "repo-acme-widget"),
+		"github", "github.com", "acme", "widget",
 	)
+	require.NoError(t, err)
 	tmpWork := filepath.Join(dir, "work")
 	runGit(t, dir, "init", "--bare", "--initial-branch=main", bare)
 	runGit(t, dir, "clone", bare, tmpWork)
@@ -272,7 +275,6 @@ func setupWrapperServerWithScriptAndDBAndServer(
 	// Point bare origin at itself so EnsureClone fetch works.
 	runGit(t, bare, "remote", "add", "origin", bare)
 
-	clones := gitclone.New(bareDir, nil)
 	worktreeDir := filepath.Join(dir, "worktrees")
 
 	repos := []ghclient.RepoRef{
@@ -1105,7 +1107,10 @@ func TestWorkspaceSetupFailureRollbackCleansWorktreeViaAPI(t *testing.T) {
 		t, script,
 	)
 	ctx := t.Context()
-	clonePath, err := srv.clones.ClonePath("github", "github.com", "acme", "widget")
+	clonePath, err := srv.clones.ClonePathForContext(
+		gitclone.WithRepositoryIdentity(ctx, "repo-acme-widget"),
+		"github", "github.com", "acme", "widget",
+	)
 	require.NoError(err)
 	featureSHA := testGitSHA(t, clonePath, "refs/heads/feature")
 

--- a/internal/server/workspaceapi/agent_hook_test.go
+++ b/internal/server/workspaceapi/agent_hook_test.go
@@ -27,6 +27,11 @@ func TestReceiveAgentHookRecordsActivityAndGeneratesClaudeContext(t *testing.T) 
 	assert := assert.New(t)
 	database := dbtest.Open(t)
 	worktree := t.TempDir()
+	_, err := database.UpsertRepo(t.Context(), db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-acme-widget", Owner: "acme", Name: "widget",
+	})
+	require.NoError(err)
 	require.NoError(database.InsertWorkspace(t.Context(), &db.Workspace{
 		ID:              "ws-agent-hook",
 		Platform:        "github",

--- a/internal/server/workspaceapi/background_test.go
+++ b/internal/server/workspaceapi/background_test.go
@@ -45,7 +45,7 @@ func TestPublishWorkspacePushedHeadResultBroadcastsDomainEvents(t *testing.T) {
 			AssociatedAt: observedAt,
 		}},
 		HeadChanges: []workspace.PushedHeadUpdate{{
-			WorkspaceID: "ws-pr", Provider: platform.KindGitHub,
+			WorkspaceID: "ws-pr", RepoID: 1, Provider: platform.KindGitHub,
 			PlatformHost: "github.com", RepoPath: "acme/widget",
 			Owner: "acme", Name: "widget", Number: 42,
 			OldSHA: "old", NewSHA: "new", RemoteName: "origin",

--- a/internal/server/workspaceapi/federation_refresh_test.go
+++ b/internal/server/workspaceapi/federation_refresh_test.go
@@ -124,6 +124,11 @@ func TestRefreshWorkspaceUsesHubProjectionWithoutLocalSyncer(t *testing.T) {
 	require := require.New(t)
 	database := dbtest.Open(t)
 	issuedAt := time.Now().UTC().Truncate(time.Second)
+	_, err := database.UpsertRepo(t.Context(), db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-acme-widget", Owner: "acme", Name: "widget",
+	})
+	require.NoError(err)
 	ws := &db.Workspace{
 		ID: "ws-federated-refresh", Platform: "github", PlatformHost: "github.com",
 		RepoOwner: "acme", RepoName: "widget",

--- a/internal/server/workspaceapi/handler.go
+++ b/internal/server/workspaceapi/handler.go
@@ -231,6 +231,9 @@ func New(deps Deps) *Handler {
 	if deps.DB != nil && deps.Workspaces != nil {
 		monitorOptions := workspace.PRMonitorOptions{
 			LaunchSpecs: deps.Workspaces, PullCandidates: deps.PullCandidates,
+			RetireUnresolvedWorkspace: func(_ context.Context, workspaceID string) error {
+				return h.queueWorkspaceRetirement(workspaceID)
+			},
 		}
 		h.workspacePRMonitor = workspace.NewPRMonitor(deps.DB, monitorOptions)
 		h.workspacePushedHeadObserver = workspace.NewPushedHeadObserver(

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -255,7 +255,6 @@ func (s *Handler) createPullWorkspaceRouteCore(
 	if err != nil {
 		return nil, workspaceLaunchSpecProblem(err)
 	}
-
 	ws, err := s.workspaces.CreateFromLaunchSpec(ctx, spec)
 	if err != nil {
 		if errors.Is(err, workspace.ErrLaunchSpecSourceHidden) ||
@@ -397,6 +396,12 @@ func (s *Handler) runWorkspaceSetupWithBasePath(ws *workspace.Workspace, basePat
 			})
 			if setupErr == nil {
 				s.runWorkspacePushedHeadObserverPass(bgCtx)
+			}
+			if errors.Is(setupErr, workspace.ErrWorkspaceRepositoryUnresolved) {
+				if deleteErr := s.queueWorkspaceRetirement(ws.ID); deleteErr != nil {
+					slog.Warn("delete unresolved workspace", "id", ws.ID, "err", deleteErr)
+				}
+				return
 			}
 
 			next, queued, queueErr := s.workspaces.StartQueuedRetryIfErrored(
@@ -656,7 +661,6 @@ func (s *Handler) createIssueWorkspaceRouteCore(
 			Body:   s.toWorkspaceResponse(ctx, summary),
 		}, nil
 	}
-
 	ws, err := s.workspaces.CreateIssueFromLaunchSpec(
 		ctx, spec,
 		workspace.CreateIssueOptions{

--- a/internal/server/workspaceapi/services_test.go
+++ b/internal/server/workspaceapi/services_test.go
@@ -3,6 +3,8 @@ package workspaceapi
 import (
 	"context"
 	"errors"
+	"fmt"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -47,7 +49,7 @@ func TestLaunchSpecCreatePersistsBeforeSetupStarts(t *testing.T) {
 	}
 	setupStarted := make(chan setupObservation, 1)
 	manager.SetWorktreeBasePathResolver(func(
-		ctx context.Context, _, _, _, _ string,
+		ctx context.Context, _ workspace.WorktreeBaseRepository,
 	) (string, bool, error) {
 		rows, readErr := database.ListWorkspaces(ctx)
 		if readErr != nil || len(rows) != 1 {
@@ -85,6 +87,78 @@ func TestLaunchSpecCreatePersistsBeforeSetupStarts(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		require.FailNow("workspace setup did not start")
 	}
+}
+
+func TestCreatePullWorkspacePreservesDisplacedRouteOwner(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	database := dbtest.Open(t)
+	base := t.TempDir()
+	observedAt := time.Now().UTC().Add(-3 * time.Minute)
+	oldIdentity := db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-old-widget", Owner: "acme", Name: "widget",
+	}
+	oldRepo, accepted, err := database.ReconcileRepositoryObservation(
+		t.Context(), oldIdentity, observedAt,
+	)
+	require.NoError(err)
+	require.True(accepted)
+	require.NotNil(oldRepo)
+	displacedPath := filepath.Join(
+		base, "github", "github.com", "acme", "widget",
+		fmt.Sprintf("repo-%d", oldRepo.Repository.ID), "pr-42",
+	)
+	require.NoError(database.InsertWorkspace(t.Context(), &db.Workspace{
+		ID: "ws-displaced", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget",
+		ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 42, ItemKey: "42",
+		GitHeadRef: "feature/old", WorkspaceBranch: "kenn-forge/pr-42",
+		WorktreePath: displacedPath, TmuxSession: "forge-ws-displaced", Status: "ready",
+	}))
+	oldIdentity.Owner = "acme-archive"
+	oldIdentity.Name = "widget-old"
+	_, accepted, err = database.ReconcileRepositoryObservation(
+		t.Context(), oldIdentity, observedAt.Add(time.Minute),
+	)
+	require.NoError(err)
+	require.True(accepted)
+	_, accepted, err = database.ReconcileRepositoryObservation(
+		t.Context(), db.RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: "repo-acme-widget", Owner: "acme", Name: "widget",
+		}, observedAt.Add(2*time.Minute),
+	)
+	require.NoError(err)
+	require.True(accepted)
+
+	resolver := stubLaunchSpecResolver{}
+	manager := workspace.NewManager(database, base)
+	manager.SetLaunchSpecResolver(resolver)
+	handler := New(Deps{
+		DB: database, Workspaces: manager,
+		LaunchSpecResolver: resolver, EnrichmentDisabled: true,
+	})
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	require.NoError(handler.Shutdown(shutdownCtx))
+	cancel()
+
+	result, err := handler.CreatePullWorkspace(t.Context(), CreatePullWorkspaceRequest{
+		Provider: "github", PlatformHost: "github.com",
+		Owner: "acme", Name: "widget", Number: 42,
+	})
+
+	require.NoError(err)
+	assert.NotEqual("ws-displaced", result.Workspace.ID)
+	preserved, err := database.GetWorkspace(t.Context(), "ws-displaced")
+	require.NoError(err)
+	require.NotNil(preserved)
+	assert.Equal(displacedPath, preserved.WorktreePath)
+	replacement, err := database.GetWorkspace(t.Context(), result.Workspace.ID)
+	require.NoError(err)
+	require.NotNil(replacement)
+	assert.NotEqual(displacedPath, replacement.WorktreePath)
+	assert.Equal("pr-42", filepath.Base(replacement.WorktreePath))
 }
 
 func TestCreatePullWorkspaceServiceSuppressesAutoAssign(t *testing.T) {

--- a/internal/server/workspaceapi/subject_activity_test.go
+++ b/internal/server/workspaceapi/subject_activity_test.go
@@ -232,7 +232,7 @@ func TestWorkspaceSubjectSnapshotUsesStableRepositoryIdentityAfterRename(t *test
 	assert.Equal(WorkspaceRef{ID: "ws-renamed", Status: "ready"}, snapshot.Subjects[key].Workspace)
 }
 
-func TestWorkspaceSubjectSnapshotRejectsAmbiguousReusedRoute(t *testing.T) {
+func TestWorkspaceSubjectSnapshotKeepsStableIdentityAcrossReusedRoute(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	h := newEnrichmentTestHandler(t, "")
@@ -277,9 +277,12 @@ func TestWorkspaceSubjectSnapshotRejectsAmbiguousReusedRoute(t *testing.T) {
 
 	snapshot, err := h.WorkspaceSubjectSnapshot(t.Context())
 	require.NoError(err)
-	assert.Empty(snapshot.OwnReferences,
-		"ambiguous historical routes must not bind the workspace to the replacement repository")
-	assert.Empty(snapshot.Subjects)
+	key := db.WorkspaceSubjectKey{
+		RepoID: oldRepo.Repository.ID, ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 45,
+	}
+	assert.Equal(WorkspaceRef{ID: "ws-old-route", Status: "ready"}, snapshot.OwnReferences[key])
+	require.Contains(snapshot.Subjects, key)
+	assert.Equal("gadget", snapshot.Subjects[key].Subject.RepoName)
 }
 
 func TestWorkspaceSubjectSnapshotKeepsNonReadyReferenceWithoutCachedActivity(t *testing.T) {

--- a/internal/server/workspaceapi/workspace_deletion.go
+++ b/internal/server/workspaceapi/workspace_deletion.go
@@ -53,6 +53,20 @@ func workspaceDeletedEvent(ws *db.Workspace) workspaceDeletedEventData {
 // QueueWorkspaceDeletion durably admits teardown before returning, then runs
 // the destructive work under the workspace domain's lifecycle.
 func (s *Handler) QueueWorkspaceDeletion(id string) error {
+	return s.queueWorkspaceDeletion(id, false, false)
+}
+
+func (s *Handler) queueWorkspaceForceDeletion(id string) error {
+	return s.queueWorkspaceDeletion(id, true, false)
+}
+
+func (s *Handler) queueWorkspaceRetirement(id string) error {
+	return s.queueWorkspaceDeletion(id, false, true)
+}
+
+func (s *Handler) queueWorkspaceDeletion(
+	id string, force, preserveDeletionFailure bool,
+) error {
 	if s == nil || s.workspaces == nil || s.db == nil {
 		return errors.New("workspace cleanup is unavailable")
 	}
@@ -70,7 +84,12 @@ func (s *Handler) QueueWorkspaceDeletion(id string) error {
 	if ws.Status == "creating" {
 		return db.ErrWorkspaceSetupInProgress
 	}
-	started, err := s.db.BeginWorkspaceDeletion(ctx, id)
+	var started bool
+	if preserveDeletionFailure {
+		started, err = s.db.BeginWorkspaceRetirement(ctx, id)
+	} else {
+		started, err = s.db.BeginWorkspaceDeletion(ctx, id)
+	}
 	if err != nil {
 		return err
 	}
@@ -80,7 +99,7 @@ func (s *Handler) QueueWorkspaceDeletion(id string) error {
 	setupDone := s.markWorkspaceDeleting(id)
 	s.broadcastWorkspaceStatus(id)
 	if s.runBackground(func(ctx context.Context) {
-		s.finishQueuedWorkspaceDeletion(ctx, ws, setupDone, false)
+		s.finishQueuedWorkspaceDeletion(ctx, ws, setupDone, force)
 	}) {
 		return nil
 	}

--- a/internal/server/workspaceapi/workspace_deletion_test.go
+++ b/internal/server/workspaceapi/workspace_deletion_test.go
@@ -147,6 +147,119 @@ func TestQueueWorkspaceDeletionIsIdempotentAfterRemoval(t *testing.T) {
 	require.NoError(t, handler.QueueWorkspaceDeletion("already-removed"))
 }
 
+func TestQueueWorkspaceForceDeletionRemovesDirtyWorkspaceRecord(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	database := dbtest.Open(t)
+	base := t.TempDir()
+	worktreePath := filepath.Join(base, "ws-dirty-force")
+	require.NoError(os.MkdirAll(worktreePath, 0o755))
+	runGit(t, worktreePath, "init")
+	require.NoError(os.WriteFile(
+		filepath.Join(worktreePath, "notes.txt"), []byte("discard me\n"), 0o644,
+	))
+	insertDeletionTestWorkspace(t, database, "ws-dirty-force", worktreePath, "ready")
+	handler := New(Deps{
+		DB:         database,
+		Workspaces: workspace.NewManager(database, base),
+	})
+	handler.Start(t.Context(), true)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(handler.Shutdown(ctx))
+	})
+
+	require.NoError(handler.queueWorkspaceForceDeletion("ws-dirty-force"))
+	require.Eventually(func() bool {
+		got, err := database.GetWorkspace(t.Context(), "ws-dirty-force")
+		return err == nil && got == nil
+	}, 3*time.Second, 10*time.Millisecond)
+	assert.DirExists(worktreePath, "an unregistered Git root is not a managed worktree")
+}
+
+func TestPRMonitorPreservesDirtyUnresolvedWorkspace(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	database := dbtest.Open(t)
+	base := t.TempDir()
+	worktreePath := filepath.Join(base, "ws-unresolved-dirty")
+	require.NoError(os.MkdirAll(worktreePath, 0o755))
+	runGit(t, worktreePath, "init")
+	require.NoError(os.WriteFile(
+		filepath.Join(worktreePath, "notes.txt"), []byte("keep me\n"), 0o644,
+	))
+	insertDeletionTestWorkspace(
+		t, database, "ws-unresolved-dirty", worktreePath, "ready",
+	)
+	observedAt := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	original := db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-original", Owner: "acme", Name: "widget",
+	}
+	_, _, err := database.ReconcileRepositoryObservation(
+		t.Context(), original, observedAt,
+	)
+	require.NoError(err)
+	original.Name = "widget-original"
+	_, _, err = database.ReconcileRepositoryObservation(
+		t.Context(), original, observedAt.Add(time.Minute),
+	)
+	require.NoError(err)
+	_, _, err = database.ReconcileRepositoryObservation(
+		t.Context(), db.RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: "repo-replacement", Owner: "acme", Name: "widget",
+		}, observedAt.Add(2*time.Minute),
+	)
+	require.NoError(err)
+
+	var eventsMu sync.Mutex
+	var events []Event
+	handler := New(Deps{
+		DB: database, Workspaces: workspace.NewManager(database, base),
+		Broadcast: func(event Event) uint64 {
+			eventsMu.Lock()
+			defer eventsMu.Unlock()
+			events = append(events, event)
+			return uint64(len(events))
+		},
+	})
+	handler.Start(t.Context(), true)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(handler.Shutdown(ctx))
+	})
+	require.NotNil(handler.workspacePRMonitor)
+	_, err = handler.workspacePRMonitor.RunOnce(t.Context())
+	require.NoError(err)
+
+	require.Eventually(func() bool {
+		got, getErr := database.GetWorkspace(t.Context(), "ws-unresolved-dirty")
+		return getErr == nil && got != nil && got.Status == "deletion_failed"
+	}, 3*time.Second, 10*time.Millisecond)
+	require.Eventually(func() bool {
+		eventsMu.Lock()
+		defer eventsMu.Unlock()
+		return len(events) >= 2
+	}, 3*time.Second, 10*time.Millisecond)
+	got, err := database.GetWorkspace(t.Context(), "ws-unresolved-dirty")
+	require.NoError(err)
+	require.NotNil(got)
+	require.NotNil(got.ErrorMessage)
+	assert.Contains(*got.ErrorMessage, "notes.txt")
+	assert.FileExists(filepath.Join(worktreePath, "notes.txt"))
+	eventsMu.Lock()
+	events = nil
+	eventsMu.Unlock()
+	_, err = handler.workspacePRMonitor.RunOnce(t.Context())
+	require.NoError(err)
+	eventsMu.Lock()
+	assert.Empty(events, "automatic retirement must not re-admit a deletion failure")
+	eventsMu.Unlock()
+}
+
 func TestDeleteWorkspaceDirtyPreservesReadyStatus(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/workspaceapi/workspace_pushed_head.go
+++ b/internal/server/workspaceapi/workspace_pushed_head.go
@@ -114,16 +114,24 @@ func (s *Handler) enqueueWorkspacePushedHeadRefresh(change workspace.PushedHeadU
 		key,
 		attrs,
 		func(ctx context.Context) error {
-			_, mr := s.lookupPushedHeadMR(ctx, change)
-			if mr == nil {
+			repo, mr := s.lookupPushedHeadMR(ctx, change)
+			if repo == nil || mr == nil {
 				return nil
 			}
-			return s.syncer.SyncMROnProvider(
+			return s.syncer.SyncMRForRepository(
 				ctx,
-				change.Provider,
-				change.PlatformHost,
-				change.Owner,
-				change.Name,
+				ghclient.RepoRef{
+					Platform:           repoProviderKind(*repo),
+					Owner:              repo.Owner,
+					Name:               repo.Name,
+					PlatformHost:       repoProviderHost(*repo),
+					RepoPath:           repo.RepoPath,
+					PlatformExternalID: repo.PlatformRepoID,
+					WebURL:             repo.WebURL,
+					CloneURL:           repo.CloneURL,
+					DefaultBranch:      repo.DefaultBranch,
+				},
+				repo.ID,
 				change.Number,
 			)
 		},
@@ -203,7 +211,7 @@ func (s *Handler) maybeEnqueuePushedHeadCIRefresh(ctx context.Context, change wo
 		headSHA = change.NewSHA
 	}
 	queuedAt := s.now().UTC()
-	key := "pr-ci:" + string(change.Provider) + ":" + change.PlatformHost + ":" + change.RepoPath + "#" + strconv.Itoa(change.Number)
+	key := "pr-ci:" + strconv.FormatInt(change.RepoID, 10) + "#" + strconv.Itoa(change.Number)
 	started := s.enqueueDetailSyncWithCompletion(
 		key,
 		[]any{"type", "pr-ci", "provider", string(change.Provider), "platform_host", change.PlatformHost, "repo_path", change.RepoPath, "number", change.Number},
@@ -216,7 +224,7 @@ func (s *Handler) maybeEnqueuePushedHeadCIRefresh(ctx context.Context, change wo
 			if currentHeadSHA == "" {
 				currentHeadSHA = change.NewSHA
 			}
-			_, err := s.syncer.RefreshMRCIStatusOnProvider(
+			_, err := s.syncer.RefreshMRCIStatusForRepository(
 				ctx,
 				ghclient.RepoRef{
 					Platform:           repoProviderKind(*currentRepo),
@@ -280,11 +288,7 @@ func (s *Handler) maybeEnqueuePushedHeadCIRefresh(ctx context.Context, change wo
 }
 
 func (s *Handler) lookupPushedHeadMR(ctx context.Context, change workspace.PushedHeadUpdate) (*db.Repo, *db.MergeRequest) {
-	repo, err := s.db.GetRepoByIdentity(ctx, db.RepoIdentity{
-		Platform:     string(change.Provider),
-		PlatformHost: change.PlatformHost,
-		RepoPath:     change.RepoPath,
-	})
+	repo, err := s.db.GetActiveRepoByID(ctx, change.RepoID)
 	if err != nil || repo == nil {
 		return nil, nil
 	}
@@ -300,5 +304,5 @@ func pushedHeadMRNeedsCIRefresh(status string, hadPending, approvalRequired bool
 }
 
 func pushedHeadPRKey(change workspace.PushedHeadUpdate) string {
-	return "pr:" + string(change.Provider) + ":" + change.PlatformHost + ":" + change.RepoPath + "#" + strconv.Itoa(change.Number)
+	return "pr:" + strconv.FormatInt(change.RepoID, 10) + "#" + strconv.Itoa(change.Number)
 }

--- a/internal/server/workspaceapi/workspace_pushed_head_integration_test.go
+++ b/internal/server/workspaceapi/workspace_pushed_head_integration_test.go
@@ -25,8 +25,19 @@ import (
 
 type pushedHeadProviderClient struct {
 	ghclient.Client
-	getPullRequest func(context.Context, string, string, int) (*gh.PullRequest, error)
-	ciCalls        atomic.Int64
+	getPullRequest       func(context.Context, string, string, int) (*gh.PullRequest, error)
+	getRepository        func(context.Context, string, string) (*gh.Repository, error)
+	beforeCombinedStatus func()
+	ciCalls              atomic.Int64
+}
+
+func (c *pushedHeadProviderClient) GetRepository(
+	ctx context.Context, owner, name string,
+) (*gh.Repository, error) {
+	if c.getRepository != nil {
+		return c.getRepository(ctx, owner, name)
+	}
+	return c.Client.GetRepository(ctx, owner, name)
 }
 
 func (c *pushedHeadProviderClient) GetPullRequest(
@@ -39,6 +50,9 @@ func (c *pushedHeadProviderClient) GetCombinedStatus(
 	ctx context.Context, owner, name, ref string,
 ) (*gh.CombinedStatus, error) {
 	c.ciCalls.Add(1)
+	if c.beforeCombinedStatus != nil {
+		c.beforeCombinedStatus()
+	}
 	return c.Client.GetCombinedStatus(ctx, owner, name, ref)
 }
 
@@ -286,7 +300,7 @@ func TestWorkspacePushedHeadQueuedCIRefreshRechecksRemovedPullRequest(t *testing
 		t.Context(), repoID, 1, headSHA, "pending", `[]`, true,
 	))
 	change := workspace.PushedHeadUpdate{
-		WorkspaceID: "ws-pr", Provider: platform.KindGitHub,
+		WorkspaceID: "ws-pr", RepoID: repoID, Provider: platform.KindGitHub,
 		PlatformHost: "github.com", RepoPath: "acme/widget",
 		Owner: "acme", Name: "widget", Number: 1, NewSHA: headSHA,
 	}
@@ -298,6 +312,108 @@ func TestWorkspacePushedHeadQueuedCIRefreshRechecksRemovedPullRequest(t *testing
 
 	require.Zero(provider.ciCalls.Load())
 	require.Len(fixture.events, 1, "removed pull must not publish CI refresh success")
+}
+
+func TestWorkspacePushedHeadQueuedCIRefreshRejectsRouteReuseDuringFetch(t *testing.T) {
+	require := require.New(t)
+	provider := newPushedHeadProvider(nil)
+	fixture := newPushedHeadIntegrationFixture(t, provider)
+	headSHA := "old-head"
+	repoID := seedPushedHeadIntegrationPR(t, fixture.database, headSHA)
+	require.NoError(fixture.database.UpdateMRCIStatusForHead(
+		t.Context(), repoID, 1, headSHA, "pending", `[]`, true,
+	))
+	change := workspace.PushedHeadUpdate{
+		WorkspaceID: "ws-pr", RepoID: repoID, Provider: platform.KindGitHub,
+		PlatformHost: "github.com", RepoPath: "acme/widget",
+		Owner: "acme", Name: "widget", Number: 1, NewSHA: headSHA,
+	}
+
+	fixture.handler.maybeEnqueuePushedHeadCIRefresh(t.Context(), change)
+	require.Len(fixture.jobs, 1)
+	provider.beforeCombinedStatus = func() {
+		replacementIdentity := db.GitHubRepoIdentity("github.com", "acme", "widget")
+		replacementIdentity.PlatformRepoID = "repo-acme-widget-replacement"
+		_, _, err := fixture.database.ReconcileRepositoryObservation(
+			context.Background(), replacementIdentity, time.Now().UTC().Add(time.Hour),
+		)
+		require.NoError(err)
+	}
+
+	fixture.jobs[0]()
+
+	require.Equal(int64(1), provider.ciCalls.Load())
+	stored, err := fixture.database.GetMergeRequestByRepoIDAndNumber(t.Context(), repoID, 1)
+	require.NoError(err)
+	require.NotNil(stored)
+	require.Equal("pending", stored.CIStatus)
+	require.True(stored.CIHadPending)
+}
+
+func TestLookupPushedHeadMRDoesNotFollowReusedRepositoryRoute(t *testing.T) {
+	require := require.New(t)
+	fixture := newPushedHeadIntegrationFixture(t, newPushedHeadProvider(nil))
+	repoID := seedPushedHeadIntegrationPR(t, fixture.database, "old-head")
+	replacementIdentity := db.GitHubRepoIdentity("github.com", "acme", "widget")
+	replacementIdentity.PlatformRepoID = "repo-acme-widget-replacement"
+	replacement, _, err := fixture.database.ReconcileRepositoryObservation(
+		t.Context(), replacementIdentity, time.Now().UTC().Add(time.Hour),
+	)
+	require.NoError(err)
+	require.NotNil(replacement)
+
+	repo, mr := fixture.handler.lookupPushedHeadMR(t.Context(), workspace.PushedHeadUpdate{
+		WorkspaceID: "ws-pr", RepoID: repoID, Provider: platform.KindGitHub,
+		PlatformHost: "github.com", RepoPath: "acme/widget",
+		Owner: "acme", Name: "widget", Number: 1,
+	})
+	require.Nil(repo)
+	require.Nil(mr)
+}
+
+func TestWorkspacePushedHeadQueuedRefreshStopsWhenRouteIsReusedDuringSync(t *testing.T) {
+	require := require.New(t)
+	var detailSyncCalls atomic.Int64
+	provider := newPushedHeadProvider(func(
+		context.Context, string, string, int,
+	) (*gh.PullRequest, error) {
+		detailSyncCalls.Add(1)
+		return pushedHeadPullRequest("replacement title", "replacement-head"), nil
+	})
+	fixture := newPushedHeadIntegrationFixture(t, provider)
+	worktreePath, oldHead := setupPushedHeadIntegrationWorktree(t)
+	repoID := seedPushedHeadIntegrationPR(t, fixture.database, oldHead)
+	insertPushedHeadIntegrationWorkspace(t, fixture.database, worktreePath)
+	pushPushedHeadIntegrationCommit(t, worktreePath)
+
+	fixture.handler.runWorkspacePushedHeadObserverPass(t.Context())
+	require.Len(fixture.jobs, 1)
+	provider.getRepository = func(
+		ctx context.Context, owner, name string,
+	) (*gh.Repository, error) {
+		replacementIdentity := db.GitHubRepoIdentity("github.com", owner, name)
+		replacementIdentity.PlatformRepoID = "repo-acme-widget-replacement"
+		_, _, err := fixture.database.ReconcileRepositoryObservation(
+			ctx, replacementIdentity, time.Now().UTC().Add(time.Hour),
+		)
+		require.NoError(err)
+		allowed := true
+		nodeID := replacementIdentity.PlatformRepoID
+		return &gh.Repository{
+			Name: &name, NodeID: &nodeID, Owner: &gh.User{Login: &owner},
+			AllowSquashMerge: &allowed, AllowMergeCommit: &allowed,
+			AllowRebaseMerge: &allowed,
+		}, nil
+	}
+
+	fixture.jobs[0]()
+
+	require.Zero(detailSyncCalls.Load())
+	stored, err := fixture.database.GetMergeRequestByRepoIDAndNumber(t.Context(), repoID, 1)
+	require.NoError(err)
+	require.NotNil(stored)
+	require.Equal("Old title", stored.Title)
+	require.Equal(oldHead, stored.PlatformHeadSHA)
 }
 
 func pushedHeadPullRequest(title, headSHA string) *gh.PullRequest {

--- a/internal/server/workspacetest/adhoc_workspace_test.go
+++ b/internal/server/workspacetest/adhoc_workspace_test.go
@@ -6,10 +6,13 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/apiclient/generated"
+	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/gitclone"
 )
 
 // Starting new work needs no provider item: a tracked repository plus an
@@ -44,6 +47,56 @@ func TestCreateAdHocWorkspaceMaterializesRequestedBranch(t *testing.T) {
 	checkedOut, err := os.ReadFile(filepath.Join(ready.WorktreePath, "base.txt"))
 	require.NoError(err)
 	assert.Equal("base\n", string(checkedOut))
+}
+
+func TestCreateAdHocWorkspaceAfterRepositoryRouteReuse(t *testing.T) {
+	require := require.New(t)
+
+	fixture := setupWorkspaceServerFixture(t, nil)
+	replacementBare, err := fixture.clones.ClonePathForContext(
+		gitclone.WithRepositoryIdentity(t.Context(), "repo-current-occupant"),
+		"github", "github.com", "acme", "widget",
+	)
+	require.NoError(err)
+	require.NotEqual(fixture.bare, replacementBare)
+	runGit(t, t.TempDir(), "clone", "--bare", fixture.remote, replacementBare)
+	runGit(
+		t, replacementBare, "remote", "set-url", "origin",
+		"https://github.com/acme/widget.git",
+	)
+	runGit(
+		t, replacementBare, "config", "--add",
+		"url."+fixture.remote+".insteadOf", "https://github.com/acme/widget.git",
+	)
+	current, _, err := fixture.database.ReconcileRepositoryObservation(
+		t.Context(),
+		db.RepoIdentity{
+			Platform:       "github",
+			PlatformHost:   "github.com",
+			PlatformRepoID: "repo-current-occupant",
+			Owner:          "acme",
+			Name:           "widget",
+		},
+		time.Now().UTC().Add(time.Hour),
+	)
+	require.NoError(err)
+	require.NotNil(current)
+
+	branch := "spike/route-reuse"
+	resp, err := fixture.client.HTTP.CreateRepoWorkspaceWithResponse(
+		t.Context(), "gh", "acme", "widget",
+		generated.CreateRepoWorkspaceJSONRequestBody{Branch: &branch},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, resp.StatusCode(), string(resp.Body))
+	require.NotNil(resp.JSON202)
+
+	ready := waitForWorkspaceReady(t, t.Context(), fixture.client, resp.JSON202.Id)
+	require.Equal(branch, ready.GitHeadRef)
+	workspace, err := fixture.database.GetWorkspace(t.Context(), ready.Id)
+	require.NoError(err)
+	require.NotNil(workspace)
+	require.Equal(current.Repository.ID, workspace.RepoID)
 }
 
 func TestCreateAdHocWorkspaceGeneratesBranchWhenOmitted(t *testing.T) {

--- a/internal/server/workspacetest/fixtures_test.go
+++ b/internal/server/workspacetest/fixtures_test.go
@@ -29,8 +29,10 @@ type workspaceServerFixture struct {
 	server           *server.Server
 	client           *apiclient.Client
 	database         *db.DB
+	clones           *gitclone.Manager
 	bare             string
 	remote           string
+	repoID           int64
 	agentActivityDir string
 	worktreeDir      string
 }
@@ -114,7 +116,12 @@ func setupWorkspaceServerFixtureWithTmuxInjection(
 
 	bareDir := filepath.Join(dir, "clones")
 	require.NoError(t, os.MkdirAll(bareDir, 0o755))
-	bare := filepath.Join(bareDir, "github.com", "acme", "widget.git")
+	clones := gitclone.New(bareDir, nil)
+	bare, err := clones.ClonePathForContext(
+		gitclone.WithRepositoryIdentity(t.Context(), "repo-acme-widget"),
+		"github", "github.com", "acme", "widget",
+	)
+	require.NoError(t, err)
 	runGit(t, dir, "clone", "--bare", remote, bare)
 	runGit(
 		t, bare, "remote", "set-url", "origin",
@@ -125,7 +132,6 @@ func setupWorkspaceServerFixtureWithTmuxInjection(
 		"url."+remote+".insteadOf", "https://github.com/acme/widget.git",
 	)
 
-	clones := gitclone.New(bareDir, nil)
 	worktreeDir := filepath.Join(dir, "worktrees")
 	repos := []ghclient.RepoRef{
 		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
@@ -136,7 +142,7 @@ func setupWorkspaceServerFixtureWithTmuxInjection(
 	if cfg != nil && cfg.BasePath != "" {
 		basePath = cfg.BasePath
 	}
-	seedPROnHost(t, database, "github.com", "acme", "widget", 1)
+	repoID := seedPROnHost(t, database, "github.com", "acme", "widget", 1)
 	options := server.ServerOptions{
 		DisableWorkspaceBackgroundMonitors: true,
 		PtyOwnerInProcess:                  true,
@@ -166,8 +172,10 @@ func setupWorkspaceServerFixtureWithTmuxInjection(
 		server:           srv,
 		client:           client,
 		database:         database,
+		clones:           clones,
 		bare:             bare,
 		remote:           remote,
+		repoID:           repoID,
 		agentActivityDir: filepath.Join(dir, "agent-activity"),
 		worktreeDir:      worktreeDir,
 	}

--- a/internal/server/workspacetest/issue_workspace_directory_recovery_test.go
+++ b/internal/server/workspacetest/issue_workspace_directory_recovery_test.go
@@ -1,6 +1,7 @@
 package workspacetest
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -23,7 +24,8 @@ func TestIssueWorkspaceRecoversExpectedDirectory(t *testing.T) {
 	branch := "kenn-forge/issue-7"
 	expectedPath := filepath.Join(
 		fixture.worktreeDir,
-		"github", "github.com", "acme", "widget", "issue-7",
+		"github", "github.com", "acme", "widget",
+		fmt.Sprintf("repo-%d", fixture.repoID), "issue-7",
 	)
 	runGit(
 		t, fixture.bare,
@@ -163,7 +165,8 @@ func TestIssueWorkspaceDirectoryRecoveryReasons(t *testing.T) {
 			seedIssue(t, fixture.database, "acme", "widget", 7, "open")
 			expectedPath := filepath.Join(
 				fixture.worktreeDir,
-				"github", "github.com", "acme", "widget", "issue-7",
+				"github", "github.com", "acme", "widget",
+				fmt.Sprintf("repo-%d", fixture.repoID), "issue-7",
 			)
 			tt.prepare(t, fixture, expectedPath)
 
@@ -209,7 +212,8 @@ func TestIssueWorkspaceConflictRejectsAlternateBranchForExistingDirectory(t *tes
 	branch := "kenn-forge/issue-7-original-title"
 	expectedPath := filepath.Join(
 		fixture.worktreeDir,
-		"github", "github.com", "acme", "widget", "issue-7",
+		"github", "github.com", "acme", "widget",
+		fmt.Sprintf("repo-%d", fixture.repoID), "issue-7",
 	)
 	runGit(t, fixture.bare, "worktree", "add", expectedPath, "-b", branch, "main")
 

--- a/internal/server/workspacetest/workspace_clone_safety_test.go
+++ b/internal/server/workspacetest/workspace_clone_safety_test.go
@@ -2,6 +2,7 @@ package workspacetest
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
@@ -573,7 +574,8 @@ func TestWorkspaceCreateRejectsSymlinkedReusableWorktreeE2E(t *testing.T) {
 	ctx := t.Context()
 
 	worktreePath := filepath.Join(
-		fixture.worktreeDir, "github", "github.com", "acme", "widget", "pr-1",
+		fixture.worktreeDir, "github", "github.com", "acme", "widget",
+		fmt.Sprintf("repo-%d", fixture.repoID), "pr-1",
 	)
 	targetPath := filepath.Join(t.TempDir(), "linked-worktree")
 	runGit(t, fixture.bare, "worktree", "add", targetPath, "feature")
@@ -743,7 +745,8 @@ func TestWorkspaceCreateOccupiedPathCreatesNoBranchesE2E(t *testing.T) {
 	require.NoError(err)
 
 	worktreePath := filepath.Join(
-		fixture.worktreeDir, "github", "github.com", "acme", "widget", "pr-2",
+		fixture.worktreeDir, "github", "github.com", "acme", "widget",
+		fmt.Sprintf("repo-%d", fixture.repoID), "pr-2",
 	)
 	require.NoError(os.MkdirAll(worktreePath, 0o755))
 	require.NoError(os.WriteFile(

--- a/internal/server/workspacetest/workspace_diff_test.go
+++ b/internal/server/workspacetest/workspace_diff_test.go
@@ -192,6 +192,10 @@ func TestWorkspaceDiffEndpointsReturnPierreTreeOrderE2E(t *testing.T) {
 	runGit(t, worktreePath, "commit", "-m", "base commit")
 
 	database := dbtest.Open(t)
+	identity := db.GitHubRepoIdentity("github.com", "acme", "widget")
+	identity.PlatformRepoID = "repo-acme-widget"
+	_, err := database.UpsertRepo(t.Context(), identity)
+	require.NoError(err)
 	srv := server.New(database, nil, nil, "/", nil, server.ServerOptions{
 		WorktreeDir: filepath.Join(dir, "managed-worktrees"),
 	})

--- a/internal/workspace/adhoc_test.go
+++ b/internal/workspace/adhoc_test.go
@@ -542,9 +542,96 @@ func TestSetupFailsClosedWhenRouteReplacedMidSetup(t *testing.T) {
 	}
 
 	err = mgr.Setup(t.Context(), ws)
-	require.ErrorContains(err, "historical occupants")
+	require.ErrorIs(err, db.ErrRepositoryRouteFenceChanged)
 	stored, getErr := d.GetWorkspace(t.Context(), ws.ID)
 	require.NoError(getErr)
 	require.NotNil(stored)
 	assert.Equal("error", stored.Status)
+}
+
+func TestSetupFailsClosedWhenRepositoryRenamedAndRouteReplacedMidSetup(t *testing.T) {
+	require := require.New(t)
+
+	d := openTestDB(t)
+	localRepo, _, platformHost := setupHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/other",
+	)
+	seedRepo(t, d, platformHost, "acme", "widget")
+
+	tmuxScript, _ := writeRecorderScript(t)
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{tmuxScript})
+	mgr.SetWorktreeBasePathResolver(staticBaseResolver(localRepo))
+
+	ws, err := mgr.CreateAdHoc(
+		t.Context(), "github", platformHost, "acme", "widget",
+		CreateAdHocOptions{BranchName: "spike/renamed-and-replaced"},
+	)
+	require.NoError(err)
+
+	mgr.beforeSetupRouteRevalidation = func() {
+		_, _, renameErr := d.ReconcileRepositoryObservation(
+			t.Context(), db.RepoIdentity{
+				Platform: "github", PlatformHost: platformHost,
+				PlatformRepoID: "repo-acme-widget", Owner: "acme", Name: "renamed",
+			}, time.Now().UTC(),
+		)
+		require.NoError(renameErr)
+		_, _, replaceErr := d.ReconcileRepositoryObservation(
+			t.Context(), db.RepoIdentity{
+				Platform: "github", PlatformHost: platformHost,
+				PlatformRepoID: "repo-acme-widget-replacement", Owner: "acme", Name: "widget",
+			}, time.Now().UTC().Add(time.Second),
+		)
+		require.NoError(replaceErr)
+	}
+
+	err = mgr.Setup(t.Context(), ws)
+	require.ErrorIs(err, db.ErrRepositoryRouteFenceChanged)
+	stored, getErr := d.GetWorkspace(t.Context(), ws.ID)
+	require.NoError(getErr)
+	require.NotNil(stored)
+	require.Equal("error", stored.Status)
+}
+
+func TestSetupUsesCurrentRepositoryAfterRouteReuse(t *testing.T) {
+	require := require.New(t)
+
+	d := openTestDB(t)
+	localRepo, _, platformHost := setupHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/other",
+	)
+	observedAt := time.Date(2026, 8, 29, 0, 0, 0, 0, time.UTC)
+	_, _, err := d.ReconcileRepositoryObservation(t.Context(), db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   platformHost,
+		PlatformRepoID: "repo-original",
+		Owner:          "acme",
+		Name:           "widget",
+	}, observedAt)
+	require.NoError(err)
+	current, _, err := d.ReconcileRepositoryObservation(t.Context(), db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   platformHost,
+		PlatformRepoID: "repo-current",
+		Owner:          "acme",
+		Name:           "widget",
+	}, observedAt.Add(time.Hour))
+	require.NoError(err)
+	require.NotNil(current)
+
+	tmuxScript, _ := writeRecorderScript(t)
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetTmuxCommand([]string{tmuxScript})
+	mgr.SetWorktreeBasePathResolver(staticBaseResolver(localRepo))
+
+	ws, err := mgr.CreateAdHoc(
+		t.Context(), "github", platformHost, "acme", "widget",
+		CreateAdHocOptions{BranchName: "spike/current-repository"},
+	)
+	require.NoError(err)
+	require.Equal(current.Repository.ID, ws.RepoID)
+
+	require.NoError(mgr.Setup(t.Context(), ws))
+	require.Equal("ready", ws.Status)
 }

--- a/internal/workspace/agent_context_test.go
+++ b/internal/workspace/agent_context_test.go
@@ -511,8 +511,10 @@ func TestRenderAgentContextForWorktreeUsesPersistedWorkspace(t *testing.T) {
 	assert := assert.New(t)
 	database := openTestDB(t)
 	worktree := t.TempDir()
+	repoID := seedRepo(t, database, "github.com", "acme", "widget")
 	workspace := &db.Workspace{
 		ID:              "ws-hook-context",
+		RepoID:          repoID,
 		Platform:        "github",
 		PlatformHost:    "github.com",
 		RepoOwner:       "acme",

--- a/internal/workspace/branch_sync_test.go
+++ b/internal/workspace/branch_sync_test.go
@@ -284,6 +284,7 @@ func TestLaunchSpecBranchSyncRefreshesExpiredLeaseBeforeGit(t *testing.T) {
 	require := require.New(t)
 	database := openTestDB(t)
 	spec := launchSpecForTest()
+	seedLaunchSpecRepository(t, database, spec)
 	workspace := &db.Workspace{
 		ID: "ws-expired-branch-sync", Platform: spec.Repository.Provider,
 		PlatformHost: spec.Repository.PlatformHost,
@@ -378,6 +379,7 @@ func TestProviderBackedBranchSyncDoesNotFallBackToAnonymousGit(t *testing.T) {
 	runWorkspaceTestGit(t, work, "commit", "-m", "ahead")
 	database := openTestDB(t)
 	spec := launchSpecForTest()
+	seedLaunchSpecRepository(t, database, spec)
 	workspace := &db.Workspace{
 		ID: "ws-required-branch-credential", Platform: spec.Repository.Provider,
 		PlatformHost: spec.Repository.PlatformHost,

--- a/internal/workspace/launch_spec.go
+++ b/internal/workspace/launch_spec.go
@@ -102,6 +102,9 @@ func (m *Manager) RequireWorkspaceLaunchSpec(
 	if m == nil || m.db == nil {
 		return nil, &LaunchSpecRefreshError{Cause: ErrLaunchSpecResolverMissing}
 	}
+	if workspace.RepoID == 0 {
+		return nil, ErrWorkspaceRepositoryUnresolved
+	}
 	spec, err := m.db.GetWorkspaceLaunchSpec(ctx, workspace.ID)
 	if err != nil {
 		return nil, fmt.Errorf("read workspace launch specification: %w", err)
@@ -114,11 +117,15 @@ func (m *Manager) RequireWorkspaceLaunchSpec(
 			return nil, err
 		}
 	}
-	if err := spec.ValidateWorkspace(*workspace); err != nil {
-		return nil, fmt.Errorf("validate workspace launch specification: %w", err)
+	routeChanged, err := m.validateWorkspaceLaunchSpec(ctx, workspace, *spec)
+	if err != nil {
+		return nil, err
 	}
-	if err := validateLaunchSpecForCreation(*spec); err != nil {
-		return nil, fmt.Errorf("validate workspace launch Git identity: %w", err)
+	if routeChanged {
+		spec, err = m.refreshWorkspaceLaunchSpec(ctx, workspace, *spec)
+		if err != nil {
+			return nil, err
+		}
 	}
 	visibilityErr := spec.RequireVisible(m.launchSpecNow())
 	switch {
@@ -134,10 +141,48 @@ func (m *Manager) RequireWorkspaceLaunchSpec(
 	default:
 		return nil, visibilityErr
 	}
+	if _, err := m.validateWorkspaceLaunchSpec(ctx, workspace, *spec); err != nil {
+		return nil, err
+	}
+	if err := validateLaunchSpecForCreation(*spec); err != nil {
+		return nil, fmt.Errorf("validate workspace launch Git identity: %w", err)
+	}
 	if err := m.applyWorkspaceLaunchSpec(ctx, workspace, *spec); err != nil {
 		return nil, err
 	}
 	return spec, nil
+}
+
+func (m *Manager) validateWorkspaceLaunchSpec(
+	ctx context.Context, workspace *Workspace, spec WorkspaceLaunchSpec,
+) (bool, error) {
+	if workspace.RepoID == 0 {
+		return false, ErrWorkspaceRepositoryUnresolved
+	}
+	repo, err := m.db.GetActiveRepoByID(ctx, workspace.RepoID)
+	if err != nil {
+		return false, fmt.Errorf("resolve workspace launch repository: %w", err)
+	}
+	if repo == nil ||
+		!strings.EqualFold(repo.Platform, spec.Repository.Provider) ||
+		!strings.EqualFold(repo.PlatformHost, spec.Repository.PlatformHost) ||
+		strings.TrimSpace(repo.PlatformRepoID) != strings.TrimSpace(spec.Repository.PlatformRepoID) {
+		return false, fmt.Errorf(
+			"%w: workspace launch specification repository identity changed",
+			db.ErrRepositoryRouteFenceChanged,
+		)
+	}
+	routeChanged := !strings.EqualFold(repo.Owner, spec.Repository.Owner) ||
+		!strings.EqualFold(repo.Name, spec.Repository.Name)
+	comparison := *workspace
+	comparison.Platform = spec.Repository.Provider
+	comparison.PlatformHost = spec.Repository.PlatformHost
+	comparison.RepoOwner = spec.Repository.Owner
+	comparison.RepoName = spec.Repository.Name
+	if err := spec.ValidateWorkspace(comparison); err != nil {
+		return false, fmt.Errorf("validate workspace launch specification: %w", err)
+	}
+	return routeChanged, nil
 }
 
 // RefreshWorkspaceLaunchSpec forces a hub refresh even while the
@@ -313,8 +358,8 @@ func (m *Manager) lifecycleSummary(
 	if spec == nil {
 		return &summary, nil
 	}
-	if err := spec.ValidateWorkspace(*workspace); err != nil {
-		return nil, fmt.Errorf("validate workspace launch specification: %w", err)
+	if _, err := m.validateWorkspaceLaunchSpec(ctx, workspace, *spec); err != nil {
+		return nil, err
 	}
 	if err := validateLaunchSpecForCreation(*spec); err != nil {
 		return nil, fmt.Errorf("validate workspace launch Git identity: %w", err)

--- a/internal/workspace/launch_spec_test.go
+++ b/internal/workspace/launch_spec_test.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -66,6 +67,19 @@ func launchSpecForTest() WorkspaceLaunchSpec {
 	}
 }
 
+func seedLaunchSpecRepository(
+	t *testing.T, database *db.DB, spec WorkspaceLaunchSpec,
+) int64 {
+	t.Helper()
+	repoID, err := database.UpsertRepo(t.Context(), db.RepoIdentity{
+		Platform: spec.Repository.Provider, PlatformHost: spec.Repository.PlatformHost,
+		PlatformRepoID: spec.Repository.PlatformRepoID,
+		Owner:          spec.Repository.Owner, Name: spec.Repository.Name,
+	})
+	require.NoError(t, err)
+	return repoID
+}
+
 func TestWorkspaceLaunchSpecVisibilityLeaseBoundary(t *testing.T) {
 	spec := launchSpecForTest()
 	require.NoError(t, spec.Validate())
@@ -107,6 +121,7 @@ func TestLaunchSpecLeaseExpiredHubUnavailableIsRetryable(t *testing.T) {
 	require := require.New(t)
 	database := openTestDB(t)
 	spec := launchSpecForTest()
+	seedLaunchSpecRepository(t, database, spec)
 	workspace := &db.Workspace{
 		ID: "ws-expired-launch", Platform: spec.Repository.Provider,
 		PlatformHost: spec.Repository.PlatformHost,
@@ -145,6 +160,7 @@ func TestMissingWorkspaceLaunchSpecIsResolvedAndPersisted(t *testing.T) {
 	require := require.New(t)
 	database := openTestDB(t)
 	spec := launchSpecForTest()
+	seedLaunchSpecRepository(t, database, spec)
 	workspace := &db.Workspace{
 		ID: "ws-missing-launch", Platform: spec.Repository.Provider,
 		PlatformHost: spec.Repository.PlatformHost,
@@ -174,6 +190,7 @@ func TestProviderBackedSetupDoesNotFallBackToAnonymousGit(t *testing.T) {
 	require := require.New(t)
 	database := openTestDB(t)
 	spec := launchSpecForTest()
+	seedLaunchSpecRepository(t, database, spec)
 	workspace := &db.Workspace{
 		ID: "ws-required-setup-credential", Platform: spec.Repository.Provider,
 		PlatformHost: spec.Repository.PlatformHost,
@@ -204,6 +221,7 @@ func TestRefreshWorkspaceLaunchSpecRenewsFreshProjection(t *testing.T) {
 	require := require.New(t)
 	database := openTestDB(t)
 	current := launchSpecForTest()
+	seedLaunchSpecRepository(t, database, current)
 	workspace := &db.Workspace{
 		ID: "ws-manual-refresh", Platform: current.Repository.Provider,
 		PlatformHost: current.Repository.PlatformHost,
@@ -300,6 +318,80 @@ func TestRefreshWorkspaceLaunchSpecAdoptsVerifiedRepositoryRename(t *testing.T) 
 	assert.Equal(refreshed, *persistedSpec)
 }
 
+func TestRequireWorkspaceLaunchSpecRefreshesVerifiedRepositoryRename(t *testing.T) {
+	for _, expired := range []bool{false, true} {
+		name := "valid lease"
+		workspaceID := "ws-require-rename-valid"
+		if expired {
+			name = "expired lease"
+			workspaceID = "ws-require-rename-expired"
+		}
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			database := openTestDB(t)
+			current := launchSpecForTest()
+			_, accepted, err := database.ReconcileRepositoryObservation(
+				t.Context(), db.RepoIdentity{
+					Platform: current.Repository.Provider, PlatformHost: current.Repository.PlatformHost,
+					PlatformRepoID: current.Repository.PlatformRepoID,
+					Owner:          current.Repository.Owner, Name: current.Repository.Name,
+				}, current.IssuedAt,
+			)
+			require.NoError(err)
+			require.True(accepted)
+
+			workspace := &db.Workspace{
+				ID: workspaceID, Platform: current.Repository.Provider,
+				PlatformHost: current.Repository.PlatformHost,
+				RepoOwner:    current.Repository.Owner, RepoName: current.Repository.Name,
+				ItemType: current.ItemType, ItemNumber: current.ItemNumber,
+				ItemKey: current.ItemKey, GitHeadRef: current.GitHeadRef,
+				WorkspaceBranch: "kenn-forge/pr-7", WorktreePath: t.TempDir(),
+				TmuxSession: "forge-ws-require-rename", Status: "ready",
+			}
+			require.NoError(database.InsertWorkspace(t.Context(), workspace))
+			require.NoError(database.PutWorkspaceLaunchSpec(t.Context(), workspace.ID, current))
+
+			now := current.IssuedAt.Add(time.Minute)
+			if expired {
+				now = current.SourceVisibleUntil
+			}
+			refreshed := current
+			refreshed.Repository.Owner = "acme-renamed"
+			refreshed.Repository.Name = "widget-renamed"
+			refreshed.Repository.CloneURL = "https://github.com/acme-renamed/widget-renamed.git"
+			refreshed.IssuedAt = now
+			refreshed.SourceVisibleUntil = now.Add(WorkspaceLaunchSpecVisibilityLease)
+			_, accepted, err = database.ReconcileRepositoryObservation(
+				t.Context(), db.RepoIdentity{
+					Platform: refreshed.Repository.Provider, PlatformHost: refreshed.Repository.PlatformHost,
+					PlatformRepoID: refreshed.Repository.PlatformRepoID,
+					Owner:          refreshed.Repository.Owner, Name: refreshed.Repository.Name,
+				}, current.IssuedAt.Add(time.Minute),
+			)
+			require.NoError(err)
+			require.True(accepted)
+
+			resolver := &staticLaunchSpecResolver{spec: refreshed}
+			manager := NewManager(database, t.TempDir())
+			manager.SetLaunchSpecResolver(resolver)
+			manager.SetNow(func() time.Time { return now })
+
+			got, err := manager.RequireWorkspaceLaunchSpec(t.Context(), workspace)
+			require.NoError(err)
+			assert.Equal(refreshed, *got)
+			assert.Equal(1, resolver.refreshCalls)
+			assert.Equal(refreshed.Repository.Owner, workspace.RepoOwner)
+			assert.Equal(refreshed.Repository.Name, workspace.RepoName)
+			persisted, err := database.GetWorkspaceLaunchSpec(t.Context(), workspace.ID)
+			require.NoError(err)
+			require.NotNil(persisted)
+			assert.Equal(refreshed, *persisted)
+		})
+	}
+}
+
 func TestCreateFromLaunchSpecDedupesRenamedRepositoryByStableIdentity(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -350,7 +442,196 @@ func TestCreateFromLaunchSpecDedupesRenamedRepositoryByStableIdentity(t *testing
 	assert.Len(summaries, 1)
 }
 
-func TestRefreshWorkspaceLaunchSpecRejectsReusedRepositoryRoute(t *testing.T) {
+func TestProviderWorkspaceCreationKeepsDisplacedRouteOwner(t *testing.T) {
+	for _, itemType := range []string{
+		db.WorkspaceItemTypePullRequest,
+		db.WorkspaceItemTypeIssue,
+	} {
+		t.Run(itemType, func(t *testing.T) {
+			require := require.New(t)
+			database := openTestDB(t)
+			original := launchSpecForTest()
+			original.ItemType = itemType
+			if itemType == db.WorkspaceItemTypeIssue {
+				original.Pull = nil
+				original.GitHeadRef = "kenn-forge/issue-7"
+			}
+			observedAt := original.IssuedAt.Add(-time.Minute)
+			originalEntry, _, err := database.ReconcileRepositoryObservation(
+				t.Context(), db.RepoIdentity{
+					Platform: original.Repository.Provider, PlatformHost: original.Repository.PlatformHost,
+					PlatformRepoID: original.Repository.PlatformRepoID,
+					Owner:          original.Repository.Owner, Name: original.Repository.Name,
+				}, observedAt,
+			)
+			require.NoError(err)
+			require.NotNil(originalEntry)
+
+			manager := NewManager(database, t.TempDir())
+			manager.SetNow(func() time.Time { return original.IssuedAt })
+			var originalWorkspace *Workspace
+			if itemType == db.WorkspaceItemTypePullRequest {
+				originalWorkspace, err = manager.CreateFromLaunchSpec(t.Context(), original)
+			} else {
+				originalWorkspace, err = manager.CreateIssueFromLaunchSpec(
+					t.Context(), original, CreateIssueOptions{},
+				)
+			}
+			require.NoError(err)
+
+			_, _, err = database.ReconcileRepositoryObservation(
+				t.Context(), db.RepoIdentity{
+					Platform: original.Repository.Provider, PlatformHost: original.Repository.PlatformHost,
+					PlatformRepoID: original.Repository.PlatformRepoID,
+					Owner:          original.Repository.Owner, Name: "moved-away",
+				}, observedAt.Add(time.Minute),
+			)
+			require.NoError(err)
+			replacement := original
+			replacement.Repository.PlatformRepoID = "repo-replacement"
+			replacement.IssuedAt = original.IssuedAt.Add(time.Minute)
+			replacement.SourceVisibleUntil = replacement.IssuedAt.Add(WorkspaceLaunchSpecVisibilityLease)
+			replacementEntry, _, err := database.ReconcileRepositoryObservation(
+				t.Context(), db.RepoIdentity{
+					Platform: replacement.Repository.Provider, PlatformHost: replacement.Repository.PlatformHost,
+					PlatformRepoID: replacement.Repository.PlatformRepoID,
+					Owner:          replacement.Repository.Owner, Name: replacement.Repository.Name,
+				}, observedAt.Add(2*time.Minute),
+			)
+			require.NoError(err)
+			require.NotNil(replacementEntry)
+			manager.SetNow(func() time.Time { return replacement.IssuedAt })
+
+			var replacementWorkspace *Workspace
+			if itemType == db.WorkspaceItemTypePullRequest {
+				replacementWorkspace, err = manager.CreateFromLaunchSpec(t.Context(), replacement)
+			} else {
+				replacementWorkspace, err = manager.CreateIssueFromLaunchSpec(
+					t.Context(), replacement, CreateIssueOptions{},
+				)
+			}
+			require.NoError(err)
+			require.NotNil(replacementWorkspace)
+			require.Contains(originalWorkspace.WorktreePath, fmt.Sprintf("repo-%d", originalEntry.Repository.ID))
+			require.Contains(replacementWorkspace.WorktreePath, fmt.Sprintf("repo-%d", replacementEntry.Repository.ID))
+			require.NotEqual(originalWorkspace.WorktreePath, replacementWorkspace.WorktreePath)
+
+			persistedOriginal, err := database.GetWorkspace(t.Context(), originalWorkspace.ID)
+			require.NoError(err)
+			require.Equal(originalWorkspace.WorktreePath, persistedOriginal.WorktreePath)
+		})
+	}
+}
+
+func TestRequireWorkspaceLaunchSpecRefreshesCurrentRouteAfterRepositoryRename(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	original := launchSpecForTest()
+	entry, _, err := database.ReconcileRepositoryObservation(
+		t.Context(), db.RepoIdentity{
+			Platform: original.Repository.Provider, PlatformHost: original.Repository.PlatformHost,
+			PlatformRepoID: original.Repository.PlatformRepoID,
+			Owner:          original.Repository.Owner, Name: original.Repository.Name,
+		}, original.IssuedAt.Add(-time.Minute),
+	)
+	require.NoError(err)
+	require.NotNil(entry)
+
+	manager := NewManager(database, t.TempDir())
+	manager.SetNow(func() time.Time { return original.IssuedAt })
+	workspace, err := manager.CreateFromLaunchSpec(t.Context(), original)
+	require.NoError(err)
+
+	renamed := original
+	renamed.Repository.Owner = "acme-renamed"
+	renamed.Repository.Name = "widget-renamed"
+	renamed.Repository.CloneURL = "https://github.com/acme-renamed/widget-renamed.git"
+	renamed.IssuedAt = original.IssuedAt.Add(time.Minute)
+	renamed.SourceVisibleUntil = renamed.IssuedAt.Add(WorkspaceLaunchSpecVisibilityLease)
+	_, _, err = database.ReconcileRepositoryObservation(
+		t.Context(), db.RepoIdentity{
+			Platform: renamed.Repository.Provider, PlatformHost: renamed.Repository.PlatformHost,
+			PlatformRepoID: renamed.Repository.PlatformRepoID,
+			Owner:          renamed.Repository.Owner, Name: renamed.Repository.Name,
+		}, renamed.IssuedAt,
+	)
+	require.NoError(err)
+
+	workspace, err = database.GetWorkspace(t.Context(), workspace.ID)
+	require.NoError(err)
+	require.Equal(renamed.Repository.Owner, workspace.RepoOwner)
+	require.Equal(renamed.Repository.Name, workspace.RepoName)
+	manager.SetLaunchSpecResolver(&staticLaunchSpecResolver{spec: renamed})
+	manager.SetNow(func() time.Time { return renamed.IssuedAt })
+
+	resolved, err := manager.RequireWorkspaceLaunchSpec(t.Context(), workspace)
+	require.NoError(err)
+	require.Equal(renamed, *resolved)
+	persisted, err := database.GetWorkspaceLaunchSpec(t.Context(), workspace.ID)
+	require.NoError(err)
+	require.Equal(renamed, *persisted)
+}
+
+func TestProviderWorkspaceCreationAllowsCurrentRepositoryOnReusedRoute(t *testing.T) {
+	for _, itemType := range []string{
+		db.WorkspaceItemTypePullRequest,
+		db.WorkspaceItemTypeIssue,
+	} {
+		t.Run(itemType, func(t *testing.T) {
+			require := require.New(t)
+			database := openTestDB(t)
+			spec := launchSpecForTest()
+			spec.ItemType = itemType
+			if itemType == db.WorkspaceItemTypeIssue {
+				spec.Pull = nil
+				spec.GitHeadRef = "kenn-forge/issue-7"
+			}
+			observedAt := spec.IssuedAt.Add(-2 * time.Minute)
+			_, _, err := database.ReconcileRepositoryObservation(
+				t.Context(), db.RepoIdentity{
+					Platform: spec.Repository.Provider, PlatformHost: spec.Repository.PlatformHost,
+					PlatformRepoID: "displaced-repository", Owner: spec.Repository.Owner,
+					Name: spec.Repository.Name,
+				}, observedAt,
+			)
+			require.NoError(err)
+			_, _, err = database.ReconcileRepositoryObservation(
+				t.Context(), db.RepoIdentity{
+					Platform: spec.Repository.Provider, PlatformHost: spec.Repository.PlatformHost,
+					PlatformRepoID: "displaced-repository", Owner: "acme",
+					Name: "moved-away",
+				}, observedAt.Add(time.Minute),
+			)
+			require.NoError(err)
+			current, _, err := database.ReconcileRepositoryObservation(
+				t.Context(), db.RepoIdentity{
+					Platform: spec.Repository.Provider, PlatformHost: spec.Repository.PlatformHost,
+					PlatformRepoID: spec.Repository.PlatformRepoID, Owner: spec.Repository.Owner,
+					Name: spec.Repository.Name,
+				}, observedAt.Add(2*time.Minute),
+			)
+			require.NoError(err)
+			require.NotNil(current)
+
+			manager := NewManager(database, t.TempDir())
+			manager.SetNow(func() time.Time { return spec.IssuedAt })
+			var workspace *Workspace
+			if itemType == db.WorkspaceItemTypePullRequest {
+				workspace, err = manager.CreateFromLaunchSpec(t.Context(), spec)
+			} else {
+				workspace, err = manager.CreateIssueFromLaunchSpec(
+					t.Context(), spec, CreateIssueOptions{},
+				)
+			}
+
+			require.NoError(err)
+			require.NotNil(workspace)
+			require.Equal(current.Repository.ID, workspace.RepoID)
+		})
+	}
+}
+
+func TestRefreshWorkspaceLaunchSpecAcceptsVerifiedIdentityAtReusedRoute(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	database := openTestDB(t)
@@ -414,16 +695,18 @@ func TestRefreshWorkspaceLaunchSpecRejectsReusedRepositoryRoute(t *testing.T) {
 	manager.SetLaunchSpecResolver(&staticLaunchSpecResolver{spec: refreshed})
 	manager.SetNow(func() time.Time { return refreshed.IssuedAt })
 
-	_, err = manager.RefreshWorkspaceLaunchSpec(t.Context(), workspace)
-	require.ErrorContains(err, "historical occupants")
+	got, err := manager.RefreshWorkspaceLaunchSpec(t.Context(), workspace)
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal(refreshed.Repository.Name, got.Repository.Name)
 	persistedWorkspace, readErr := database.GetWorkspace(t.Context(), workspace.ID)
 	require.NoError(readErr)
 	require.NotNil(persistedWorkspace)
-	assert.Equal(current.Repository.Name, persistedWorkspace.RepoName)
+	assert.Equal(refreshed.Repository.Name, persistedWorkspace.RepoName)
 	persistedSpec, readErr := database.GetWorkspaceLaunchSpec(t.Context(), workspace.ID)
 	require.NoError(readErr)
 	require.NotNil(persistedSpec)
-	assert.Equal(current, *persistedSpec)
+	assert.Equal(refreshed, *persistedSpec)
 }
 
 func TestLaunchSpecSummaryPreservesSourceIdentity(t *testing.T) {

--- a/internal/workspace/launch_spec_test_helpers_test.go
+++ b/internal/workspace/launch_spec_test_helpers_test.go
@@ -20,10 +20,24 @@ type databaseLaunchSpecResolver struct {
 func (r databaseLaunchSpecResolver) ResolveWorkspaceLaunchSpec(
 	ctx context.Context, request providerplane.WorkspaceLaunchRequest,
 ) (db.WorkspaceLaunchSpec, error) {
-	repo, err := r.db.GetRepoByIdentity(ctx, db.RepoIdentity{
-		Platform: request.Repository.Provider, PlatformHost: request.Repository.PlatformHost,
-		Owner: request.Repository.Owner, Name: request.Repository.Name,
-	})
+	var repo *db.Repo
+	var err error
+	if strings.TrimSpace(request.PlatformRepoID) != "" {
+		entry, lookupErr := r.db.GetRepositoryByProviderID(
+			ctx, request.Repository.Provider, request.Repository.PlatformHost,
+			request.PlatformRepoID,
+		)
+		err = lookupErr
+		if entry != nil {
+			resolved := entry.Repository
+			repo = &resolved
+		}
+	} else {
+		repo, err = r.db.GetRepoByIdentity(ctx, db.RepoIdentity{
+			Platform: request.Repository.Provider, PlatformHost: request.Repository.PlatformHost,
+			Owner: request.Repository.Owner, Name: request.Repository.Name,
+		})
+	}
 	if err != nil {
 		return db.WorkspaceLaunchSpec{}, err
 	}
@@ -121,7 +135,8 @@ func (r databaseLaunchSpecResolver) RefreshWorkspaceLaunchSpec(
 			Provider: current.Repository.Provider, PlatformHost: current.Repository.PlatformHost,
 			Owner: current.Repository.Owner, Name: current.Repository.Name,
 		},
-		ItemType: current.ItemType, ItemNumber: current.ItemNumber,
+		PlatformRepoID: current.Repository.PlatformRepoID,
+		ItemType:       current.ItemType, ItemNumber: current.ItemNumber,
 		ItemKey: current.ItemKey, GitHeadRef: current.GitHeadRef,
 	})
 }

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -81,10 +81,20 @@ type Manager struct {
 	roborevRepositoryInvalidator     func()
 }
 
+// WorktreeBaseRepository identifies a tracked remote repository when resolving
+// a user-configured checkout for new git worktrees.
+type WorktreeBaseRepository struct {
+	Platform       string
+	PlatformHost   string
+	PlatformRepoID string
+	Owner          string
+	Name           string
+}
+
 // WorktreeBasePathResolver resolves a tracked remote repository to a
 // user-configured local repository that should own new git worktrees.
 type WorktreeBasePathResolver func(
-	ctx context.Context, platform, platformHost, owner, name string,
+	ctx context.Context, repo WorktreeBaseRepository,
 ) (path string, ok bool, err error)
 
 // CreateIssueOptions controls how issue-backed workspaces choose their branch.
@@ -175,12 +185,13 @@ var workspacePersistTimeout = 5 * time.Second
 var workspaceCleanupTimeout = 5 * time.Second
 
 var (
-	ErrWorkspaceNotFound          = errors.New("workspace not found")
-	ErrWorkspaceNotSynced         = errors.New("workspace merge request not synced")
-	ErrWorkspaceDuplicate         = errors.New("workspace already exists")
-	ErrWorkspaceInvalidState      = errors.New("workspace invalid state")
-	ErrWorkspaceOwnershipUnproven = errors.New("workspace worktree ownership cannot be verified")
-	errWorkspaceOwnershipMarker   = errors.New("workspace ownership marker failed")
+	ErrWorkspaceNotFound             = errors.New("workspace not found")
+	ErrWorkspaceNotSynced            = errors.New("workspace merge request not synced")
+	ErrWorkspaceDuplicate            = errors.New("workspace already exists")
+	ErrWorkspaceRepositoryUnresolved = errors.New("workspace repository identity is unresolved")
+	ErrWorkspaceInvalidState         = errors.New("workspace invalid state")
+	ErrWorkspaceOwnershipUnproven    = errors.New("workspace worktree ownership cannot be verified")
+	errWorkspaceOwnershipMarker      = errors.New("workspace ownership marker failed")
 	// ErrInvalidBranchName lets HTTP handlers map a rejected branch to a
 	// validation response with errors.Is instead of matching on the git
 	// message this error carries.
@@ -474,13 +485,10 @@ func (m *Manager) CreateFromLaunchSpec(
 	} else if existing != nil {
 		return nil, fmt.Errorf("%w: %s", ErrWorkspaceDuplicate, existing.ID)
 	}
-	if err := m.verifyRepoRouteUnoccupied(
-		ctx, spec.Repository.Provider, spec.Repository.PlatformHost,
-		spec.Repository.Owner, spec.Repository.Name,
-	); err != nil {
+	repo, err := m.repositoryForLaunchSpec(ctx, spec)
+	if err != nil {
 		return nil, err
 	}
-
 	id, err := newWorkspaceID()
 	if err != nil {
 		return nil, err
@@ -492,16 +500,20 @@ func (m *Manager) CreateFromLaunchSpec(
 		PlatformHost:    spec.Repository.PlatformHost,
 		RepoOwner:       spec.Repository.Owner,
 		RepoName:        spec.Repository.Name,
+		RepoID:          repo.ID,
 		ItemType:        db.WorkspaceItemTypePullRequest,
 		ItemNumber:      spec.ItemNumber,
 		ItemKey:         spec.ItemKey,
 		GitHeadRef:      spec.GitHeadRef,
 		MRHeadRepo:      workspaceHeadRepoFromLaunchSpec(spec),
 		WorkspaceBranch: workspaceBranchUnknown,
-		WorktreePath: filepath.Join(
-			m.worktreeDir, spec.Repository.Provider,
-			spec.Repository.PlatformHost, spec.Repository.Owner,
-			spec.Repository.Name, fmt.Sprintf("pr-%d", spec.ItemNumber),
+		WorktreePath: m.newWorkspacePath(
+			workspaceRepoRef{
+				ID: repo.ID, Platform: spec.Repository.Provider,
+				PlatformHost: spec.Repository.PlatformHost,
+				Owner:        spec.Repository.Owner, Name: spec.Repository.Name,
+			},
+			fmt.Sprintf("pr-%d", spec.ItemNumber),
 		),
 		TmuxSession:     "forge-" + id,
 		TerminalBackend: m.PreferredTerminalBackend(),
@@ -565,13 +577,10 @@ func (m *Manager) CreateIssueFromLaunchSpec(
 	} else if existing != nil {
 		return nil, fmt.Errorf("%w: %s", ErrWorkspaceDuplicate, existing.ID)
 	}
-	if err := m.verifyRepoRouteUnoccupied(
-		ctx, spec.Repository.Provider, spec.Repository.PlatformHost,
-		spec.Repository.Owner, spec.Repository.Name,
-	); err != nil {
+	repo, err := m.repositoryForLaunchSpec(ctx, spec)
+	if err != nil {
 		return nil, err
 	}
-
 	gitHeadRef := spec.GitHeadRef
 	if err := validateLocalBranchName(ctx, "", gitHeadRef); err != nil {
 		return nil, err
@@ -593,15 +602,19 @@ func (m *Manager) CreateIssueFromLaunchSpec(
 		PlatformHost:    spec.Repository.PlatformHost,
 		RepoOwner:       spec.Repository.Owner,
 		RepoName:        spec.Repository.Name,
+		RepoID:          repo.ID,
 		ItemType:        db.WorkspaceItemTypeIssue,
 		ItemNumber:      spec.ItemNumber,
 		ItemKey:         spec.ItemKey,
 		GitHeadRef:      gitHeadRef,
 		WorkspaceBranch: gitHeadRef,
-		WorktreePath: filepath.Join(
-			m.worktreeDir, spec.Repository.Provider,
-			spec.Repository.PlatformHost, spec.Repository.Owner,
-			spec.Repository.Name, fmt.Sprintf("issue-%d", spec.ItemNumber),
+		WorktreePath: m.newWorkspacePath(
+			workspaceRepoRef{
+				ID: repo.ID, Platform: spec.Repository.Provider,
+				PlatformHost: spec.Repository.PlatformHost,
+				Owner:        spec.Repository.Owner, Name: spec.Repository.Name,
+			},
+			fmt.Sprintf("issue-%d", spec.ItemNumber),
 		),
 		TmuxSession:     "forge-" + id,
 		TerminalBackend: m.PreferredTerminalBackend(),
@@ -641,11 +654,13 @@ func (m *Manager) CreateIssueFromLaunchSpec(
 	}
 
 	if !opts.ReuseExistingDirectory {
-		branchDir, ok, localBase, err := m.branchInspectionDir(
-			ctx, spec.Repository.Provider, spec.Repository.PlatformHost,
-			spec.Repository.Owner, spec.Repository.Name,
-			spec.Repository.CloneURL,
-		)
+		branchDir, ok, localBase, err := m.branchInspectionDir(ctx, workspaceRepoRef{
+			ID: repo.ID, Platform: spec.Repository.Provider,
+			PlatformHost: spec.Repository.PlatformHost,
+			ProviderID:   spec.Repository.PlatformRepoID,
+			Owner:        spec.Repository.Owner, Name: spec.Repository.Name,
+			RemoteURL: spec.Repository.CloneURL,
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -668,6 +683,36 @@ func (m *Manager) CreateIssueFromLaunchSpec(
 		return nil, fmt.Errorf("insert workspace and launch specification: %w", err)
 	}
 	return ws, nil
+}
+
+func (m *Manager) repositoryForLaunchSpec(
+	ctx context.Context, spec WorkspaceLaunchSpec,
+) (*db.Repo, error) {
+	repo, err := m.workspaceRepo(
+		ctx, spec.Repository.Provider, spec.Repository.PlatformHost,
+		spec.Repository.Owner, spec.Repository.Name,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if repo == nil {
+		if err := m.verifyRepoRouteUnoccupied(
+			ctx, spec.Repository.Provider, spec.Repository.PlatformHost,
+			spec.Repository.Owner, spec.Repository.Name,
+		); err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("%w: repository not tracked", ErrWorkspaceNotFound)
+	}
+	if strings.TrimSpace(repo.PlatformRepoID) !=
+		strings.TrimSpace(spec.Repository.PlatformRepoID) {
+		return nil, fmt.Errorf(
+			"%w: workspace repository identity changed for route: %s/%s",
+			db.ErrRepositoryRouteFenceChanged,
+			spec.Repository.Owner, spec.Repository.Name,
+		)
+	}
+	return repo, nil
 }
 
 func (m *Manager) validateExistingWorkspaceDirectory(
@@ -791,12 +836,16 @@ func (m *Manager) CreateKataTask(
 		PlatformHost:    platformHost,
 		RepoOwner:       owner,
 		RepoName:        name,
+		RepoID:          repo.ID,
 		ItemType:        db.WorkspaceItemTypeKataTask,
 		ItemKey:         itemKey,
 		GitHeadRef:      gitHeadRef,
 		WorkspaceBranch: gitHeadRef,
-		WorktreePath: filepath.Join(
-			m.worktreeDir, repo.Platform, platformHost, owner, name,
+		WorktreePath: m.newWorkspacePath(
+			workspaceRepoRef{
+				ID: repo.ID, Platform: repo.Platform, PlatformHost: platformHost,
+				Owner: owner, Name: name,
+			},
 			"kata-"+branchID,
 		),
 		TmuxSession:     "forge-" + id,
@@ -852,10 +901,11 @@ func (m *Manager) CreateAdHoc(
 
 	workspaceBranch := gitHeadRef
 	nextHashAttempt := 0
-	branchDir, ok, localBase, err := m.branchInspectionDir(
-		ctx, repo.Platform, platformHost, owner, name,
-		workspaceCloneRemoteURL(repo, platformHost, owner, name),
-	)
+	branchDir, ok, localBase, err := m.branchInspectionDir(ctx, workspaceRepoRef{
+		ID: repo.ID, Platform: repo.Platform, PlatformHost: platformHost,
+		ProviderID: repo.PlatformRepoID, Owner: owner, Name: name,
+		RemoteURL: workspaceCloneRemoteURL(repo, platformHost, owner, name),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -886,6 +936,7 @@ func (m *Manager) CreateAdHoc(
 		PlatformHost:    platformHost,
 		RepoOwner:       owner,
 		RepoName:        name,
+		RepoID:          repo.ID,
 		ItemType:        db.WorkspaceItemTypeAdHoc,
 		TmuxSession:     "forge-" + id,
 		TerminalBackend: m.PreferredTerminalBackend(),
@@ -936,10 +987,21 @@ func (m *Manager) setAdHocWorkspaceIdentity(
 	ws.GitHeadRef = identityBranch
 	ws.WorkspaceBranch = managedBranch
 	ws.ItemKey = db.AdHocWorkspaceItemKey(identityBranch)
-	ws.WorktreePath = filepath.Join(
-		m.worktreeDir,
-		ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+	ws.WorktreePath = m.newWorkspacePath(
+		workspaceRepoRef{
+			ID: ws.RepoID, Platform: ws.Platform, PlatformHost: ws.PlatformHost,
+			Owner: ws.RepoOwner, Name: ws.RepoName,
+		},
 		adHocWorktreeDirName(identityBranch),
+	)
+}
+
+func (m *Manager) newWorkspacePath(
+	repo workspaceRepoRef, itemDir string,
+) string {
+	return filepath.Join(
+		m.worktreeDir, repo.Platform, repo.PlatformHost, repo.Owner, repo.Name,
+		fmt.Sprintf("repo-%d", repo.ID), itemDir,
 	)
 }
 
@@ -1014,38 +1076,62 @@ func newWorkspaceID() (string, error) {
 	return hex.EncodeToString(idBytes), nil
 }
 
-func workspaceCloneNamespace(platform string) string {
-	platform = strings.ToLower(strings.TrimSpace(platform))
-	if platform == "" || platform == "github" {
-		return ""
-	}
-	return platform
+type workspaceRepoRef struct {
+	ID           int64
+	Platform     string
+	PlatformHost string
+	ProviderID   string
+	Owner        string
+	Name         string
+	RemoteURL    string
 }
 
 func (m *Manager) branchInspectionDir(
-	ctx context.Context, platform, platformHost, owner, name, remoteURL string,
+	ctx context.Context, repo workspaceRepoRef,
 ) (dir string, ok bool, localBase bool, err error) {
-	if baseDir, ok, err := m.localWorktreeBaseDir(ctx, platform, platformHost, owner, name); err != nil || ok {
+	if baseDir, ok, err := m.localWorktreeBaseDir(ctx, repo); err != nil || ok {
 		return baseDir, ok, ok, err
 	}
 	if m.clones == nil {
 		return "", false, false, nil
 	}
 
-	if err := m.verifyRepoRouteUnoccupied(
-		ctx, platform, platformHost, owner, name,
-	); err != nil {
-		return "", false, false, err
+	var validateRoute func(context.Context) error
+	if repo.ID == 0 {
+		validateRoute = func(validationCtx context.Context) error {
+			return m.verifyRepoRouteUnoccupied(
+				validationCtx, repo.Platform, repo.PlatformHost, repo.Owner, repo.Name,
+			)
+		}
+	} else {
+		identity := db.RepoIdentity{
+			Platform: repo.Platform, PlatformHost: repo.PlatformHost,
+			Owner: repo.Owner, Name: repo.Name,
+		}
+		fence, found, fenceErr := m.db.CurrentRepositoryRouteFence(
+			ctx, identity, repo.ID,
+		)
+		if fenceErr != nil {
+			return "", false, false, fenceErr
+		}
+		if !found {
+			return "", false, false, fmt.Errorf(
+				"%w: workspace repository route changed",
+				db.ErrRepositoryRouteFenceChanged,
+			)
+		}
+		validateRoute = m.workspaceCloneRouteValidator(identity, repo.ID, fence)
 	}
-	if err := m.clones.EnsureCloneInNamespace(
-		ctx, workspaceCloneNamespace(platform), platform, platformHost,
-		owner, name, remoteURL,
+	cloneCtx := gitclone.WithRepositoryIdentity(ctx, repo.ProviderID)
+	if err := m.clones.EnsureCloneValidated(
+		cloneCtx, repo.Platform, repo.PlatformHost, repo.Owner, repo.Name, repo.RemoteURL,
+		validateRoute,
 	); err != nil {
 		return "", false, false, fmt.Errorf("ensure clone: %w", err)
 	}
 
-	cloneDir, err := m.clones.ClonePathInNamespace(
-		workspaceCloneNamespace(platform), platformHost, owner, name,
+	cloneDir, err := m.clones.ClonePathForContext(
+		cloneCtx, repo.Platform, repo.PlatformHost, repo.Owner, repo.Name,
 	)
 	if err != nil {
 		return "", false, false, err
@@ -1153,12 +1239,59 @@ type SetupOptions struct {
 	RoborevInitManagedClones bool
 }
 
-func (m *Manager) verifyWorkspaceRouteUnoccupied(
+func (m *Manager) verifyWorkspaceRepository(
 	ctx context.Context, ws *Workspace,
 ) error {
-	return m.verifyRepoRouteUnoccupied(
-		ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
-	)
+	return m.verifyWorkspaceRepositoryCurrent(ctx, ws)
+}
+
+func (m *Manager) verifyWorkspaceRepositoryUnderReconciliationRead(
+	ctx context.Context, ws *Workspace,
+) error {
+	return m.verifyWorkspaceRepositoryCurrent(ctx, ws)
+}
+
+func (m *Manager) verifyWorkspaceRepositoryCurrent(
+	ctx context.Context, ws *Workspace,
+) error {
+	if ws == nil {
+		return ErrWorkspaceNotFound
+	}
+	if m.db == nil {
+		return nil
+	}
+	if ws.ID != "" {
+		current, err := m.db.GetWorkspace(ctx, ws.ID)
+		if err != nil {
+			return fmt.Errorf("reload workspace repository identity: %w", err)
+		}
+		if current == nil && ws.RepoID != 0 {
+			return ErrWorkspaceNotFound
+		}
+		if current != nil {
+			*ws = *current
+		}
+	}
+	if ws.RepoID == 0 {
+		return m.verifyRepoRouteUnoccupied(
+			ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+		)
+	}
+	repo, err := m.db.GetActiveRepoByID(ctx, ws.RepoID)
+	if err != nil {
+		return fmt.Errorf("verify workspace repository identity: %w", err)
+	}
+	if repo == nil {
+		return fmt.Errorf(
+			"%w: workspace repository identity changed for route: %s/%s",
+			db.ErrRepositoryRouteFenceChanged, ws.RepoOwner, ws.RepoName,
+		)
+	}
+	ws.Platform = repo.Platform
+	ws.PlatformHost = repo.PlatformHost
+	ws.RepoOwner = repo.Owner
+	ws.RepoName = repo.Name
+	return nil
 }
 
 // verifyRepoRouteUnoccupied fails closed on routes with contested history so
@@ -1217,10 +1350,40 @@ func (m *Manager) SetupWithOptions(
 		ctx = gitclone.WithRequiredCredential(ctx)
 	}
 	// Setup is the chokepoint for every path that fetches code — initial
-	// creation, retries, and recovery — so it re-checks the same route
-	// fail-closed condition InsertWorkspace enforced at creation time.
-	if err := m.verifyWorkspaceRouteUnoccupied(ctx, ws); err != nil {
+	// creation, retries, and recovery — so reload and verify the workspace's
+	// stable repository identity before any Git or provider access.
+	if err := m.verifyWorkspaceRepository(ctx, ws); err != nil {
 		return m.failSetup(ctx, ws.ID, workspaceSetupStageSetup, err)
+	}
+	routeIdentity := db.RepoIdentity{
+		Platform: ws.Platform, PlatformHost: ws.PlatformHost,
+		Owner: ws.RepoOwner, Name: ws.RepoName,
+	}
+	var routeFence db.RepositoryRouteFence
+	var validateCloneRoute func(context.Context) error
+	if m.db != nil && ws.RepoID != 0 {
+		var found bool
+		routeFence, found, err = m.db.CurrentRepositoryRouteFence(
+			ctx, routeIdentity, ws.RepoID,
+		)
+		if err != nil {
+			return m.failSetup(ctx, ws.ID, workspaceSetupStageSetup, err)
+		}
+		if !found {
+			return m.failSetup(
+				ctx, ws.ID, workspaceSetupStageSetup,
+				fmt.Errorf("%w: workspace repository route changed", db.ErrRepositoryRouteFenceChanged),
+			)
+		}
+		validateCloneRoute = m.workspaceCloneRouteValidator(
+			routeIdentity, ws.RepoID, routeFence,
+		)
+	} else {
+		validateCloneRoute = func(validationCtx context.Context) error {
+			return m.verifyRepoRouteUnoccupied(
+				validationCtx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+			)
+		}
 	}
 	if recoveryPending {
 		if err := m.validateExistingWorkspaceDirectory(ctx, ws); err != nil {
@@ -1228,7 +1391,9 @@ func (m *Manager) SetupWithOptions(
 		}
 	}
 
-	reuse, err := m.reuseExistingWorkspaceWorktreeDetails(ctx, ws, launchSpec)
+	reuse, err := m.reuseExistingWorkspaceWorktreeDetails(
+		ctx, ws, launchSpec, validateCloneRoute,
+	)
 	branch, reusedWorktree := reuse.branch, reuse.reused
 	var gitDir string
 	commonDir, managedClone := reuse.commonDir, reuse.managedClone
@@ -1257,7 +1422,7 @@ func (m *Manager) SetupWithOptions(
 		}
 		var refreshBeforeAdd bool
 		gitDir, refreshBeforeAdd, err = m.workspaceSetupGitDir(
-			ctx, ws, worktreeBasePath, launchSpec,
+			ctx, ws, worktreeBasePath, launchSpec, validateCloneRoute,
 		)
 		if err != nil {
 			return m.failSetup(
@@ -1267,7 +1432,9 @@ func (m *Manager) SetupWithOptions(
 		}
 
 		branch, err = m.addWorktree(
-			ctx, gitDir, refreshBeforeAdd, ws, launchSpec,
+			ctx, gitDir, refreshBeforeAdd, ws, workspaceGitFetchOptions{
+				launchSpec: launchSpec, validateRoute: validateCloneRoute,
+			},
 		)
 		if err != nil {
 			return m.failSetup(
@@ -1299,7 +1466,24 @@ func (m *Manager) SetupWithOptions(
 	// The route can be reconciled away while the clone runs (setup holds no
 	// reconciliation lock — clones can take minutes), so re-check before
 	// declaring the workspace ready.
-	if routeErr := m.verifyWorkspaceRouteUnoccupied(ctx, ws); routeErr != nil {
+	var routeErr error
+	if routeFence.RepoID != 0 {
+		currentFence, found, fenceErr := m.db.CurrentRepositoryRouteFence(
+			ctx, routeIdentity, ws.RepoID,
+		)
+		if fenceErr != nil {
+			routeErr = fenceErr
+		} else if !found || currentFence != routeFence {
+			routeErr = fmt.Errorf(
+				"%w: workspace repository route changed during setup",
+				db.ErrRepositoryRouteFenceChanged,
+			)
+		}
+	}
+	if routeErr == nil {
+		routeErr = m.verifyWorkspaceRepository(ctx, ws)
+	}
+	if routeErr != nil {
 		if !reusedWorktree {
 			m.rollbackWorktree(ctx, gitDir, ws, branch)
 		}
@@ -1438,6 +1622,9 @@ func (m *Manager) RefreshWorkspaceHeadRepoSnapshot(
 		}
 		*ws = *current
 	}
+	if ws.ID != "" && ws.RepoID == 0 {
+		return nil, ErrWorkspaceRepositoryUnresolved
+	}
 	if ws.ItemType != db.WorkspaceItemTypePullRequest {
 		return nil, nil
 	}
@@ -1445,49 +1632,26 @@ func (m *Manager) RefreshWorkspaceHeadRepoSnapshot(
 		if m.beforeHeadRepoSnapshotRepoLookup != nil {
 			m.beforeHeadRepoSnapshotRepoLookup()
 		}
-		repo, err := m.workspaceRepoUnderReconciliationRead(
-			ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
-		)
+		var repo *db.Repo
+		if ws.RepoID != 0 {
+			repo, err = m.db.GetActiveRepoByID(ctx, ws.RepoID)
+		} else {
+			repo, err = m.workspaceRepoUnderReconciliationRead(
+				ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+			)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("look up workspace repo: %w", err)
 		}
 		if repo == nil {
+			if ws.RepoID != 0 {
+				return nil, ErrWorkspaceRepositoryUnresolved
+			}
 			refreshed := WorkspaceHeadRepo(
 				ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName, "",
 			)
 			if m.afterHeadRepoSnapshotRead != nil {
 				m.afterHeadRepoSnapshotRead()
-			}
-			if ws.ID == "" {
-				ws.MRHeadRepo = refreshed
-				return &WorkspaceHeadRepoSnapshot{
-					MRHeadRepo: refreshed,
-				}, nil
-			}
-			applied, updateErr :=
-				m.db.UpdateWorkspaceMRHeadRepoForMissingRepo(
-					ctx,
-					ws.ID,
-					db.RepoIdentity{
-						Platform:     ws.Platform,
-						PlatformHost: ws.PlatformHost,
-						Owner:        ws.RepoOwner,
-						Name:         ws.RepoName,
-						RepoPath:     ws.RepoOwner + "/" + ws.RepoName,
-					},
-					refreshed,
-				)
-			if updateErr != nil {
-				return nil, fmt.Errorf(
-					"persist missing-repo head classification: %w",
-					updateErr,
-				)
-			}
-			if !applied {
-				if err := ctx.Err(); err != nil {
-					return nil, err
-				}
-				continue
 			}
 			ws.MRHeadRepo = refreshed
 			return &WorkspaceHeadRepoSnapshot{
@@ -1573,12 +1737,15 @@ type existingWorkspaceWorktreeResult struct {
 func (m *Manager) reuseExistingWorkspaceWorktree(
 	ctx context.Context, ws *Workspace, launchSpec *WorkspaceLaunchSpec,
 ) (string, bool, error) {
-	result, err := m.reuseExistingWorkspaceWorktreeDetails(ctx, ws, launchSpec)
+	result, err := m.reuseExistingWorkspaceWorktreeDetails(ctx, ws, launchSpec, nil)
 	return result.branch, result.reused, err
 }
 
 func (m *Manager) reuseExistingWorkspaceWorktreeDetails(
-	ctx context.Context, ws *Workspace, launchSpec *WorkspaceLaunchSpec,
+	ctx context.Context,
+	ws *Workspace,
+	launchSpec *WorkspaceLaunchSpec,
+	validateCloneRoute func(context.Context) error,
 ) (existingWorkspaceWorktreeResult, error) {
 	info, err := os.Lstat(ws.WorktreePath)
 	if err != nil {
@@ -1596,9 +1763,6 @@ func (m *Manager) reuseExistingWorkspaceWorktreeDetails(
 			return existingWorkspaceWorktreeResult{}, nil
 		}
 		return existingWorkspaceWorktreeResult{}, fmt.Errorf("inspect existing worktree: %w", err)
-	}
-	if !m.gitDirMatchesWorkspaceRepo(ctx, commonDir, ws) {
-		return existingWorkspaceWorktreeResult{}, nil
 	}
 	owned, err := gitDirOwnsLinkedWorktree(ctx, commonDir, ws.WorktreePath)
 	if err != nil {
@@ -1626,11 +1790,43 @@ func (m *Manager) reuseExistingWorkspaceWorktreeDetails(
 		); err != nil {
 			return err
 		}
+		var previousOriginURLs []string
+		if !localBase {
+			var originErr error
+			previousOriginURLs, originErr = gitConfigValues(
+				ctx, commonDir, "remote.origin.url",
+			)
+			if originErr != nil {
+				return fmt.Errorf("snapshot managed clone origin: %w", originErr)
+			}
+			if err := m.retargetManagedCloneOrigin(
+				ctx, commonDir, ws, launchSpec, validateCloneRoute,
+			); err != nil {
+				restoreErr := restoreGitConfigValues(
+					context.WithoutCancel(ctx), commonDir,
+					"remote.origin.url", previousOriginURLs,
+				)
+				if restoreErr != nil {
+					restoreErr = fmt.Errorf("restore managed clone origin: %w", restoreErr)
+				}
+				return errors.Join(err, restoreErr)
+			}
+		}
 		useMergeRequestHeadRef, refreshErr := m.refreshExistingWorkspaceWorktree(
-			ctx, commonDir, ws, launchSpec,
+			ctx, commonDir, ws, launchSpec, validateCloneRoute,
 		)
 		if refreshErr != nil {
-			return refreshErr
+			if localBase {
+				return refreshErr
+			}
+			restoreErr := restoreGitConfigValues(
+				context.WithoutCancel(ctx), commonDir,
+				"remote.origin.url", previousOriginURLs,
+			)
+			if restoreErr != nil {
+				restoreErr = fmt.Errorf("restore managed clone origin: %w", restoreErr)
+			}
+			return errors.Join(refreshErr, restoreErr)
 		}
 		currentBranch, branchErr := worktreeCurrentBranch(ctx, ws.WorktreePath)
 		if branchErr != nil {
@@ -1765,7 +1961,11 @@ func (m *Manager) existingWorkspaceWorktreeProvenance(
 	commonDir string,
 	ws *Workspace,
 ) (localBase bool, reusable bool, err error) {
-	if m.existingWorktreeUsesManagedClone(ctx, commonDir, ws) {
+	usesManagedClone, err := m.existingWorktreeUsesManagedClone(ctx, commonDir, ws)
+	if err != nil {
+		return false, false, err
+	}
+	if usesManagedClone {
 		return false, true, nil
 	}
 	if ws.MRHeadRepo != nil {
@@ -1788,30 +1988,186 @@ func (m *Manager) existingWorktreeUsesManagedClone(
 	ctx context.Context,
 	commonDir string,
 	ws *Workspace,
-) bool {
+) (bool, error) {
 	if m.clones == nil {
-		return false
+		return false, nil
 	}
-	cloneDir, err := m.clones.ClonePathInNamespace(
-		workspaceCloneNamespace(ws.Platform),
-		ws.PlatformHost, ws.RepoOwner, ws.RepoName,
-	)
+	candidates, err := m.workspaceManagedCloneCandidates(ctx, ws)
 	if err != nil {
-		return false
-	}
-	ready, err := gitCloneDirReady(cloneDir)
-	if err != nil || !ready {
-		return false
+		return false, err
 	}
 	actualDir, err := canonicalFilesystemPath(commonDir)
 	if err != nil {
-		return false
+		return false, nil
 	}
-	expectedDir, err := canonicalFilesystemPath(cloneDir)
+	pathMatches := false
+	for _, candidate := range candidates {
+		ready, err := gitCloneDirReady(candidate.path)
+		if err != nil || !ready {
+			continue
+		}
+		expectedDir, err := canonicalFilesystemPath(candidate.path)
+		if err == nil && actualDir == expectedDir {
+			pathMatches = true
+			break
+		}
+	}
+	if !pathMatches {
+		return false, nil
+	}
+	for _, candidate := range candidates {
+		if validateOriginRemoteURLs(
+			ctx, commonDir, candidate.platformHost,
+			candidate.owner, candidate.name,
+			m.allowsInsecureHTTP(candidate.platform, candidate.platformHost),
+		) == nil {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+type managedCloneCandidate struct {
+	path         string
+	platform     string
+	platformHost string
+	owner        string
+	name         string
+}
+
+func (m *Manager) workspaceManagedCloneCandidates(
+	ctx context.Context, ws *Workspace,
+) ([]managedCloneCandidate, error) {
+	repo, err := m.workspaceRepositoryRef(ctx, ws)
 	if err != nil {
-		return false
+		return nil, err
 	}
-	return actualDir == expectedDir && m.gitDirMatchesWorkspaceRepo(ctx, commonDir, ws)
+	cloneCtx := gitclone.WithRepositoryIdentity(ctx, repo.ProviderID)
+	candidates := make([]managedCloneCandidate, 0, 4)
+	seen := make(map[string]struct{})
+	appendCandidate := func(
+		candidateCtx context.Context,
+		platform, host, owner, name string,
+	) error {
+		path, err := m.clones.ClonePathForContext(
+			candidateCtx, platform, host, owner, name,
+		)
+		if err != nil {
+			return err
+		}
+		if _, ok := seen[path]; ok {
+			return nil
+		}
+		seen[path] = struct{}{}
+		candidates = append(candidates, managedCloneCandidate{
+			path: path, platform: platform, platformHost: host,
+			owner: owner, name: name,
+		})
+		return nil
+	}
+	if err := appendCandidate(
+		cloneCtx,
+		repo.Platform, repo.PlatformHost, repo.Owner, repo.Name,
+	); err != nil {
+		return nil, err
+	}
+	if repo.ProviderID != "" && m.db != nil {
+		entry, err := m.db.GetRepositoryByProviderID(
+			ctx, repo.Platform, repo.PlatformHost, repo.ProviderID,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("load managed clone repository routes: %w", err)
+		}
+		if entry == nil || entry.Repository.ID != repo.ID {
+			return nil, fmt.Errorf(
+				"%w: managed clone repository identity changed",
+				ErrWorkspaceNotFound,
+			)
+		}
+		for _, route := range entry.Routes {
+			if err := appendCandidate(
+				cloneCtx,
+				route.Platform, route.PlatformHost, route.Owner, route.Name,
+			); err != nil {
+				return nil, err
+			}
+			collision, err := m.db.RepositoryRouteHasOtherRepository(
+				ctx, db.RepoIdentity{
+					Platform: route.Platform, PlatformHost: route.PlatformHost,
+					Owner: route.Owner, Name: route.Name,
+				}, repo.ID,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("verify legacy managed clone route: %w", err)
+			}
+			if !collision {
+				if err := appendCandidate(
+					ctx, route.Platform, route.PlatformHost,
+					route.Owner, route.Name,
+				); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	return candidates, nil
+}
+
+// workspaceManagedClonePaths returns every route-keyed path within the stable
+// provider-identity namespace plus pre-identity paths for current or historical
+// routes that have never belonged to another repository. Existing linked
+// worktrees cannot be moved between bare repositories, so safe historical
+// locations remain valid until those workspaces are recreated.
+func (m *Manager) workspaceManagedClonePaths(
+	ctx context.Context, ws *Workspace,
+) ([]string, error) {
+	candidates, err := m.workspaceManagedCloneCandidates(ctx, ws)
+	if err != nil {
+		return nil, err
+	}
+	paths := make([]string, 0, len(candidates)+1)
+	for _, candidate := range candidates {
+		paths = append(paths, candidate.path)
+	}
+	return paths, nil
+}
+
+func (m *Manager) retargetManagedCloneOrigin(
+	ctx context.Context,
+	commonDir string,
+	ws *Workspace,
+	launchSpec *WorkspaceLaunchSpec,
+	validateCloneRoute func(context.Context) error,
+) error {
+	if validateCloneRoute != nil {
+		if err := validateCloneRoute(ctx); err != nil {
+			return err
+		}
+	}
+	remoteURL := ""
+	if launchSpec != nil {
+		remoteURL = launchSpec.Repository.CloneURL
+	} else {
+		var err error
+		remoteURL, err = m.workspaceSetupRemoteURL(
+			ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	if err := validateOriginRemoteURL(
+		remoteURL, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+		m.allowsInsecureHTTP(ws.Platform, ws.PlatformHost),
+	); err != nil {
+		return fmt.Errorf("validate managed clone origin after rename: %w", err)
+	}
+	if err := runGitWithoutHooks(
+		ctx, commonDir, "remote", "set-url", "origin", remoteURL,
+	); err != nil {
+		return fmt.Errorf("update managed clone origin after rename: %w", err)
+	}
+	return nil
 }
 
 func (m *Manager) refreshExistingWorkspaceWorktree(
@@ -1819,10 +2175,16 @@ func (m *Manager) refreshExistingWorkspaceWorktree(
 	commonDir string,
 	ws *Workspace,
 	launchSpec *WorkspaceLaunchSpec,
+	validateCloneRoute func(context.Context) error,
 ) (bool, error) {
-	if err := m.fetchWorkspaceBase(
-		ctx, commonDir, ws.Platform, ws.PlatformHost,
-		ws.RepoOwner, ws.RepoName, false,
+	if err := runRouteValidatedFetch(
+		ctx, commonDir, validateCloneRoute,
+		func() error {
+			return m.fetchWorkspaceBase(
+				ctx, commonDir, ws.Platform, ws.PlatformHost,
+				ws.RepoOwner, ws.RepoName, false,
+			)
+		},
 	); err != nil {
 		return false, err
 	}
@@ -1832,11 +2194,17 @@ func (m *Manager) refreshExistingWorkspaceWorktree(
 	if ws.ItemType != db.WorkspaceItemTypePullRequest {
 		return false, nil
 	}
-	if err := m.fetchWorkspaceMergeRequestHeadRef(
-		ctx, commonDir, ws, launchSpec,
-	); err != nil {
+	fetchErr := runRouteValidatedFetch(
+		ctx, commonDir, validateCloneRoute,
+		func() error {
+			return m.fetchWorkspaceMergeRequestHeadRef(
+				ctx, commonDir, ws, launchSpec,
+			)
+		},
+	)
+	if fetchErr != nil {
 		if ws.MRHeadRepo != nil {
-			return false, err
+			return false, fetchErr
 		}
 		return false, nil
 	}
@@ -1848,9 +2216,11 @@ func (m *Manager) workspaceWorktreeUsesLocalBase(
 	commonDir string,
 	ws *Workspace,
 ) (bool, error) {
-	baseDir, ok, err := m.localWorktreeBaseDir(
-		ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
-	)
+	repo, err := m.workspaceRepositoryRef(ctx, ws)
+	if err != nil {
+		return false, err
+	}
+	baseDir, ok, err := m.localWorktreeBaseDir(ctx, repo)
 	if err != nil || !ok {
 		return false, err
 	}
@@ -1962,7 +2332,15 @@ func (m *Manager) workspaceSetupGitDir(
 	ws *Workspace,
 	worktreeBasePath string,
 	launchSpec *WorkspaceLaunchSpec,
+	validateCloneRoute func(context.Context) error,
 ) (string, bool, error) {
+	repo, err := m.workspaceRepositoryRef(ctx, ws)
+	if err != nil {
+		return "", false, err
+	}
+	if launchSpec != nil {
+		repo.ProviderID = launchSpec.Repository.PlatformRepoID
+	}
 	if ws.MRHeadRepo == nil {
 		if strings.TrimSpace(worktreeBasePath) != "" {
 			baseDir, err := ValidateWorktreeBasePath(
@@ -1971,9 +2349,7 @@ func (m *Manager) workspaceSetupGitDir(
 			)
 			return baseDir, err == nil, err
 		}
-		if baseDir, ok, err := m.localWorktreeBaseDir(
-			ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
-		); err != nil || ok {
+		if baseDir, ok, err := m.localWorktreeBaseDir(ctx, repo); err != nil || ok {
 			return baseDir, ok, err
 		}
 	}
@@ -1994,21 +2370,41 @@ func (m *Manager) workspaceSetupGitDir(
 			return "", false, err
 		}
 	}
-	if err := m.clones.EnsureCloneInNamespace(
-		ctx, workspaceCloneNamespace(ws.Platform), ws.Platform, ws.PlatformHost,
-		ws.RepoOwner, ws.RepoName, remoteURL,
+	cloneCtx := gitclone.WithRepositoryIdentity(ctx, repo.ProviderID)
+	if err := m.clones.EnsureCloneValidated(
+		cloneCtx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName, remoteURL,
+		validateCloneRoute,
 	); err != nil {
 		return "", false, err
 	}
 
-	cloneDir, err := m.clones.ClonePathInNamespace(
-		workspaceCloneNamespace(ws.Platform),
-		ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+	cloneDir, err := m.clones.ClonePathForContext(
+		cloneCtx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
 	)
 	if err != nil {
 		return "", false, err
 	}
 	return cloneDir, false, nil
+}
+
+func (m *Manager) workspaceCloneRouteValidator(
+	identity db.RepoIdentity,
+	repoID int64,
+	fence db.RepositoryRouteFence,
+) func(context.Context) error {
+	return func(ctx context.Context) error {
+		current, found, err := m.db.CurrentRepositoryRouteFence(ctx, identity, repoID)
+		if err != nil {
+			return err
+		}
+		if !found || current != fence {
+			return fmt.Errorf(
+				"%w: workspace repository route changed during clone",
+				db.ErrRepositoryRouteFenceChanged,
+			)
+		}
+		return nil
+	}
 }
 
 func (m *Manager) workspaceSetupRemoteURL(
@@ -2027,12 +2423,18 @@ func (m *Manager) workspaceSetupRemoteURL(
 }
 
 func (m *Manager) localWorktreeBaseDir(
-	ctx context.Context, platform, platformHost, owner, name string,
+	ctx context.Context, repo workspaceRepoRef,
 ) (string, bool, error) {
 	if m.worktreeBaseResolver == nil {
 		return "", false, nil
 	}
-	raw, ok, err := m.worktreeBaseResolver(ctx, platform, platformHost, owner, name)
+	raw, ok, err := m.worktreeBaseResolver(ctx, WorktreeBaseRepository{
+		Platform:       repo.Platform,
+		PlatformHost:   repo.PlatformHost,
+		PlatformRepoID: repo.ProviderID,
+		Owner:          repo.Owner,
+		Name:           repo.Name,
+	})
 	if err != nil {
 		return "", false, err
 	}
@@ -2041,13 +2443,39 @@ func (m *Manager) localWorktreeBaseDir(
 		return "", false, nil
 	}
 	abs, err := ValidateWorktreeBasePath(
-		ctx, raw, platformHost, owner, name,
-		m.allowsInsecureHTTP(platform, platformHost),
+		ctx, raw, repo.PlatformHost, repo.Owner, repo.Name,
+		m.allowsInsecureHTTP(repo.Platform, repo.PlatformHost),
 	)
 	if err != nil {
 		return "", false, err
 	}
 	return abs, true, nil
+}
+
+func (m *Manager) workspaceRepositoryRef(
+	ctx context.Context, ws *Workspace,
+) (workspaceRepoRef, error) {
+	repoRef := workspaceRepoRef{
+		ID:           ws.RepoID,
+		Platform:     ws.Platform,
+		PlatformHost: ws.PlatformHost,
+		Owner:        ws.RepoOwner,
+		Name:         ws.RepoName,
+	}
+	if ws.RepoID == 0 {
+		return repoRef, nil
+	}
+	repo, err := m.db.GetRepoByID(ctx, ws.RepoID)
+	if err != nil {
+		return workspaceRepoRef{}, fmt.Errorf("look up workspace repository: %w", err)
+	}
+	if repo == nil {
+		return workspaceRepoRef{}, fmt.Errorf(
+			"%w: workspace repository not found", ErrWorkspaceNotFound,
+		)
+	}
+	repoRef.ProviderID = repo.PlatformRepoID
+	return repoRef, nil
 }
 
 func (m *Manager) localWorktreeBaseLockRoot(path string) string {
@@ -2341,6 +2769,26 @@ func gitConfigValues(ctx context.Context, dir, key string) ([]string, error) {
 	return values, nil
 }
 
+func restoreGitConfigValues(
+	ctx context.Context, dir, key string, before []string,
+) error {
+	current, err := gitConfigValues(ctx, dir, key)
+	if err != nil || slices.Equal(current, before) {
+		return err
+	}
+	if len(current) > 0 {
+		if err := runGitWithoutHooks(ctx, dir, "config", "--unset-all", key); err != nil {
+			return err
+		}
+	}
+	for _, value := range before {
+		if err := runGitWithoutHooks(ctx, dir, "config", "--add", key, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func localGitConfigKeys(ctx context.Context, dir string) ([]string, error) {
 	keys, err := localGitConfigKeysForScope(ctx, dir, "--local")
 	if err != nil {
@@ -2386,20 +2834,30 @@ func localGitConfigKeysForScope(
 // addWorktree creates the workspace's worktree and branch under the
 // per-repo lock. The lock prevents concurrent worktree mutations on
 // the same git repository from clobbering each other; see FileLockManager.
+type workspaceGitFetchOptions struct {
+	launchSpec    *WorkspaceLaunchSpec
+	validateRoute func(context.Context) error
+}
+
 func (m *Manager) addWorktree(
 	ctx context.Context,
 	cloneDir string,
 	refreshBeforeAdd bool,
 	ws *Workspace,
-	launchSpec *WorkspaceLaunchSpec,
+	fetchOptions workspaceGitFetchOptions,
 ) (string, error) {
 	var branch string
 	err := m.withRepoLockForGitDir(ctx, cloneDir, func() error {
 		if refreshBeforeAdd {
-			if err := m.fetchWorkspaceBase(
-				ctx, cloneDir, ws.Platform, ws.PlatformHost,
-				ws.RepoOwner, ws.RepoName,
-				workspaceUsesOriginHead(ws),
+			if err := runRouteValidatedFetch(
+				ctx, cloneDir, fetchOptions.validateRoute,
+				func() error {
+					return m.fetchWorkspaceBase(
+						ctx, cloneDir, ws.Platform, ws.PlatformHost,
+						ws.RepoOwner, ws.RepoName,
+						workspaceUsesOriginHead(ws),
+					)
+				},
 			); err != nil {
 				return err
 			}
@@ -2412,7 +2870,7 @@ func (m *Manager) addWorktree(
 		}
 		var addErr error
 		branch, addErr = m.addWorktreeLocked(
-			ctx, cloneDir, refreshBeforeAdd, ws, launchSpec,
+			ctx, cloneDir, refreshBeforeAdd, ws, fetchOptions,
 		)
 		if addErr != nil {
 			return addErr
@@ -2429,15 +2887,20 @@ func (m *Manager) addWorktreeLocked(
 	cloneDir string,
 	localBase bool,
 	ws *Workspace,
-	launchSpec *WorkspaceLaunchSpec,
+	fetchOptions workspaceGitFetchOptions,
 ) (string, error) {
 	if workspaceUsesOriginHead(ws) {
 		return m.addIssueWorktree(ctx, cloneDir, ws)
 	}
 	mergeRequestHeadRefFetched := false
 	if ws.MRHeadRepo != nil {
-		if err := m.fetchWorkspaceMergeRequestHeadRef(
-			ctx, cloneDir, ws, launchSpec,
+		if err := runRouteValidatedFetch(
+			ctx, cloneDir, fetchOptions.validateRoute,
+			func() error {
+				return m.fetchWorkspaceMergeRequestHeadRef(
+					ctx, cloneDir, ws, fetchOptions.launchSpec,
+				)
+			},
 		); err != nil {
 			return "", fmt.Errorf("fetch merge request head ref: %w", err)
 		}
@@ -2457,8 +2920,13 @@ func (m *Manager) addWorktreeLocked(
 	var fetchHeadErr error
 	useMergeRequestHeadRef := mergeRequestHeadRefFetched
 	if !useMergeRequestHeadRef {
-		fetchHeadErr = m.fetchWorkspaceMergeRequestHeadRef(
-			ctx, cloneDir, ws, launchSpec,
+		fetchHeadErr = runRouteValidatedFetch(
+			ctx, cloneDir, fetchOptions.validateRoute,
+			func() error {
+				return m.fetchWorkspaceMergeRequestHeadRef(
+					ctx, cloneDir, ws, fetchOptions.launchSpec,
+				)
+			},
 		)
 		useMergeRequestHeadRef = fetchHeadErr == nil
 	}
@@ -3415,9 +3883,22 @@ func nextWorkspaceRecoveryPath(
 func (m *Manager) workspaceCleanupGitDir(
 	ctx context.Context, ws *Workspace,
 ) (string, bool, error) {
-	if baseDir, ok, err := m.localWorktreeBaseDir(
-		ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
-	); err != nil || ok {
+	if commonDir, err := worktreeCommonGitDir(ctx, ws.WorktreePath); err == nil {
+		owned, err := workspaceRegistrationMatches(
+			ctx, commonDir, ws.WorktreePath, ws.ID,
+		)
+		if err != nil {
+			return "", false, err
+		}
+		if owned {
+			return commonDir, true, nil
+		}
+	}
+	repo, err := m.workspaceRepositoryRef(ctx, ws)
+	if err != nil {
+		return "", false, err
+	}
+	if baseDir, ok, err := m.localWorktreeBaseDir(ctx, repo); err != nil || ok {
 		if err != nil {
 			baseDir, ok = "", false
 		}
@@ -3438,18 +3919,18 @@ func (m *Manager) workspaceCleanupGitDir(
 	}
 
 	if m.clones != nil {
-		cloneDir, err := m.clones.ClonePathInNamespace(
-			workspaceCloneNamespace(ws.Platform),
-			ws.PlatformHost, ws.RepoOwner, ws.RepoName,
-		)
+		cloneDirs, err := m.workspaceManagedClonePaths(ctx, ws)
 		if err != nil {
 			return "", false, err
 		}
-		ready, err := gitCloneDirReady(cloneDir)
-		if err != nil {
-			return "", false, err
-		}
-		if ready {
+		for _, cloneDir := range cloneDirs {
+			ready, err := gitCloneDirReady(cloneDir)
+			if err != nil {
+				return "", false, err
+			}
+			if !ready {
+				continue
+			}
 			owned, err := gitDirOwnsCleanupWorktree(
 				ctx, cloneDir, ws.WorktreePath, ws.ID,
 			)
@@ -3468,9 +3949,11 @@ func (m *Manager) workspaceCleanupGitDir(
 func (m *Manager) workspaceRegisteredCleanupGitDir(
 	ctx context.Context, ws *Workspace,
 ) (string, bool, error) {
-	if baseDir, ok, err := m.localWorktreeBaseDir(
-		ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
-	); err == nil && ok {
+	repo, err := m.workspaceRepositoryRef(ctx, ws)
+	if err != nil {
+		return "", false, err
+	}
+	if baseDir, ok, err := m.localWorktreeBaseDir(ctx, repo); err == nil && ok {
 		stale, err := gitDirHasStaleWorktreeRegistration(
 			ctx, baseDir, ws.WorktreePath,
 		)
@@ -3485,24 +3968,29 @@ func (m *Manager) workspaceRegisteredCleanupGitDir(
 	if m.clones == nil {
 		return "", false, nil
 	}
-	cloneDir, err := m.clones.ClonePathInNamespace(
-		workspaceCloneNamespace(ws.Platform),
-		ws.PlatformHost, ws.RepoOwner, ws.RepoName,
-	)
+	cloneDirs, err := m.workspaceManagedClonePaths(ctx, ws)
 	if err != nil {
 		return "", false, err
 	}
-	ready, err := gitCloneDirReady(cloneDir)
-	if err != nil || !ready {
-		return "", false, err
+	for _, cloneDir := range cloneDirs {
+		ready, err := gitCloneDirReady(cloneDir)
+		if err != nil {
+			return "", false, err
+		}
+		if !ready {
+			continue
+		}
+		stale, err := gitDirHasStaleWorktreeRegistration(
+			ctx, cloneDir, ws.WorktreePath,
+		)
+		if err != nil {
+			return "", false, err
+		}
+		if stale {
+			return cloneDir, true, nil
+		}
 	}
-	stale, err := gitDirHasStaleWorktreeRegistration(
-		ctx, cloneDir, ws.WorktreePath,
-	)
-	if err != nil {
-		return "", false, err
-	}
-	return cloneDir, stale, nil
+	return "", false, nil
 }
 
 // removeStaleWorktreeRegistrationMetadata clears only the linked-worktree
@@ -3849,15 +4337,6 @@ func pathContains(parent, child string) bool {
 	return rel == "." ||
 		(rel != ".." &&
 			!strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
-}
-
-func (m *Manager) gitDirMatchesWorkspaceRepo(
-	ctx context.Context, dir string, ws *Workspace,
-) bool {
-	return validateOriginRemoteURLs(
-		ctx, dir, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
-		m.allowsInsecureHTTP(ws.Platform, ws.PlatformHost),
-	) == nil
 }
 
 func (m *Manager) cleanupTmuxSession(
@@ -5157,6 +5636,105 @@ func gitCombinedOutput(
 	return string(out), nil
 }
 
+type gitRefState struct {
+	objectName string
+	symref     string
+}
+
+func snapshotGitRefs(ctx context.Context, dir string) (map[string]gitRefState, error) {
+	out, err := gitCombinedOutput(
+		ctx, dir, "for-each-ref", "--format=%(refname)%09%(objectname)%09%(symref)",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot git refs: %w", err)
+	}
+	refs := make(map[string]gitRefState)
+	for line := range strings.SplitSeq(strings.TrimSuffix(out, "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 3)
+		if len(parts) != 3 {
+			return nil, fmt.Errorf("snapshot git refs: malformed ref record %q", line)
+		}
+		refs[parts[0]] = gitRefState{objectName: parts[1], symref: parts[2]}
+	}
+	return refs, nil
+}
+
+func restoreGitRefs(ctx context.Context, dir string, before map[string]gitRefState) error {
+	current, err := snapshotGitRefs(ctx, dir)
+	if err != nil {
+		return err
+	}
+	var deleteRefs []string
+	for ref := range current {
+		if _, ok := before[ref]; !ok {
+			deleteRefs = append(deleteRefs, ref)
+		}
+	}
+	slices.Sort(deleteRefs)
+	slices.Reverse(deleteRefs)
+	var restoreErr error
+	for _, ref := range deleteRefs {
+		restoreErr = errors.Join(
+			restoreErr,
+			runGitWithoutHooks(ctx, dir, "update-ref", "--no-deref", "-d", ref),
+		)
+	}
+	var refs []string
+	for ref := range before {
+		refs = append(refs, ref)
+	}
+	slices.Sort(refs)
+	for _, ref := range refs {
+		state := before[ref]
+		if currentState, ok := current[ref]; ok && currentState == state {
+			continue
+		}
+		if state.symref != "" {
+			restoreErr = errors.Join(
+				restoreErr,
+				runGitWithoutHooks(ctx, dir, "symbolic-ref", ref, state.symref),
+			)
+			continue
+		}
+		restoreErr = errors.Join(
+			restoreErr,
+			runGitWithoutHooks(ctx, dir, "update-ref", "--no-deref", ref, state.objectName),
+		)
+	}
+	return restoreErr
+}
+
+func runRouteValidatedFetch(
+	ctx context.Context,
+	dir string,
+	validateRoute func(context.Context) error,
+	fetch func() error,
+) error {
+	if validateRoute == nil {
+		return fetch()
+	}
+	if err := validateRoute(ctx); err != nil {
+		return err
+	}
+	refs, err := snapshotGitRefs(ctx, dir)
+	if err != nil {
+		return err
+	}
+	fetchErr := fetch()
+	validationErr := validateRoute(ctx)
+	if fetchErr == nil && validationErr == nil {
+		return nil
+	}
+	restoreErr := restoreGitRefs(context.WithoutCancel(ctx), dir, refs)
+	if restoreErr != nil {
+		restoreErr = fmt.Errorf("restore git refs after rejected fetch: %w", restoreErr)
+	}
+	return errors.Join(fetchErr, validationErr, restoreErr)
+}
+
 func gitArgsWithoutHooks(args ...string) []string {
 	gitArgs := make([]string, 0, len(args)+2)
 	gitArgs = append(gitArgs, "-c", "core.hooksPath=/dev/null")
@@ -5310,7 +5888,7 @@ func (m *Manager) syncWorkspaceBaseBranch(
 		return fmt.Errorf("lock repository reconciliation for base branch sync: %w", err)
 	}
 	defer releaseReconciliation()
-	if err := m.verifyWorkspaceRouteUnoccupied(ctx, ws); err != nil {
+	if err := m.verifyWorkspaceRepositoryUnderReconciliationRead(ctx, ws); err != nil {
 		return err
 	}
 	repo, err := m.workspaceRepoUnderReconciliationRead(

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -43,7 +43,7 @@ func openTestDB(t *testing.T) *db.DB {
 // configured local worktree base.
 func staticBaseResolver(path string) WorktreeBasePathResolver {
 	return func(
-		context.Context, string, string, string, string,
+		context.Context, WorktreeBaseRepository,
 	) (string, bool, error) {
 		return path, true, nil
 	}
@@ -367,6 +367,473 @@ func TestCreatePRHeadRepoClassification(t *testing.T) {
 	}
 }
 
+func TestRefreshWorkspaceHeadRepo(t *testing.T) {
+	tests := []struct {
+		name        string
+		cloneURL    string
+		wantUnknown bool
+		wantFork    string
+	}{
+		{
+			name:     "current same-repo metadata",
+			cloneURL: "https://github.com/acme/widget.git",
+		},
+		{
+			name:        "missing current metadata",
+			wantUnknown: true,
+		},
+		{
+			name:     "current fork metadata",
+			cloneURL: "https://github.com/contributor/widget.git",
+			wantFork: "https://github.com/contributor/widget.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			d := openTestDB(t)
+			repoID := seedRepo(t, d, "github.com", "acme", "widget")
+			seedMRWithHeadRepo(t, d, repoID, 42, "feature/thing", tt.cloneURL)
+			ws := &Workspace{
+				Platform:     "github",
+				PlatformHost: "github.com",
+				RepoOwner:    "acme",
+				RepoName:     "widget",
+				ItemType:     db.WorkspaceItemTypePullRequest,
+				ItemNumber:   42,
+				GitHeadRef:   "feature/thing",
+			}
+			mgr := NewManager(d, t.TempDir())
+
+			err := mgr.RefreshWorkspaceHeadRepo(t.Context(), ws)
+
+			require.NoError(err)
+			switch {
+			case tt.wantUnknown:
+				require.NotNil(ws.MRHeadRepo)
+				assert.Empty(*ws.MRHeadRepo)
+			case tt.wantFork != "":
+				require.NotNil(ws.MRHeadRepo)
+				assert.Equal(tt.wantFork, *ws.MRHeadRepo)
+			default:
+				assert.Nil(ws.MRHeadRepo)
+			}
+		})
+	}
+}
+
+func TestRefreshWorkspaceHeadRepoRejectsPersistedWorkspaceWithoutRepositoryID(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	ws := &Workspace{
+		ID:           "ws-missing-repo",
+		Platform:     "github",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "missing",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   42,
+		GitHeadRef:   "feature/thing",
+		WorktreePath: t.TempDir(),
+		Status:       "ready",
+	}
+	require.NoError(d.InsertWorkspace(t.Context(), ws))
+	mgr := NewManager(d, t.TempDir())
+
+	err := mgr.RefreshWorkspaceHeadRepo(t.Context(), ws)
+
+	require.ErrorIs(err, ErrWorkspaceRepositoryUnresolved)
+	require.Nil(ws.MRHeadRepo)
+	stored, err := d.GetWorkspace(t.Context(), ws.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	require.Nil(stored.MRHeadRepo)
+}
+
+func TestRefreshWorkspaceHeadRepoFollowsStableRepositoryAfterRename(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	providerRepoID := "gid://gitlab/Project/42"
+	repoID, err := d.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "gitlab",
+		PlatformHost:   "gitlab.com",
+		PlatformRepoID: providerRepoID,
+		Owner:          "old-group",
+		Name:           "old-name",
+	})
+	require.NoError(err)
+	oldSameRepoURL := "https://gitlab.com/old-group/old-name.git"
+	seedMRWithHeadRepo(t, d, repoID, 42, "feature/thing", oldSameRepoURL)
+	ws := &Workspace{
+		ID:           "ws-renamed-repo",
+		Platform:     "gitlab",
+		PlatformHost: "gitlab.com",
+		RepoOwner:    "old-group",
+		RepoName:     "old-name",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   42,
+		GitHeadRef:   "feature/thing",
+		WorktreePath: t.TempDir(),
+		Status:       "ready",
+	}
+	require.NoError(d.InsertWorkspace(ctx, ws))
+
+	_, _, err = d.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform:       "gitlab",
+		PlatformHost:   "gitlab.com",
+		PlatformRepoID: providerRepoID,
+		Owner:          "new-group",
+		Name:           "new-name",
+	}, time.Now().UTC())
+	require.NoError(err)
+
+	mgr := NewManager(d, t.TempDir())
+	require.NoError(mgr.RefreshWorkspaceHeadRepo(ctx, ws))
+
+	assert.Equal("new-group", ws.RepoOwner)
+	assert.Equal("new-name", ws.RepoName)
+	require.NotNil(ws.MRHeadRepo)
+	assert.Equal(oldSameRepoURL, *ws.MRHeadRepo)
+	stored, err := d.GetWorkspace(ctx, ws.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal("new-group", stored.RepoOwner)
+	assert.Equal("new-name", stored.RepoName)
+	require.NotNil(stored.MRHeadRepo)
+	assert.Equal(oldSameRepoURL, *stored.MRHeadRepo)
+}
+
+func TestRefreshWorkspaceHeadRepoRejectsReplacementAtInactiveRepositoryRoute(
+	t *testing.T,
+) {
+	require := require.New(t)
+	database := openTestDB(t)
+	observedAt := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	original, _, err := database.ReconcileRepositoryObservation(
+		t.Context(), db.RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: "repo-original", Owner: "acme", Name: "widget",
+		}, observedAt,
+	)
+	require.NoError(err)
+	require.NotNil(original)
+	seedMRWithHeadRepo(
+		t, database, original.Repository.ID, 42, "feature/original",
+		"https://github.com/acme/widget.git",
+	)
+	workspace := &Workspace{
+		ID: "ws-inactive-repository", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget",
+		ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 42,
+		GitHeadRef: "feature/original", WorktreePath: t.TempDir(), Status: "ready",
+	}
+	require.NoError(database.InsertWorkspace(t.Context(), workspace))
+	require.Equal(original.Repository.ID, workspace.RepoID)
+	_, err = database.DeactivateRepositoryObservation(
+		t.Context(), "github", "github.com", "repo-original",
+		observedAt.Add(time.Minute),
+	)
+	require.NoError(err)
+	replacement, _, err := database.ReconcileRepositoryObservation(
+		t.Context(), db.RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: "repo-replacement", Owner: "acme", Name: "widget",
+		}, observedAt.Add(2*time.Minute),
+	)
+	require.NoError(err)
+	require.NotNil(replacement)
+	seedMRWithHeadRepo(
+		t, database, replacement.Repository.ID, 42, "feature/replacement",
+		"https://github.com/contributor/widget.git",
+	)
+
+	manager := NewManager(database, t.TempDir())
+	err = manager.RefreshWorkspaceHeadRepo(t.Context(), workspace)
+
+	require.ErrorIs(err, ErrWorkspaceRepositoryUnresolved)
+	stored, err := database.GetWorkspace(t.Context(), workspace.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	require.Nil(stored.MRHeadRepo)
+}
+
+func TestRefreshWorkspaceHeadRepoBlocksRepositoryReconciliation(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	providerRepoID := "gid://gitlab/Project/42"
+	sourceID, err := d.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "gitlab",
+		PlatformHost:   "gitlab.com",
+		PlatformRepoID: providerRepoID,
+		Owner:          "old-group",
+		Name:           "old-name",
+	})
+	require.NoError(err)
+	forkURL := "https://gitlab.com/contributor/widget.git"
+	seedMRWithHeadRepo(t, d, sourceID, 42, "feature/thing", forkURL)
+	_, err = d.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:     "gitlab",
+		PlatformHost: "gitlab.com",
+		Owner:        "new-group",
+		Name:         "new-name",
+	})
+	require.NoError(err)
+	ws := &Workspace{
+		ID:           "ws-reconciliation-barrier",
+		Platform:     "gitlab",
+		PlatformHost: "gitlab.com",
+		RepoOwner:    "old-group",
+		RepoName:     "old-name",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   42,
+		GitHeadRef:   "feature/thing",
+		WorktreePath: t.TempDir(),
+		Status:       "ready",
+	}
+	require.NoError(d.InsertWorkspace(ctx, ws))
+
+	snapshotRead := make(chan struct{})
+	continueRefresh := make(chan struct{})
+	var signalSnapshot sync.Once
+	mgr := NewManager(d, t.TempDir())
+	mgr.afterHeadRepoSnapshotRead = func() {
+		signalSnapshot.Do(func() { close(snapshotRead) })
+		<-continueRefresh
+	}
+	refreshDone := make(chan error, 1)
+	go func() {
+		refreshDone <- mgr.RefreshWorkspaceHeadRepo(ctx, ws)
+	}()
+	select {
+	case <-snapshotRead:
+	case <-time.After(5 * time.Second):
+		require.Fail("head-repository refresh did not reach snapshot read")
+	}
+
+	writeLockAttempted := make(chan struct{})
+	restoreWriteLockHook := d.SetBeforeRepositoryReconciliationWriteLockForTest(
+		func() { close(writeLockAttempted) },
+	)
+	defer restoreWriteLockHook()
+	reconciliationDone := make(chan error, 1)
+	go func() {
+		_, _, reconcileErr := d.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+			Platform:       "gitlab",
+			PlatformHost:   "gitlab.com",
+			PlatformRepoID: providerRepoID,
+			Owner:          "new-group",
+			Name:           "new-name",
+		}, time.Now().UTC())
+		reconciliationDone <- reconcileErr
+	}()
+	select {
+	case <-writeLockAttempted:
+	case <-time.After(5 * time.Second):
+		require.Fail("repository reconciliation did not attempt its write lock")
+	}
+	select {
+	case upsertErr := <-reconciliationDone:
+		require.NoError(upsertErr)
+		require.Fail("repository reconciliation bypassed the active refresh barrier")
+	default:
+	}
+
+	close(continueRefresh)
+	select {
+	case refreshErr := <-refreshDone:
+		require.NoError(refreshErr)
+	case <-time.After(5 * time.Second):
+		require.Fail("head-repository refresh did not finish")
+	}
+	select {
+	case upsertErr := <-reconciliationDone:
+		require.NoError(upsertErr)
+	case <-time.After(5 * time.Second):
+		require.Fail("repository reconciliation did not resume")
+	}
+
+	stored, err := d.GetWorkspace(ctx, ws.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal("new-group", stored.RepoOwner)
+	assert.Equal("new-name", stored.RepoName)
+	require.NotNil(stored.MRHeadRepo)
+	assert.Equal(forkURL, *stored.MRHeadRepo)
+}
+
+func TestRefreshWorkspaceHeadRepoRejectsLegacyWorkspaceWhenRouteAppearsLater(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	ws := &Workspace{
+		ID:           "ws-repo-appears",
+		Platform:     "github",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   42,
+		GitHeadRef:   "feature/thing",
+		WorktreePath: t.TempDir(),
+		Status:       "ready",
+	}
+	require.NoError(d.InsertWorkspace(t.Context(), ws))
+	mgr := NewManager(d, t.TempDir())
+	forkURL := "https://github.com/contributor/widget.git"
+
+	require.ErrorIs(
+		mgr.RefreshWorkspaceHeadRepo(t.Context(), ws),
+		ErrWorkspaceRepositoryUnresolved,
+	)
+
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMRWithHeadRepo(
+		t, d, repoID, ws.ItemNumber, ws.GitHeadRef, forkURL,
+	)
+
+	err := mgr.RefreshWorkspaceHeadRepo(t.Context(), ws)
+
+	require.ErrorIs(err, ErrWorkspaceRepositoryUnresolved)
+	require.Nil(ws.MRHeadRepo)
+	stored, err := d.GetWorkspace(t.Context(), ws.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	require.Nil(stored.MRHeadRepo)
+}
+
+func TestRefreshWorkspaceHeadRepoSnapshotRetriesAfterRevisionChange(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMRWithHeadRepo(
+		t,
+		d,
+		repoID,
+		42,
+		"feature/thing",
+		"https://github.com/acme/widget.git",
+	)
+	ws := &Workspace{
+		ID:           "ws-refresh-head-repo-race",
+		Platform:     "github",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   42,
+		GitHeadRef:   "feature/thing",
+		WorktreePath: t.TempDir(),
+		Status:       "ready",
+	}
+	require.NoError(d.InsertWorkspace(t.Context(), ws))
+
+	mgr := NewManager(d, t.TempDir())
+	var advanced bool
+	mgr.afterHeadRepoSnapshotRead = func() {
+		if advanced {
+			return
+		}
+		advanced = true
+		current, err := d.GetMergeRequestByRepoIDAndNumber(
+			t.Context(), repoID, ws.ItemNumber,
+		)
+		require.NoError(err)
+		require.NotNil(current)
+		updated := *current
+		updated.HeadRepoCloneURL = "https://github.com/forker/widget.git"
+		updated.UpdatedAt = updated.UpdatedAt.Add(time.Minute)
+		updated.LastActivityAt = updated.UpdatedAt
+		_, accepted, err := d.UpsertMergeRequestSnapshot(t.Context(), &updated)
+		require.NoError(err)
+		require.True(accepted)
+	}
+
+	snapshot, err := mgr.RefreshWorkspaceHeadRepoSnapshot(t.Context(), ws)
+
+	require.NoError(err)
+	require.NotNil(snapshot)
+	require.NotNil(snapshot.MRHeadRepo)
+	assert.Equal("https://github.com/forker/widget.git", *snapshot.MRHeadRepo)
+	latest, err := d.GetMergeRequestByRepoIDAndNumber(
+		t.Context(), repoID, ws.ItemNumber,
+	)
+	require.NoError(err)
+	require.NotNil(latest)
+	assert.Equal(latest.SnapshotRevision, snapshot.SnapshotRevision)
+	stored, err := d.GetWorkspace(t.Context(), ws.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	require.NotNil(stored.MRHeadRepo)
+	assert.Equal("https://github.com/forker/widget.git", *stored.MRHeadRepo)
+}
+
+func TestRefreshWorkspaceHeadRepoSnapshotRetriesAfterRemoval(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMRWithHeadRepo(
+		t,
+		d,
+		repoID,
+		42,
+		"feature/thing",
+		"https://github.com/acme/widget.git",
+	)
+	ws := &Workspace{
+		ID:           "ws-refresh-head-repo-removal-race",
+		Platform:     "github",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   42,
+		GitHeadRef:   "feature/thing",
+		WorktreePath: t.TempDir(),
+		Status:       "ready",
+	}
+	require.NoError(d.InsertWorkspace(ctx, ws))
+
+	mgr := NewManager(d, t.TempDir())
+	var removed bool
+	mgr.afterHeadRepoSnapshotRead = func() {
+		if removed {
+			return
+		}
+		removed = true
+		now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+		_, err := d.WriteDB().ExecContext(ctx, `
+			INSERT INTO forge_archive_items (
+				repo_id, item_type, item_number, provider_item_id,
+				provider_created_at, provider_updated_at, lifecycle_state
+			) VALUES (?, 'merge_request', 42, 'pull-42', ?, ?, 'removed_upstream')`,
+			repoID, now, now,
+		)
+		require.NoError(err)
+	}
+
+	snapshot, err := mgr.RefreshWorkspaceHeadRepoSnapshot(ctx, ws)
+
+	require.NoError(err)
+	require.NotNil(snapshot)
+	require.NotNil(snapshot.MRHeadRepo)
+	assert.Empty(*snapshot.MRHeadRepo)
+	stored, err := d.GetWorkspace(ctx, ws.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	require.NotNil(stored.MRHeadRepo)
+	assert.Empty(*stored.MRHeadRepo)
+}
+
 func TestCreateIssueDefaultBranchSluggified(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -497,7 +964,7 @@ func TestCreateKataTaskNormalizesRelativeWorktreeDir(t *testing.T) {
 
 	d := openTestDB(t)
 	ctx := t.Context()
-	seedRepo(t, d, "github.com", "acme", "widget")
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
 
 	mgr := newTestManager(t, d, "relative-worktrees")
 	metadata := db.WorkspaceKataMetadata{
@@ -515,7 +982,8 @@ func TestCreateKataTaskNormalizesRelativeWorktreeDir(t *testing.T) {
 	assert.Equal(
 		filepath.Join(
 			cwd, "relative-worktrees", "github", "github.com",
-			"acme", "widget", "kata-"+kataTaskBranchID(metadata),
+			"acme", "widget", fmt.Sprintf("repo-%d", repoID),
+			"kata-"+kataTaskBranchID(metadata),
 		),
 		ws.WorktreePath,
 	)
@@ -606,7 +1074,8 @@ func TestCreateIssueRecoversExpectedExistingDirectory(t *testing.T) {
 
 	const branch = "kenn-forge/issue-7"
 	expectedPath := filepath.Join(
-		worktreeRoot, "github", platformHost, "acme", "widget", "issue-7",
+		worktreeRoot, "github", platformHost, "acme", "widget",
+		fmt.Sprintf("repo-%d", repoID), "issue-7",
 	)
 	runWorkspaceTestGit(
 		t, localRepo,
@@ -672,7 +1141,8 @@ func TestIssueWorkspaceBranchDoesNotCollideWithRecoveryState(t *testing.T) {
 
 			const branch = "__kenn_forge_recovery_pending__"
 			expectedPath := filepath.Join(
-				worktreeRoot, "github", platformHost, "acme", "widget", "issue-7",
+				worktreeRoot, "github", platformHost, "acme", "widget",
+				fmt.Sprintf("repo-%d", repoID), "issue-7",
 			)
 			if recoverExisting {
 				runWorkspaceTestGit(
@@ -777,7 +1247,8 @@ func TestCreateIssueRecoveryRejectsInvalidExpectedDirectory(t *testing.T) {
 			seedIssue(t, d, repoID, 7, "")
 			const branch = "kenn-forge/issue-7"
 			expectedPath := filepath.Join(
-				worktreeRoot, "github", platformHost, "acme", "widget", "issue-7",
+				worktreeRoot, "github", platformHost, "acme", "widget",
+				fmt.Sprintf("repo-%d", repoID), "issue-7",
 			)
 			tt.prepare(t, localRepo, expectedPath, branch)
 
@@ -822,7 +1293,10 @@ func TestCreateIssueRecoveryRejectsManagedCloneWithWrongOrigin(t *testing.T) {
 	seedIssue(t, d, repoID, 7, "")
 
 	clones := gitclone.New(t.TempDir(), nil)
-	cloneDir, err := clones.ClonePath("github", host, owner, name)
+	cloneDir, err := clones.ClonePathForContext(
+		gitclone.WithRepositoryIdentity(t.Context(), "repo-acme-widget"),
+		"github", host, owner, name,
+	)
 	require.NoError(err)
 	seedWorkspaceBareCloneAt(t, cloneDir)
 	runWorkspaceTestGit(
@@ -830,7 +1304,8 @@ func TestCreateIssueRecoveryRejectsManagedCloneWithWrongOrigin(t *testing.T) {
 		"https://github.com/other/repository.git",
 	)
 	expectedPath := filepath.Join(
-		worktreeRoot, "github", host, owner, name, "issue-7",
+		worktreeRoot, "github", host, owner, name,
+		fmt.Sprintf("repo-%d", repoID), "issue-7",
 	)
 	runWorkspaceTestGit(
 		t, cloneDir,
@@ -869,34 +1344,31 @@ func TestSetupRecoveryRejectsManagedCloneWhoseOriginChanged(t *testing.T) {
 	repoID := seedRepo(t, d, host, owner, name)
 	seedIssue(t, d, repoID, 7, "")
 
+	mgr := newTestManager(t, d, worktreeRoot)
+	ws, err := mgr.CreateIssue(
+		t.Context(), host, owner, name, 7,
+		CreateIssueOptions{Provider: "github", GitHeadRef: branch},
+	)
+	require.NoError(err)
+	require.NotNil(ws)
+
 	clones := gitclone.New(t.TempDir(), nil)
-	cloneDir, err := clones.ClonePath("github", host, owner, name)
+	cloneDir, err := clones.ClonePathForContext(
+		gitclone.WithRepositoryIdentity(t.Context(), "repo-acme-widget"),
+		"github", host, owner, name,
+	)
 	require.NoError(err)
 	seedWorkspaceBareCloneAt(t, cloneDir)
 	runWorkspaceTestGit(
 		t, cloneDir, "remote", "set-url", "origin",
 		"https://github.com/acme/widget.git",
 	)
-	expectedPath := filepath.Join(
-		worktreeRoot, "github", host, owner, name, "issue-7",
-	)
 	runWorkspaceTestGit(
 		t, cloneDir,
-		"worktree", "add", expectedPath, "-b", branch, "HEAD",
+		"worktree", "add", ws.WorktreePath, "-b", branch, "HEAD",
 	)
 
-	mgr := newTestManager(t, d, worktreeRoot)
 	mgr.SetClones(clones)
-	ws, err := mgr.CreateIssue(
-		t.Context(), host, owner, name, 7,
-		CreateIssueOptions{
-			Provider:               "github",
-			GitHeadRef:             branch,
-			ReuseExistingDirectory: true,
-		},
-	)
-	require.NoError(err)
-	require.NotNil(ws)
 	runWorkspaceTestGit(
 		t, cloneDir, "remote", "set-url", "origin",
 		"https://github.com/other/repository.git",
@@ -913,6 +1385,272 @@ func TestSetupRecoveryRejectsManagedCloneWhoseOriginChanged(t *testing.T) {
 	assert.Equal("error", stored.Status)
 }
 
+func TestSetupReusesPreIdentityManagedCloneAfterRepositoryBackfill(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	worktreeRoot := t.TempDir()
+	_, _, platformHost := setupHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/seven",
+	)
+	remoteURL := "http://" + platformHost + "/acme/widget.git"
+	repoID := seedRepo(t, database, platformHost, "acme", "widget")
+	require.NoError(database.UpdateRepoProviderMetadata(
+		t.Context(), repoID, db.RepoProviderMetadata{
+			CloneURL: remoteURL, DefaultBranch: "main",
+		},
+	))
+
+	spec := launchSpecForTest()
+	spec.Repository.PlatformHost = platformHost
+	spec.Repository.PlatformRepoID = "repo-acme-widget"
+	spec.Repository.CloneURL = remoteURL
+	manager := NewManager(database, worktreeRoot)
+	manager.SetNow(func() time.Time { return spec.IssuedAt })
+	workspace, err := manager.CreateFromLaunchSpec(t.Context(), spec)
+	require.NoError(err)
+
+	clones := gitclone.New(t.TempDir(), nil)
+	require.NoError(clones.EnsureClone(
+		t.Context(), "github", platformHost, "acme", "widget", remoteURL,
+	))
+	legacyClone, err := clones.ClonePath("github", platformHost, "acme", "widget")
+	require.NoError(err)
+	runWorkspaceTestGit(
+		t, legacyClone, "worktree", "add", "-b", syntheticPRWorktreeBranch(spec.ItemNumber),
+		workspace.WorktreePath, "refs/remotes/origin/"+spec.GitHeadRef,
+	)
+	manager.SetClones(clones)
+
+	err = manager.Setup(t.Context(), workspace)
+
+	require.NoError(err)
+	persisted, err := database.GetWorkspace(t.Context(), workspace.ID)
+	require.NoError(err)
+	require.NotNil(persisted)
+	require.Equal("ready", persisted.Status)
+	commonDir, err := worktreeCommonGitDir(t.Context(), workspace.WorktreePath)
+	require.NoError(err)
+	canonicalLegacyClone, err := canonicalFilesystemPath(legacyClone)
+	require.NoError(err)
+	require.Equal(canonicalLegacyClone, commonDir)
+}
+
+func TestSetupReusesIdentityManagedCloneAfterRepositoryRename(t *testing.T) {
+	testSetupReusesManagedCloneAfterRepositoryRename(t, true)
+}
+
+func TestSetupReusesPreIdentityManagedCloneAfterRepositoryRename(t *testing.T) {
+	testSetupReusesManagedCloneAfterRepositoryRename(t, false)
+}
+
+func testSetupReusesManagedCloneAfterRepositoryRename(
+	t *testing.T, identityScoped bool,
+) {
+	require := require.New(t)
+	database := openTestDB(t)
+	worktreeRoot := t.TempDir()
+	_, remote, platformHost := setupHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/seven",
+	)
+	renamedRemote := filepath.Join(filepath.Dir(remote), "renamed.git")
+	require.NoError(os.Symlink(remote, renamedRemote))
+	twiceRenamedRemote := filepath.Join(filepath.Dir(remote), "twice-renamed.git")
+	require.NoError(os.Symlink(remote, twiceRenamedRemote))
+	oldRemoteURL := "http://" + platformHost + "/acme/widget.git"
+	newRemoteURL := "http://" + platformHost + "/acme/renamed.git"
+	twiceRenamedRemoteURL := "http://" + platformHost + "/acme/twice-renamed.git"
+	repoID := seedRepo(t, database, platformHost, "acme", "widget")
+	require.NoError(database.UpdateRepoProviderMetadata(
+		t.Context(), repoID, db.RepoProviderMetadata{
+			CloneURL: oldRemoteURL, DefaultBranch: "main",
+		},
+	))
+
+	spec := launchSpecForTest()
+	spec.Repository.PlatformHost = platformHost
+	spec.Repository.PlatformRepoID = "repo-acme-widget"
+	spec.Repository.CloneURL = oldRemoteURL
+	manager := NewManager(database, worktreeRoot)
+	manager.SetTmuxCommand([]string{"/usr/bin/true"})
+	manager.SetNow(func() time.Time { return spec.IssuedAt })
+	workspace, err := manager.CreateFromLaunchSpec(t.Context(), spec)
+	require.NoError(err)
+
+	clones := gitclone.New(t.TempDir(), nil)
+	cloneCtx := t.Context()
+	if identityScoped {
+		cloneCtx = gitclone.WithRepositoryIdentity(
+			cloneCtx, spec.Repository.PlatformRepoID,
+		)
+	}
+	require.NoError(clones.EnsureClone(
+		cloneCtx, "github", platformHost, "acme", "widget", oldRemoteURL,
+	))
+	oldClone, err := clones.ClonePathForContext(
+		cloneCtx, "github", platformHost, "acme", "widget",
+	)
+	require.NoError(err)
+	runWorkspaceTestGit(
+		t, oldClone, "worktree", "add", "-b", syntheticPRWorktreeBranch(spec.ItemNumber),
+		workspace.WorktreePath, "refs/remotes/origin/"+spec.GitHeadRef,
+	)
+	manager.SetClones(clones)
+
+	_, _, err = database.ReconcileRepositoryObservation(
+		t.Context(), db.RepoIdentity{
+			Platform: "github", PlatformHost: platformHost,
+			PlatformRepoID: spec.Repository.PlatformRepoID,
+			Owner:          "acme", Name: "renamed",
+		}, time.Now().UTC().Add(time.Hour),
+	)
+	require.NoError(err)
+	require.NoError(database.UpdateRepoProviderMetadata(
+		t.Context(), repoID, db.RepoProviderMetadata{
+			CloneURL: newRemoteURL, DefaultBranch: "main",
+		},
+	))
+	renamedSpec := spec
+	renamedSpec.Repository.Name = "renamed"
+	renamedSpec.Repository.CloneURL = newRemoteURL
+	renamedSpec.IssuedAt = spec.IssuedAt.Add(time.Minute)
+	renamedSpec.SourceVisibleUntil = renamedSpec.IssuedAt.Add(
+		WorkspaceLaunchSpecVisibilityLease,
+	)
+	manager.SetLaunchSpecResolver(&staticLaunchSpecResolver{spec: renamedSpec})
+	manager.SetNow(func() time.Time { return renamedSpec.IssuedAt })
+
+	err = manager.Setup(t.Context(), workspace)
+
+	require.NoError(err)
+	runWorkspaceTestGit(t, oldClone, "remote", "set-url", "origin", oldRemoteURL)
+	validationCalls := 0
+	_, err = manager.reuseExistingWorkspaceWorktreeDetails(
+		t.Context(), workspace, &renamedSpec,
+		func(context.Context) error {
+			validationCalls++
+			if validationCalls == 3 {
+				return db.ErrRepositoryRouteFenceChanged
+			}
+			return nil
+		},
+	)
+	require.ErrorIs(err, db.ErrRepositoryRouteFenceChanged)
+	originURLs, err := gitConfigValues(t.Context(), oldClone, "remote.origin.url")
+	require.NoError(err)
+	require.Equal([]string{oldRemoteURL}, originURLs,
+		"a rejected refresh must restore the historical origin")
+	require.NoError(manager.Setup(t.Context(), workspace),
+		"a retargeted historical clone must remain reusable")
+	persisted, err := database.GetWorkspace(t.Context(), workspace.ID)
+	require.NoError(err)
+	require.NotNil(persisted)
+	require.Equal("ready", persisted.Status)
+	commonDir, err := worktreeCommonGitDir(t.Context(), workspace.WorktreePath)
+	require.NoError(err)
+	canonicalOldClone, err := canonicalFilesystemPath(oldClone)
+	require.NoError(err)
+	require.Equal(canonicalOldClone, commonDir)
+	originURLs, err = gitConfigValues(t.Context(), oldClone, "remote.origin.url")
+	require.NoError(err)
+	require.Equal([]string{newRemoteURL}, originURLs)
+
+	_, _, err = database.ReconcileRepositoryObservation(
+		t.Context(), db.RepoIdentity{
+			Platform: "github", PlatformHost: platformHost,
+			PlatformRepoID: spec.Repository.PlatformRepoID,
+			Owner:          "acme", Name: "twice-renamed",
+		}, time.Now().UTC().Add(2*time.Hour),
+	)
+	require.NoError(err)
+	require.NoError(database.UpdateRepoProviderMetadata(
+		t.Context(), repoID, db.RepoProviderMetadata{
+			CloneURL: twiceRenamedRemoteURL, DefaultBranch: "main",
+		},
+	))
+	twiceRenamedSpec := renamedSpec
+	twiceRenamedSpec.Repository.Name = "twice-renamed"
+	twiceRenamedSpec.Repository.CloneURL = twiceRenamedRemoteURL
+	twiceRenamedSpec.IssuedAt = renamedSpec.IssuedAt.Add(time.Minute)
+	twiceRenamedSpec.SourceVisibleUntil = twiceRenamedSpec.IssuedAt.Add(
+		WorkspaceLaunchSpecVisibilityLease,
+	)
+	manager.SetLaunchSpecResolver(&staticLaunchSpecResolver{spec: twiceRenamedSpec})
+	manager.SetNow(func() time.Time { return twiceRenamedSpec.IssuedAt })
+
+	require.NoError(manager.Setup(t.Context(), workspace),
+		"a clone retargeted by an earlier rename must survive another rename")
+	commonDir, err = worktreeCommonGitDir(t.Context(), workspace.WorktreePath)
+	require.NoError(err)
+	require.Equal(canonicalOldClone, commonDir)
+	originURLs, err = gitConfigValues(t.Context(), oldClone, "remote.origin.url")
+	require.NoError(err)
+	require.Equal([]string{twiceRenamedRemoteURL}, originURLs)
+}
+
+func TestManagedClonePathsExcludeLegacyRouteAfterReuse(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	observedAt := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	original := db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-original", Owner: "acme", Name: "widget",
+	}
+	entry, _, err := database.ReconcileRepositoryObservation(
+		t.Context(), original, observedAt,
+	)
+	require.NoError(err)
+	require.NotNil(entry)
+
+	original.Name = "widget-original"
+	_, _, err = database.ReconcileRepositoryObservation(
+		t.Context(), original, observedAt.Add(time.Minute),
+	)
+	require.NoError(err)
+	replacement := db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-replacement", Owner: "acme", Name: "widget",
+	}
+	_, _, err = database.ReconcileRepositoryObservation(
+		t.Context(), replacement, observedAt.Add(2*time.Minute),
+	)
+	require.NoError(err)
+	replacement.Name = "widget-replacement"
+	_, _, err = database.ReconcileRepositoryObservation(
+		t.Context(), replacement, observedAt.Add(3*time.Minute),
+	)
+	require.NoError(err)
+	original.Name = "widget"
+	_, _, err = database.ReconcileRepositoryObservation(
+		t.Context(), original, observedAt.Add(4*time.Minute),
+	)
+	require.NoError(err)
+
+	clones := gitclone.New(t.TempDir(), nil)
+	manager := NewManager(database, t.TempDir())
+	manager.SetClones(clones)
+	paths, err := manager.workspaceManagedClonePaths(t.Context(), &Workspace{
+		RepoID: entry.Repository.ID, Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget",
+	})
+
+	require.NoError(err)
+	require.Len(paths, 3)
+	legacyPath, err := clones.ClonePath("github", "github.com", "acme", "widget")
+	require.NoError(err)
+	require.NotContains(paths, legacyPath)
+	historicalPath, err := clones.ClonePathForContext(
+		gitclone.WithRepositoryIdentity(t.Context(), original.PlatformRepoID),
+		"github", "github.com", "acme", "widget-original",
+	)
+	require.NoError(err)
+	require.Contains(paths, historicalPath)
+	historicalLegacyPath, err := clones.ClonePath(
+		"github", "github.com", "acme", "widget-original",
+	)
+	require.NoError(err)
+	require.Contains(paths, historicalLegacyPath)
+}
+
 func TestCreateIssueReportsRecoverableDirectoryBranch(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -927,7 +1665,8 @@ func TestCreateIssueReportsRecoverableDirectoryBranch(t *testing.T) {
 
 	const existingBranch = "kenn-forge/issue-7-original-title"
 	expectedPath := filepath.Join(
-		worktreeRoot, "github", platformHost, "acme", "widget", "issue-7",
+		worktreeRoot, "github", platformHost, "acme", "widget",
+		fmt.Sprintf("repo-%d", repoID), "issue-7",
 	)
 	runWorkspaceTestGit(
 		t, localRepo,
@@ -967,7 +1706,8 @@ func TestSetupDirectoryRecoveryNeverCreatesReplacement(t *testing.T) {
 
 	const branch = "kenn-forge/issue-7"
 	expectedPath := filepath.Join(
-		worktreeRoot, "github", platformHost, "acme", "widget", "issue-7",
+		worktreeRoot, "github", platformHost, "acme", "widget",
+		fmt.Sprintf("repo-%d", repoID), "issue-7",
 	)
 	runWorkspaceTestGit(
 		t, localRepo,
@@ -1020,7 +1760,8 @@ func TestRetryDirectoryRecoveryPreservesExistingWorktree(t *testing.T) {
 
 	const branch = "kenn-forge/issue-7"
 	expectedPath := filepath.Join(
-		worktreeRoot, "github", platformHost, "acme", "widget", "issue-7",
+		worktreeRoot, "github", platformHost, "acme", "widget",
+		fmt.Sprintf("repo-%d", repoID), "issue-7",
 	)
 	runWorkspaceTestGit(
 		t, localRepo,
@@ -1077,7 +1818,8 @@ func TestDeletePendingDirectoryRecoveryPreservesExistingWorktree(t *testing.T) {
 
 	const branch = "kenn-forge/issue-7"
 	expectedPath := filepath.Join(
-		worktreeRoot, "github", platformHost, "acme", "widget", "issue-7",
+		worktreeRoot, "github", platformHost, "acme", "widget",
+		fmt.Sprintf("repo-%d", repoID), "issue-7",
 	)
 	runWorkspaceTestGit(
 		t, localRepo,
@@ -1300,12 +2042,12 @@ func TestSetupWithOptionsConfirmsRoborevBeforeTerminal(t *testing.T) {
 			))
 
 			clones := gitclone.New(t.TempDir(), nil)
-			require.NoError(clones.EnsureCloneInNamespace(
-				ctx, workspaceCloneNamespace("github"), "github", platformHost,
-				"acme", "widget", remote,
+			cloneCtx := gitclone.WithRepositoryIdentity(ctx, "repo-acme-widget")
+			require.NoError(clones.EnsureClone(
+				cloneCtx, "github", platformHost, "acme", "widget", remote,
 			))
-			cloneDir, cloneErr := clones.ClonePathInNamespace(
-				workspaceCloneNamespace("github"), platformHost, "acme", "widget",
+			cloneDir, cloneErr := clones.ClonePathForContext(
+				cloneCtx, "github", platformHost, "acme", "widget",
 			)
 			require.NoError(cloneErr)
 			originalHook := []byte("#!/bin/sh\n# existing security hook\n")
@@ -1425,12 +2167,11 @@ func TestManagedRepositoryHookSetupSerializesRegistration(t *testing.T) {
 		t, "feature/source",
 	)
 	clones := gitclone.New(t.TempDir(), nil)
-	require.NoError(clones.EnsureCloneInNamespace(
-		ctx, workspaceCloneNamespace("github"), "github", "github.com",
-		"acme", "widget", remote,
+	require.NoError(clones.EnsureClone(
+		ctx, "github", "github.com", "acme", "widget", remote,
 	))
-	cloneDir, err := clones.ClonePathInNamespace(
-		workspaceCloneNamespace("github"), "github.com", "acme", "widget",
+	cloneDir, err := clones.ClonePathForContext(
+		ctx, "github", "github.com", "acme", "widget",
 	)
 	require.NoError(err)
 	worktreePath := filepath.Join(t.TempDir(), "worktree")
@@ -2347,7 +3088,8 @@ func TestCreateIssueUsesProviderCloneURLForNamespacedManagedClone(t *testing.T) 
 	require.NoError(err)
 	require.NotNil(ws)
 	assert.Equal("gitlab", ws.Platform)
-	cloneDir, err := clones.ClonePathInNamespace(
+	cloneDir, err := clones.ClonePathForContext(
+		gitclone.WithRepositoryIdentity(ctx, "repo-gitlab-project"),
 		"gitlab", "gitlab.example.com", "group", "project",
 	)
 	require.NoError(err)
@@ -2398,7 +3140,8 @@ func TestCreateIssueClonesExplicitlyAllowedGiteaHTTPRemote(t *testing.T) {
 
 	require.NoError(err)
 	require.NotNil(ws)
-	cloneDir, err := clones.ClonePathInNamespace(
+	cloneDir, err := clones.ClonePathForContext(
+		gitclone.WithRepositoryIdentity(ctx, "repo-gitea-widget"),
 		"gitea", platformHost, "acme", "widget",
 	)
 	require.NoError(err)
@@ -2406,6 +3149,82 @@ func TestCreateIssueClonesExplicitlyAllowedGiteaHTTPRemote(t *testing.T) {
 	assert.Equal(cloneURL, strings.TrimSpace(string(runWorkspaceTestGit(
 		t, cloneDir, "config", "--get", "remote.origin.url",
 	))))
+}
+
+func TestBranchInspectionPartitionsManagedCloneByProviderIdentity(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	_, _, platformHost := setupHTTPWorktreeBaseForWorkspaceGitTest(t, "feature/thing")
+	remote := "http://" + platformHost + "/acme/widget.git"
+	repoID := seedRepo(t, d, platformHost, "acme", "widget")
+
+	clones := gitclone.New(t.TempDir(), nil)
+	clones.SetAllowInsecureHTTP("github", platformHost, true)
+	mgr := newTestManager(t, d, t.TempDir())
+	mgr.SetClones(clones)
+
+	repo := workspaceRepoRef{
+		ID: repoID, Platform: "github", PlatformHost: platformHost,
+		ProviderID: "provider-repo-a", Owner: "acme", Name: "widget",
+		RemoteURL: remote,
+	}
+	firstDir, ok, localBase, err := mgr.branchInspectionDir(ctx, repo)
+	require.NoError(err)
+	require.True(ok)
+	assert.False(localBase)
+
+	repo.ProviderID = "provider-repo-b"
+	secondDir, ok, localBase, err := mgr.branchInspectionDir(ctx, repo)
+	require.NoError(err)
+	require.True(ok)
+	assert.False(localBase)
+	assert.NotEqual(firstDir, secondDir)
+}
+
+func TestWorkspaceSetupGitDirRemovesCloneWhenRouteChangesDuringClone(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	database := openTestDB(t)
+	_, remote := setupLocalWorktreeBaseWithRemoteForWorkspaceGitTest(
+		t, "feature/thing",
+	)
+	repoID := seedRepo(t, database, "github.com", "acme", "widget")
+	require.NoError(database.UpdateRepoProviderMetadata(
+		t.Context(), repoID, db.RepoProviderMetadata{
+			CloneURL: remote, DefaultBranch: "main",
+		},
+	))
+	clones := gitclone.New(t.TempDir(), nil)
+	manager := newTestManager(t, database, t.TempDir())
+	manager.SetClones(clones)
+	workspace := &Workspace{
+		RepoID: repoID, Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget",
+	}
+	routeChanged := errors.New("repository route changed")
+	validations := 0
+
+	_, _, err := manager.workspaceSetupGitDir(
+		t.Context(), workspace, "", nil,
+		func(context.Context) error {
+			validations++
+			if validations == 1 {
+				return nil
+			}
+			return routeChanged
+		},
+	)
+
+	require.ErrorIs(err, routeChanged)
+	assert.Equal(2, validations)
+	clonePath, err := clones.ClonePathForContext(
+		gitclone.WithRepositoryIdentity(t.Context(), "repo-acme-widget"),
+		"github", "github.com", "acme", "widget",
+	)
+	require.NoError(err)
+	assert.NoDirExists(clonePath)
 }
 
 func TestCreateUsesProviderQualifiedRepo(t *testing.T) {
@@ -2444,7 +3263,8 @@ func TestCreateUsesProviderQualifiedRepo(t *testing.T) {
 	assert.Equal("feature/gitlab", ws.GitHeadRef)
 	assert.Equal(
 		filepath.Join(
-			worktreeDir, "gitlab", "forge.example.com", "acme", "widget", "pr-42",
+			worktreeDir, "gitlab", "forge.example.com", "acme", "widget",
+			fmt.Sprintf("repo-%d", gitlabRepoID), "pr-42",
 		),
 		ws.WorktreePath,
 	)
@@ -2473,7 +3293,10 @@ func TestSetupUsesManagedCloneForForkPRWithConfiguredWorktreeBasePath(t *testing
 		"https://github.com/acme/widget.git",
 	)
 	clones := gitclone.New(cloneBaseDir, nil)
-	cloneDir, err := clones.ClonePath("github", host, owner, name)
+	cloneDir, err := clones.ClonePathForContext(
+		gitclone.WithRepositoryIdentity(t.Context(), "repo-acme-widget"),
+		"github", host, owner, name,
+	)
 	require.NoError(err)
 	require.NoError(os.MkdirAll(filepath.Dir(cloneDir), 0o755))
 	runWorkspaceTestGit(t, cloneBaseDir, "clone", "--bare", remote, cloneDir)
@@ -2678,7 +3501,9 @@ func TestAddAndRefreshPRWorktreeFastForwardLocalBaseBranch(t *testing.T) {
 	launchSpec, err := mgr.RequireWorkspaceLaunchSpec(t.Context(), ws)
 	require.NoError(err)
 
-	_, err = mgr.addWorktree(t.Context(), localRepo, true, ws, launchSpec)
+	_, err = mgr.addWorktree(t.Context(), localRepo, true, ws, workspaceGitFetchOptions{
+		launchSpec: launchSpec,
+	})
 	require.NoError(err)
 	localBaseSHA := strings.TrimSpace(string(runWorkspaceTestGit(
 		t, localRepo, "rev-parse", "refs/heads/main",
@@ -2693,13 +3518,112 @@ func TestAddAndRefreshPRWorktreeFastForwardLocalBaseBranch(t *testing.T) {
 	runWorkspaceTestGit(t, remote, "update-server-info")
 
 	_, err = mgr.refreshExistingWorkspaceWorktree(
-		t.Context(), localRepo, ws, launchSpec,
+		t.Context(), localRepo, ws, launchSpec, nil,
 	)
 	require.NoError(err)
 	localBaseSHA = strings.TrimSpace(string(runWorkspaceTestGit(
 		t, localRepo, "rev-parse", "refs/heads/main",
 	)))
 	assert.Equal(secondBaseSHA, localBaseSHA)
+}
+
+func TestAddWorktreeRestoresBaseRefsWhenRouteChangesDuringFetch(t *testing.T) {
+	require := require.New(t)
+	localRepo, remote, platformHost := setupHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/route-fence",
+	)
+	originalSHA, exists, err := gitRefSHA(
+		t.Context(), localRepo, "refs/remotes/origin/main",
+	)
+	require.NoError(err)
+	require.True(exists)
+	runWorkspaceTestGit(t, remote, "config", "user.email", "test@test.com")
+	runWorkspaceTestGit(t, remote, "config", "user.name", "Test")
+	newSHA := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, remote, "commit-tree", "refs/heads/main^{tree}",
+		"-p", "refs/heads/main", "-m", "replacement base",
+	)))
+	runWorkspaceTestGit(t, remote, "update-ref", "refs/heads/main", newSHA)
+	runWorkspaceTestGit(t, remote, "update-server-info")
+
+	validationCalls := 0
+	validateRoute := func(context.Context) error {
+		validationCalls++
+		if validationCalls > 1 {
+			return db.ErrRepositoryRouteFenceChanged
+		}
+		return nil
+	}
+	ws := &Workspace{
+		ID: "ws-base-route-fence", Platform: "github", PlatformHost: platformHost,
+		RepoOwner: "acme", RepoName: "widget", ItemType: db.WorkspaceItemTypeIssue,
+		ItemNumber: 42, GitHeadRef: "issue-42",
+		WorktreePath: filepath.Join(t.TempDir(), "worktree"),
+	}
+	mgr := newTestManager(t, openTestDB(t), t.TempDir())
+
+	_, err = mgr.addWorktree(
+		t.Context(), localRepo, true, ws, workspaceGitFetchOptions{
+			validateRoute: validateRoute,
+		},
+	)
+
+	require.ErrorIs(err, db.ErrRepositoryRouteFenceChanged)
+	restoredSHA, exists, refErr := gitRefSHA(
+		t.Context(), localRepo, "refs/remotes/origin/main",
+	)
+	require.NoError(refErr)
+	require.True(exists)
+	require.Equal(originalSHA, restoredSHA)
+	_, statErr := os.Stat(ws.WorktreePath)
+	require.ErrorIs(statErr, os.ErrNotExist)
+}
+
+func TestAddWorktreeRestoresPullRefWhenRouteChangesDuringFetch(t *testing.T) {
+	require := require.New(t)
+	const prNumber = 43
+	localRepo, remote, platformHost := setupHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/route-fence",
+	)
+	pullRef := fmt.Sprintf("refs/pull/%d/head", prNumber)
+	runWorkspaceTestGit(
+		t, remote, "update-ref", pullRef, "refs/heads/feature/route-fence",
+	)
+	runWorkspaceTestGit(t, remote, "update-server-info")
+	_, exists, err := gitRefSHA(t.Context(), localRepo, pullRef)
+	require.NoError(err)
+	require.False(exists)
+
+	validationCalls := 0
+	validateRoute := func(context.Context) error {
+		validationCalls++
+		if validationCalls > 1 {
+			return db.ErrRepositoryRouteFenceChanged
+		}
+		return nil
+	}
+	headRepo := "http://" + platformHost + "/acme/widget.git"
+	ws := &Workspace{
+		ID: "ws-pull-route-fence", Platform: "github", PlatformHost: platformHost,
+		RepoOwner: "acme", RepoName: "widget", ItemType: db.WorkspaceItemTypePullRequest,
+		ItemNumber: prNumber, GitHeadRef: "feature/route-fence",
+		MRHeadRepo: &headRepo, WorktreePath: filepath.Join(t.TempDir(), "worktree"),
+	}
+	mgr := newTestManager(t, openTestDB(t), t.TempDir())
+
+	_, err = mgr.addWorktreeLocked(
+		t.Context(), localRepo, true, ws, workspaceGitFetchOptions{
+			launchSpec:    pullLaunchSpecForWorkspace(ws, "same_repo", ""),
+			validateRoute: validateRoute,
+		},
+	)
+
+	require.ErrorIs(err, db.ErrRepositoryRouteFenceChanged)
+	_, exists, refErr := gitRefSHA(t.Context(), localRepo, pullRef)
+	require.NoError(refErr)
+	require.False(exists)
+	_, statErr := os.Stat(ws.WorktreePath)
+	require.ErrorIs(statErr, os.ErrNotExist)
 }
 
 func TestSyncLocalBaseBranchSkipsCheckedOutAndDivergedBranches(t *testing.T) {
@@ -2951,6 +3875,92 @@ func TestCleanupDeletesLiveRegisteredWorktreeWithoutOwnershipMarker(t *testing.T
 	branchExists, err := localBranchExists(t.Context(), localRepo, branch)
 	require.NoError(err)
 	require.False(branchExists)
+}
+
+func TestCleanupFindsManagedCloneAfterRepositoryRename(t *testing.T) {
+	require := require.New(t)
+
+	const branch = "kenn-forge/pr-42"
+	oldClone := setupLocalWorktreeBaseForWorkspaceGitTest(t, "feature/thing")
+	worktreePath := filepath.Join(t.TempDir(), "workspace")
+	runWorkspaceTestGit(
+		t, oldClone,
+		"worktree", "add", worktreePath, "-b", branch, "HEAD",
+	)
+
+	mgr := newTestManager(t, openTestDB(t), t.TempDir())
+	ws := &Workspace{
+		ID: "ws-renamed-clone", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "renamed",
+		ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 42,
+		GitHeadRef: "feature/thing", WorkspaceBranch: branch,
+		WorktreePath: worktreePath,
+	}
+	require.NoError(writeWorkspaceOwnershipMarker(t.Context(), oldClone, ws))
+
+	require.NoError(mgr.cleanupWorkspaceArtifactsForDelete(t.Context(), ws))
+	require.NoDirExists(worktreePath)
+	branchExists, err := localBranchExists(t.Context(), oldClone, branch)
+	require.NoError(err)
+	require.False(branchExists)
+}
+
+func TestCleanupFindsMissingIdentityManagedWorktreeAfterRepositoryRename(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	observedAt := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	identity := db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-acme-widget", Owner: "acme", Name: "widget",
+	}
+	entry, _, err := database.ReconcileRepositoryObservation(
+		t.Context(), identity, observedAt,
+	)
+	require.NoError(err)
+	require.NotNil(entry)
+
+	clones := gitclone.New(t.TempDir(), nil)
+	cloneCtx := gitclone.WithRepositoryIdentity(
+		t.Context(), identity.PlatformRepoID,
+	)
+	oldClone, err := clones.ClonePathForContext(
+		cloneCtx, identity.Platform, identity.PlatformHost,
+		identity.Owner, identity.Name,
+	)
+	require.NoError(err)
+	seedWorkspaceBareCloneAt(t, oldClone)
+	const branch = "kenn-forge/pr-42"
+	worktreePath := filepath.Join(t.TempDir(), "missing-worktree")
+	runWorkspaceTestGit(
+		t, oldClone, "worktree", "add", worktreePath, "-b", branch, "HEAD",
+	)
+	ws := &Workspace{
+		ID: "ws-renamed-missing-worktree", RepoID: entry.Repository.ID,
+		Platform: identity.Platform, PlatformHost: identity.PlatformHost,
+		RepoOwner: identity.Owner, RepoName: identity.Name,
+		ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 42,
+		GitHeadRef: "feature/thing", WorkspaceBranch: branch,
+		WorktreePath: worktreePath,
+	}
+	require.NoError(writeWorkspaceOwnershipMarker(t.Context(), oldClone, ws))
+	require.NoError(os.RemoveAll(worktreePath))
+
+	identity.Name = "renamed"
+	_, _, err = database.ReconcileRepositoryObservation(
+		t.Context(), identity, observedAt.Add(time.Minute),
+	)
+	require.NoError(err)
+	ws.RepoName = identity.Name
+	manager := newTestManager(t, database, t.TempDir())
+	manager.SetClones(clones)
+
+	require.NoError(manager.cleanupWorkspaceArtifactsForDelete(t.Context(), ws))
+	branchExists, err := localBranchExists(t.Context(), oldClone, branch)
+	require.NoError(err)
+	require.False(branchExists)
+	tracked, err := gitDirTracksWorktreePath(t.Context(), oldClone, worktreePath)
+	require.NoError(err)
+	require.False(tracked)
 }
 
 func TestCleanupDoesNotTrustReplacementCloneAtWorkspacePath(t *testing.T) {
@@ -3327,8 +4337,8 @@ func TestCleanupUsesProviderScopedManagedClone(t *testing.T) {
 	const host = "forge.example.com"
 	cloneBaseDir := t.TempDir()
 	clones := gitclone.New(cloneBaseDir, nil)
-	cloneDir, err := clones.ClonePathInNamespace(
-		workspaceCloneNamespace("gitlab"), host, "acme", "widget",
+	cloneDir, err := clones.ClonePathForContext(
+		t.Context(), "gitlab", host, "acme", "widget",
 	)
 	require.NoError(err)
 	require.NoError(os.MkdirAll(filepath.Dir(cloneDir), 0o755))
@@ -3554,7 +4564,9 @@ func TestAddWorktreeUsesFallbackWhenLocalBasePreferredBranchCheckedOut(t *testin
 		WorktreePath: filepath.Join(t.TempDir(), "worktree"),
 	}
 
-	gotBranch, err := mgr.addWorktreeLocked(t.Context(), localRepo, true, ws, nil)
+	gotBranch, err := mgr.addWorktreeLocked(
+		t.Context(), localRepo, true, ws, workspaceGitFetchOptions{},
+	)
 
 	require.NoError(err)
 	assert.Equal(syntheticPRWorktreeBranch(42), gotBranch)
@@ -3614,7 +4626,9 @@ func TestAddWorktreeFallbackBranchTracksPRHeadBranch(t *testing.T) {
 	}
 	mgr := newTestManager(t, openTestDB(t), t.TempDir())
 
-	branch, err := mgr.addWorktreeLocked(t.Context(), cloneDir, false, ws, nil)
+	branch, err := mgr.addWorktreeLocked(
+		t.Context(), cloneDir, false, ws, workspaceGitFetchOptions{},
+	)
 
 	require.NoError(err)
 	require.Equal(syntheticPRWorktreeBranch(prNumber), branch)
@@ -3657,7 +4671,9 @@ func TestAddWorktreeLockedRecordsOwnershipBeforeReturning(t *testing.T) {
 	}
 	mgr := newTestManager(t, openTestDB(t), t.TempDir())
 
-	_, err := mgr.addWorktreeLocked(t.Context(), cloneDir, false, ws, nil)
+	_, err := mgr.addWorktreeLocked(
+		t.Context(), cloneDir, false, ws, workspaceGitFetchOptions{},
+	)
 	require.NoError(err)
 	owned, err := workspaceRegistrationMatches(
 		t.Context(), cloneDir, ws.WorktreePath, ws.ID,
@@ -3756,7 +4772,9 @@ func TestAddWorktreeUniquifiesFallbackBranchWhenSyntheticNameTaken(t *testing.T)
 	}
 	mgr := newTestManager(t, openTestDB(t), t.TempDir())
 
-	branch, err := mgr.addWorktreeLocked(t.Context(), cloneDir, false, ws, nil)
+	branch, err := mgr.addWorktreeLocked(
+		t.Context(), cloneDir, false, ws, workspaceGitFetchOptions{},
+	)
 
 	require.NoError(err)
 	assert.Equal(takenBranch+"-2", branch)
@@ -3830,7 +4848,9 @@ func TestAddWorktreeFallsBackToDetachedWorktreeWhenBranchNamesExhausted(
 	}
 	mgr := newTestManager(t, openTestDB(t), t.TempDir())
 
-	branch, err := mgr.addWorktreeLocked(t.Context(), cloneDir, false, ws, nil)
+	branch, err := mgr.addWorktreeLocked(
+		t.Context(), cloneDir, false, ws, workspaceGitFetchOptions{},
+	)
 
 	require.NoError(err)
 	// No managed branch: cleanup and delete must not remove anyone else's.
@@ -3876,8 +4896,9 @@ func TestAddWorktreeUnknownHeadRepoDoesNotTrackMatchingOriginBranch(t *testing.T
 	require.NoError(err)
 
 	_, err = mgr.addWorktreeLocked(
-		t.Context(), cloneDir, false, ws,
-		pullLaunchSpecForWorkspace(ws, "unknown", ""),
+		t.Context(), cloneDir, false, ws, workspaceGitFetchOptions{
+			launchSpec: pullLaunchSpecForWorkspace(ws, "unknown", ""),
+		},
 	)
 	require.Error(err)
 	assert.ErrorContains(err, "head repository identity is unavailable")
@@ -3926,8 +4947,9 @@ func TestAddWorktreeLocalBaseFetchesPullRefWhenHeadBranchDeleted(t *testing.T) {
 	}
 
 	gotBranch, err := mgr.addWorktree(
-		t.Context(), localRepo, true, ws,
-		pullLaunchSpecForWorkspace(ws, "same_repo", ""),
+		t.Context(), localRepo, true, ws, workspaceGitFetchOptions{
+			launchSpec: pullLaunchSpecForWorkspace(ws, "same_repo", ""),
+		},
 	)
 
 	require.NoError(err)
@@ -3978,8 +5000,9 @@ func TestAddWorktreeLocalBaseIgnoresStalePullRefWhenFetchFails(t *testing.T) {
 	}
 
 	gotBranch, err := mgr.addWorktree(
-		t.Context(), localRepo, true, ws,
-		pullLaunchSpecForWorkspace(ws, "same_repo", ""),
+		t.Context(), localRepo, true, ws, workspaceGitFetchOptions{
+			launchSpec: pullLaunchSpecForWorkspace(ws, "same_repo", ""),
+		},
 	)
 
 	require.NoError(err)
@@ -4012,7 +5035,9 @@ func TestLocalBaseExistingPRBranchIsNotDeletedOnCleanup(t *testing.T) {
 		Status:          "ready",
 	}
 
-	managedBranch, err := mgr.addWorktreeLocked(t.Context(), localRepo, true, ws, nil)
+	managedBranch, err := mgr.addWorktreeLocked(
+		t.Context(), localRepo, true, ws, workspaceGitFetchOptions{},
+	)
 	require.NoError(err)
 	require.Empty(managedBranch)
 	ws.WorkspaceBranch = managedBranch
@@ -4049,7 +5074,9 @@ func TestLocalBaseExistingPRBranchPreservesUpstream(t *testing.T) {
 		Status:          "ready",
 	}
 
-	managedBranch, err := mgr.addWorktreeLocked(t.Context(), localRepo, true, ws, nil)
+	managedBranch, err := mgr.addWorktreeLocked(
+		t.Context(), localRepo, true, ws, workspaceGitFetchOptions{},
+	)
 
 	require.NoError(err)
 	assert.Empty(managedBranch)
@@ -4213,8 +5240,9 @@ func TestAddWorktreeGitLabForkMRFetchesHeadBeforePreferredBranch(t *testing.T) {
 	mgr := newTestManager(t, openTestDB(t), t.TempDir())
 
 	branch, err := mgr.addWorktreeLocked(
-		t.Context(), cloneDir, false, ws,
-		pullLaunchSpecForWorkspace(ws, "fork", forkRemote),
+		t.Context(), cloneDir, false, ws, workspaceGitFetchOptions{
+			launchSpec: pullLaunchSpecForWorkspace(ws, "fork", forkRemote),
+		},
 	)
 
 	require.NoError(err)
@@ -4260,8 +5288,9 @@ func TestAddWorktreeMergedSameRepoPRUsesPullRefWhenHeadBranchDeleted(
 	mgr := newTestManager(t, openTestDB(t), t.TempDir())
 
 	branch, err := mgr.addWorktreeLocked(
-		t.Context(), cloneDir, false, ws,
-		pullLaunchSpecForWorkspace(ws, "same_repo", ""),
+		t.Context(), cloneDir, false, ws, workspaceGitFetchOptions{
+			launchSpec: pullLaunchSpecForWorkspace(ws, "same_repo", ""),
+		},
 	)
 
 	require.NoError(err)
@@ -4313,8 +5342,9 @@ func TestAddWorktreeGitLabMRUsesMergeRequestRefWhenHeadBranchDeleted(
 	mgr := newTestManager(t, openTestDB(t), t.TempDir())
 
 	branch, err := mgr.addWorktreeLocked(
-		t.Context(), cloneDir, false, ws,
-		pullLaunchSpecForWorkspace(ws, "same_repo", ""),
+		t.Context(), cloneDir, false, ws, workspaceGitFetchOptions{
+			launchSpec: pullLaunchSpecForWorkspace(ws, "same_repo", ""),
+		},
 	)
 
 	require.NoError(err)
@@ -4360,8 +5390,9 @@ func TestAddWorktreeGitLabMRFetchesSpecificMergeRequestRef(t *testing.T) {
 	mgr := newTestManager(t, openTestDB(t), t.TempDir())
 
 	branch, err := mgr.addWorktreeLocked(
-		t.Context(), cloneDir, false, ws,
-		pullLaunchSpecForWorkspace(ws, "same_repo", ""),
+		t.Context(), cloneDir, false, ws, workspaceGitFetchOptions{
+			launchSpec: pullLaunchSpecForWorkspace(ws, "same_repo", ""),
+		},
 	)
 
 	require.NoError(err)
@@ -4646,6 +5677,48 @@ func setupHTTPWorktreeBaseForWorkspaceGitTest(
 		"refs/remotes/origin/HEAD", "refs/remotes/origin/main",
 	)
 	return repo, remote, platformHost
+}
+
+func setupRouteChangingCloneRemoteForWorkspaceTest(
+	t *testing.T, onFirstRequest func() error,
+) (platformHost, cloneURL string) {
+	t.Helper()
+	root := t.TempDir()
+	remote := filepath.Join(root, "acme", "widget.git")
+	work := filepath.Join(root, "work")
+	require.NoError(t, os.MkdirAll(filepath.Dir(remote), 0o755))
+	runWorkspaceTestGit(t, root, "init", "--bare", "--initial-branch=main", remote)
+	runWorkspaceTestGit(t, root, "init", "--initial-branch=main", work)
+	runWorkspaceTestGit(t, work, "config", "user.email", "test@test.com")
+	runWorkspaceTestGit(t, work, "config", "user.name", "Test")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(work, "base.txt"), []byte("base\n"), 0o644,
+	))
+	runWorkspaceTestGit(t, work, "add", ".")
+	runWorkspaceTestGit(t, work, "commit", "-m", "base commit")
+	runWorkspaceTestGit(t, work, "remote", "add", "origin", remote)
+	runWorkspaceTestGit(t, work, "push", "origin", "main")
+	runWorkspaceTestGit(t, remote, "symbolic-ref", "HEAD", "refs/heads/main")
+	runWorkspaceTestGit(t, remote, "update-server-info")
+
+	files := http.FileServer(http.Dir(root))
+	var once sync.Once
+	var routeChangeErr error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		once.Do(func() { routeChangeErr = onFirstRequest() })
+		if routeChangeErr != nil {
+			http.Error(w, routeChangeErr.Error(), http.StatusInternalServerError)
+			return
+		}
+		files.ServeHTTP(w, r)
+	}))
+	t.Cleanup(func() {
+		server.Close()
+		require.NoError(t, routeChangeErr)
+	})
+	parsed, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	return parsed.Host, server.URL + "/acme/widget.git"
 }
 
 func setupRemoteForForkPRWorktreeTest(
@@ -7167,7 +8240,9 @@ func TestManagerAddWorktreeAcquiresRepoLock(t *testing.T) {
 	}
 	done := make(chan error, 1)
 	go func() {
-		_, err := mgr.addWorktree(t.Context(), cloneDir, false, ws, nil)
+		_, err := mgr.addWorktree(
+			t.Context(), cloneDir, false, ws, workspaceGitFetchOptions{},
+		)
 		done <- err
 	}()
 
@@ -7208,7 +8283,9 @@ func TestManagerAddWorktreeRechecksOccupiedPathAfterWaitingForLock(t *testing.T)
 	require.NoError(err)
 	done := make(chan error, 1)
 	go func() {
-		_, err := mgr.addWorktree(t.Context(), cloneDir, false, ws, nil)
+		_, err := mgr.addWorktree(
+			t.Context(), cloneDir, false, ws, workspaceGitFetchOptions{},
+		)
 		done <- err
 	}()
 
@@ -7376,7 +8453,7 @@ func TestManagerCleanupForDeleteAcquiresRepoLock(t *testing.T) {
 
 // TestSetupFailsClosedWhenRepositoryRouteReused verifies that setup — the
 // chokepoint for every code-fetching path, including retries — refuses to
-// operate on a workspace whose stored route now has historical occupants.
+// operate when a workspace's stable repository no longer owns its route.
 func TestSetupFailsClosedWhenRepositoryRouteReused(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -7424,11 +8501,117 @@ func TestSetupFailsClosedWhenRepositoryRouteReused(t *testing.T) {
 
 	mgr := newTestManager(t, d, t.TempDir())
 	err = mgr.Setup(t.Context(), ws)
-	require.ErrorContains(err, "historical occupants")
+	require.ErrorContains(err, "repository identity changed")
 	stored, getErr := d.GetWorkspace(t.Context(), ws.ID)
 	require.NoError(getErr)
 	require.NotNil(stored)
 	assert.Equal("error", stored.Status)
+}
+
+func TestSetupRemovesManagedCloneWhenRepositoryRouteChangesDuringFetch(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	observedAt := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	var platformHost string
+	platformHost, cloneURL := setupRouteChangingCloneRemoteForWorkspaceTest(
+		t, func() error {
+			_, _, err := database.ReconcileRepositoryObservation(
+				context.Background(), db.RepoIdentity{
+					Platform: "github", PlatformHost: platformHost,
+					PlatformRepoID: "provider-replacement",
+					Owner:          "acme", Name: "widget",
+				}, observedAt.Add(time.Hour),
+			)
+			return err
+		},
+	)
+	entry, _, err := database.ReconcileRepositoryObservation(
+		t.Context(), db.RepoIdentity{
+			Platform: "github", PlatformHost: platformHost,
+			PlatformRepoID: "provider-original",
+			Owner:          "acme", Name: "widget",
+		}, observedAt,
+	)
+	require.NoError(err)
+	require.NotNil(entry)
+	require.NoError(database.UpdateRepoProviderMetadata(
+		t.Context(), entry.Repository.ID, db.RepoProviderMetadata{
+			CloneURL: cloneURL, DefaultBranch: "main",
+		},
+	))
+	workspace := &Workspace{
+		ID: "ws-route-change-during-fetch", Platform: "github",
+		PlatformHost: platformHost, RepoOwner: "acme", RepoName: "widget",
+		ItemType: db.WorkspaceItemTypeAdHoc, ItemKey: "spike/route-change",
+		GitHeadRef: "spike/route-change", WorkspaceBranch: "spike/route-change",
+		WorktreePath: filepath.Join(t.TempDir(), "worktree"),
+		TmuxSession:  "forge-ws-route-change-during-fetch", Status: "creating",
+	}
+	require.NoError(database.InsertWorkspace(t.Context(), workspace))
+	require.Equal(entry.Repository.ID, workspace.RepoID)
+
+	clones := gitclone.New(t.TempDir(), nil)
+	manager := NewManager(database, t.TempDir())
+	manager.SetClones(clones)
+	cloneCtx := gitclone.WithRepositoryIdentity(t.Context(), "provider-original")
+	cloneDir, err := clones.ClonePathForContext(
+		cloneCtx, "github", platformHost, "acme", "widget",
+	)
+	require.NoError(err)
+
+	err = manager.Setup(t.Context(), workspace)
+	require.ErrorIs(err, db.ErrRepositoryRouteFenceChanged)
+	require.NoDirExists(cloneDir)
+}
+
+func TestCreateIssueRemovesManagedCloneWhenRepositoryRouteChangesDuringFetch(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	observedAt := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	var platformHost string
+	platformHost, cloneURL := setupRouteChangingCloneRemoteForWorkspaceTest(
+		t, func() error {
+			_, _, err := database.ReconcileRepositoryObservation(
+				context.Background(), db.RepoIdentity{
+					Platform: "github", PlatformHost: platformHost,
+					PlatformRepoID: "provider-replacement",
+					Owner:          "acme", Name: "widget",
+				}, observedAt.Add(time.Hour),
+			)
+			return err
+		},
+	)
+	entry, _, err := database.ReconcileRepositoryObservation(
+		t.Context(), db.RepoIdentity{
+			Platform: "github", PlatformHost: platformHost,
+			PlatformRepoID: "provider-original",
+			Owner:          "acme", Name: "widget",
+		}, observedAt,
+	)
+	require.NoError(err)
+	require.NotNil(entry)
+	require.NoError(database.UpdateRepoProviderMetadata(
+		t.Context(), entry.Repository.ID, db.RepoProviderMetadata{
+			CloneURL: cloneURL, DefaultBranch: "main",
+		},
+	))
+	seedIssue(t, database, entry.Repository.ID, 7, "Route changes during clone")
+
+	clones := gitclone.New(t.TempDir(), nil)
+	manager := newTestManager(t, database, t.TempDir())
+	manager.SetClones(clones)
+	cloneCtx := gitclone.WithRepositoryIdentity(t.Context(), "provider-original")
+	cloneDir, err := clones.ClonePathForContext(
+		cloneCtx, "github", platformHost, "acme", "widget",
+	)
+	require.NoError(err)
+
+	_, err = manager.CreateIssue(
+		t.Context(), platformHost, "acme", "widget", 7,
+		CreateIssueOptions{Provider: "github"},
+	)
+	require.Error(err)
+	require.NoDirExists(cloneDir)
 }
 
 func TestSetupFailsBeforeGitWhenSourceItemWasRemovedUpstream(t *testing.T) {
@@ -7466,7 +8649,7 @@ func TestSetupFailsBeforeGitWhenSourceItemWasRemovedUpstream(t *testing.T) {
 			require.NotNil(spec)
 			require.NotNil(ws)
 			mgr.SetWorktreeBasePathResolver(func(
-				context.Context, string, string, string, string,
+				context.Context, WorktreeBaseRepository,
 			) (string, bool, error) {
 				resolverCalls.Add(1)
 				return "", false, errors.New("git setup must not start")
@@ -7503,4 +8686,146 @@ func TestSetupFailsBeforeGitWhenSourceItemWasRemovedUpstream(t *testing.T) {
 			require.Equal("error", stored.Status)
 		})
 	}
+}
+
+func TestRefreshWorkspaceHeadRepoSnapshotSurvivesQueuedReconciliation(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMRWithHeadRepo(
+		t, d, repoID, 42, "feature/thing", "https://github.com/acme/widget.git",
+	)
+	ws := &Workspace{
+		ID:           "ws-refresh-queued-writer",
+		Platform:     "github",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   42,
+		GitHeadRef:   "feature/thing",
+		WorktreePath: t.TempDir(),
+		Status:       "ready",
+	}
+	require.NoError(d.InsertWorkspace(t.Context(), ws))
+
+	mgr := NewManager(d, t.TempDir())
+	writerQueued := make(chan struct{})
+	restoreHook := d.SetBeforeRepositoryReconciliationWriteLockForTest(func() {
+		close(writerQueued)
+	})
+	defer restoreHook()
+	writerDone := make(chan error, 1)
+	var interleaved bool
+	mgr.beforeHeadRepoSnapshotRepoLookup = func() {
+		if interleaved {
+			return
+		}
+		interleaved = true
+		go func() {
+			_, _, err := d.ReconcileRepositoryObservation(
+				context.Background(), db.RepoIdentity{
+					Platform: "github", PlatformHost: "github.com",
+					PlatformRepoID: "repo-acme-other",
+					Owner:          "acme", Name: "other",
+					RepoPath: "acme/other",
+				}, time.Now().UTC(),
+			)
+			writerDone <- err
+		}()
+		<-writerQueued
+	}
+
+	refreshDone := make(chan error, 1)
+	go func() {
+		_, err := mgr.RefreshWorkspaceHeadRepoSnapshot(context.Background(), ws)
+		refreshDone <- err
+	}()
+	select {
+	case err := <-refreshDone:
+		require.NoError(err)
+	case <-time.After(10 * time.Second):
+		require.Fail("head-repo refresh deadlocked behind a queued reconciliation writer")
+	}
+	select {
+	case err := <-writerDone:
+		require.NoError(err)
+	case <-time.After(10 * time.Second):
+		require.Fail("reconciliation writer never completed")
+	}
+}
+
+func TestSyncWorkspaceBaseBranchSurvivesQueuedReconciliationWriter(t *testing.T) {
+	if os.Getenv("KENN_FORGE_TEST_SYNC_BASE_BRANCH_QUEUED_WRITER") != "1" {
+		preparedDBPath := filepath.Join(t.TempDir(), "prepared.db")
+		preparedDB := dbtest.OpenAt(t, preparedDBPath)
+		require.NoError(t, preparedDB.Close())
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		defer cancel()
+		cmd := procutil.CommandContext(
+			ctx, os.Args[0],
+			"-test.run=^TestSyncWorkspaceBaseBranchSurvivesQueuedReconciliationWriter$",
+		)
+		cmd.Env = append(
+			os.Environ(),
+			"KENN_FORGE_TEST_SYNC_BASE_BRANCH_QUEUED_WRITER=1",
+			"KENN_FORGE_TEST_SYNC_BASE_BRANCH_DB="+preparedDBPath,
+		)
+		output, err := cmd.CombinedOutput()
+		require.NoError(t, ctx.Err(),
+			"workspace base-branch sync deadlocked behind a queued reconciliation writer: %s", output,
+		)
+		require.NoError(t, err, string(output))
+		return
+	}
+
+	require := require.New(t)
+	preparedDBPath := os.Getenv("KENN_FORGE_TEST_SYNC_BASE_BRANCH_DB")
+	require.NotEmpty(preparedDBPath)
+	d := dbtest.OpenPreparedAt(t, preparedDBPath)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	ws := &Workspace{
+		ID: "ws-verify-queued-writer", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widget", RepoID: repoID,
+		ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 42,
+		WorktreePath: t.TempDir(), Status: "ready",
+	}
+	require.NoError(d.InsertWorkspace(t.Context(), ws))
+
+	d.ReadDB().SetMaxOpenConns(1)
+	readConn, err := d.ReadDB().Conn(t.Context())
+	require.NoError(err)
+	syncDone := make(chan error, 1)
+	mgr := NewManager(d, t.TempDir())
+	go func() {
+		syncDone <- mgr.syncWorkspaceBaseBranch(
+			context.Background(), ws.WorktreePath, ws,
+		)
+	}()
+	deadline := time.Now().Add(5 * time.Second)
+	for d.ReadDB().Stats().WaitCount == 0 && time.Now().Before(deadline) {
+		runtime.Gosched()
+	}
+	require.Positive(d.ReadDB().Stats().WaitCount, "base-branch sync never reached its repository read")
+
+	writerQueued := make(chan struct{})
+	restoreHook := d.SetBeforeRepositoryReconciliationWriteLockForTest(func() {
+		close(writerQueued)
+	})
+	defer restoreHook()
+	writerDone := make(chan error, 1)
+	go func() {
+		_, _, err := d.ReconcileRepositoryObservation(
+			context.Background(), db.RepoIdentity{
+				Platform: "github", PlatformHost: "github.com",
+				PlatformRepoID: "repo-acme-other", Owner: "acme", Name: "other",
+				RepoPath: "acme/other",
+			}, time.Now().UTC(),
+		)
+		writerDone <- err
+	}()
+	<-writerQueued
+	require.NoError(readConn.Close())
+	require.NoError(<-syncDone)
+	require.NoError(<-writerDone)
 }

--- a/internal/workspace/monitor.go
+++ b/internal/workspace/monitor.go
@@ -25,14 +25,16 @@ type PullCandidateSource interface {
 }
 
 type PRMonitorOptions struct {
-	LaunchSpecs    *Manager
-	PullCandidates PullCandidateSource
+	LaunchSpecs               *Manager
+	PullCandidates            PullCandidateSource
+	RetireUnresolvedWorkspace func(context.Context, string) error
 }
 
 type PRMonitor struct {
-	db             *db.DB
-	launchSpecs    *Manager
-	pullCandidates PullCandidateSource
+	db                        *db.DB
+	launchSpecs               *Manager
+	pullCandidates            PullCandidateSource
+	retireUnresolvedWorkspace func(context.Context, string) error
 }
 
 func NewPRMonitor(database *db.DB, options ...PRMonitorOptions) *PRMonitor {
@@ -40,6 +42,7 @@ func NewPRMonitor(database *db.DB, options ...PRMonitorOptions) *PRMonitor {
 	if len(options) > 0 {
 		monitor.launchSpecs = options[0].LaunchSpecs
 		monitor.pullCandidates = options[0].PullCandidates
+		monitor.retireUnresolvedWorkspace = options[0].RetireUnresolvedWorkspace
 	}
 	return monitor
 }
@@ -55,6 +58,12 @@ func (m *PRMonitor) RunOnce(
 	var updates []PRAssociationUpdate
 	for i := range workspaces {
 		ws := workspaces[i]
+		if retired, retireErr := m.retireUnresolvedRepositoryWorkspace(ctx, &ws); retired {
+			if retireErr != nil {
+				slog.Warn("retire unresolved workspace", "workspace_id", ws.ID, "err", retireErr)
+			}
+			continue
+		}
 		if !workspacePRMonitorEligible(&ws) {
 			continue
 		}
@@ -92,7 +101,25 @@ func (m *PRMonitor) RefreshWorkspaceAssociation(
 			"workspace %q not found", workspaceID,
 		)
 	}
+	if retired, err := m.retireUnresolvedRepositoryWorkspace(ctx, ws); retired {
+		return PRAssociationUpdate{}, false, err
+	}
 	return m.refreshWorkspaceAssociation(ctx, ws)
+}
+
+func (m *PRMonitor) retireUnresolvedRepositoryWorkspace(
+	ctx context.Context, ws *Workspace,
+) (bool, error) {
+	if ws == nil || ws.RepoID != 0 ||
+		strings.TrimSpace(ws.PlatformHost) == "" ||
+		strings.TrimSpace(ws.RepoOwner) == "" ||
+		strings.TrimSpace(ws.RepoName) == "" {
+		return false, nil
+	}
+	if m.retireUnresolvedWorkspace == nil {
+		return true, nil
+	}
+	return true, m.retireUnresolvedWorkspace(ctx, ws.ID)
 }
 
 func (m *PRMonitor) refreshWorkspaceAssociation(
@@ -195,6 +222,23 @@ func (m *PRMonitor) listOpenPullCandidates(
 ) ([]db.MergeRequest, error) {
 	if m.pullCandidates != nil {
 		return m.pullCandidates.ListOpenPullCandidates(ctx, *workspace)
+	}
+	if workspace.RepoID != 0 {
+		repo, err := m.db.GetActiveRepoByID(ctx, workspace.RepoID)
+		if err != nil || repo == nil {
+			return nil, err
+		}
+		return m.db.ListMergeRequests(ctx, db.ListMergeRequestsOpts{
+			RepoID: repo.ID,
+			State:  "open",
+		})
+	}
+	collision, err := m.db.WorkspaceRepoRouteHasHistoricalOccupants(
+		ctx, workspaceProvider(workspace), workspace.PlatformHost,
+		workspace.RepoOwner, workspace.RepoName,
+	)
+	if err != nil || collision {
+		return nil, err
 	}
 	repo, err := m.db.GetRepoByIdentity(ctx, db.RepoIdentity{
 		Platform:     workspaceProvider(workspace),

--- a/internal/workspace/monitor_test.go
+++ b/internal/workspace/monitor_test.go
@@ -120,6 +120,106 @@ func seedIssue(
 	require.NoError(t, err)
 }
 
+func replaceMonitorRepoRoute(t *testing.T, d *db.DB) int64 {
+	t.Helper()
+	identity := db.GitHubRepoIdentity("github.com", "acme", "widget")
+	identity.PlatformRepoID = "repo-acme-widget-replacement"
+	replacement, _, err := d.ReconcileRepositoryObservation(
+		t.Context(), identity, time.Now().UTC().Add(time.Hour),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, replacement)
+	return replacement.Repository.ID
+}
+
+func TestPRMonitorRunOnceSkipsWorkspaceForInactiveRepository(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	seedRepo(t, d, "github.com", "acme", "widget")
+	worktreePath := setupMonitorRepo(t)
+	runWorkspaceTestGit(t, worktreePath, "checkout", "-b", "feature/replacement")
+	insertMonitorWorkspace(t, d, worktreePath, nil)
+
+	replacementID := replaceMonitorRepoRoute(t, d)
+	seedMRWithHeadRepo(
+		t, d, replacementID, 42,
+		"feature/replacement", "https://github.com/acme/widget.git",
+	)
+
+	updates, err := NewPRMonitor(d).RunOnce(t.Context())
+	require.NoError(err)
+	require.Empty(updates)
+	workspace, err := d.GetWorkspace(t.Context(), "ws-issue")
+	require.NoError(err)
+	require.Nil(workspace.AssociatedPRNumber)
+}
+
+func TestPRMonitorLegacyWorkspaceSkipsHistoricallyReusedRoute(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	insertMonitorWorkspace(t, database, t.TempDir(), nil)
+	workspace, err := database.GetWorkspace(t.Context(), "ws-issue")
+	require.NoError(err)
+	require.Zero(workspace.RepoID)
+
+	observedAt := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	_, _, err = database.ReconcileRepositoryObservation(t.Context(), db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "repo-original",
+		Owner: "acme", Name: "widget",
+	}, observedAt)
+	require.NoError(err)
+	_, _, err = database.ReconcileRepositoryObservation(t.Context(), db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "repo-original",
+		Owner: "acme", Name: "moved-away",
+	}, observedAt.Add(time.Minute))
+	require.NoError(err)
+	replacement, _, err := database.ReconcileRepositoryObservation(t.Context(), db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "repo-replacement",
+		Owner: "acme", Name: "widget",
+	}, observedAt.Add(2*time.Minute))
+	require.NoError(err)
+	require.NotNil(replacement)
+	seedMRWithHeadRepo(
+		t, database, replacement.Repository.ID, 42,
+		"feature/replacement", "https://github.com/acme/widget.git",
+	)
+
+	candidates, err := NewPRMonitor(database).listOpenPullCandidates(t.Context(), workspace)
+	require.NoError(err)
+	require.Empty(candidates)
+}
+
+func TestPRMonitorRetiresWorkspaceWithoutRepositoryIdentity(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	database := openTestDB(t)
+	workspaceID := insertMonitorWorkspaceWithIdentity(
+		t, database, "ws-unresolved", "github", "github.com",
+		"acme", "widget", t.TempDir(),
+	)
+	replacementID := seedRepo(t, database, "github.com", "acme", "widget")
+	seedMRWithHeadRepo(
+		t, database, replacementID, 42,
+		"feature/replacement", "https://github.com/acme/widget.git",
+	)
+	source := &staticPullCandidateSource{}
+	var retired []string
+	monitor := NewPRMonitor(database, PRMonitorOptions{
+		PullCandidates: source,
+		RetireUnresolvedWorkspace: func(_ context.Context, id string) error {
+			retired = append(retired, id)
+			return nil
+		},
+	})
+
+	updates, err := monitor.RunOnce(t.Context())
+
+	require.NoError(err)
+	assert.Empty(updates)
+	assert.Equal([]string{workspaceID}, retired)
+	assert.Zero(source.calls)
+}
+
 func TestPRMonitorRunOnceUsesUpstreamBranchMatch(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -161,10 +261,11 @@ func TestPRMonitorRunOnceUsesUpstreamBranchMatch(t *testing.T) {
 	assert.Equal(42, *ws.AssociatedPRNumber)
 }
 
-func TestLaunchSpecMonitorUsesHubCandidatesWithoutProviderRows(t *testing.T) {
+func TestLaunchSpecMonitorUsesHubCandidatesWithoutProviderItemRows(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	database := openTestDB(t)
+	seedRepo(t, database, "github.com", "acme", "widget")
 	worktreePath := setupMonitorRepo(t)
 	runWorkspaceTestGit(t, worktreePath, "checkout", "-b", "feature/issue-7")
 	require.NoError(os.WriteFile(
@@ -212,11 +313,6 @@ func TestLaunchSpecMonitorUsesHubCandidatesWithoutProviderRows(t *testing.T) {
 	assert.Equal(workspaceID, updates[0].WorkspaceID)
 	assert.Equal(42, updates[0].PRNumber)
 	assert.Equal(1, source.calls)
-	repo, err := database.GetRepoByIdentity(t.Context(), db.RepoIdentity{
-		Platform: "github", PlatformHost: "github.com", Owner: "acme", Name: "widget",
-	})
-	require.NoError(err)
-	assert.Nil(repo, "spoke lifecycle must not need a provider repository row")
 }
 
 func TestPRMonitorRunOnceFallsBackToLocalBranchNameAndHeadSHA(t *testing.T) {

--- a/internal/workspace/pushed_head_observer.go
+++ b/internal/workspace/pushed_head_observer.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -14,6 +15,7 @@ import (
 
 type remoteHeadKey struct {
 	WorkspaceID  string
+	RepoID       int64
 	Provider     platform.Kind
 	PlatformHost string
 	RepoPath     string
@@ -33,6 +35,7 @@ type remoteHeadObservation struct {
 
 type PushedHeadUpdate struct {
 	WorkspaceID  string
+	RepoID       int64
 	Provider     platform.Kind
 	PlatformHost string
 	RepoPath     string
@@ -170,6 +173,7 @@ func (o *PushedHeadObserver) MarkRefreshSucceeded(update PushedHeadUpdate, at ti
 func (u PushedHeadUpdate) remoteHeadKey() remoteHeadKey {
 	return remoteHeadKey{
 		WorkspaceID:  u.WorkspaceID,
+		RepoID:       u.RepoID,
 		Provider:     u.Provider,
 		PlatformHost: u.PlatformHost,
 		RepoPath:     u.RepoPath,
@@ -191,6 +195,12 @@ func (o *PushedHeadObserver) RunOnce(ctx context.Context) (PushedHeadPassResult,
 	trackingCache := make(map[string]trackingLookup)
 	for i := range workspaces {
 		ws := workspaces[i]
+		if retired, retireErr := o.monitor.retireUnresolvedRepositoryWorkspace(ctx, &ws); retired {
+			if retireErr != nil {
+				o.recordFailure(ws.ID, retireErr)
+			}
+			continue
+		}
 		if !pushedHeadWorkspaceEligible(&ws) {
 			continue
 		}
@@ -313,6 +323,25 @@ func (o *PushedHeadObserver) workspaceRepository(
 	ws *Workspace,
 	launchSpec *WorkspaceLaunchSpec,
 ) (*db.Repo, error) {
+	if ws.RepoID != 0 {
+		repo, err := o.db.GetActiveRepoByID(ctx, ws.RepoID)
+		if err != nil || repo == nil {
+			return repo, err
+		}
+		if launchSpec != nil {
+			if repo.PlatformRepoID != launchSpec.Repository.PlatformRepoID {
+				return nil, errors.New("workspace launch repository identity changed")
+			}
+			repo.Platform = launchSpec.Repository.Provider
+			repo.PlatformHost = launchSpec.Repository.PlatformHost
+			repo.Owner = launchSpec.Repository.Owner
+			repo.Name = launchSpec.Repository.Name
+			repo.RepoPath = launchSpec.Repository.Owner + "/" + launchSpec.Repository.Name
+			repo.CloneURL = launchSpec.Repository.CloneURL
+			repo.DefaultBranch = launchSpec.Repository.DefaultBranch
+		}
+		return repo, nil
+	}
 	if launchSpec != nil {
 		return &db.Repo{
 			Platform:       launchSpec.Repository.Provider,
@@ -324,6 +353,12 @@ func (o *PushedHeadObserver) workspaceRepository(
 			CloneURL:       launchSpec.Repository.CloneURL,
 			DefaultBranch:  launchSpec.Repository.DefaultBranch,
 		}, nil
+	}
+	collision, err := o.db.WorkspaceRepoRouteHasHistoricalOccupants(
+		ctx, workspaceProvider(ws), ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+	)
+	if err != nil || collision {
+		return nil, err
 	}
 	repo, err := o.db.GetRepoByIdentity(ctx, db.RepoIdentity{
 		Platform:     workspaceProvider(ws),
@@ -394,6 +429,7 @@ func (o *PushedHeadObserver) observeWorkspacePR(ctx context.Context, ws *Workspa
 	observedAt := o.now().UTC()
 	key := remoteHeadKey{
 		WorkspaceID:  ws.ID,
+		RepoID:       repo.ID,
 		Provider:     provider,
 		PlatformHost: host,
 		RepoPath:     repo.RepoPath,
@@ -405,6 +441,7 @@ func (o *PushedHeadObserver) observeWorkspacePR(ctx context.Context, ws *Workspa
 	}
 	update := PushedHeadUpdate{
 		WorkspaceID:  ws.ID,
+		RepoID:       repo.ID,
 		Provider:     provider,
 		PlatformHost: host,
 		RepoPath:     repo.RepoPath,

--- a/internal/workspace/pushed_head_observer_test.go
+++ b/internal/workspace/pushed_head_observer_test.go
@@ -124,6 +124,66 @@ func newPushedHeadObserverForTest(
 	return observer
 }
 
+func TestPushedHeadObserverSkipsWorkspaceForInactiveRepository(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	seedRepo(t, d, "github.com", "acme", "widget")
+	insertPushedHeadWorkspace(
+		t, d, "ws-pr", db.WorkspaceItemTypePullRequest, 42, nil,
+	)
+	replacementID := replaceMonitorRepoRoute(t, d)
+	seedMRWithPlatformHead(
+		t, d, replacementID, 42, "feature/remote-head", "1111111", "",
+	)
+	reader := &fakeRemoteHeadReader{
+		branch:      "feature/remote-head",
+		trackingSHA: "2222222",
+		trackingRef: "refs/remotes/origin/feature/remote-head",
+		trackingOK:  true,
+	}
+	observer := newPushedHeadObserverForTest(t, d, reader)
+
+	result, err := observer.RunOnce(t.Context())
+	require.NoError(err)
+	require.Empty(result.Associations)
+	require.Empty(result.HeadChanges)
+	require.Zero(reader.branchCalls)
+}
+
+func TestPushedHeadObserverLegacyWorkspaceSkipsHistoricallyReusedRoute(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	insertPushedHeadWorkspace(
+		t, database, "ws-legacy-pr", db.WorkspaceItemTypePullRequest, 42, nil,
+	)
+	workspace, err := database.GetWorkspace(t.Context(), "ws-legacy-pr")
+	require.NoError(err)
+	require.Zero(workspace.RepoID)
+
+	observedAt := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	_, _, err = database.ReconcileRepositoryObservation(t.Context(), db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "repo-original",
+		Owner: "acme", Name: "widget",
+	}, observedAt)
+	require.NoError(err)
+	_, _, err = database.ReconcileRepositoryObservation(t.Context(), db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "repo-original",
+		Owner: "acme", Name: "moved-away",
+	}, observedAt.Add(time.Minute))
+	require.NoError(err)
+	_, _, err = database.ReconcileRepositoryObservation(t.Context(), db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "repo-replacement",
+		Owner: "acme", Name: "widget",
+	}, observedAt.Add(2*time.Minute))
+	require.NoError(err)
+
+	repo, err := NewPushedHeadObserver(database).workspaceRepository(
+		t.Context(), workspace, nil,
+	)
+	require.NoError(err)
+	require.Nil(repo)
+}
+
 func TestPushedHeadObserverFirstObservationSkipsWhenProviderHeadMatches(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -151,12 +211,13 @@ func TestPushedHeadObserverFirstObservationSkipsWhenProviderHeadMatches(t *testi
 	assert.Equal(1, reader.trackingCalls)
 }
 
-func TestLaunchSpecPushedHeadObserverUsesHubCandidatesWithoutProviderRows(
+func TestLaunchSpecPushedHeadObserverUsesHubCandidatesWithoutProviderItemRows(
 	t *testing.T,
 ) {
 	require := require.New(t)
 	assert := assert.New(t)
 	database := openTestDB(t)
+	seedRepo(t, database, "github.com", "acme", "widget")
 	insertPushedHeadWorkspace(
 		t, database, "ws-spoke-pr", db.WorkspaceItemTypePullRequest, 42, nil,
 	)
@@ -211,11 +272,6 @@ func TestLaunchSpecPushedHeadObserverUsesHubCandidatesWithoutProviderRows(
 	assert.Equal("1111111", result.HeadChanges[0].OldSHA)
 	assert.Equal("2222222", result.HeadChanges[0].NewSHA)
 	assert.Equal(1, source.calls)
-	repo, err := database.GetRepoByIdentity(t.Context(), db.RepoIdentity{
-		Platform: "github", PlatformHost: "github.com", Owner: "acme", Name: "widget",
-	})
-	require.NoError(err)
-	assert.Nil(repo)
 }
 
 func TestPushedHeadObserverFirstObservationEnqueuesWhenProviderHeadDiffers(t *testing.T) {
@@ -243,6 +299,7 @@ func TestPushedHeadObserverFirstObservationEnqueuesWhenProviderHeadDiffers(t *te
 	require.Len(result.HeadChanges, 1)
 	change := result.HeadChanges[0]
 	assert.Equal("ws-pr", change.WorkspaceID)
+	assert.Equal(repoID, change.RepoID)
 	assert.Equal("github", string(change.Provider))
 	assert.Equal("github.com", change.PlatformHost)
 	assert.Equal("acme/widget", change.RepoPath)

--- a/internal/workspace/repository_hooks.go
+++ b/internal/workspace/repository_hooks.go
@@ -837,7 +837,7 @@ func (m *Manager) setupManagedRepositoryHooks(
 		); err != nil {
 			return errors.Join(err, checkpoint.restore())
 		}
-		if err := m.verifyWorkspaceRouteUnoccupied(ctx, ws); err != nil {
+		if err := m.verifyWorkspaceRepository(ctx, ws); err != nil {
 			return errors.Join(err, checkpoint.restore())
 		}
 		return nil

--- a/internal/workspace/testmain_test.go
+++ b/internal/workspace/testmain_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"go.kenn.io/forge/internal/testutil/gitsafe"
 	"go.kenn.io/forge/internal/testutil/testsignal"
 	"go.kenn.io/forge/internal/testutil/testtmux"
 )
@@ -34,7 +35,7 @@ func TestMain(m *testing.M) {
 			fmt.Fprintf(os.Stderr, "cleanup private test tmux servers: %v\n", cleanupErr)
 		},
 	)
-	code := m.Run()
+	code := gitsafe.RunIsolatedMain(m)
 	if cleanupErr := runCleanup(); cleanupErr != nil {
 		fmt.Fprintf(os.Stderr, "cleanup private test tmux servers: %v\n", cleanupErr)
 		if code == 0 {


### PR DESCRIPTION
Workspaces now stay attached to the same repository when it is renamed. If another repository later takes the old owner/name route, Forge creates a separate workspace and checkout instead of rejecting the request or reusing the previous repository's files.

- Store provider workspaces by stable repository ID, while continuing to show the repository's current owner and name.
- Give new clones and worktrees identity-specific paths. Existing managed clones can be recovered across renames only when their history proves they belong to the same repository.
- Check repository identity before and after network Git operations. If the route changes during a fetch, restore the existing clone instead of keeping data from the new occupant.
- Refresh launch data, pull request state, and workspace associations by repository ID. Legacy rows that cannot be identified safely are retired without deleting uncommitted work.
- Update migration 55 to backfill unambiguous rows, remove duplicate workspaces for the same item, and add the stable-ID constraint. No additional migration is introduced.

Tests cover route reuse, consecutive renames, clone rollback and recovery, dirty-workspace preservation, launch data, database migration and cleanup, and concurrent deletion handling. The relevant Go suites, vet, lint, migration-history check, and repository hooks pass locally.
