### PR TITLE
fix: accept valid Roborev repository inventories

### DIFF
--- a/frontend/tests/e2e-full/00-terminal-kitty-keyboard.spec.ts
+++ b/frontend/tests/e2e-full/00-terminal-kitty-keyboard.spec.ts
@@ -57,21 +57,38 @@ async function openTerminalPanel(page: Page): Promise<Locator> {
   return container;
 }
 
-function observeTerminalOutput(page: Page): { tail(): string; cursorResult(): string | undefined } {
-  const streams: string[] = [];
+function observeTerminalOutput(page: Page): {
+  cursorResult(): string | undefined;
+  replayReady(): boolean;
+  tail(): string;
+} {
+  const streams: Array<{ output: string; replayReady: boolean }> = [];
   page.on("websocket", (socket) => {
-    const streamIndex = streams.push("") - 1;
+    const stream = { output: "", replayReady: false };
+    streams.push(stream);
     const decoder = new TextDecoder();
     socket.on("framereceived", ({ payload }) => {
+      if (typeof payload === "string") {
+        try {
+          if ((JSON.parse(payload) as { type?: string }).type === "replay_ready") stream.replayReady = true;
+        } catch {
+          // Terminal output can also arrive as text from non-runtime sockets.
+        }
+      }
       const chunk = typeof payload === "string" ? payload : decoder.decode(payload, { stream: true });
-      streams[streamIndex] = (streams[streamIndex] + chunk).slice(-64 * 1024);
+      stream.output = (stream.output + chunk).slice(-64 * 1024);
     });
   });
   return {
-    tail: () => streams.join("\n").slice(-2_000),
+    tail: () =>
+      streams
+        .map((stream) => stream.output)
+        .join("\n")
+        .slice(-2_000),
+    replayReady: () => streams.some((stream) => stream.replayReady),
     cursorResult: () =>
       streams
-        .map((stream) => stream.match(/KITTY_CURSOR_KEYS_(?:HANDLED|UNEXPECTED_[0-9a-f_]+)/)?.[0])
+        .map((stream) => stream.output.match(/KITTY_CURSOR_KEYS_(?:HANDLED|UNEXPECTED_[0-9a-f_]+)/)?.[0])
         .find((result) => result !== undefined),
   };
 }
@@ -115,7 +132,7 @@ test("Kitty cursor keys reach and are handled by the PTY application", async ({ 
 
     await page.goto(`${isolatedServer.info.base_url}/terminal/${workspace.id}`);
     const terminal = await openTerminalPanel(page);
-    await expect.poll(() => output.tail(), { timeout: terminalOutputTimeoutMs }).toMatch(shellPromptPattern);
+    await expect.poll(() => output.replayReady(), { timeout: terminalOutputTimeoutMs }).toBe(true);
     await terminal.click({ position: { x: 10, y: 10 } });
     await page.keyboard.insertText(kittyCursorProbeCommand());
     await page.keyboard.press("Enter");

--- a/frontend/tests/e2e-full/00-terminal-kitty-keyboard.spec.ts
+++ b/frontend/tests/e2e-full/00-terminal-kitty-keyboard.spec.ts
@@ -16,6 +16,7 @@ type WorkspaceStatusResponse = {
 };
 
 const terminalOutputTimeoutMs = 15_000;
+const workspaceTestTimeoutMs = 120_000;
 
 function hasCommand(command: string, args: string[] = ["--version"]): boolean {
   try {
@@ -97,6 +98,7 @@ print("KITTY_CURSOR_KEYS_HANDLED" if q==b"\x1b[?3u" and R==E else "KITTY_CURSOR_
 }
 
 test("Kitty cursor keys reach and are handled by the PTY application", async ({ page }) => {
+  test.setTimeout(workspaceTestTimeoutMs);
   test.skip(
     !hasCommand("git") || !hasCommand("python3", ["--version"]),
     "git and python3 are required for the real workspace flow",
@@ -112,6 +114,7 @@ test("Kitty cursor keys reach and are handled by the PTY application", async ({ 
 
     await page.goto(`${isolatedServer.info.base_url}/terminal/${workspace.id}`);
     const terminal = await openTerminalPanel(page);
+    await expect.poll(() => output.tail(), { timeout: terminalOutputTimeoutMs }).toContain("issue-10");
     await terminal.click({ position: { x: 10, y: 10 } });
     await page.keyboard.insertText(kittyCursorProbeCommand());
     await page.keyboard.press("Enter");

--- a/frontend/tests/e2e-full/00-terminal-kitty-keyboard.spec.ts
+++ b/frontend/tests/e2e-full/00-terminal-kitty-keyboard.spec.ts
@@ -17,7 +17,6 @@ type WorkspaceStatusResponse = {
 
 const terminalOutputTimeoutMs = 15_000;
 const workspaceTestTimeoutMs = 120_000;
-const shellPromptPattern = /[#$%]\s/;
 
 function hasCommand(command: string, args: string[] = ["--version"]): boolean {
   try {

--- a/frontend/tests/e2e-full/00-terminal-kitty-keyboard.spec.ts
+++ b/frontend/tests/e2e-full/00-terminal-kitty-keyboard.spec.ts
@@ -17,6 +17,7 @@ type WorkspaceStatusResponse = {
 
 const terminalOutputTimeoutMs = 15_000;
 const workspaceTestTimeoutMs = 120_000;
+const shellPromptPattern = /[#$%]\s/;
 
 function hasCommand(command: string, args: string[] = ["--version"]): boolean {
   try {
@@ -114,7 +115,7 @@ test("Kitty cursor keys reach and are handled by the PTY application", async ({ 
 
     await page.goto(`${isolatedServer.info.base_url}/terminal/${workspace.id}`);
     const terminal = await openTerminalPanel(page);
-    await expect.poll(() => output.tail(), { timeout: terminalOutputTimeoutMs }).toContain("issue-10");
+    await expect.poll(() => output.tail(), { timeout: terminalOutputTimeoutMs }).toMatch(shellPromptPattern);
     await terminal.click({ position: { x: 10, y: 10 } });
     await page.keyboard.insertText(kittyCursorProbeCommand());
     await page.keyboard.press("Enter");

--- a/internal/server/roborev_repositories.go
+++ b/internal/server/roborev_repositories.go
@@ -54,7 +54,7 @@ type roborevTrackedRepository struct {
 
 type roborevRepositoryInventory struct {
 	Repos      json.RawMessage `json:"repos"`
-	TotalCount *int            `json:"total_count"`
+	TotalCount *int            `json:"total_count"` // Total review jobs, not repositories.
 }
 
 type roborevRepositoryProbeDeps struct {
@@ -429,9 +429,6 @@ func loadRoborevRepositoryInventory(
 		}
 		if repositories == nil {
 			repositories = []roborevTrackedRepository{}
-		}
-		if *inventory.TotalCount != len(repositories) {
-			return nil, errors.New("decode roborev repository inventory")
 		}
 		for i := range repositories {
 			repositories[i].RootPath = strings.TrimSpace(repositories[i].RootPath)

--- a/internal/server/roborev_repositories_test.go
+++ b/internal/server/roborev_repositories_test.go
@@ -403,13 +403,13 @@ func TestLoadRoborevRepositoryInventoryValidatesCompleteEnvelope(t *testing.T) {
 		want []roborevTrackedRepository
 	}{
 		{
-			name: "valid",
-			body: `{"repos":[{"root_path":"/repo","identity":"https://github.com/acme/widgets.git"}],"total_count":1}`,
+			name: "valid repo without review jobs",
+			body: `{"repos":[{"root_path":"/repo","identity":"https://github.com/acme/widgets.git"}],"total_count":0}`,
 			want: []roborevTrackedRepository{{RootPath: "/repo", Identity: "https://github.com/acme/widgets.git"}},
 		},
 		{
 			name: "valid mixed identity availability",
-			body: `{"repos":[{"root_path":"/repo","identity":"https://github.com/acme/widgets.git"},{"root_path":"/local"}],"total_count":2}`,
+			body: `{"repos":[{"root_path":"/repo","identity":"https://github.com/acme/widgets.git"},{"root_path":"/local"}],"total_count":3}`,
 			want: []roborevTrackedRepository{
 				{RootPath: "/repo", Identity: "https://github.com/acme/widgets.git"},
 				{RootPath: "/local"},
@@ -431,7 +431,6 @@ func TestLoadRoborevRepositoryInventoryValidatesCompleteEnvelope(t *testing.T) {
 
 	invalid := []string{
 		`{}`,
-		`{"repos":[],"total_count":1}`,
 		`{"repos":[{"identity":"https://github.com/acme/widgets.git"}],"total_count":1}`,
 		`{"repos":[],"total_count":0} trailing`,
 	}

--- a/internal/server/workspacetest/fixtures_test.go
+++ b/internal/server/workspacetest/fixtures_test.go
@@ -378,7 +378,7 @@ func waitForWorkspaceReady(
 ) *generated.WorkspaceResponse {
 	t.Helper()
 
-	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	waitCtx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
 	ticker := time.NewTicker(25 * time.Millisecond)

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -1274,7 +1274,7 @@ func TestSetupWithOptionsConfirmsRoborevBeforeTerminal(t *testing.T) {
 		response string
 		wantErr  string
 	}{
-		{name: "registered", response: "registered"},
+		{name: "registered repo without review jobs", response: "registered"},
 		{name: "malformed inventory", response: "malformed", wantErr: "invalid daemon response"},
 		{name: "absent registration", response: "absent", wantErr: "workspace is absent"},
 	}
@@ -1340,7 +1340,7 @@ chmod +x "$hooks/post-commit" "$hooks/post-rewrite"
 				case "registered":
 					_ = json.NewEncoder(w).Encode(map[string]any{
 						"repos":       []map[string]string{{"root_path": ws.WorktreePath}},
-						"total_count": 1,
+						"total_count": 0,
 					})
 				case "malformed":
 					_, _ = w.Write([]byte("{"))

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -1276,6 +1276,7 @@ func TestSetupWithOptionsConfirmsRoborevBeforeTerminal(t *testing.T) {
 	}{
 		{name: "registered repo without review jobs", response: "registered"},
 		{name: "malformed inventory", response: "malformed", wantErr: "invalid daemon response"},
+		{name: "missing total count", response: "missing total count", wantErr: "invalid daemon response"},
 		{name: "absent registration", response: "absent", wantErr: "workspace is absent"},
 	}
 	for _, tt := range tests {
@@ -1344,6 +1345,10 @@ chmod +x "$hooks/post-commit" "$hooks/post-rewrite"
 					})
 				case "malformed":
 					_, _ = w.Write([]byte("{"))
+				case "missing total count":
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"repos": []map[string]string{{"root_path": ws.WorktreePath}},
+					})
 				case "absent":
 					_ = json.NewEncoder(w).Encode(map[string]any{
 						"repos":       []map[string]string{},

--- a/internal/workspace/repository_hooks.go
+++ b/internal/workspace/repository_hooks.go
@@ -781,7 +781,6 @@ type roborevRegistrationInventory struct {
 	Repos []struct {
 		RootPath string `json:"root_path"`
 	} `json:"repos"`
-	TotalCount *int `json:"total_count"`
 }
 
 func confirmRoborevRegistration(
@@ -808,7 +807,7 @@ func confirmRoborevRegistration(
 		return fmt.Errorf("confirm Roborev registration: invalid daemon response")
 	}
 	var inventory roborevRegistrationInventory
-	if err := json.Unmarshal(content, &inventory); err != nil || inventory.TotalCount == nil || *inventory.TotalCount != len(inventory.Repos) {
+	if err := json.Unmarshal(content, &inventory); err != nil {
 		return fmt.Errorf("confirm Roborev registration: invalid daemon response")
 	}
 	want, err := canonicalFilesystemPath(workspacePath)

--- a/internal/workspace/repository_hooks.go
+++ b/internal/workspace/repository_hooks.go
@@ -781,6 +781,7 @@ type roborevRegistrationInventory struct {
 	Repos []struct {
 		RootPath string `json:"root_path"`
 	} `json:"repos"`
+	TotalCount *int `json:"total_count"`
 }
 
 func confirmRoborevRegistration(
@@ -807,7 +808,7 @@ func confirmRoborevRegistration(
 		return fmt.Errorf("confirm Roborev registration: invalid daemon response")
 	}
 	var inventory roborevRegistrationInventory
-	if err := json.Unmarshal(content, &inventory); err != nil {
+	if err := json.Unmarshal(content, &inventory); err != nil || inventory.TotalCount == nil {
 		return fmt.Errorf("confirm Roborev registration: invalid daemon response")
 	}
 	want, err := canonicalFilesystemPath(workspacePath)


### PR DESCRIPTION
Managed-clone setup rejected valid Roborev `/api/repos` responses when `total_count` differed from the number of repositories. Roborev uses that field for the total number of review jobs, so a repository with no jobs could not finish workspace setup.

This change confirms registration by matching the workspace path in the returned repository roots and keeps malformed-response and missing-registration errors. The regression test covers a registered repository with zero review jobs.
