### PR TITLE
fix: stop touch flings from typing NaN garbage into terminal apps

### DIFF
--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -293,6 +293,10 @@ stale tabs.
 - Agent TUIs in the normal buffer with no local scrollback receive vertical wheel gestures as cursor input; xterm/tmux
   keep ownership when scrollback, the alternate buffer, mouse tracking, or browser Ctrl-wheel zoom is active
   (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::handleTerminalWheel`).
+- Touch-fling momentum must never reach mouse-tracking apps as unpositioned wheel reports: xterm's post-lift
+  `-xterm-gesturechange` events omit `clientX`/`clientY`, so the pane pins them to the last finger position in a
+  capture listener before xterm encodes `ESC[<65;NaN;NaNM`
+  (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::handleTerminalGestureChange`).
 - macOS loopback clipboard fallback must run `pbcopy` with `LC_ALL=en_US.UTF-8`; service launchers may omit
   a UTF-8 locale and make `pbcopy` reinterpret unchanged UTF-8 input
   (`internal/systemclipboard/systemclipboard.go::nativeWriter.WriteText`).

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -127,6 +127,7 @@
   let clipboardFailureReported = false;
   let activePointerId: number | null = null;
   let pointerOrigin: { clientX: number; clientY: number } | null = null;
+  let lastTouchGesturePoint: { clientX: number; clientY: number } | null = null;
   let explicitFocusRequested = false;
   const encoder = new TextEncoder();
   let clipboardWriter: TerminalClipboardWriter | undefined;
@@ -362,6 +363,25 @@
   function isBrowserPasteShortcut(event: KeyboardEvent): boolean {
     const pasteModifierPressed = terminalLinkUsesMetaKey ? event.metaKey : event.ctrlKey;
     return !event.altKey && pasteModifierPressed && event.key.toLowerCase() === "v";
+  }
+
+  // xterm turns touch flings into momentum "gesturechange" events after the
+  // finger lifts. Those synthetic events carry a translation but no
+  // clientX/clientY, so when an app has mouse tracking on (Codex, tmux, vim)
+  // xterm reports the wheel at NaN;NaN and the app receives the tail of the
+  // malformed sequence as typed text. Capture runs before xterm's own listener
+  // on the screen element, so pin momentum reports to the last finger position.
+  const XTERM_GESTURE_CHANGE_EVENT = "-xterm-gesturechange";
+
+  function handleTerminalGestureChange(event: Event): void {
+    const gesture = event as Event & { clientX?: number; clientY?: number };
+    if (Number.isFinite(gesture.clientX) && Number.isFinite(gesture.clientY)) {
+      lastTouchGesturePoint = { clientX: gesture.clientX!, clientY: gesture.clientY! };
+      return;
+    }
+    if (lastTouchGesturePoint === null) return;
+    gesture.clientX = lastTouchGesturePoint.clientX;
+    gesture.clientY = lastTouchGesturePoint.clientY;
   }
 
   function handleInsecureTerminalRightMouse(event: MouseEvent): void {
@@ -923,6 +943,8 @@
     requestFirstPaint = () => {};
     publishClipboardWrite = () => {};
     containerEl?.removeEventListener("paste", handleTerminalPaste, true);
+    containerEl?.removeEventListener(XTERM_GESTURE_CHANGE_EVENT, handleTerminalGestureChange, true);
+    lastTouchGesturePoint = null;
     if (terminal) {
       unregisterTextureAtlasParticipant?.();
       unregisterTextureAtlasParticipant = null;
@@ -1090,6 +1112,7 @@
       term.parser.registerOscHandler(52, handleOsc52Clipboard);
       switchTimer.record("terminal-constructed");
       containerEl.addEventListener("paste", handleTerminalPaste, true);
+      containerEl.addEventListener(XTERM_GESTURE_CHANGE_EVENT, handleTerminalGestureChange, true);
 
       const fit = new FitAddon();
       fitAddon = fit;

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.touch-scroll.browser.svelte.ts
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.touch-scroll.browser.svelte.ts
@@ -1,0 +1,161 @@
+import { mount, unmount } from "svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { Effect } from "effect";
+import { makeAppRuntime, type OwnedAppRuntime } from "../../app/runtime.js";
+import { createSettingsStore } from "../../stores/settings.svelte.js";
+import { STORES_KEY } from "../../context.js";
+import XtermTerminalPaneTestHarness from "./XtermTerminalPaneTestHarness.svelte";
+
+const controlledSockets: ControlledWebSocket[] = [];
+
+class ControlledWebSocket extends EventTarget {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  readonly CONNECTING = ControlledWebSocket.CONNECTING;
+  readonly OPEN = ControlledWebSocket.OPEN;
+  readonly CLOSING = ControlledWebSocket.CLOSING;
+  readonly CLOSED = ControlledWebSocket.CLOSED;
+  binaryType: BinaryType = "arraybuffer";
+  readyState = ControlledWebSocket.CONNECTING;
+  readonly sent: Array<string | ArrayBufferView> = [];
+
+  constructor(readonly url: string) {
+    super();
+    controlledSockets.push(this);
+    queueMicrotask(() => {
+      this.readyState = ControlledWebSocket.OPEN;
+      this.dispatchEvent(new Event("open"));
+    });
+  }
+
+  close(): void {
+    this.readyState = ControlledWebSocket.CLOSED;
+  }
+
+  send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void {
+    if (typeof data === "string" || ArrayBuffer.isView(data)) this.sent.push(data);
+  }
+
+  receive(text: string): void {
+    const bytes = new TextEncoder().encode(text);
+    this.dispatchEvent(new MessageEvent("message", { data: bytes.buffer }));
+  }
+
+  sentText(): string[] {
+    return this.sent.map((frame) => (typeof frame === "string" ? frame : new TextDecoder().decode(frame)));
+  }
+}
+
+const ENABLE_SGR_WHEEL_TRACKING = "\x1b[?1000;1006h";
+const SGR_WHEEL_REPORT = /\x1b\[<6[45];(\d+);(\d+)M/;
+
+function touchEvent(type: string, target: Element, clientX: number, clientY: number): TouchEvent {
+  const touch = new Touch({
+    identifier: 7,
+    target,
+    clientX,
+    clientY,
+    pageX: clientX + window.scrollX,
+    pageY: clientY + window.scrollY,
+  });
+  const touches = type === "touchend" ? [] : [touch];
+  return new TouchEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    touches,
+    targetTouches: touches,
+    changedTouches: [touch],
+  });
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+describe("XtermTerminalPane touch scrolling", () => {
+  let runtime: OwnedAppRuntime;
+
+  beforeEach(() => {
+    // xterm only installs its touch gesture recognizer on pages that look
+    // like a touch device; headless desktop Chromium reports zero touch points.
+    Object.defineProperty(navigator, "maxTouchPoints", { value: 5, configurable: true });
+    runtime = makeAppRuntime();
+    controlledSockets.length = 0;
+  });
+
+  afterEach(async () => {
+    await Effect.runPromise(runtime.disposeEffect);
+    vi.unstubAllGlobals();
+    delete (navigator as { maxTouchPoints?: number }).maxTouchPoints;
+  });
+
+  it("keeps momentum-scroll mouse reports positioned when an app tracks the wheel", async () => {
+    vi.stubGlobal("WebSocket", ControlledWebSocket);
+
+    const target = document.createElement("div");
+    target.style.width = "600px";
+    target.style.height = "400px";
+    document.body.appendChild(target);
+    const props = $state({
+      runtime,
+      websocketPath: "/api/v1/workspaces/ws-1/runtime/sessions/s1/attach",
+      active: true,
+    });
+    const component = mount(XtermTerminalPaneTestHarness, {
+      target,
+      props,
+      context: new Map([[STORES_KEY, { settings: createSettingsStore() }]]),
+    });
+    try {
+      await vi.waitFor(() => {
+        expect(controlledSockets).toHaveLength(1);
+        expect(target.querySelector(".xterm-screen")).not.toBeNull();
+      });
+      const socket = controlledSockets[0]!;
+      const screen = target.querySelector<HTMLElement>(".xterm-screen")!;
+
+      // The app (Codex, tmux, vim, ...) turns on SGR mouse tracking. xterm
+      // marks its element once the mode is active, so wait for that before
+      // the touch gesture starts.
+      socket.receive(ENABLE_SGR_WHEEL_TRACKING);
+      const xterm = target.querySelector<HTMLElement>(".xterm")!;
+      await vi.waitFor(() => {
+        expect(xterm.classList.contains("enable-mouse-events")).toBe(true);
+      });
+      socket.sent.length = 0;
+
+      // A fast upward flick like Android Chrome produces: finger down, a few
+      // fast moves, then lift. The lift starts xterm's inertia scrolling.
+      const bounds = screen.getBoundingClientRect();
+      const x = bounds.left + 100;
+      let y = bounds.top + 300;
+      screen.dispatchEvent(touchEvent("touchstart", screen, x, y));
+      for (let step = 0; step < 4; step++) {
+        await sleep(16);
+        y -= 60;
+        screen.dispatchEvent(touchEvent("touchmove", screen, x, y));
+      }
+      screen.dispatchEvent(touchEvent("touchend", screen, x, y));
+
+      // Let momentum run out (xterm's friction stops the fling within ~1s).
+      await vi.waitFor(() => {
+        expect(socket.sentText().join("")).toContain("\x1b[<6");
+      });
+      await sleep(1200);
+
+      const frames = socket.sentText();
+      const joined = frames.join("");
+      expect(JSON.stringify(joined)).not.toContain("NaN");
+      const reports = joined.match(new RegExp(SGR_WHEEL_REPORT.source, "g")) ?? [];
+      expect(reports.length).toBeGreaterThan(0);
+      for (const report of reports) {
+        const [, col, row] = report.match(SGR_WHEEL_REPORT)!;
+        expect(Number(col)).toBeGreaterThanOrEqual(1);
+        expect(Number(row)).toBeGreaterThanOrEqual(1);
+      }
+    } finally {
+      unmount(component);
+      target.remove();
+    }
+  });
+});


### PR DESCRIPTION
On Android Chrome, flicking a workspace terminal that runs an app with mouse tracking on (Codex, tmux, vim) filled the app's prompt with repeated `aN;NaNM` text. Dragging with the finger down scrolled fine; the garbage arrived from the momentum that continues after the finger lifts.

xterm.js emits that momentum as gesture events that carry a scroll distance but no `clientX`/`clientY`. With mouse tracking active it encodes each one as the SGR wheel report `ESC[<65;NaN;NaNM`. The app's escape parser stops at the first `N` and the rest of the sequence lands in the input as typed characters. The newest xterm.js beta still does this.

The terminal pane now handles xterm's `-xterm-gesturechange` event in the capture phase, which runs before xterm's own listener on the same element, and fills the missing coordinates with the last finger position. Momentum keeps scrolling the app at the right cell instead of being dropped, with no dependency patch.

- Reproducer: open a workspace terminal on an Android phone in an app that enables mouse tracking, flick the output, and lift your finger.
- Browser test drives the real pane in headless Chromium with real `TouchEvent`s and mouse tracking on. It captured `ESC[<65;NaN;NaNM` from the pty stream before the fix; after it, every report has finite coordinates and the test asserts no `NaN` can be sent. It sets `navigator.maxTouchPoints` before mounting because xterm only installs its touch recognizer on pages that report a touch device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
