### PR TITLE
fix: keep mobile description actions together

### DIFF
--- a/frontend/src/CollapsibleDescription.browser.svelte.ts
+++ b/frontend/src/CollapsibleDescription.browser.svelte.ts
@@ -40,19 +40,21 @@ describe("collapsible description browser layout", () => {
     }
   });
 
-  it("aligns the copy control with the card's right edge on mobile", async () => {
+  it("keeps the copy control in the description header on mobile", async () => {
     await page.viewport(390, 844);
     const { container, unmount } = render(CollapsibleDescriptionBrowserFixture);
 
     try {
       const copyButton = container.querySelector(".kit-copy-btn.body-copy");
-      const card = container.querySelector(".detail-description-card");
+      const editButton = container.querySelector(".fixture-edit");
       expect(copyButton).not.toBeNull();
-      expect(card).not.toBeNull();
+      expect(editButton).not.toBeNull();
 
-      const copyRight = (copyButton as Element).getBoundingClientRect().right;
-      const cardRight = (card as Element).getBoundingClientRect().right;
-      expect(Math.abs(copyRight - cardRight)).toBeLessThanOrEqual(1);
+      const copyBox = (copyButton as Element).getBoundingClientRect();
+      const editBox = (editButton as Element).getBoundingClientRect();
+      const copyCenter = copyBox.top + copyBox.height / 2;
+      const editCenter = editBox.top + editBox.height / 2;
+      expect(Math.abs(copyCenter - editCenter)).toBeLessThanOrEqual(1);
     } finally {
       unmount();
     }

--- a/frontend/src/CollapsibleDescription.browser.svelte.ts
+++ b/frontend/src/CollapsibleDescription.browser.svelte.ts
@@ -7,6 +7,7 @@ import CollapsibleDescriptionBrowserFixture from "./test/CollapsibleDescriptionB
 
 describe("collapsible description browser layout", () => {
   it("creates a 320px vertical scroll container when collapsed", async () => {
+    await page.viewport(1280, 900);
     const { container, unmount } = render(CollapsibleDescriptionBrowserFixture);
 
     try {
@@ -34,6 +35,24 @@ describe("collapsible description browser layout", () => {
       expect(restoredCard).not.toBeNull();
       expect((restoredCard as Element).clientHeight).toBe(expandedHeight);
       expect((restoredCard as Element).clientHeight).toBeGreaterThan(collapsedHeight);
+    } finally {
+      unmount();
+    }
+  });
+
+  it("aligns the copy control with the card's right edge on mobile", async () => {
+    await page.viewport(390, 844);
+    const { container, unmount } = render(CollapsibleDescriptionBrowserFixture);
+
+    try {
+      const copyButton = container.querySelector(".kit-copy-btn.body-copy");
+      const card = container.querySelector(".detail-description-card");
+      expect(copyButton).not.toBeNull();
+      expect(card).not.toBeNull();
+
+      const copyRight = (copyButton as Element).getBoundingClientRect().right;
+      const cardRight = (card as Element).getBoundingClientRect().right;
+      expect(Math.abs(copyRight - cardRight)).toBeLessThanOrEqual(1);
     } finally {
       unmount();
     }

--- a/frontend/src/lib/components/detail/CollapsibleDescription.svelte
+++ b/frontend/src/lib/components/detail/CollapsibleDescription.svelte
@@ -20,49 +20,58 @@
   }
 </script>
 
-<div class="detail-description__header">
-  <span class="detail-description__title">Description</span>
-  <div class="detail-description__actions">
-    {#if headerActions}
-      {@render headerActions()}
-    {/if}
-    {#if isLong}
-      <button
-        type="button"
-        class="detail-description__toggle"
-        aria-label={isLong && collapsed ? "Expand description" : "Collapse description"}
-        aria-expanded={!(isLong && collapsed)}
-        onclick={toggleCollapsed}
-      >
-        {isLong && collapsed ? "Expand" : "Collapse"}
-      </button>
-    {/if}
+<div class="detail-description">
+  <div class="detail-description__header">
+    <span class="detail-description__title">Description</span>
+    <div class="detail-description__actions">
+      {#if headerActions}
+        {@render headerActions()}
+      {/if}
+      {#if isLong}
+        <button
+          type="button"
+          class="detail-description__toggle"
+          aria-label={isLong && collapsed ? "Expand description" : "Collapse description"}
+          aria-expanded={!(isLong && collapsed)}
+          onclick={toggleCollapsed}
+        >
+          {isLong && collapsed ? "Expand" : "Collapse"}
+        </button>
+      {/if}
+      <CopyButton
+        class={copied ? "body-copy body-copy--copied" : "body-copy"}
+        {copied}
+        onclick={oncopy}
+        revealOnHover
+        ariaLabel="Copy to clipboard"
+        copiedAriaLabel="Copied!"
+        title="Copy to clipboard"
+        copiedTitle="Copied!"
+      />
+    </div>
   </div>
-</div>
-<div class="detail-description__card-wrap">
-  <CopyButton
-    class={copied ? "body-copy body-copy--copied" : "body-copy"}
-    {copied}
-    onclick={oncopy}
-    revealOnHover
-    ariaLabel="Copy to clipboard"
-    copiedAriaLabel="Copied!"
-    title="Copy to clipboard"
-    copiedTitle="Copied!"
-  />
-  <Card
-    level="inset"
-    padding="none"
-    class={isLong && collapsed
-      ? "detail-description-card detail-description-card--compact"
-      : "detail-description-card"}
-  >
-    {@render children()}
-  </Card>
+  <div class="detail-description__card-wrap">
+    <Card
+      level="inset"
+      padding="none"
+      class={isLong && collapsed
+        ? "detail-description-card detail-description-card--compact"
+        : "detail-description-card"}
+    >
+      {@render children()}
+    </Card>
+  </div>
 </div>
 
 <style>
+  .detail-description {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+  }
+
   .detail-description__header {
+    position: relative;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -96,19 +105,15 @@
     color: var(--accent-blue);
   }
 
-  .detail-description__card-wrap {
-    position: relative;
-  }
-
-  .detail-description__card-wrap :global(.kit-copy-btn.body-copy) {
+  .detail-description__header :global(.kit-copy-btn.body-copy) {
     position: absolute;
-    top: var(--space-3);
+    top: calc(100% + var(--space-4) + var(--space-3));
     right: var(--space-3);
     z-index: 1;
   }
 
-  .detail-description__card-wrap:hover :global(.kit-copy-btn.body-copy),
-  .detail-description__card-wrap :global(.kit-copy-btn.body-copy--copied) {
+  .detail-description:hover :global(.kit-copy-btn.body-copy),
+  .detail-description :global(.kit-copy-btn.body-copy--copied) {
     opacity: 1;
   }
 
@@ -122,10 +127,6 @@
   }
 
   @media (max-width: 640px) {
-    .detail-description__card-wrap {
-      display: grid;
-    }
-
     .detail-description__toggle {
       display: inline-flex;
       align-items: center;
@@ -136,9 +137,8 @@
       font-size: var(--detail-mobile-type-sm, var(--font-size-sm));
     }
 
-    .detail-description__card-wrap :global(.kit-copy-btn.body-copy) {
+    .detail-description__header :global(.kit-copy-btn.body-copy) {
       position: static;
-      justify-self: end;
       min-width: var(--detail-mobile-hit-target, 37px);
       min-height: var(--detail-mobile-hit-target, 37px);
       padding: var(--detail-mobile-space-xs, var(--space-3));

--- a/frontend/src/lib/components/detail/CollapsibleDescription.svelte
+++ b/frontend/src/lib/components/detail/CollapsibleDescription.svelte
@@ -122,6 +122,10 @@
   }
 
   @media (max-width: 640px) {
+    .detail-description__card-wrap {
+      display: grid;
+    }
+
     .detail-description__toggle {
       display: inline-flex;
       align-items: center;
@@ -134,6 +138,7 @@
 
     .detail-description__card-wrap :global(.kit-copy-btn.body-copy) {
       position: static;
+      justify-self: end;
       min-width: var(--detail-mobile-hit-target, 37px);
       min-height: var(--detail-mobile-hit-target, 37px);
       padding: var(--detail-mobile-space-xs, var(--space-3));

--- a/frontend/src/test/CollapsibleDescriptionBrowserFixture.svelte
+++ b/frontend/src/test/CollapsibleDescriptionBrowserFixture.svelte
@@ -7,5 +7,8 @@
   copied={false}
   oncopy={() => {}}
 >
+  {#snippet headerActions()}
+    <button type="button" class="fixture-edit">Edit</button>
+  {/snippet}
   <div style="height: 640px">Long rendered description</div>
 </CollapsibleDescription>


### PR DESCRIPTION
Phone pull request descriptions now keep Copy beside Edit and Collapse in the Description header. The previous mobile layout gave Copy its own row, leaving a large empty gap; desktop keeps the copy control inset over the card on hover.
