### PR TITLE
fix: keep active spokes online through hub outages

### DIFF
--- a/cmd/kenn-forge/spoke_startup.go
+++ b/cmd/kenn-forge/spoke_startup.go
@@ -95,13 +95,7 @@ func activateFederationSpokeAtStartup(
 	if !ok || !slices.Contains(credential.Scopes, federationauth.ScopeEnrollmentActivate) {
 		return fail(federationStartupActionRequired, "fleet spoke hub credential is unavailable")
 	}
-	if !cfg.Fleet.Enabled {
-		if local.State != federation.EnrollmentActive {
-			return fail(
-				federationStartupActionRequired,
-				"fleet spoke activation cannot complete while federation is disabled",
-			)
-		}
+	if local.State == federation.EnrollmentActive {
 		if err := promoteFederationSpokeCredentialScopes(
 			credentials, local.HubID,
 		); err != nil {
@@ -111,6 +105,12 @@ func activateFederationSpokeAtStartup(
 			)
 		}
 		return federationSpokeStartup{State: federationStartupActive}
+	}
+	if !cfg.Fleet.Enabled {
+		return fail(
+			federationStartupActionRequired,
+			"fleet spoke activation cannot complete while federation is disabled",
+		)
 	}
 
 	client := spokeActivationHTTPClient(httpClient)

--- a/cmd/kenn-forge/spoke_startup_test.go
+++ b/cmd/kenn-forge/spoke_startup_test.go
@@ -165,6 +165,39 @@ func TestFederationSpokeStartupActivatesMatchingSealAndRetriesSafely(t *testing.
 	assert.False(local.PreparationRequired)
 }
 
+func TestFederationSpokeStartupKeepsActiveEnrollmentDuringHubOutage(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var requests atomic.Int32
+	hub := httptest.NewTLSServer(http.HandlerFunc(func(
+		w http.ResponseWriter, _ *http.Request,
+	) {
+		requests.Add(1)
+		http.Error(w, "hub unavailable", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(hub.Close)
+	database := dbtest.Open(t)
+	enrollments, credentials, cfg := spokeStartupFixture(
+		t, database, hub.URL, true,
+	)
+	require.NoError(enrollments.MarkLocalActive(t.Context(), startupEnrollmentID))
+	require.NoError(credentials.UpdateInboundScopes(
+		startupHubID, federationauth.HubToSpokeScopes(),
+	))
+	require.NoError(credentials.UpdateOutboundScopes(
+		startupHubID, federationauth.SpokeToHubScopes(),
+	))
+
+	status := activateFederationSpokeAtStartup(
+		t.Context(), database, cfg, startupNodeID,
+		enrollments, credentials, hub.Client(),
+	)
+
+	assert.Equal(federationStartupActive, status.State, status.Reason)
+	assert.Zero(requests.Load(),
+		"an active sealed enrollment must not depend on hub reachability at boot")
+}
+
 func TestFederationSpokeStartupKeepsActiveBindingDormantWhileDisabled(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/context/server-runtime.md
+++ b/context/server-runtime.md
@@ -30,6 +30,9 @@ and the root event stream.
   host drop only that host while healthy hosts keep syncing; unattributable
   failures degrade to no provider sync. Dropped hosts serve cached data until a
   later restart (`cmd/kenn-forge/provider_startup.go::buildProviderControlPlaneOrDegraded`).
+- A fully sealed active spoke never requires hub reachability at process start;
+  its event lifecycle owns reconnection after transient network or DNS outages
+  (`cmd/kenn-forge/spoke_startup.go::activateFederationSpokeAtStartup`).
 - Provider API origins and cleartext acknowledgements are startup-bound. Config
   reload reports `restart_required` when either changes instead of claiming the
   boot-time client and clone policy were updated


### PR DESCRIPTION
An already enrolled spoke could enter local-only mode for the rest of its process lifetime when hub DNS or network access was briefly unavailable during daemon startup. Startup repeated hub activation even though the spoke had sealed active local state.

- Start fully validated active spokes from their local enrollment state, allowing the existing event-stream lifecycle to reconnect when the hub returns.
- Keep remote activation and its retry and error handling unchanged for pending enrollments.

This preserves all local seal, database, node identity, hub binding, and credential validation before the active-state decision.
