### PR TITLE
feat: let reviewers collapse the diff file tree

### DIFF
--- a/frontend/src/lib/components/diff/DiffFilesLayout.svelte
+++ b/frontend/src/lib/components/diff/DiffFilesLayout.svelte
@@ -120,6 +120,11 @@
   let filesLayout: HTMLDivElement | undefined = $state();
   let filesLayoutWidth = $state(0);
   let fileTreeWidth = $state(loadFileTreeWidth());
+  let fileTreeHidden = $state(false);
+
+  function toggleFileTree(): void {
+    fileTreeHidden = !fileTreeHidden;
+  }
 
   function saveFileTreeWidth(width: number): void {
     safeSetItem(storageKey, String(width));
@@ -173,26 +178,34 @@
 </script>
 
 <div class="files-view">
-  <DiffToolbar />
+  <DiffToolbar
+    fileListHidden={fileTreeHidden}
+    onToggleFileList={toggleFileTree}
+  />
   <div class="files-layout" bind:this={filesLayout}>
-    <aside
-      class="files-sidebar"
-      aria-label="Changed files"
-      style:--diff-file-tree-width={`${fileTreeWidth}px`}
-    >
-      <DiffSidebar showCommits={false} />
-    </aside>
-    <SplitResizeHandle
-      class="files-resize-handle"
-      ariaLabel="Resize file tree"
-      orientation="horizontal"
-      ariaValueMin={minAllowedFileTreeWidth()}
-      ariaValueMax={maxAllowedFileTreeWidth()}
-      ariaValueNow={fileTreeWidth}
-      onResizeStart={handleFileTreeResizeStart}
-      onResize={handleFileTreeResize}
-      onResizeEnd={handleFileTreeResizeEnd}
-    />
+    {#if !fileTreeHidden}
+      <aside
+        class="files-sidebar"
+        aria-label="Changed files"
+        style:--diff-file-tree-width={`${fileTreeWidth}px`}
+      >
+        <DiffSidebar
+          showCommits={false}
+          onCollapseFileTree={toggleFileTree}
+        />
+      </aside>
+      <SplitResizeHandle
+        class="files-resize-handle"
+        ariaLabel="Resize file tree"
+        orientation="horizontal"
+        ariaValueMin={minAllowedFileTreeWidth()}
+        ariaValueMax={maxAllowedFileTreeWidth()}
+        ariaValueNow={fileTreeWidth}
+        onResizeStart={handleFileTreeResizeStart}
+        onResize={handleFileTreeResize}
+        onResizeEnd={handleFileTreeResizeEnd}
+      />
+    {/if}
     <div class="files-main">
       <DiffView
         {provider}

--- a/frontend/src/lib/components/diff/DiffFilesLayout.test.ts
+++ b/frontend/src/lib/components/diff/DiffFilesLayout.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/svelte";
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import type { ProviderCapabilities, RepoOperations } from "../../api/types.js";
 
@@ -136,5 +136,21 @@ describe("DiffFilesLayout operation gates", () => {
 
     expect(screen.getByTestId("keyboard-active").textContent).toBe("false");
     expect(screen.getByTestId("page-keyboard-active").textContent).toBe("true");
+  });
+
+  it("collapses and restores the changed-file tree", async () => {
+    renderLayout(operations({}));
+
+    expect(screen.getByRole("complementary", { name: "Changed files" })).toBeTruthy();
+    expect(screen.getByRole("separator", { name: "Resize file tree" })).toBeTruthy();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Collapse file tree" }));
+
+    expect(screen.queryByRole("complementary", { name: "Changed files" })).toBeNull();
+    expect(screen.queryByRole("separator", { name: "Resize file tree" })).toBeNull();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Expand file tree" }));
+
+    expect(screen.getByRole("complementary", { name: "Changed files" })).toBeTruthy();
   });
 });

--- a/frontend/src/lib/components/diff/DiffFilesLayoutTestSidebar.svelte
+++ b/frontend/src/lib/components/diff/DiffFilesLayoutTestSidebar.svelte
@@ -1,1 +1,13 @@
-<aside data-testid="diff-sidebar"></aside>
+<script lang="ts">
+  interface Props {
+    onCollapseFileTree?: (() => void) | undefined;
+  }
+
+  const { onCollapseFileTree }: Props = $props();
+</script>
+
+<aside data-testid="diff-sidebar">
+  {#if onCollapseFileTree}
+    <button onclick={onCollapseFileTree}>Collapse file tree</button>
+  {/if}
+</aside>

--- a/frontend/src/lib/components/diff/DiffFilesLayoutTestToolbar.svelte
+++ b/frontend/src/lib/components/diff/DiffFilesLayoutTestToolbar.svelte
@@ -1,1 +1,17 @@
-<div data-testid="diff-toolbar"></div>
+<script lang="ts">
+  interface Props {
+    fileListHidden?: boolean;
+    onToggleFileList?: (() => void) | undefined;
+  }
+
+  const {
+    fileListHidden = false,
+    onToggleFileList,
+  }: Props = $props();
+</script>
+
+<div data-testid="diff-toolbar">
+  {#if fileListHidden && onToggleFileList}
+    <button onclick={onToggleFileList}>Expand file tree</button>
+  {/if}
+</div>

--- a/frontend/src/lib/components/diff/DiffSidebar.svelte
+++ b/frontend/src/lib/components/diff/DiffSidebar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { SearchInput } from "@kenn-io/kit-ui";
+  import { SearchInput, SidebarToggle } from "@kenn-io/kit-ui";
   import { getStores } from "../../context.js";
   import CommitListSection from "./CommitListSection.svelte";
   import PierreFileTree from "./PierreFileTree.svelte";
@@ -13,9 +13,14 @@
   interface Props {
     showCommits?: boolean;
     resetKey?: string;
+    onCollapseFileTree?: (() => void) | undefined;
   }
 
-  const { showCommits = true, resetKey = "" }: Props = $props();
+  const {
+    showCommits = true,
+    resetKey = "",
+    onCollapseFileTree,
+  }: Props = $props();
 
   function handleTreeSelection(path: string): void {
     diff.requestScrollToFile(path);
@@ -60,15 +65,27 @@
   {#if diff.isFileListLoading() && !diff.getFileList()}
     <div class="diff-files-state diff-files-state--loading">Loading files</div>
   {:else if filteredDiffFiles}
-    {#if showFileFilter}
-      <div class="diff-files-filter">
-        <SearchInput
-          size="sm"
-          block
-          placeholder="Filter files..."
-          ariaLabel="Filter files"
-          bind:value={fileFilterText}
-        />
+    {#if showFileFilter || onCollapseFileTree}
+      <div class="diff-files-controls">
+        {#if showFileFilter}
+          <div class="diff-files-filter">
+            <SearchInput
+              size="sm"
+              block
+              placeholder="Filter files..."
+              ariaLabel="Filter files"
+              bind:value={fileFilterText}
+            />
+          </div>
+        {/if}
+        {#if onCollapseFileTree}
+          <SidebarToggle
+            state="expanded"
+            label="file tree"
+            onclick={onCollapseFileTree}
+            class="kit-sidebar-toggle--compact"
+          />
+        {/if}
       </div>
     {/if}
     <PierreFileTree
@@ -91,8 +108,17 @@
     overflow: hidden;
   }
 
+  .diff-files-controls {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--space-1);
+    padding: var(--space-2) var(--space-5) var(--space-3) var(--space-7);
+  }
+
   .diff-files-filter {
-    padding: 4px 10px 6px 24px;
+    flex: 1;
+    min-width: 0;
   }
 
   .diff-files-state {

--- a/frontend/src/lib/components/diff/DiffToolbar.svelte
+++ b/frontend/src/lib/components/diff/DiffToolbar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Toggle } from "@kenn-io/kit-ui";
+  import { SidebarToggle, Toggle } from "@kenn-io/kit-ui";
   import MoreHorizontalIcon from "@lucide/svelte/icons/more-horizontal";
   import { getStores } from "../../context.js";
   import {
@@ -177,6 +177,14 @@
 <svelte:document onclick={handleDocumentClick} onkeydown={handleDocumentKeydown} />
 
 <div class={["diff-toolbar", compact && "diff-toolbar--compact"]}>
+  {#if fileListHidden && onToggleFileList}
+    <SidebarToggle
+      state="collapsed"
+      label="file tree"
+      onclick={onToggleFileList}
+      class="kit-sidebar-toggle--compact"
+    />
+  {/if}
   {#if compact}
     <div class="compact-summary">
       <span class="toolbar-label">Files</span>

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -1753,6 +1753,36 @@ test.describe("diff view", () => {
       .toBe(beforeWidth + 80);
   });
 
+  test("collapses and restores the changed-file tree", async ({ page }) => {
+    await mockDiffApi(page, largeDiff);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+    await waitForSidebarFilesLoaded(page);
+
+    const fileTree = page.getByRole("complementary", {
+      name: "Changed files",
+    });
+    const resizeHandle = page.getByRole("separator", {
+      name: "Resize file tree",
+    });
+    const fileTreeControls = fileTree.locator(".diff-files-controls");
+    await expect(fileTreeControls.getByRole("searchbox", { name: "Filter files" })).toBeVisible();
+    const initialWidth = await fileTree.evaluate((element) => element.getBoundingClientRect().width);
+
+    await fileTreeControls.getByRole("button", { name: "Collapse file tree" }).click();
+
+    await expect(fileTree).toBeHidden();
+    await expect(resizeHandle).toBeHidden();
+
+    await page.getByRole("button", { name: "Expand file tree" }).click();
+
+    await expect(fileTree).toBeVisible();
+    await expect(resizeHandle).toBeVisible();
+    await expect
+      .poll(async () => fileTree.evaluate((element) => element.getBoundingClientRect().width))
+      .toBe(initialWidth);
+  });
+
   test("clamps persisted file tree width inside narrow split panes", async ({ page }) => {
     await page.setViewportSize({ width: 780, height: 720 });
     await page.addInitScript(() => {


### PR DESCRIPTION
Reviewers can now hide the changed-file tree after choosing a file, giving the diff the full pane width without losing the tree's remembered width.

- Adds a compact, keyboard-accessible collapse control beside the file filter.
- Keeps a restore control visible in the diff toolbar while the tree is hidden.

Expanded | Collapsed
--- | ---
![Expanded changed-file tree](https://github.com/user-attachments/assets/893dfc9d-2d5f-4d8a-a01c-0053e0428933) | ![Collapsed changed-file tree](https://github.com/user-attachments/assets/38f6afe4-3e5e-47b1-a527-e4a9e7f67d72)
