### PR TITLE
fix: isolate JavaScript Git fixtures from host repositories

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -27,6 +27,11 @@ Report security findings only when a skill accepts unapproved external input,
 listens beyond loopback, publishes artifacts, or accesses undeclared state.
 Correctness, data loss, and unsafe shell behavior remain in scope.
 
+Treat every new or changed `git init` in tests or automation as CRITICAL
+severity. Reject the change unless it strips inherited Git variables, uses
+scratch global and system configuration, and creates the fixture outside every
+repository and worktree. A working directory or `git -C` is not isolation.
+
 The root-level kenn-forge package (forge.go) is the embedding API.
 It does not have a stable API and can be changed arbitrarily until it
 stabilizes. Do not flag breaking changes to its exported surface.

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -38,6 +38,12 @@ fixtures, or changing shell-script coverage.
 - Shell-script tests must execute the script against controlled inputs and
   assert observable output, side effects, or exit status. Do not grep scripts,
   workflows, config, or docs for expected implementation text.
+- JavaScript tests that create or mutate Git repositories must use the shared
+  isolated fixture; raw child processes can inherit hook bindings and mutate the
+  hosting checkout (`scripts/test-git-fixture.mjs::createGitTestRepository`).
+- Isolation must strip inherited Git variables, use scratch global and system
+  configuration, and keep the fixture outside every checkout; a working
+  directory or `git -C` alone does not isolate Git.
 - Private tmux tests retain markers on gate, read, validation, or identity errors;
   one deadline covers gate closure and startup draining, and cleanup never addresses
   the default server. (`internal/testutil/testtmux/owner.go::Owner`)

--- a/scripts/context-sync.test.mjs
+++ b/scripts/context-sync.test.mjs
@@ -1,75 +1,46 @@
 import assert from "node:assert/strict";
 import { execFile as execFileCallback } from "node:child_process";
-import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
-import os from "node:os";
+import { mkdir, readFile, symlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 import { test } from "node:test";
 
+import { createGitTestRepository } from "./test-git-fixture.mjs";
+
 const execFile = promisify(execFileCallback);
 const scriptPath = path.join(path.dirname(fileURLToPath(import.meta.url)), "context-sync");
-const gitRepositoryEnvVars = [
-  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
-  "GIT_COMMON_DIR",
-  "GIT_CONFIG",
-  "GIT_CONFIG_COUNT",
-  "GIT_CONFIG_PARAMETERS",
-  "GIT_DIR",
-  "GIT_GRAFT_FILE",
-  "GIT_IMPLICIT_WORK_TREE",
-  "GIT_INDEX_FILE",
-  "GIT_NO_REPLACE_OBJECTS",
-  "GIT_OBJECT_DIRECTORY",
-  "GIT_PREFIX",
-  "GIT_REPLACE_REF_BASE",
-  "GIT_SHALLOW_FILE",
-  "GIT_WORK_TREE",
-];
-
-function isolatedGitEnv(env = process.env) {
-  const isolated = { ...env };
-  for (const name of gitRepositoryEnvVars) {
-    delete isolated[name];
-  }
-  for (const name of Object.keys(isolated)) {
-    if (/^GIT_CONFIG_(?:KEY|VALUE)_\d+$/.test(name)) {
-      delete isolated[name];
-    }
-  }
-  return isolated;
-}
-
 async function createContextRoot(t, env = process.env) {
-  const root = await mkdtemp(path.join(os.tmpdir(), "kenn-forge-context-sync-test-"));
-  t.after(() => rm(root, { recursive: true, force: true }));
-
-  await execFile("git", ["init", "--quiet", root], { env: isolatedGitEnv(env) });
+  const repository = createGitTestRepository(t, {
+    env,
+    prefix: "kenn-forge-context-sync-test-",
+  });
+  const { root } = repository;
   await mkdir(path.join(root, "skills", "context-sync"), { recursive: true });
   await writeFile(path.join(root, "CLAUDE.md"), "# Agent instructions\n");
   await symlink("CLAUDE.md", path.join(root, "AGENTS.md"));
   await writeFile(path.join(root, "skills", "context-sync", "SKILL.md"), "# Context sync\n");
-  return root;
+  return repository;
 }
 
 test("context sync accepts a valid routed context surface", async (t) => {
-  const root = await createContextRoot(t);
+  const { env, root } = await createContextRoot(t);
 
   const result = await execFile(scriptPath, ["--check"], {
     cwd: root,
-    env: isolatedGitEnv(),
+    env,
   });
 
   assert.match(result.stdout, /structural check passed/);
 });
 
 test("context sync accepts a skill-required Superpowers design spec", async (t) => {
-  const root = await createContextRoot(t);
+  const { env, root } = await createContextRoot(t);
   const specs = path.join(root, "docs", "superpowers", "specs");
   await mkdir(specs, { recursive: true });
   await writeFile(path.join(specs, "active-design.md"), "# Active design\n");
 
-  await assert.rejects(execFile(scriptPath, ["--check"], { cwd: root, env: isolatedGitEnv() }), (error) => {
+  await assert.rejects(execFile(scriptPath, ["--check"], { cwd: root, env }), (error) => {
     assert.match(error.stderr, /docs\/superpowers must remain absent/);
     assert.match(error.stderr, /do not convert them into ADRs/);
     assert.match(error.stderr, /structural check failed/);
@@ -78,9 +49,10 @@ test("context sync accepts a skill-required Superpowers design spec", async (t) 
 });
 
 test("context sync fixtures ignore inherited hook repository bindings", async (t) => {
-  const hostRoot = await mkdtemp(path.join(os.tmpdir(), "kenn-forge-hook-host-test-"));
-  t.after(() => rm(hostRoot, { recursive: true, force: true }));
-  await execFile("git", ["init", "--quiet", hostRoot], { env: isolatedGitEnv() });
+  const hostRepository = createGitTestRepository(t, {
+    prefix: "kenn-forge-hook-host-test-",
+  });
+  const hostRoot = hostRepository.root;
 
   const hostConfigPath = path.join(hostRoot, ".git", "config");
   const originalHostConfig = await readFile(hostConfigPath, "utf8");
@@ -90,10 +62,10 @@ test("context sync fixtures ignore inherited hook repository bindings", async (t
     GIT_WORK_TREE: hostRoot,
   };
 
-  const root = await createContextRoot(t, hookEnv);
+  const { env, root } = await createContextRoot(t, hookEnv);
   const result = await execFile(scriptPath, ["--check"], {
     cwd: root,
-    env: isolatedGitEnv(hookEnv),
+    env,
   });
 
   assert.match(result.stdout, /structural check passed/);

--- a/scripts/docs-assets-sync.test.mjs
+++ b/scripts/docs-assets-sync.test.mjs
@@ -1,32 +1,21 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
-import os from "node:os";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { test } from "node:test";
 
-const assets = [
-  "first-workflow.svg",
-  "second-workflow.svg",
-];
+import { createGitTestRepository } from "./test-git-fixture.mjs";
 
-function run(command, args, options = {}) {
-  const result = spawnSync(command, args, { encoding: "utf8", ...options });
-  assert.equal(result.status, 0, result.stderr || result.stdout);
-  return result;
-}
+const assets = ["first-workflow.svg", "second-workflow.svg"];
 
-function git(root, ...args) {
-  return run("git", ["-C", root, ...args]);
-}
-
-async function initRepo(root) {
-  git(root, "init", "-b", "main");
-  git(root, "config", "user.name", "Docs Test");
-  git(root, "config", "user.email", "docs@example.com");
-  await writeFile(path.join(root, "README.md"), "fixture\n");
-  git(root, "add", "README.md");
-  git(root, "commit", "-m", "fixture");
+async function createDocsAssetsRepository(t) {
+  const repository = createGitTestRepository(t, {
+    prefix: "kenn-forge-docs-assets-test-",
+  });
+  await writeFile(path.join(repository.root, "README.md"), "fixture\n");
+  repository.git("add", "README.md");
+  repository.git("commit", "-m", "fixture");
+  return repository;
 }
 
 async function writeAssetSet(root, selected = assets) {
@@ -35,13 +24,13 @@ async function writeAssetSet(root, selected = assets) {
   }
 }
 
-function sync(root, extraEnv = {}) {
+function sync(repository, extraEnv = {}) {
   return spawnSync("bash", ["scripts/sync-docs-assets.sh"], {
     cwd: path.resolve("."),
     encoding: "utf8",
     env: {
-      ...process.env,
-      DOCS_ASSETS_REPO_ROOT: root,
+      ...repository.env,
+      DOCS_ASSETS_REPO_ROOT: repository.root,
       DOCS_ASSETS_REMOTE: "missing-remote",
       DOCS_ASSETS_RAW_ROOT: "http://127.0.0.1:1/unavailable",
       ...extraEnv,
@@ -50,20 +39,19 @@ function sync(root, extraEnv = {}) {
 }
 
 test("asset sync publishes the pinned generation instead of a newer branch tip", async (t) => {
-  const root = await mkdtemp(path.join(os.tmpdir(), "kenn-forge-docs-assets-test-"));
-  t.after(() => rm(root, { recursive: true, force: true }));
-  await initRepo(root);
+  const repository = await createDocsAssetsRepository(t);
+  const { git, root } = repository;
 
-  git(root, "checkout", "--orphan", "docs-assets");
-  git(root, "rm", "-rf", ".");
+  git("checkout", "--orphan", "docs-assets");
+  git("rm", "-rf", ".");
   await writeAssetSet(root);
-  git(root, "add", ".");
-  git(root, "commit", "-m", "assets");
-  const pinnedRef = git(root, "rev-parse", "HEAD").stdout.trim();
+  git("add", ".");
+  git("commit", "-m", "assets");
+  const pinnedRef = git("rev-parse", "HEAD").stdout.trim();
   await writeFile(path.join(root, assets[0]), "<svg><title>newer unreviewed generation</title></svg>\n");
-  git(root, "add", assets[0]);
-  git(root, "commit", "-m", "newer assets");
-  git(root, "checkout", "main");
+  git("add", assets[0]);
+  git("commit", "-m", "newer assets");
+  git("checkout", "main");
   const manifest = path.join(root, "docs-assets-test.txt");
   await writeFile(manifest, `${assets.join("\n")}\n`);
 
@@ -71,37 +59,30 @@ test("asset sync publishes the pinned generation instead of a newer branch tip",
   await mkdir(destination, { recursive: true });
   await writeFile(path.join(destination, "stale.svg"), "stale\n");
 
-  const result = sync(root, {
+  const result = sync(repository, {
     DOCS_ASSETS_MANIFEST: manifest,
     DOCS_ASSETS_REF: pinnedRef,
   });
   assert.equal(result.status, 0, result.stderr || result.stdout);
-  assert.deepEqual(
-    (await readdir(destination)).filter((entry) => entry.endsWith(".svg")).sort(),
-    assets,
-  );
-  assert.equal(
-    await readFile(path.join(destination, assets[0]), "utf8"),
-    `<svg><title>${assets[0]}</title></svg>\n`,
-  );
+  assert.deepEqual((await readdir(destination)).filter((entry) => entry.endsWith(".svg")).sort(), assets);
+  assert.equal(await readFile(path.join(destination, assets[0]), "utf8"), `<svg><title>${assets[0]}</title></svg>\n`);
   const generationManifest = await readFile(path.join(destination, ".docs-assets.synced"), "utf8");
   assert.match(generationManifest, /first-workflow\.svg/);
   assert.match(generationManifest, /second-workflow\.svg/);
 });
 
 test("asset sync rejects an unsafe pinned SVG without replacing the current generation", async (t) => {
-  const root = await mkdtemp(path.join(os.tmpdir(), "kenn-forge-docs-assets-test-"));
-  t.after(() => rm(root, { recursive: true, force: true }));
-  await initRepo(root);
+  const repository = await createDocsAssetsRepository(t);
+  const { git, root } = repository;
 
-  git(root, "checkout", "--orphan", "docs-assets");
-  git(root, "rm", "-rf", ".");
+  git("checkout", "--orphan", "docs-assets");
+  git("rm", "-rf", ".");
   await writeAssetSet(root);
   await writeFile(path.join(root, assets[0]), '<svg><script>alert("unsafe")</script></svg>\n');
-  git(root, "add", ".");
-  git(root, "commit", "-m", "unsafe assets");
-  const pinnedRef = git(root, "rev-parse", "HEAD").stdout.trim();
-  git(root, "checkout", "main");
+  git("add", ".");
+  git("commit", "-m", "unsafe assets");
+  const pinnedRef = git("rev-parse", "HEAD").stdout.trim();
+  git("checkout", "main");
   const manifest = path.join(root, "docs-assets-test.txt");
   await writeFile(manifest, `${assets.join("\n")}\n`);
 
@@ -109,7 +90,7 @@ test("asset sync rejects an unsafe pinned SVG without replacing the current gene
   await mkdir(destination, { recursive: true });
   await writeFile(path.join(destination, "current.svg"), "current generation\n");
 
-  const result = sync(root, {
+  const result = sync(repository, {
     DOCS_ASSETS_MANIFEST: manifest,
     DOCS_ASSETS_REF: pinnedRef,
   });
@@ -119,29 +100,27 @@ test("asset sync rejects an unsafe pinned SVG without replacing the current gene
 });
 
 test("asset sync leaves the current generation intact when the fetched branch is incomplete", async (t) => {
-  const root = await mkdtemp(path.join(os.tmpdir(), "kenn-forge-docs-assets-test-"));
-  const remote = await mkdtemp(path.join(os.tmpdir(), "kenn-forge-docs-assets-remote-"));
-  t.after(() => rm(root, { recursive: true, force: true }));
-  t.after(() => rm(remote, { recursive: true, force: true }));
-  await initRepo(root);
+  const repository = await createDocsAssetsRepository(t);
+  const { git, root, scratch } = repository;
+  const remote = path.join(scratch, "remote.git");
 
-  git(root, "checkout", "--orphan", "docs-assets");
-  git(root, "rm", "-rf", ".");
+  git("checkout", "--orphan", "docs-assets");
+  git("rm", "-rf", ".");
   await writeAssetSet(root, [assets[0]]);
-  git(root, "add", ".");
-  git(root, "commit", "-m", "incomplete assets");
-  const pinnedRef = git(root, "rev-parse", "HEAD").stdout.trim();
-  git(root, "checkout", "main");
+  git("add", ".");
+  git("commit", "-m", "incomplete assets");
+  const pinnedRef = git("rev-parse", "HEAD").stdout.trim();
+  git("checkout", "main");
   const manifest = path.join(root, "docs-assets-test.txt");
   await writeFile(manifest, `${assets.join("\n")}\n`);
-  run("git", ["clone", "--bare", root, remote]);
-  git(root, "remote", "add", "fixture-origin", remote);
+  git("clone", "--bare", root, remote);
+  git("remote", "add", "fixture-origin", remote);
 
   const destination = path.join(root, "docs", "assets", "generated");
   await mkdir(destination, { recursive: true });
   await writeFile(path.join(destination, "current.svg"), "current generation\n");
 
-  const result = sync(root, {
+  const result = sync(repository, {
     DOCS_ASSETS_MANIFEST: manifest,
     DOCS_ASSETS_REMOTE: "fixture-origin",
     DOCS_ASSETS_REF: pinnedRef,

--- a/scripts/test-git-fixture.mjs
+++ b/scripts/test-git-fixture.mjs
@@ -1,0 +1,48 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export function isolatedGitEnv(env = process.env) {
+  return Object.fromEntries(
+    Object.entries(env).filter(([name]) => {
+      const normalized = name.toUpperCase();
+      return !normalized.startsWith("GIT_") && normalized !== "SSH_ASKPASS";
+    }),
+  );
+}
+
+export function createGitTestRepository(t, options = {}) {
+  const { env = process.env, initialBranch = "main", prefix = "kenn-forge-git-test-" } = options;
+  const scratch = mkdtempSync(path.join(os.tmpdir(), prefix));
+  t.after(() => rmSync(scratch, { recursive: true, force: true }));
+
+  const root = path.join(scratch, "repo");
+  mkdirSync(root);
+  const globalConfig = path.join(scratch, "global.gitconfig");
+  writeFileSync(globalConfig, "");
+  const gitEnv = {
+    ...isolatedGitEnv(env),
+    GIT_CONFIG_GLOBAL: globalConfig,
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_TERMINAL_PROMPT: "0",
+  };
+
+  function git(...args) {
+    const result = spawnSync("git", ["-C", root, ...args], {
+      encoding: "utf8",
+      env: gitEnv,
+    });
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      throw new Error(result.stderr || result.stdout || `git exited with status ${result.status}`);
+    }
+    return result;
+  }
+
+  git("init", "--quiet", "-b", initialBranch);
+  git("config", "user.name", "Test");
+  git("config", "user.email", "test@example.invalid");
+
+  return { env: gitEnv, git, root, scratch };
+}


### PR DESCRIPTION
Pre-commit script tests inherited Git's repository-binding environment. The docs-assets test then ran fixture `git init`, commit, and branch commands against the hosting checkout despite passing `git -C` with a temporary path.

This moves every JavaScript Git fixture onto one helper that strips inherited Git state, uses scratch configuration, and creates repositories outside all checkouts. RoboRev now treats any future unisolated `git init` in tests or automation as a critical finding.

<sup>generated by a clanker</sup>
