### PR TITLE
fix: align issue page actions on the kit action grid

### DIFF
--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -119,7 +119,12 @@ otherwise fails only in the Vitest/Playwright transform tier, not in
   Provider-mode repo selector visibility must not move the tab row; non-provider
   modes reserve its footprint unless embed config hides it
   (`frontend/src/lib/components/layout/AppHeader.svelte::reserveProviderRepoSelectorSlot`).
-- `AdaptiveActionGrid`: the phone PR primary-action surface. Phone-like PR
+- `AdaptiveActionGrid`: the issue detail action row on every layout
+  (`frontend/src/lib/components/detail/IssueDetail.svelte::issue-actions-grid`,
+  adaptive layout, `frame="none"`, `padding={0}`) and the phone PR
+  primary-action surface. Controls inside a grid never pass their own `size`:
+  the grid item supplies the shared control height and type, and an explicit
+  `sm` opts out and misaligns. Phone-like PR
   routes (`phonePresentation` threaded from
   `frontend/src/App.svelte::phoneDetailProps`) render approve, merge, close,
   reopen, ready, workflows, and the workspace action with kit's
@@ -136,8 +141,8 @@ otherwise fails only in the Vitest/Playwright transform tier, not in
   phone hit target (`--focus-detail-hit-target`), or the control overflows
   its cell. Desktop-narrow focus presentation keeps `FitStages`.
 - `WorkspaceCreateSplitButton` takes its control height from the kit `size` it
-  is given, never a pinned `min-height`; detail action rows pass `sm` so it
-  matches the buttons beside it
+  is given (or the surrounding grid item), never a pinned `min-height`; the
+  desktop PR `FitStages` row passes `sm` to match the buttons beside it
   (`frontend/src/lib/components/workspace/WorkspaceCreateSplitButton.svelte`).
 - `FitStages`: how an action row degrades under pressure (richest labelled
   `Button` row to compact labelled or `IconButton` rows, then a measured menu

--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -135,6 +135,10 @@ otherwise fails only in the Vitest/Playwright transform tier, not in
   wrapper around a kit control must not hardcode a width smaller than the
   phone hit target (`--focus-detail-hit-target`), or the control overflows
   its cell. Desktop-narrow focus presentation keeps `FitStages`.
+- `WorkspaceCreateSplitButton` takes its control height from the kit `size` it
+  is given, never a pinned `min-height`; detail action rows pass `sm` so it
+  matches the buttons beside it
+  (`frontend/src/lib/components/workspace/WorkspaceCreateSplitButton.svelte`).
 - `FitStages`: how an action row degrades under pressure (richest labelled
   `Button` row to compact labelled or `IconButton` rows, then a measured menu
   trigger when needed), never a media query, Button-internal overrides, or a

--- a/frontend/src/App.issue-actions-grid.browser.svelte.ts
+++ b/frontend/src/App.issue-actions-grid.browser.svelte.ts
@@ -1,0 +1,53 @@
+// The issue detail action row is one kit AdaptiveActionGrid. Every control in
+// it, including the compound Create Workspace split button, must sit at the
+// grid's shared control height. The row used to be a hand-rolled flex row
+// whose split button pinned its own 30px while the buttons beside it were
+// 24px "sm" controls; only a real layout engine can show that they now match,
+// so this runs in Chromium against the mounted app with fetch mocked at the
+// network boundary.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { page } from "vite-plus/test/browser";
+
+import { mountBrowserApp, resetKeyboardModuleState, type MountedBrowserApp } from "./test/browserAppHarness.js";
+
+const WAIT = 10_000;
+
+describe("issue detail action grid", () => {
+  vi.setConfig({ testTimeout: 30_000 });
+
+  let mounted: MountedBrowserApp | null = null;
+
+  beforeEach(async () => {
+    await page.viewport(1280, 900);
+  });
+
+  afterEach(async () => {
+    mounted?.unmount();
+    mounted = null;
+    localStorage.clear();
+    await resetKeyboardModuleState();
+  });
+
+  it("renders Create Workspace and Close issue at one shared control height", async () => {
+    mounted = await mountBrowserApp("/issues/github/acme/widgets/7");
+
+    const grid = page.getByRole("group", { name: "Issue actions" });
+    await expect.element(grid).toBeVisible();
+    const close = grid.getByRole("button", { name: "Close issue" });
+    await expect.element(close).toBeVisible();
+
+    await vi.waitFor(() => {
+      const closeHeight = close.element().getBoundingClientRect().height;
+      const primary = grid.getByRole("button", { name: "Create Workspace", exact: true }).element();
+      const options = grid.getByRole("button", { name: "Create Workspace options" }).element();
+
+      expect(closeHeight).toBeGreaterThan(0);
+      expect(primary.getBoundingClientRect().height).toBeCloseTo(closeHeight, 1);
+      expect(options.getBoundingClientRect().height).toBeCloseTo(closeHeight, 1);
+      // Both segments are one control: the cap must not float above or below
+      // the primary segment.
+      expect(options.getBoundingClientRect().top).toBeCloseTo(primary.getBoundingClientRect().top, 1);
+    }, WAIT);
+  });
+});

--- a/frontend/src/WorkspaceCreateSplitButton.browser.svelte.ts
+++ b/frontend/src/WorkspaceCreateSplitButton.browser.svelte.ts
@@ -3,9 +3,10 @@ import { page } from "vite-plus/test/browser";
 import { cleanup, render } from "vitest-browser-svelte";
 import "./app.css";
 
-import { setThemeMode } from "@kenn-io/kit-ui";
+import { Button, setThemeMode } from "@kenn-io/kit-ui";
 import type { LaunchTarget } from "./lib/api/types.js";
 import { STORES_KEY } from "./lib/context.js";
+import WorkspaceCreateSplitButtonRuntimeHarness from "./lib/components/workspace/WorkspaceCreateSplitButtonRuntimeHarness.svelte";
 import { createMockApiFetch, jsonResponse } from "./test/mockApiFetch.js";
 import NewWorkspaceDialogRuntimeHarness from "./test/NewWorkspaceDialogRuntimeHarness.svelte";
 
@@ -29,6 +30,34 @@ function resolvedColor(value: string): string {
   probe.remove();
   return color;
 }
+
+describe("workspace create split button control height", () => {
+  afterEach(cleanup);
+
+  // The detail action rows put this split button beside plain "sm" kit buttons
+  // (Close issue, Reopen issue, Open Workspace). It used to pin its own 30px
+  // min-height and ignore the requested size, so it stood taller than every
+  // neighbour. Both segments must now measure exactly like a sibling button of
+  // the same size, which only real CSS can tell us.
+  for (const size of ["sm", "md"] as const) {
+    it(`matches a sibling ${size} kit button on both segments`, async () => {
+      render(WorkspaceCreateSplitButtonRuntimeHarness, {
+        props: { label: "Create Workspace", size, launchTargets, onCreate: () => {} },
+      });
+      render(Button, { props: { size, label: "Close issue" } });
+
+      const sibling = page.getByRole("button", { name: "Close issue" });
+      await expect.element(sibling).toBeVisible();
+
+      const expected = sibling.element().getBoundingClientRect().height;
+      const primary = page.getByRole("button", { name: "Create Workspace", exact: true }).element();
+      const options = page.getByRole("button", { name: "Create Workspace options" }).element();
+
+      expect(primary.getBoundingClientRect().height).toBeCloseTo(expected, 1);
+      expect(options.getBoundingClientRect().height).toBeCloseTo(expected, 1);
+    });
+  }
+});
 
 describe("workspace create split button in the New workspace dialog", () => {
   const originalFetch = globalThis.fetch;

--- a/frontend/src/lib/components/detail/IssueDetail.svelte
+++ b/frontend/src/lib/components/detail/IssueDetail.svelte
@@ -28,7 +28,7 @@
   import DetailRefreshButton from "./DetailRefreshButton.svelte";
   import IssueCommentBox from "./IssueCommentBox.svelte";
   import WorkspaceCreateSplitButton from "../workspace/WorkspaceCreateSplitButton.svelte";
-    import { Button, Chip, Modal } from "@kenn-io/kit-ui";
+    import { AdaptiveActionGrid, Button, Chip, Modal } from "@kenn-io/kit-ui";
   import { Spinner } from "@kenn-io/kit-ui";
   import LabelRow from "../shared/LabelRow.svelte";
   import { ScrollBox } from "@kenn-io/kit-ui";
@@ -1328,8 +1328,10 @@
         {/if}
       </div>
 
-      <!-- Actions -->
-      <div class="actions-row">
+      <!-- Actions. The kit grid owns the row geometry: every control inherits
+           its 28px control height and md type from the grid item, so no
+           button here asks for its own size. -->
+      {#snippet workspaceAction()}
         {#if workspace}
           {#if inlineWorkspace}
             <Button
@@ -1341,30 +1343,10 @@
               }}
               tone="info"
               surface="soft"
-              size="sm"
               label="Focus Terminal"
               shortLabel="Terminal"
             >
               <MonitorUpIcon size="14" strokeWidth="2.2" aria-hidden="true" />
-            </Button>
-            <Button
-              class="btn--workspace-secondary"
-              disabled={staleIssue}
-              onclick={() => {
-                if (staleIssue) return;
-                if (workspaceDeletionLifecycle) {
-                  navigate("/workspaces");
-                } else {
-                  inlineWorkspace.openInWorkspaces(workspace);
-                }
-              }}
-              tone="neutral"
-              surface="soft"
-              size="sm"
-              label={workspaceDeletionLifecycle ? "View in Workspaces" : "Open in Workspaces"}
-              shortLabel="Workspaces"
-            >
-              <ExternalLinkIcon size="14" strokeWidth="2.2" aria-hidden="true" />
             </Button>
           {:else}
             <Button
@@ -1383,7 +1365,6 @@
               }}
               tone="info"
               surface="soft"
-              size="sm"
               label={workspaceDeletionLifecycle ? "View in Workspaces" : "Open Workspace"}
               shortLabel={workspaceDeletionLifecycle ? "Workspaces" : "Workspace"}
             >
@@ -1394,7 +1375,6 @@
           <WorkspaceCreateSplitButton
             label="Create Workspace"
             busyLabel="Creating..."
-            size="sm"
             launchTargets={settings.getLaunchTargets()}
             busy={workspaceCreateBlocked}
             disabled={staleIssue}
@@ -1407,13 +1387,30 @@
             )}
           />
         {/if}
-        {#if !workspace}
-          <span id={createWorkspaceDescriptionId} class="kit-sr-only">
-            {staleIssue
-              ? "Refresh details before creating a workspace."
-              : createWorkspaceTitle}
-          </span>
+      {/snippet}
+      {#snippet workspaceSecondaryAction()}
+        {#if workspace && inlineWorkspace}
+          <Button
+            class="btn--workspace-secondary"
+            disabled={staleIssue}
+            onclick={() => {
+              if (staleIssue) return;
+              if (workspaceDeletionLifecycle) {
+                navigate("/workspaces");
+              } else {
+                inlineWorkspace.openInWorkspaces(workspace);
+              }
+            }}
+            tone="neutral"
+            surface="soft"
+            label={workspaceDeletionLifecycle ? "View in Workspaces" : "Open in Workspaces"}
+            shortLabel="Workspaces"
+          >
+            <ExternalLinkIcon size="14" strokeWidth="2.2" aria-hidden="true" />
+          </Button>
         {/if}
+      {/snippet}
+      {#snippet stateAction()}
         {#if issue.State === "open" && capabilities.state_mutation}
           {@const closeGate = operationGate(repoOperations?.close_issue)}
           <Button
@@ -1426,7 +1423,6 @@
             }}
             tone="danger"
             surface="outline"
-            size="sm"
             label={stateSubmitting ? "Closing..." : "Close issue"}
             shortLabel={stateSubmitting ? "Closing..." : "Close"}
           >
@@ -1444,31 +1440,54 @@
             }}
             tone="success"
             surface="solid"
-            size="sm"
             label={stateSubmitting ? "Reopening..." : "Reopen issue"}
             shortLabel={stateSubmitting ? "Reopening..." : "Reopen"}
           >
             <RefreshCwIcon size="14" strokeWidth="2.2" aria-hidden="true" />
           </Button>
         {/if}
-        {#each actions.issue ?? [] as action (action.id)}
-          <Button
-            class="btn--embedding-action"
-            onclick={() => {
-              if (staleIssue) return;
-              action.handler({
-                surface: "issue-detail", owner, name, number,
-              });
-            }}
-            disabled={staleIssue}
-            tone="neutral"
-            surface="outline"
-            size="sm"
-          >
-            {action.label}
-          </Button>
-        {/each}
-      </div>
+      {/snippet}
+      {#snippet embeddingActions()}
+        <div class="embedding-actions">
+          {#each actions.issue ?? [] as action (action.id)}
+            <Button
+              class="btn--embedding-action"
+              onclick={() => {
+                if (staleIssue) return;
+                action.handler({
+                  surface: "issue-detail", owner, name, number,
+                });
+              }}
+              disabled={staleIssue}
+              tone="neutral"
+              surface="outline"
+            >
+              {action.label}
+            </Button>
+          {/each}
+        </div>
+      {/snippet}
+      {#if !workspace}
+        <span id={createWorkspaceDescriptionId} class="kit-sr-only">
+          {staleIssue
+            ? "Refresh details before creating a workspace."
+            : createWorkspaceTitle}
+        </span>
+      {/if}
+      <AdaptiveActionGrid
+        class="issue-actions-grid"
+        ariaLabel="Issue actions"
+        frame="none"
+        padding={0}
+        rowGap={4}
+        columnGap={4}
+        items={[
+          { id: "workspace", content: workspaceAction },
+          ...(workspace && inlineWorkspace ? [{ id: "workspace-secondary", content: workspaceSecondaryAction }] : []),
+          ...(capabilities.state_mutation ? [{ id: "state", content: stateAction }] : []),
+          ...((actions.issue ?? []).length > 0 ? [{ id: "embedding", content: embeddingActions }] : []),
+        ]}
+      />
 
       <!-- Issue body -->
       {#if issue.Body}
@@ -1882,11 +1901,16 @@
     line-height: 1.6;
   }
 
-  .actions-row {
+  .issue-detail :global(.issue-actions-grid) {
+    padding: var(--space-4) 0;
+  }
+
+  /* Embed-host actions are one custom grid item so each host action stays a
+   * separate button; the wrapper lays them out like the grid's own row. */
+  .issue-detail :global(.embedding-actions) {
     display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 8px 0;
+    flex-wrap: wrap;
+    gap: var(--space-4);
   }
 
   .refresh-banner {
@@ -2091,11 +2115,7 @@
       line-height: 1.25;
     }
 
-    .actions-row {
-      gap: var(--detail-mobile-space-sm);
-    }
-
-    .actions-row :global(.kit-button),
+    .issue-detail :global(.issue-actions-grid .kit-button),
     .field-input {
       min-height: var(--detail-mobile-hit-target);
       font-size: var(--font-size-sm);

--- a/frontend/src/lib/components/detail/IssueDetail.svelte
+++ b/frontend/src/lib/components/detail/IssueDetail.svelte
@@ -1394,6 +1394,7 @@
           <WorkspaceCreateSplitButton
             label="Create Workspace"
             busyLabel="Creating..."
+            size="sm"
             launchTargets={settings.getLaunchTargets()}
             busy={workspaceCreateBlocked}
             disabled={staleIssue}

--- a/frontend/src/lib/components/detail/IssueDetail.test.ts
+++ b/frontend/src/lib/components/detail/IssueDetail.test.ts
@@ -509,6 +509,20 @@ describe("IssueDetail activity view", () => {
     }
   });
 
+  it("sizes the create-workspace split button like the other action-row buttons", () => {
+    renderIssueDetail(issueDetail());
+
+    const create = screen.getByRole("button", { name: "Create Workspace" });
+    const options = screen.getByRole("button", { name: "Create Workspace options" });
+    const close = screen.getByRole("button", { name: "Close issue" });
+
+    // The split button used to fall back to the kit default size while every
+    // sibling asked for "sm", so it rendered visibly taller in the row.
+    expect(close.classList.contains("kit-button--sm")).toBe(true);
+    expect(create.classList.contains("kit-button--sm")).toBe(true);
+    expect(options.classList.contains("kit-button--sm")).toBe(true);
+  });
+
   it("labels an active stale-detail refresh", () => {
     renderIssueDetail(issueDetail(), undefined, { staleRefreshing: true });
 

--- a/frontend/src/lib/components/detail/IssueDetail.test.ts
+++ b/frontend/src/lib/components/detail/IssueDetail.test.ts
@@ -509,18 +509,21 @@ describe("IssueDetail activity view", () => {
     }
   });
 
-  it("sizes the create-workspace split button like the other action-row buttons", () => {
+  it("renders every issue action inside one kit action grid at the grid's size", () => {
     renderIssueDetail(issueDetail());
 
-    const create = screen.getByRole("button", { name: "Create Workspace" });
-    const options = screen.getByRole("button", { name: "Create Workspace options" });
-    const close = screen.getByRole("button", { name: "Close issue" });
+    const grid = screen.getByRole("group", { name: "Issue actions" });
+    expect(grid.classList.contains("kit-adaptive-action-grid")).toBe(true);
 
-    // The split button used to fall back to the kit default size while every
-    // sibling asked for "sm", so it rendered visibly taller in the row.
-    expect(close.classList.contains("kit-button--sm")).toBe(true);
-    expect(create.classList.contains("kit-button--sm")).toBe(true);
-    expect(options.classList.contains("kit-button--sm")).toBe(true);
+    // The grid owns control geometry through its item context. A button that
+    // asks for its own size (the old size="sm" row, the split button's pinned
+    // height) opts out of that and renders taller or shorter than its
+    // neighbours, which is the misalignment this row shipped with.
+    for (const name of ["Create Workspace", "Create Workspace options", "Close issue"]) {
+      const button = screen.getByRole("button", { name });
+      expect(grid.contains(button)).toBe(true);
+      expect(button.classList.contains("kit-button--md")).toBe(true);
+    }
   });
 
   it("labels an active stale-detail refresh", () => {

--- a/frontend/src/lib/components/detail/PullDetail.svelte
+++ b/frontend/src/lib/components/detail/PullDetail.svelte
@@ -2629,6 +2629,7 @@
           <WorkspaceCreateSplitButton
             label="Create Workspace"
             busyLabel="Creating..."
+            size="sm"
             launchTargets={settings.getLaunchTargets()}
             busy={wsCreateBlocked}
             disabled={stalePR}

--- a/frontend/src/lib/components/workspace/WorkspaceCreateSplitButton.svelte
+++ b/frontend/src/lib/components/workspace/WorkspaceCreateSplitButton.svelte
@@ -22,6 +22,7 @@
     disabledReason?: string;
     descriptionId?: string;
     surface?: "soft" | "solid";
+    size?: "sm" | "md";
     primaryType?: "button" | "submit";
     onCreate: (targetKey?: string) => void;
   }
@@ -35,6 +36,7 @@
     disabledReason = "",
     descriptionId = "",
     surface = "soft",
+    size = "md",
     primaryType = "button",
     onCreate,
   }: Props = $props();
@@ -174,12 +176,13 @@
   });
 </script>
 
-<div class="workspace-create-split" bind:this={root}>
+<div class="workspace-create-split workspace-create-split--{size}" bind:this={root}>
   <Button
     type={primaryType}
     class="create-primary"
     tone="info"
     {surface}
+    {size}
     ariaLabel={busy ? busyLabel : label}
     ariaDescribedby={descriptionId || undefined}
     title={disabledReason || label}
@@ -195,6 +198,7 @@
     <Button
       surface={surface === "solid" ? "solid" : "soft"}
       tone="info"
+      {size}
       class="create-options-button"
       ariaLabel={`${label} options`}
       title={disabledReason || "Create and launch an agent"}
@@ -236,16 +240,25 @@
 </div>
 
 <style>
+  /* The chevron segment is a square cap on the primary control, so its width
+   * tracks the kit control height for the requested size. Heights themselves
+   * come from kit: hardcoding one here made the split button taller than the
+   * `sm` siblings it sits beside in the detail action rows. */
   .workspace-create-split {
+    --create-options-width: var(--kit-control-height, 28px);
+
     display: inline-flex;
     min-width: 0;
     max-width: 100%;
   }
 
+  .workspace-create-split--sm {
+    --create-options-width: 24px;
+  }
+
   .workspace-create-split :global(.create-primary) {
     flex: 1 1 auto;
     min-width: 0;
-    min-height: 30px;
     overflow: hidden;
     padding-inline: var(--space-4);
     border-radius: var(--kit-control-radius, var(--radius-sm)) 0 0 var(--kit-control-radius, var(--radius-sm));
@@ -257,8 +270,8 @@
     white-space: nowrap;
   }
 
-  /* Sized by its button: phone hit-target rules widen the button beyond
-   * 30px, and a fixed wrapper width would let it overflow the control. */
+  /* Sized by its button: phone hit-target rules widen the button beyond the
+   * square cap, and a fixed wrapper width would let it overflow the control. */
   .create-options {
     display: inline-flex;
     flex: 0 0 auto;
@@ -266,8 +279,7 @@
 
   .create-options :global(.create-options-button) {
     flex-shrink: 0;
-    width: 30px;
-    min-height: 30px;
+    width: var(--create-options-width);
     padding: 0;
     border-left: 0;
     border-radius: 0 var(--kit-control-radius, var(--radius-sm)) var(--kit-control-radius, var(--radius-sm)) 0;


### PR DESCRIPTION
On the issue page, Create Workspace rendered taller than Close issue and the other buttons beside it. The row was a hand-rolled flex row where each button picked its own size, and the split button pinned its own height on top of that.

The issue action row is now kit-ui's `AdaptiveActionGrid` on every layout. The grid supplies one control height and type scale to everything inside it, so the buttons no longer request a size and line up as one group.

- Create Workspace, Close issue, Reopen issue, Open Workspace, Focus Terminal, and embed-host actions render inside the grid at the kit default 28px control height.
- `WorkspaceCreateSplitButton` takes a `size` and no longer pins a 30px height; its chevron cap follows the control height. The desktop pull request row keeps `FitStages` and passes `sm` there.
- The New workspace dialog's split button now matches its Cancel button too.

![issue-actions-grid.png](https://github.com/user-attachments/assets/e33020b9-c088-4af2-910f-c02a6bef3497)

<sup>generated by a clanker</sup>
