### PR TITLE
feat: make fleet workspace ownership explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -738,7 +738,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: roborev-e2e-report
-          path: frontend/playwright-report/
+          path: frontend/test-results/
           retention-days: 7
 
   test_browser:

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ node_modules/
 packages/*/node_modules/
 frontend/playwright-report/
 frontend/test-results/
+/test-results/
 frontend/tests/demo/screenshots/
 frontend/.vitest-attachments/
 frontend/src/**/__screenshots__/

--- a/cmd/kenn-forge/main.go
+++ b/cmd/kenn-forge/main.go
@@ -748,13 +748,18 @@ func run(opts serve.Options) error {
 			FederationSpokeID:                runtimeIdentity.LockMetadata.NodeID,
 			FederationSpokeActive:            spokeStartup.Active(),
 			FederationSpokeUnavailableReason: spokeStartup.Reason,
-			MCPURL:                           mcpURL,
-			WorktreeDir:                      filepath.Join(cfg.DataDir, "worktrees"),
-			PtyOwnerManagerPath:              os.Getenv("KENN_FORGE_PTY_MANAGER"),
-			Telemetry:                        telemetryReporter,
-			TokenSources:                     tokenSources,
-			Archive:                          archiveService,
-			DetachRuntimeSessionsForRestart:  os.Getenv("KENN_FORGE_DEV_RESTART") == "1",
+			MaintainFederationSpokeActivation: func(ctx context.Context) {
+				maintainFederationSpokeActivation(
+					ctx, federationEnrollments, federationCredentials, nil,
+				)
+			},
+			MCPURL:                          mcpURL,
+			WorktreeDir:                     filepath.Join(cfg.DataDir, "worktrees"),
+			PtyOwnerManagerPath:             os.Getenv("KENN_FORGE_PTY_MANAGER"),
+			Telemetry:                       telemetryReporter,
+			TokenSources:                    tokenSources,
+			Archive:                         archiveService,
+			DetachRuntimeSessionsForRestart: os.Getenv("KENN_FORGE_DEV_RESTART") == "1",
 		},
 	)
 	srv.AttachHTTPServer(httpSrv, ln)

--- a/cmd/kenn-forge/spoke_startup.go
+++ b/cmd/kenn-forge/spoke_startup.go
@@ -95,13 +95,7 @@ func activateFederationSpokeAtStartup(
 	if !ok || !slices.Contains(credential.Scopes, federationauth.ScopeEnrollmentActivate) {
 		return fail(federationStartupActionRequired, "fleet spoke hub credential is unavailable")
 	}
-	if !cfg.Fleet.Enabled {
-		if local.State != federation.EnrollmentActive {
-			return fail(
-				federationStartupActionRequired,
-				"fleet spoke activation cannot complete while federation is disabled",
-			)
-		}
+	if local.State == federation.EnrollmentActive {
 		if err := promoteFederationSpokeCredentialScopes(
 			credentials, local.HubID,
 		); err != nil {
@@ -111,6 +105,12 @@ func activateFederationSpokeAtStartup(
 			)
 		}
 		return federationSpokeStartup{State: federationStartupActive}
+	}
+	if !cfg.Fleet.Enabled {
+		return fail(
+			federationStartupActionRequired,
+			"fleet spoke activation cannot complete while federation is disabled",
+		)
 	}
 
 	client := spokeActivationHTTPClient(httpClient)

--- a/cmd/kenn-forge/spoke_startup.go
+++ b/cmd/kenn-forge/spoke_startup.go
@@ -39,6 +39,7 @@ var (
 	errHubProtocolMismatch      = errors.New("hub federation protocol is incompatible")
 	errHubActivationInvalid     = errors.New("hub federation activation response is invalid")
 	errSpokeActivationSuspended = errors.New("fleet spoke activation renewal is suspended")
+	errSpokeActivationInactive  = errors.New("fleet spoke enrollment is inactive")
 )
 
 type federationSpokeStartup struct {
@@ -339,8 +340,9 @@ func maintainFederationSpokeActivation(
 		if err := renewFederationSpokeActivation(
 			ctx, enrollments, credentials, spokeActivationHTTPClient(httpClient),
 		); err != nil {
-			if errors.Is(err, errSpokeActivationSuspended) {
-				slog.Warn("suspend fleet spoke activation lease renewal", "err", err)
+			if errors.Is(err, errSpokeActivationSuspended) ||
+				errors.Is(err, errSpokeActivationInactive) {
+				slog.Warn("stop fleet spoke activation lease renewal", "err", err)
 				return
 			}
 			delay = spokeActivationRetryInterval
@@ -353,6 +355,9 @@ func maintainFederationSpokeActivation(
 func nextSpokeActivationRenewal(
 	enrollments *federation.Store, now time.Time,
 ) time.Duration {
+	if enrollments == nil {
+		return spokeActivationRetryInterval
+	}
 	local, ok := enrollments.Local()
 	if !ok || !local.ActivationValidUntil.After(now) {
 		return spokeActivationRetryInterval
@@ -371,7 +376,10 @@ func renewFederationSpokeActivation(
 	client *http.Client,
 ) error {
 	local, ok := enrollments.Local()
-	if !ok || local.State != federation.EnrollmentActive || local.Preparation == nil {
+	if !ok || local.State != federation.EnrollmentActive {
+		return errSpokeActivationInactive
+	}
+	if local.Preparation == nil {
 		return errors.New("active sealed fleet spoke enrollment is unavailable")
 	}
 	credential, ok := credentials.Outbound(local.HubID)

--- a/cmd/kenn-forge/spoke_startup.go
+++ b/cmd/kenn-forge/spoke_startup.go
@@ -36,8 +36,9 @@ const (
 )
 
 var (
-	errHubProtocolMismatch  = errors.New("hub federation protocol is incompatible")
-	errHubActivationInvalid = errors.New("hub federation activation response is invalid")
+	errHubProtocolMismatch      = errors.New("hub federation protocol is incompatible")
+	errHubActivationInvalid     = errors.New("hub federation activation response is invalid")
+	errSpokeActivationSuspended = errors.New("fleet spoke activation renewal is suspended")
 )
 
 type federationSpokeStartup struct {
@@ -289,8 +290,9 @@ func validateAndActivateFederationSpoke(
 			local.EnrollmentID+"/activate",
 		local.NodeID, credential.Token,
 		map[string]any{
-			"protocol_version": federation.ProtocolVersion,
-			"preparation_seal": local.Preparation.Seal,
+			"protocol_version":         federation.ProtocolVersion,
+			"activation_lease_version": federation.ActivationLeaseVersion,
+			"preparation_seal":         local.Preparation.Seal,
 		},
 		&active,
 	); err != nil {
@@ -299,6 +301,7 @@ func validateAndActivateFederationSpoke(
 	if active.ID != local.EnrollmentID || active.NodeID != local.NodeID ||
 		active.HubID != local.HubID ||
 		active.ProtocolVersion != federation.ProtocolVersion ||
+		active.ActivationLeaseVersion != federation.ActivationLeaseVersion ||
 		active.State != federation.EnrollmentActive {
 		return time.Time{}, fmt.Errorf(
 			"%w: response does not match the sealed enrollment",
@@ -336,10 +339,11 @@ func maintainFederationSpokeActivation(
 		if err := renewFederationSpokeActivation(
 			ctx, enrollments, credentials, spokeActivationHTTPClient(httpClient),
 		); err != nil {
-			delay = min(
-				spokeActivationRetryInterval,
-				nextSpokeActivationRenewal(enrollments, time.Now().UTC()),
-			)
+			if errors.Is(err, errSpokeActivationSuspended) {
+				slog.Warn("suspend fleet spoke activation lease renewal", "err", err)
+				return
+			}
+			delay = spokeActivationRetryInterval
 			slog.Warn("renew fleet spoke activation lease", "err", err)
 		}
 		timer.Reset(delay)
@@ -351,7 +355,7 @@ func nextSpokeActivationRenewal(
 ) time.Duration {
 	local, ok := enrollments.Local()
 	if !ok || !local.ActivationValidUntil.After(now) {
-		return time.Second
+		return spokeActivationRetryInterval
 	}
 	delay := local.ActivationValidUntil.Sub(now) / 2
 	if delay > spokeActivationRenewalInterval {
@@ -382,14 +386,29 @@ func renewFederationSpokeActivation(
 			); suspendErr != nil {
 				return errors.Join(err, suspendErr)
 			}
+			return errors.Join(errSpokeActivationSuspended, err)
 		}
 		return err
 	}
-	if err := enrollments.MarkLocalActive(ctx, local.EnrollmentID, validUntil); err != nil {
+	if err := enrollments.RenewLocalActivationLease(
+		ctx, local.EnrollmentID, validUntil,
+	); err != nil {
 		return fmt.Errorf("persist fleet spoke activation lease: %w", err)
 	}
 	if err := promoteFederationSpokeCredentialScopes(credentials, local.HubID); err != nil {
 		return fmt.Errorf("restore fleet spoke credential scopes: %w", err)
+	}
+	current, ok := enrollments.Local()
+	if !ok || current.EnrollmentID != local.EnrollmentID ||
+		current.State != federation.EnrollmentActive ||
+		current.ActivationLeaseVersion != federation.ActivationLeaseVersion ||
+		!current.ActivationValidUntil.After(time.Now().UTC()) {
+		if err := suspendFederationSpokeActivation(
+			ctx, enrollments, credentials, local,
+		); err != nil {
+			return errors.Join(errSpokeActivationSuspended, err)
+		}
+		return errSpokeActivationSuspended
 	}
 	return nil
 }

--- a/cmd/kenn-forge/spoke_startup.go
+++ b/cmd/kenn-forge/spoke_startup.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"slices"
 	"strings"
@@ -29,9 +30,15 @@ const (
 
 	maxSpokeActivationResponseBytes = 1 << 20
 	spokeActivationAttempts         = 3
+	spokeActivationRenewalInterval  = 6 * time.Hour
+	spokeActivationRetryInterval    = time.Minute
+	spokeActivationClockSkew        = 5 * time.Minute
 )
 
-var errHubProtocolMismatch = errors.New("hub federation protocol is incompatible")
+var (
+	errHubProtocolMismatch  = errors.New("hub federation protocol is incompatible")
+	errHubActivationInvalid = errors.New("hub federation activation response is invalid")
+)
 
 type federationSpokeStartup struct {
 	State  federationSpokeStartupState
@@ -95,7 +102,7 @@ func activateFederationSpokeAtStartup(
 	if !ok || !slices.Contains(credential.Scopes, federationauth.ScopeEnrollmentActivate) {
 		return fail(federationStartupActionRequired, "fleet spoke hub credential is unavailable")
 	}
-	if local.State == federation.EnrollmentActive {
+	if local.State == federation.EnrollmentActive && !cfg.Fleet.Enabled {
 		if err := promoteFederationSpokeCredentialScopes(
 			credentials, local.HubID,
 		); err != nil {
@@ -115,11 +122,13 @@ func activateFederationSpokeAtStartup(
 
 	client := spokeActivationHTTPClient(httpClient)
 	for attempt := range spokeActivationAttempts {
-		activationErr := validateAndActivateFederationSpoke(
+		activationValidUntil, activationErr := validateAndActivateFederationSpoke(
 			ctx, client, local, credential,
 		)
 		if activationErr == nil {
-			if err := enrollments.MarkLocalActive(ctx, local.EnrollmentID); err != nil {
+			if err := enrollments.MarkLocalActive(
+				ctx, local.EnrollmentID, activationValidUntil,
+			); err != nil {
 				return fail(federationStartupActionRequired, "persist fleet spoke activation: "+err.Error())
 			}
 			if err := promoteFederationSpokeCredentialScopes(
@@ -130,9 +139,40 @@ func activateFederationSpokeAtStartup(
 			return federationSpokeStartup{State: federationStartupActive}
 		}
 		if errors.Is(activationErr, errHubProtocolMismatch) {
+			if err := suspendFederationSpokeActivation(
+				ctx, enrollments, credentials, local,
+			); err != nil {
+				slog.Error(
+					"suspend incompatible fleet spoke activation",
+					"activation_err", activationErr, "err", err,
+				)
+			}
 			return fail(federationStartupIncompatible, activationErr.Error())
 		}
 		if !isRetryableSpokeActivationError(activationErr) || attempt+1 == spokeActivationAttempts {
+			if isRetryableSpokeActivationError(activationErr) &&
+				local.State == federation.EnrollmentActive &&
+				local.ActivationValidUntil.After(time.Now().UTC()) {
+				if err := promoteFederationSpokeCredentialScopes(
+					credentials, local.HubID,
+				); err != nil {
+					return fail(
+						federationStartupActionRequired,
+						"repair fleet spoke credential scopes: "+err.Error(),
+					)
+				}
+				return federationSpokeStartup{State: federationStartupActive}
+			}
+			if !isRetryableSpokeActivationError(activationErr) {
+				if err := suspendFederationSpokeActivation(
+					ctx, enrollments, credentials, local,
+				); err != nil {
+					return fail(
+						federationStartupActionRequired,
+						"invalidate fleet spoke activation lease: "+err.Error(),
+					)
+				}
+			}
 			return fail(
 				federationStartupActionRequired,
 				"fleet spoke hub activation failed: "+activationErr.Error(),
@@ -202,6 +242,10 @@ func (e *spokeActivationHTTPError) Error() string {
 }
 
 func isRetryableSpokeActivationError(err error) bool {
+	if errors.Is(err, errHubProtocolMismatch) ||
+		errors.Is(err, errHubActivationInvalid) {
+		return false
+	}
 	if responseErr, ok := errors.AsType[*spokeActivationHTTPError](err); ok {
 		return responseErr.status >= http.StatusInternalServerError
 	}
@@ -213,7 +257,7 @@ func validateAndActivateFederationSpoke(
 	client *http.Client,
 	local federation.LocalEnrollment,
 	credential federationauth.Credential,
-) error {
+) (time.Time, error) {
 	var identity struct {
 		NodeID          string `json:"node_id"`
 		ProtocolVersion int    `json:"protocol_version"`
@@ -223,17 +267,20 @@ func validateAndActivateFederationSpoke(
 		local.HubURL+"/api/v1/federation/identity",
 		local.NodeID, credential.Token, nil, &identity,
 	); err != nil {
-		return err
+		return time.Time{}, err
 	}
 	if identity.ProtocolVersion != federation.ProtocolVersion {
-		return fmt.Errorf(
+		return time.Time{}, fmt.Errorf(
 			"%w: expected %d, got %d",
 			errHubProtocolMismatch,
 			federation.ProtocolVersion, identity.ProtocolVersion,
 		)
 	}
 	if identity.NodeID != local.HubID {
-		return errors.New("hub identity does not match the sealed enrollment")
+		return time.Time{}, fmt.Errorf(
+			"%w: hub identity does not match the sealed enrollment",
+			errHubActivationInvalid,
+		)
 	}
 	var active federation.Enrollment
 	if err := doSpokeActivationJSON(
@@ -247,15 +294,121 @@ func validateAndActivateFederationSpoke(
 		},
 		&active,
 	); err != nil {
-		return err
+		return time.Time{}, err
 	}
 	if active.ID != local.EnrollmentID || active.NodeID != local.NodeID ||
 		active.HubID != local.HubID ||
 		active.ProtocolVersion != federation.ProtocolVersion ||
 		active.State != federation.EnrollmentActive {
-		return errors.New("hub activation response does not match the sealed enrollment")
+		return time.Time{}, fmt.Errorf(
+			"%w: response does not match the sealed enrollment",
+			errHubActivationInvalid,
+		)
+	}
+	now := time.Now().UTC()
+	validUntil := active.ActivationValidUntil.UTC()
+	if !validUntil.After(now) || validUntil.After(
+		now.Add(federation.SpokeActivationLeaseDuration+spokeActivationClockSkew),
+	) {
+		return time.Time{}, fmt.Errorf(
+			"%w: response has an invalid lease", errHubActivationInvalid,
+		)
+	}
+	return validUntil, nil
+}
+
+func maintainFederationSpokeActivation(
+	ctx context.Context,
+	enrollments *federation.Store,
+	credentials *federationauth.Store,
+	httpClient *http.Client,
+) {
+	timer := time.NewTimer(nextSpokeActivationRenewal(enrollments, time.Now().UTC()))
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+
+		delay := spokeActivationRenewalInterval
+		if err := renewFederationSpokeActivation(
+			ctx, enrollments, credentials, spokeActivationHTTPClient(httpClient),
+		); err != nil {
+			delay = min(
+				spokeActivationRetryInterval,
+				nextSpokeActivationRenewal(enrollments, time.Now().UTC()),
+			)
+			slog.Warn("renew fleet spoke activation lease", "err", err)
+		}
+		timer.Reset(delay)
+	}
+}
+
+func nextSpokeActivationRenewal(
+	enrollments *federation.Store, now time.Time,
+) time.Duration {
+	local, ok := enrollments.Local()
+	if !ok || !local.ActivationValidUntil.After(now) {
+		return time.Second
+	}
+	delay := local.ActivationValidUntil.Sub(now) / 2
+	if delay > spokeActivationRenewalInterval {
+		return spokeActivationRenewalInterval
+	}
+	return max(delay, time.Second)
+}
+
+func renewFederationSpokeActivation(
+	ctx context.Context,
+	enrollments *federation.Store,
+	credentials *federationauth.Store,
+	client *http.Client,
+) error {
+	local, ok := enrollments.Local()
+	if !ok || local.State != federation.EnrollmentActive || local.Preparation == nil {
+		return errors.New("active sealed fleet spoke enrollment is unavailable")
+	}
+	credential, ok := credentials.Outbound(local.HubID)
+	if !ok || !slices.Contains(credential.Scopes, federationauth.ScopeEnrollmentActivate) {
+		return errors.New("fleet spoke hub credential is unavailable")
+	}
+	validUntil, err := validateAndActivateFederationSpoke(ctx, client, local, credential)
+	if err != nil {
+		if !isRetryableSpokeActivationError(err) {
+			if suspendErr := suspendFederationSpokeActivation(
+				ctx, enrollments, credentials, local,
+			); suspendErr != nil {
+				return errors.Join(err, suspendErr)
+			}
+		}
+		return err
+	}
+	if err := enrollments.MarkLocalActive(ctx, local.EnrollmentID, validUntil); err != nil {
+		return fmt.Errorf("persist fleet spoke activation lease: %w", err)
+	}
+	if err := promoteFederationSpokeCredentialScopes(credentials, local.HubID); err != nil {
+		return fmt.Errorf("restore fleet spoke credential scopes: %w", err)
 	}
 	return nil
+}
+
+func suspendFederationSpokeActivation(
+	ctx context.Context,
+	enrollments *federation.Store,
+	credentials *federationauth.Store,
+	local federation.LocalEnrollment,
+) error {
+	return errors.Join(
+		enrollments.InvalidateLocalActivationLease(ctx, local.EnrollmentID),
+		credentials.UpdateInboundScopes(
+			local.HubID, federationauth.PendingHubToSpokeScopes(),
+		),
+		credentials.UpdateOutboundScopes(
+			local.HubID, federationauth.PendingSpokeToHubScopes(),
+		),
+	)
 }
 
 func doSpokeActivationJSON(

--- a/cmd/kenn-forge/spoke_startup_test.go
+++ b/cmd/kenn-forge/spoke_startup_test.go
@@ -130,6 +130,10 @@ func TestFederationSpokeStartupActivatesMatchingSealAndRetriesSafely(t *testing.
 			var body map[string]any
 			assert.NoError(json.NewDecoder(r.Body).Decode(&body))
 			assert.Equal(startupSeal, body["preparation_seal"])
+			assert.InDelta(
+				float64(federation.ActivationLeaseVersion),
+				body["activation_lease_version"], 0,
+			)
 			if hubActive.CompareAndSwap(false, true) {
 				membershipWrites.Add(1)
 				_, _ = w.Write([]byte("{"))
@@ -137,9 +141,10 @@ func TestFederationSpokeStartupActivatesMatchingSealAndRetriesSafely(t *testing.
 			}
 			_ = json.NewEncoder(w).Encode(federation.Enrollment{
 				ID: startupEnrollmentID, NodeID: startupNodeID,
-				HubID:           startupHubID,
-				ProtocolVersion: federation.ProtocolVersion,
-				State:           federation.EnrollmentActive,
+				HubID:                  startupHubID,
+				ProtocolVersion:        federation.ProtocolVersion,
+				ActivationLeaseVersion: federation.ActivationLeaseVersion,
+				State:                  federation.EnrollmentActive,
 				ActivationValidUntil: time.Now().Add(
 					federation.SpokeActivationLeaseDuration,
 				),
@@ -273,6 +278,107 @@ func TestFederationSpokeStartupDoesNotUseLeaseAfterHubRejectsEnrollment(t *testi
 	assert.False(principal.Has(federationauth.ScopeTerminalAttach))
 }
 
+func TestFederationSpokeRenewalCannotReactivateRevokedEnrollment(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	activationStarted := make(chan struct{})
+	releaseActivation := make(chan struct{})
+	hub := httptest.NewTLSServer(http.HandlerFunc(func(
+		w http.ResponseWriter, r *http.Request,
+	) {
+		switch r.URL.Path {
+		case "/api/v1/federation/identity":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"node_id": startupHubID, "protocol_version": federation.ProtocolVersion,
+			})
+		case "/api/v1/federation/enrollments/" + startupEnrollmentID + "/activate":
+			close(activationStarted)
+			<-releaseActivation
+			_ = json.NewEncoder(w).Encode(federation.Enrollment{
+				ID: startupEnrollmentID, NodeID: startupNodeID, HubID: startupHubID,
+				ProtocolVersion:        federation.ProtocolVersion,
+				ActivationLeaseVersion: federation.ActivationLeaseVersion,
+				State:                  federation.EnrollmentActive,
+				ActivationValidUntil: time.Now().Add(
+					federation.SpokeActivationLeaseDuration,
+				),
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(hub.Close)
+	enrollments, credentials, _ := spokeStartupFixture(
+		t, dbtest.Open(t), hub.URL, true,
+	)
+	require.NoError(enrollments.MarkLocalActive(
+		t.Context(), startupEnrollmentID, time.Now().Add(time.Hour),
+	))
+	renewed := make(chan error, 1)
+	go func() {
+		renewed <- renewFederationSpokeActivation(
+			t.Context(), enrollments, credentials, hub.Client(),
+		)
+	}()
+	<-activationStarted
+	local, ok := enrollments.Local()
+	require.True(ok)
+	local.State = federation.EnrollmentRevoked
+	require.NoError(enrollments.SaveLocal(t.Context(), local))
+	close(releaseActivation)
+
+	require.ErrorIs(<-renewed, federation.ErrEnrollmentRevoked)
+	local, ok = enrollments.Local()
+	require.True(ok)
+	assert.Equal(federation.EnrollmentRevoked, local.State)
+	principal, ok := credentials.Authenticate("hub-to-spoke")
+	require.True(ok)
+	assert.False(principal.Has(federationauth.ScopeWorkspaceWrite))
+	assert.False(principal.Has(federationauth.ScopeTerminalAttach))
+}
+
+func TestFederationSpokeRenewalSuspendsAfterHubRejection(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	hub := httptest.NewTLSServer(http.HandlerFunc(func(
+		w http.ResponseWriter, r *http.Request,
+	) {
+		if r.URL.Path == "/api/v1/federation/identity" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"node_id": startupHubID, "protocol_version": federation.ProtocolVersion,
+			})
+			return
+		}
+		http.Error(w, "revoked", http.StatusForbidden)
+	}))
+	t.Cleanup(hub.Close)
+	enrollments, credentials, _ := spokeStartupFixture(
+		t, dbtest.Open(t), hub.URL, true,
+	)
+	require.NoError(enrollments.MarkLocalActive(
+		t.Context(), startupEnrollmentID, time.Now().Add(time.Hour),
+	))
+	require.NoError(promoteFederationSpokeCredentialScopes(credentials, startupHubID))
+
+	err := renewFederationSpokeActivation(
+		t.Context(), enrollments, credentials, hub.Client(),
+	)
+
+	require.ErrorIs(err, errSpokeActivationSuspended)
+	local, ok := enrollments.Local()
+	require.True(ok)
+	assert.True(local.ActivationValidUntil.IsZero())
+	principal, ok := credentials.Authenticate("hub-to-spoke")
+	require.True(ok)
+	assert.False(principal.Has(federationauth.ScopeWorkspaceWrite))
+	assert.False(principal.Has(federationauth.ScopeTerminalAttach))
+}
+
+func TestMissingOrExpiredSpokeLeaseRetriesAfterBackoff(t *testing.T) {
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	assert.Equal(t, spokeActivationRetryInterval, nextSpokeActivationRenewal(nil, now))
+}
+
 func TestFederationSpokeStartupKeepsActiveBindingDormantWhileDisabled(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -386,6 +492,51 @@ func TestFederationSpokeStartupSuppressesIncompatibleHub(t *testing.T) {
 		enrollments, credentials, hub.Client(),
 	)
 	assert.Equal(t, federationStartupIncompatible, status.State)
+}
+
+func TestFederationSpokeStartupRejectsLeaseUnawareHub(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	hub := httptest.NewTLSServer(http.HandlerFunc(func(
+		w http.ResponseWriter, r *http.Request,
+	) {
+		switch r.URL.Path {
+		case "/api/v1/federation/identity":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"node_id": startupHubID, "protocol_version": federation.ProtocolVersion,
+			})
+		case "/api/v1/federation/enrollments/" + startupEnrollmentID + "/activate":
+			_ = json.NewEncoder(w).Encode(federation.Enrollment{
+				ID: startupEnrollmentID, NodeID: startupNodeID, HubID: startupHubID,
+				ProtocolVersion: federation.ProtocolVersion,
+				State:           federation.EnrollmentActive,
+				ActivationValidUntil: time.Now().Add(
+					federation.SpokeActivationLeaseDuration,
+				),
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(hub.Close)
+	database := dbtest.Open(t)
+	enrollments, credentials, cfg := spokeStartupFixture(
+		t, database, hub.URL, true,
+	)
+	require.NoError(enrollments.MarkLocalActive(
+		t.Context(), startupEnrollmentID, time.Now().Add(time.Hour),
+	))
+
+	status := activateFederationSpokeAtStartup(
+		t.Context(), database, cfg, startupNodeID,
+		enrollments, credentials, hub.Client(),
+	)
+
+	assert.Equal(federationStartupActionRequired, status.State)
+	assert.Contains(status.Reason, "response does not match")
+	local, ok := enrollments.Local()
+	require.True(ok)
+	assert.True(local.ActivationValidUntil.IsZero())
 }
 
 func TestFederationSpokeStartupLoadsOldProtocolAsIncompatibleWithoutTraffic(t *testing.T) {

--- a/cmd/kenn-forge/spoke_startup_test.go
+++ b/cmd/kenn-forge/spoke_startup_test.go
@@ -140,6 +140,9 @@ func TestFederationSpokeStartupActivatesMatchingSealAndRetriesSafely(t *testing.
 				HubID:           startupHubID,
 				ProtocolVersion: federation.ProtocolVersion,
 				State:           federation.EnrollmentActive,
+				ActivationValidUntil: time.Now().Add(
+					federation.SpokeActivationLeaseDuration,
+				),
 			})
 		default:
 			http.NotFound(w, r)
@@ -163,9 +166,10 @@ func TestFederationSpokeStartupActivatesMatchingSealAndRetriesSafely(t *testing.
 	require.True(ok)
 	assert.Equal(federation.EnrollmentActive, local.State)
 	assert.False(local.PreparationRequired)
+	assert.True(local.ActivationValidUntil.After(time.Now()))
 }
 
-func TestFederationSpokeStartupKeepsActiveEnrollmentDuringHubOutage(t *testing.T) {
+func TestFederationSpokeStartupUsesUnexpiredLeaseDuringHubOutage(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	var requests atomic.Int32
@@ -180,7 +184,9 @@ func TestFederationSpokeStartupKeepsActiveEnrollmentDuringHubOutage(t *testing.T
 	enrollments, credentials, cfg := spokeStartupFixture(
 		t, database, hub.URL, true,
 	)
-	require.NoError(enrollments.MarkLocalActive(t.Context(), startupEnrollmentID))
+	require.NoError(enrollments.MarkLocalActive(
+		t.Context(), startupEnrollmentID, time.Now().Add(time.Hour),
+	))
 	require.NoError(credentials.UpdateInboundScopes(
 		startupHubID, federationauth.HubToSpokeScopes(),
 	))
@@ -194,8 +200,77 @@ func TestFederationSpokeStartupKeepsActiveEnrollmentDuringHubOutage(t *testing.T
 	)
 
 	assert.Equal(federationStartupActive, status.State, status.Reason)
-	assert.Zero(requests.Load(),
-		"an active sealed enrollment must not depend on hub reachability at boot")
+	assert.Equal(int32(spokeActivationAttempts), requests.Load())
+}
+
+func TestFederationSpokeStartupRejectsExpiredLeaseDuringHubOutage(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var requests atomic.Int32
+	hub := httptest.NewTLSServer(http.HandlerFunc(func(
+		w http.ResponseWriter, _ *http.Request,
+	) {
+		requests.Add(1)
+		http.Error(w, "hub unavailable", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(hub.Close)
+	database := dbtest.Open(t)
+	enrollments, credentials, cfg := spokeStartupFixture(
+		t, database, hub.URL, true,
+	)
+	require.NoError(enrollments.MarkLocalActive(
+		t.Context(), startupEnrollmentID, time.Now().Add(time.Minute),
+	))
+	local, ok := enrollments.Local()
+	require.True(ok)
+	local.ActivationValidUntil = time.Now().Add(-time.Minute)
+	require.NoError(enrollments.SaveLocal(t.Context(), local))
+
+	status := activateFederationSpokeAtStartup(
+		t.Context(), database, cfg, startupNodeID,
+		enrollments, credentials, hub.Client(),
+	)
+
+	assert.Equal(federationStartupActionRequired, status.State)
+	assert.Contains(status.Reason, "HTTP 503")
+	assert.Equal(int32(spokeActivationAttempts), requests.Load())
+}
+
+func TestFederationSpokeStartupDoesNotUseLeaseAfterHubRejectsEnrollment(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var requests atomic.Int32
+	hub := httptest.NewTLSServer(http.HandlerFunc(func(
+		w http.ResponseWriter, _ *http.Request,
+	) {
+		requests.Add(1)
+		http.Error(w, "enrollment revoked", http.StatusForbidden)
+	}))
+	t.Cleanup(hub.Close)
+	database := dbtest.Open(t)
+	enrollments, credentials, cfg := spokeStartupFixture(
+		t, database, hub.URL, true,
+	)
+	require.NoError(enrollments.MarkLocalActive(
+		t.Context(), startupEnrollmentID, time.Now().Add(time.Hour),
+	))
+
+	status := activateFederationSpokeAtStartup(
+		t.Context(), database, cfg, startupNodeID,
+		enrollments, credentials, hub.Client(),
+	)
+
+	assert.Equal(federationStartupActionRequired, status.State)
+	assert.Contains(status.Reason, "HTTP 403")
+	assert.Equal(int32(1), requests.Load())
+	local, ok := enrollments.Local()
+	require.True(ok)
+	assert.True(local.ActivationValidUntil.IsZero())
+	principal, ok := credentials.Authenticate("hub-to-spoke")
+	require.True(ok)
+	assert.True(principal.Has(federationauth.ScopeEnrollmentActivate))
+	assert.False(principal.Has(federationauth.ScopeWorkspaceWrite))
+	assert.False(principal.Has(federationauth.ScopeTerminalAttach))
 }
 
 func TestFederationSpokeStartupKeepsActiveBindingDormantWhileDisabled(t *testing.T) {
@@ -213,7 +288,9 @@ func TestFederationSpokeStartupKeepsActiveBindingDormantWhileDisabled(t *testing
 	enrollments, credentials, cfg := spokeStartupFixture(
 		t, database, hub.URL, true,
 	)
-	require.NoError(enrollments.MarkLocalActive(t.Context(), startupEnrollmentID))
+	require.NoError(enrollments.MarkLocalActive(
+		t.Context(), startupEnrollmentID, time.Now().Add(time.Hour),
+	))
 	require.NoError(credentials.UpdateInboundScopes(
 		startupHubID, federationauth.HubToSpokeScopes(),
 	))
@@ -254,7 +331,9 @@ func TestDisabledFederationSpokeStartupRepairsInterruptedCredentialPromotion(t *
 			enrollments, credentials, cfg := spokeStartupFixture(
 				t, database, "https://hub.example", true,
 			)
-			require.NoError(enrollments.MarkLocalActive(t.Context(), startupEnrollmentID))
+			require.NoError(enrollments.MarkLocalActive(
+				t.Context(), startupEnrollmentID, time.Now().Add(time.Hour),
+			))
 			if test.prepare != nil {
 				test.prepare(t, credentials)
 			}

--- a/cmd/kenn-forge/spoke_startup_test.go
+++ b/cmd/kenn-forge/spoke_startup_test.go
@@ -379,6 +379,12 @@ func TestMissingOrExpiredSpokeLeaseRetriesAfterBackoff(t *testing.T) {
 	assert.Equal(t, spokeActivationRetryInterval, nextSpokeActivationRenewal(nil, now))
 }
 
+func TestFederationSpokeRenewalStopsWhenEnrollmentIsInactive(t *testing.T) {
+	err := renewFederationSpokeActivation(t.Context(), nil, nil, nil)
+
+	require.ErrorIs(t, err, errSpokeActivationInactive)
+}
+
 func TestFederationSpokeStartupKeepsActiveBindingDormantWhileDisabled(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/cmd/kenn-forge/spoke_startup_test.go
+++ b/cmd/kenn-forge/spoke_startup_test.go
@@ -165,6 +165,39 @@ func TestFederationSpokeStartupActivatesMatchingSealAndRetriesSafely(t *testing.
 	assert.False(local.PreparationRequired)
 }
 
+func TestFederationSpokeStartupKeepsActiveEnrollmentDuringHubOutage(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var requests atomic.Int32
+	hub := httptest.NewTLSServer(http.HandlerFunc(func(
+		w http.ResponseWriter, _ *http.Request,
+	) {
+		requests.Add(1)
+		http.Error(w, "hub unavailable", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(hub.Close)
+	database := dbtest.Open(t)
+	enrollments, credentials, cfg := spokeStartupFixture(
+		t, database, hub.URL, true,
+	)
+	require.NoError(enrollments.MarkLocalActive(t.Context(), startupEnrollmentID))
+	require.NoError(credentials.UpdateInboundScopes(
+		startupHubID, federationauth.HubToSpokeScopes(),
+	))
+	require.NoError(credentials.UpdateOutboundScopes(
+		startupHubID, federationauth.SpokeToHubScopes(),
+	))
+
+	status := activateFederationSpokeAtStartup(
+		t.Context(), database, cfg, startupNodeID,
+		enrollments, credentials, hub.Client(),
+	)
+
+	assert.Equal(federationStartupActive, status.State, status.Reason)
+	assert.Zero(requests.Load(),
+		"an active sealed enrollment must not depend on hub reachability at boot")
+}
+
 func TestFederationSpokeStartupKeepsActiveBindingDormantWhileDisabled(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/context/fleet-architecture.md
+++ b/context/fleet-architecture.md
@@ -118,9 +118,9 @@ or remote workspace and session operations.
   `internal/server/api_auth.go::Server.federationPrincipalEnrollmentState`).
 - Active peer bearers are accepted only after the versioned activation-lease
   handshake and while the hub and spoke copies of the renewable 24-hour lease
-  are current. Lease-unaware or expired peers may reach only the identity
-  preflight and activation handshake, or revocation; explicit hub rejection
-  never falls back to a cached lease
+  are current and federation remains enabled. Lease-unaware or expired peers
+  may reach only the identity preflight and activation handshake, or revocation;
+  explicit hub rejection never falls back to a cached lease
   (`internal/server/api_auth.go::Server.federationPrincipalEnrollmentState`,
   `internal/server/api_auth.go::Server.allowsActivationLeaseHandshake`).
 - The credential store persists inbound bearers only as SHA-256 digests and

--- a/context/fleet-architecture.md
+++ b/context/fleet-architecture.md
@@ -118,10 +118,11 @@ or remote workspace and session operations.
   `internal/server/api_auth.go::Server.federationPrincipalEnrollmentState`).
 - Active peer bearers are accepted only after the versioned activation-lease
   handshake and while the hub and spoke copies of the renewable 24-hour lease
-  are current. Lease-unaware peers may reach only activation or revocation;
-  explicit hub rejection never falls back to a cached lease
+  are current. Lease-unaware or expired peers may reach only the identity
+  preflight and activation handshake, or revocation; explicit hub rejection
+  never falls back to a cached lease
   (`internal/server/api_auth.go::Server.federationPrincipalEnrollmentState`,
-  `internal/server/api_auth.go::Server.allowsActivationLeaseRenewal`).
+  `internal/server/api_auth.go::Server.allowsActivationLeaseHandshake`).
 - The credential store persists inbound bearers only as SHA-256 digests and
   keeps outbound bearers readable for request construction. Atomic 0600 writes
   publish immutable in-memory snapshots only after persistence, so revocation

--- a/context/fleet-architecture.md
+++ b/context/fleet-architecture.md
@@ -75,9 +75,9 @@ or remote workspace and session operations.
   Explicitly incomplete aggregates retain absent-host rows; authoritative views
   retain only explicitly degraded hosts and remove absent membership
   (`frontend/src/lib/components/terminal/workspace-list-schema.ts::retainDegradedHostWorkspaces`).
-- Workspaces does not repeat host labels or healthy fleet inventory in its list;
-  host navigation belongs to the global Forge selector, while fleet chrome is
-  reserved for actionable degradation (`frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte`).
+- Hub workspace rows show a compact execution-host badge; spoke rows remain
+  unlabeled because their actionable workspace surface is local-only. Fleet
+  chrome remains reserved for actionable degradation (`frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte`).
 - The reserved `self` alias and stable node ID address local. An active spoke routes
   only when config matches its enrollment; that enrollment supplies the credential-bound destination
   (`internal/server/fleetapi/fleet_proxy.go::Handler.resolveEnrolledSpoke`).

--- a/context/fleet-architecture.md
+++ b/context/fleet-architecture.md
@@ -64,6 +64,9 @@ or remote workspace and session operations.
 - A failed, incompatible, or unauthenticated member degrades only that member to
   an unreachable summary; it must not fail local or other member results
   (`internal/server/fleetapi/fleet_hub.go::Handler.fetchMemberRaw`).
+- Structured peer rejections must retain an operator-actionable cause; do not
+  collapse enrollment or identity failures to an HTTP status alone
+  (`internal/server/fleetapi/fleet_hub.go::federationPeerResponseError`).
 - A spoke supplies its aggregate member budget; the hub uses the smaller local
   or requested timeout, while the spoke reserves twice that budget for the full
   response (`internal/server/fleetapi/fleet_routes.go::Handler.getSnapshotAggregate`).

--- a/context/fleet-architecture.md
+++ b/context/fleet-architecture.md
@@ -116,9 +116,9 @@ or remote workspace and session operations.
   Activation upgrades both directions
   (`internal/federationauth/scope.go::HubToSpokeScopes`,
   `internal/server/api_auth.go::Server.federationPrincipalEnrollmentState`).
-- An active hub bearer is accepted by a spoke only when that daemon's
-  startup activation succeeded. This is a local lifecycle gate inside the
-  trusted fleet, not isolation from a malicious activated hub.
+- An active hub bearer is accepted by a spoke only after startup activation
+  and while its renewable 24-hour activation lease is current; explicit hub
+  rejection never falls back to a cached lease (`internal/server/api_auth.go::Server.federationPrincipalEnrollmentState`).
 - The credential store persists inbound bearers only as SHA-256 digests and
   keeps outbound bearers readable for request construction. Atomic 0600 writes
   publish immutable in-memory snapshots only after persistence, so revocation
@@ -199,10 +199,9 @@ or remote workspace and session operations.
   credential route, rejects a historically occupied mutable route, and records
   only repository routing metadata in its spoke catalog (`internal/providerplane/client.go::ValidateFederationWorkspaceLaunchSpecResponse`,
   `internal/server/provider_sources.go::hubProviderSource.ResolveWorkspaceLaunchSpec`).
-- Federated MCP workspace creation resolves a hub repository descriptor
-  before capturing the spoke-local route fence, so repositories discovered after
-  activation become locally executable without a prior settings refresh
-  (`internal/server/mcp_backend.go::mcpBackend.resolveWorkspaceRepositoryFence`).
+- Federated ad-hoc and MCP workspace creation resolve a hub repository descriptor
+  before local lookup or route fencing, so newly discovered repositories do not
+  require a settings refresh (`internal/server/provider_sources.go::hubProviderSource.ResolveRepositoryRoute`).
 - Registered spoke projects resolve stable hub repository identity during
   preparation and future registration; raw fleet snapshots remain read-only
   (`internal/server/spoke_preparation.go::Server.reconcileSpokePreparationProjects`).

--- a/context/fleet-architecture.md
+++ b/context/fleet-architecture.md
@@ -116,9 +116,12 @@ or remote workspace and session operations.
   Activation upgrades both directions
   (`internal/federationauth/scope.go::HubToSpokeScopes`,
   `internal/server/api_auth.go::Server.federationPrincipalEnrollmentState`).
-- An active hub bearer is accepted by a spoke only after startup activation
-  and while its renewable 24-hour activation lease is current; explicit hub
-  rejection never falls back to a cached lease (`internal/server/api_auth.go::Server.federationPrincipalEnrollmentState`).
+- Active peer bearers are accepted only after the versioned activation-lease
+  handshake and while the hub and spoke copies of the renewable 24-hour lease
+  are current. Lease-unaware peers may reach only activation or revocation;
+  explicit hub rejection never falls back to a cached lease
+  (`internal/server/api_auth.go::Server.federationPrincipalEnrollmentState`,
+  `internal/server/api_auth.go::Server.allowsActivationLeaseRenewal`).
 - The credential store persists inbound bearers only as SHA-256 digests and
   keeps outbound bearers readable for request construction. Atomic 0600 writes
   publish immutable in-memory snapshots only after persistence, so revocation
@@ -273,6 +276,12 @@ or remote workspace and session operations.
 - Federation protocol version 3 requires an exact match; there is no
   translation or compatibility fallback
   (`internal/federation/protocol.go::ProtocolVersion`).
+- Activation leases negotiate their own version 1 inside protocol 3. This
+  keeps snapshot compatibility separate from the authorization handshake:
+  upgraded hubs isolate lease-unaware active spokes until they upgrade and
+  activate again, without rewriting enrollment storage or requiring
+  re-enrollment (`internal/federation/protocol.go::ActivationLeaseVersion`,
+  `internal/server/fleetapi/fleet_enrollment.go::Handler.activateEnrollment`).
 - Enrollment accepts only canonical HTTPS origins. Each token is consumed by
   its first accepted request; retry or rekey requires a new token
   (`internal/federation/enrollment_store.go::Store.Begin`).
@@ -320,8 +329,11 @@ or remote workspace and session operations.
   (`internal/server/spoke_preparation.go::Server.persistPreparedSpokeRole`).
 - Activation retries are bounded and reuse the sealed enrollment; the
   hub validates its issued seal, and already-active retries never
-  duplicate membership. Invalid state is `action_required`, protocol mismatch
-  is `incompatible`, and both preserve local execution while suppressing routes
+  duplicate membership. Renewal is conditional on the enrollment remaining
+  active, so a response that races revocation cannot restore the lease.
+  Retryable failures back off for one minute; definitive rejection clears the
+  lease and stops renewal until restart. Invalid state is `action_required`,
+  protocol mismatch is `incompatible`, and both preserve local execution while suppressing routes
   (`cmd/kenn-forge/spoke_startup.go::activateFederationSpokeAtStartup`,
   `internal/server/fleetapi/fleet_enrollment.go::Handler.activateEnrollment`).
 - Hub-initiated revocation makes each side retry-safe. The spoke marks its local

--- a/context/server-runtime.md
+++ b/context/server-runtime.md
@@ -30,6 +30,9 @@ and the root event stream.
   host drop only that host while healthy hosts keep syncing; unattributable
   failures degrade to no provider sync. Dropped hosts serve cached data until a
   later restart (`cmd/kenn-forge/provider_startup.go::buildProviderControlPlaneOrDegraded`).
+- A fully sealed active spoke never requires hub reachability at process start;
+  its event lifecycle owns reconnection after transient network or DNS outages
+  (`cmd/kenn-forge/spoke_startup.go::activateFederationSpokeAtStartup`).
 - Provider API origins and cleartext acknowledgements are startup-bound. Config
   reload reports `restart_required` when either changes instead of claiming the
   boot-time client and clone policy were updated

--- a/context/testing.md
+++ b/context/testing.md
@@ -260,6 +260,8 @@ The `e2e-roborev` daemon pin (`ROBOREV_REF` in `.github/workflows/ci.yml`) must 
 Managed-clone initialization must exercise the pinned real Roborev CLI and daemon;
 a fake hook writer cannot validate linked-worktree registration
 (`scripts/run-roborev-e2e.sh:72`).
+Container fixture package downloads must use bounded retries and timeouts; an
+unbounded mirror stall can monopolize a public CI runner without reaching tests.
 
 Playwright waits must observe the state consumed by the next assertion. Direct API reads after an optimistic
 mutation wait for its response; rendered assertions wait for rendered state, since route refinement can pair new

--- a/context/testing.md
+++ b/context/testing.md
@@ -255,6 +255,7 @@ Roborev `hide_classify_jobs` e2e fixtures must cover skipped design rows and cla
 Seed classify rows terminal unless testing worker mutation; live workers can rewrite queued/running rows during browser assertions (`internal/testutil/roborev_fixtures.go::seedRoborevMutationFixtures`).
 Keep injected Roborev `panel_run` failures controlled until the assertion observes them; drawer/list refresh demand can immediately retry member fetches and clear transient panel errors (`frontend/src/lib/stores/roborev/jobs.svelte.ts::wantsPanelMembers`).
 Roborev `/api/stream/events` is NDJSON, not SSE: use an abortable Fetch reader with bounded reconnects, and abort both pre-header and active-body requests on teardown (`frontend/src/lib/stores/roborev/jobs.svelte.ts::connectEventStream`).
+Playwright retries that write to a persistent authority must use per-attempt mutation identities or reset state; a committed first attempt otherwise poisons its retry (`frontend/tests/e2e-full/roborev-e2e.spec.ts:923`).
 The `e2e-roborev` daemon pin (`ROBOREV_REF` in `.github/workflows/ci.yml`) must be at or after the roborev commit the generated schema (`frontend/src/lib/api/roborev/generated/`) was produced from; a stale pin makes the daemon silently omit newer response fields while seed inserts still succeed, because the seeder creates its own schema.
 Managed-clone initialization must exercise the pinned real Roborev CLI and daemon;
 a fake hook writer cannot validate linked-worktree registration

--- a/context/testing.md
+++ b/context/testing.md
@@ -260,8 +260,8 @@ The `e2e-roborev` daemon pin (`ROBOREV_REF` in `.github/workflows/ci.yml`) must 
 Managed-clone initialization must exercise the pinned real Roborev CLI and daemon;
 a fake hook writer cannot validate linked-worktree registration
 (`scripts/run-roborev-e2e.sh:72`).
-Container fixture package downloads must use bounded retries and timeouts; an
-unbounded mirror stall can monopolize a public CI runner without reaching tests.
+Container fixture package downloads must bound both transfers and total wall
+time; package-manager retry backoff can otherwise monopolize a public CI runner.
 
 Playwright waits must observe the state consumed by the next assertion. Direct API reads after an optimistic
 mutation wait for its response; rendered assertions wait for rendered state, since route refinement can pair new

--- a/context/testing.md
+++ b/context/testing.md
@@ -260,8 +260,9 @@ The `e2e-roborev` daemon pin (`ROBOREV_REF` in `.github/workflows/ci.yml`) must 
 Managed-clone initialization must exercise the pinned real Roborev CLI and daemon;
 a fake hook writer cannot validate linked-worktree registration
 (`scripts/run-roborev-e2e.sh:72`).
-Container fixture package downloads must bound both transfers and total wall
-time; package-manager retry backoff can otherwise monopolize a public CI runner.
+Container fixtures must not fetch operating-system packages from public mirrors
+during CI. Build small fixture-only helpers from the repository and reuse an
+already-required toolchain base image instead (`tests/integration/roborev/Dockerfile`).
 
 Playwright waits must observe the state consumed by the next assertion. Direct API reads after an optimistic
 mutation wait for its response; rendered assertions wait for rendered state, since route refinement can pair new

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -65,6 +65,8 @@ embedder protocol for arbitrary host state.
   (`internal/workspace/monitor.go::workspacePRMonitorEligible`); that number is
   the workspace's item identity for display, links, and search, so surfaces must
   never gate PR affordances on `item_type == "pull_request"` alone.
+  A hub may route this creation to itself or a writable spoke; a spoke offers
+  only itself as an execution target (`internal/server/fleetapi/fleet_proxy.go::Handler.registerFleetOperationRoutes`).
 - `GET /kata/daemons/{daemon_id}/references`: search canonical Kata issue references on an explicitly pinned daemon for link and workspace creation.
 - `GET /kata/daemons/{daemon_id}/issues/{issue_uid}`: return one read-only issue detail envelope plus the daemon health schema version. Forge does not cache or persist the task payload.
 - `GET /kata/daemons/{daemon_id}/issues/{issue_uid}/launch-target`: resolve Kata’s safe external browser target.

--- a/docs/federated-fleet.md
+++ b/docs/federated-fleet.md
@@ -592,9 +592,11 @@ Read the full degraded-host message in the hub. Forge preserves the peer's
 authorization reason instead of reducing it to an HTTP status.
 
 If the message says fleet authorization is inactive, inspect the spoke service's
-startup log and confirm it can resolve and reach the hub. An already active,
-sealed enrollment starts without a synchronous hub request and reconnects when
-the hub becomes reachable.
+startup log and confirm it can resolve and reach the hub. An active spoke
+revalidates its sealed enrollment with the hub at startup and every six hours.
+If the hub is temporarily unavailable, the spoke can use its last confirmed
+activation lease for up to 24 hours. Once that lease expires, hub requests are
+rejected until the spoke reaches the hub and renews it.
 
 If the peer rejects the hub identity, check that the enrollment is active and
 has not been revoked. Re-enroll instead of widening or copying a token by hand.

--- a/docs/federated-fleet.md
+++ b/docs/federated-fleet.md
@@ -1,18 +1,101 @@
 # Federated Forge
 
-A Kenn Forge fleet gives several development machines one shared view without
-moving their local work to a central server.
+A Kenn Forge fleet gives several development machines one shared control point
+without moving their repositories, worktrees, or agent sessions to a central
+server.
 
-- One **hub** owns provider synchronization, provider mutations, and
-  the fleet-wide view.
-- Each **spoke** owns its local repositories, workspaces, processes, Git
-  traffic, and tmux sessions.
-- Every machine keeps its own directly accessible Forge UI.
-- Forge-to-Forge requests and terminal WebSockets use authenticated HTTPS.
+## Why use a fleet
 
-Every machine runs the same `kenn-forge` binary. The hub does not use
-SSH to start a spoke or attach to its tmux server. Start and supervise each
-daemon on its own machine.
+Use a fleet when one machine is not the right place for every task. For example,
+you may keep routine work on a laptop, run large builds on a workstation, and
+use a machine with a special operating system or GPU when a task needs it.
+
+- Open the hub to see workspaces from every machine and the node that owns each
+  one.
+- Create a repository workspace on the hub itself or any writable spoke.
+- Sync pull requests, issues, and activity once instead of spending provider
+  API budget on every machine.
+- Open a spoke directly for a local-only workspace view when you want to work
+  in that machine's environment.
+- Keep each repository, worktree, process, and tmux session on its execution
+  machine.
+
+If one machine already handles all your work, keep Forge standalone. A fleet
+adds value when the execution location matters.
+
+## The mental model
+
+One **hub** owns provider synchronization, provider changes, and the fleet-wide
+view. Each **spoke** owns its local repositories, workspaces, Git commands,
+processes, and tmux sessions. The hub can also own local workspaces, so it is an
+execution machine as well as the coordinator.
+
+<figure class="fleet-diagram">
+  <svg viewBox="0 0 960 560" role="img" aria-labelledby="fleet-topology-title fleet-topology-description">
+    <title id="fleet-topology-title">Forge hub-and-spoke topology</title>
+    <desc id="fleet-topology-description">A browser can open the hub or either spoke. The hub talks to the Git provider for synchronized provider data and sends workspace or terminal operations to the spoke that owns the work. Each spoke keeps its own repositories, workspaces, and agents.</desc>
+    <defs>
+      <marker id="fleet-arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+        <path d="M0,0 L0,6 L9,3 z" class="fleet-diagram__arrowhead" />
+      </marker>
+      <marker id="fleet-arrow-start" markerWidth="10" markerHeight="10" refX="1" refY="3" orient="auto-start-reverse" markerUnits="strokeWidth">
+        <path d="M9,0 L9,6 L0,3 z" class="fleet-diagram__arrowhead" />
+      </marker>
+    </defs>
+    <rect class="fleet-diagram__node" x="55" y="45" width="230" height="90" rx="14" />
+    <text class="fleet-diagram__title" x="170" y="82" text-anchor="middle">Your browser</text>
+    <text class="fleet-diagram__body" x="170" y="111" text-anchor="middle">Open any Forge directly</text>
+
+    <rect class="fleet-diagram__node" x="675" y="45" width="230" height="90" rx="14" />
+    <text class="fleet-diagram__title" x="790" y="82" text-anchor="middle">Git provider</text>
+    <text class="fleet-diagram__body" x="790" y="111" text-anchor="middle">Pull requests, issues, Git</text>
+
+    <rect class="fleet-diagram__node fleet-diagram__node--hub" x="330" y="210" width="300" height="130" rx="14" />
+    <text class="fleet-diagram__eyebrow" x="480" y="245" text-anchor="middle">HUB</text>
+    <text class="fleet-diagram__title" x="480" y="276" text-anchor="middle">Shared provider data + fleet view</text>
+    <text class="fleet-diagram__body" x="480" y="307" text-anchor="middle">Also owns its local workspaces</text>
+
+    <rect class="fleet-diagram__node" x="55" y="425" width="330" height="100" rx="14" />
+    <text class="fleet-diagram__eyebrow" x="220" y="458" text-anchor="middle">SPOKE A</text>
+    <text class="fleet-diagram__title" x="220" y="489" text-anchor="middle">Local repos, workspaces, agents</text>
+
+    <rect class="fleet-diagram__node" x="575" y="425" width="330" height="100" rx="14" />
+    <text class="fleet-diagram__eyebrow" x="740" y="458" text-anchor="middle">SPOKE B</text>
+    <text class="fleet-diagram__title" x="740" y="489" text-anchor="middle">Local repos, workspaces, agents</text>
+
+    <path class="fleet-diagram__line fleet-diagram__line--secondary" d="M282 115 C340 145 380 165 415 210" marker-end="url(#fleet-arrow)" />
+    <path class="fleet-diagram__line fleet-diagram__line--secondary" d="M145 135 C110 245 120 340 185 425" marker-end="url(#fleet-arrow)" />
+    <path class="fleet-diagram__line fleet-diagram__line--secondary" d="M215 135 C420 165 845 140 830 425" marker-end="url(#fleet-arrow)" />
+    <text class="fleet-diagram__label" x="177" y="220">private HTTPS</text>
+
+    <path class="fleet-diagram__line" d="M630 250 C690 225 745 185 775 136" marker-start="url(#fleet-arrow-start)" marker-end="url(#fleet-arrow)" />
+    <text class="fleet-diagram__label" x="700" y="214">provider API</text>
+
+    <path class="fleet-diagram__line" d="M405 340 C360 375 315 397 270 425" marker-start="url(#fleet-arrow-start)" marker-end="url(#fleet-arrow)" />
+    <path class="fleet-diagram__line" d="M555 340 C600 375 645 397 690 425" marker-start="url(#fleet-arrow-start)" marker-end="url(#fleet-arrow)" />
+    <text class="fleet-diagram__label" x="480" y="389" text-anchor="middle">authenticated Forge API</text>
+  </svg>
+  <figcaption>The hub coordinates the fleet. It does not become the filesystem or process owner for a spoke.</figcaption>
+</figure>
+
+Every machine runs the same `kenn-forge` binary and keeps its own directly
+accessible UI. Forge-to-Forge requests and terminal WebSockets use authenticated
+HTTPS. The hub does not use SSH to start a spoke or attach to its tmux server;
+start and supervise each daemon on its own machine.
+
+### Fleet rules at a glance
+
+| Question | Hub | Spoke |
+| --- | --- | --- |
+| Which workspaces appear? | Workspaces from the full fleet, each with an execution-node badge | Workspaces owned by this spoke |
+| Where can **New workspace** run? | The hub or any writable spoke selected in the dialog | This spoke only |
+| Where do pull-request and issue workspace buttons run? | On the hub | On this spoke |
+| Who runs Git and agent processes? | The machine that owns the workspace | This spoke |
+| Who syncs provider data and applies provider changes? | The hub | The spoke asks the hub |
+
+The pull-request and issue buttons stay local to the Forge UI you opened. To
+choose a different machine, open **Workspaces**, select **New workspace**, and
+use **Run on**.
 
 This guide uses the following example topology. Each name is a private HTTPS
 origin reachable from every fleet machine:
@@ -66,6 +149,57 @@ allowed; default `:443` is normalized away.
 
 Federation also requires Forge to use the root base path (`base_path = "/"`).
 Non-root UI prefixes are not part of the federation protocol.
+
+## Setup at a glance
+
+Set up the hub and spoke services first. Then enroll one spoke at a time. A
+spoke stays standalone until preparation has safely moved provider ownership to
+the hub and a service restart activates the enrollment.
+
+<figure class="fleet-diagram fleet-diagram--flow">
+  <svg viewBox="0 0 960 260" role="img" aria-labelledby="fleet-enrollment-title fleet-enrollment-description">
+    <title id="fleet-enrollment-title">Four steps to enroll one Forge spoke</title>
+    <desc id="fleet-enrollment-description">Set up a hub and standalone spoke, create a one-time token on the hub and join from the spoke, prepare the spoke so provider state moves to the hub, then restart and verify the active spoke.</desc>
+    <defs>
+      <marker id="fleet-flow-arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+        <path d="M0,0 L0,6 L9,3 z" class="fleet-diagram__arrowhead" />
+      </marker>
+    </defs>
+
+    <circle class="fleet-diagram__step" cx="75" cy="42" r="23" />
+    <text class="fleet-diagram__step-number" x="75" y="49" text-anchor="middle">1</text>
+    <rect class="fleet-diagram__node" x="35" y="78" width="200" height="125" rx="14" />
+    <text class="fleet-diagram__title" x="135" y="115" text-anchor="middle">Set up services</text>
+    <text class="fleet-diagram__body" x="135" y="146" text-anchor="middle">Hub + standalone spoke</text>
+    <text class="fleet-diagram__command" x="135" y="176" text-anchor="middle">fleet setup</text>
+
+    <circle class="fleet-diagram__step" cx="310" cy="42" r="23" />
+    <text class="fleet-diagram__step-number" x="310" y="49" text-anchor="middle">2</text>
+    <rect class="fleet-diagram__node" x="270" y="78" width="200" height="125" rx="14" />
+    <text class="fleet-diagram__title" x="370" y="115" text-anchor="middle">Join</text>
+    <text class="fleet-diagram__body" x="370" y="146" text-anchor="middle">One-time hub token</text>
+    <text class="fleet-diagram__command" x="370" y="176" text-anchor="middle">fleet join</text>
+
+    <circle class="fleet-diagram__step" cx="545" cy="42" r="23" />
+    <text class="fleet-diagram__step-number" x="545" y="49" text-anchor="middle">3</text>
+    <rect class="fleet-diagram__node" x="505" y="78" width="200" height="125" rx="14" />
+    <text class="fleet-diagram__title" x="605" y="115" text-anchor="middle">Prepare</text>
+    <text class="fleet-diagram__body" x="605" y="146" text-anchor="middle">Drain + hand off state</text>
+    <text class="fleet-diagram__command" x="605" y="176" text-anchor="middle">fleet prepare-spoke</text>
+
+    <circle class="fleet-diagram__step" cx="780" cy="42" r="23" />
+    <text class="fleet-diagram__step-number" x="780" y="49" text-anchor="middle">4</text>
+    <rect class="fleet-diagram__node fleet-diagram__node--hub" x="740" y="78" width="185" height="125" rx="14" />
+    <text class="fleet-diagram__title" x="832" y="115" text-anchor="middle">Activate</text>
+    <text class="fleet-diagram__body" x="832" y="146" text-anchor="middle">Restart + verify</text>
+    <text class="fleet-diagram__command" x="832" y="176" text-anchor="middle">active spoke</text>
+
+    <path class="fleet-diagram__line" d="M235 141 H265" marker-end="url(#fleet-flow-arrow)" />
+    <path class="fleet-diagram__line" d="M470 141 H500" marker-end="url(#fleet-flow-arrow)" />
+    <path class="fleet-diagram__line" d="M705 141 H735" marker-end="url(#fleet-flow-arrow)" />
+  </svg>
+  <figcaption>Complete all four steps for one spoke and verify it before enrolling the next.</figcaption>
+</figure>
 
 ## Set up the hub
 
@@ -334,10 +468,15 @@ cursors; changing one Forge tab does not retarget another.
 Open the hub UI for the aggregate workspace view and fleet-wide
 operations. Supported actions call the owning spoke's HTTPS API:
 
-- create, inspect, refresh, or remove a workspace;
+- create a repository workspace on the hub or a selected writable spoke;
+- inspect, refresh, or remove a workspace on its owning machine;
 - launch or stop a runtime session;
 - inspect local Git state;
 - open a terminal through the WebSocket bridge.
+
+Every hub workspace row shows its execution-node badge. The **Run on** selector
+in **New workspace** defaults to the hub, keeps unavailable spokes visible with
+their reason, and sends the create request directly to the selected owner.
 
 The hub never creates a local proxy process for a remote terminal.
 Input, output, resize messages, and close events pass between the two WebSocket
@@ -449,9 +588,18 @@ hub does not log in to start it.
 
 ### A request is forbidden
 
-Check that the enrollment is active and has not been revoked. A valid
-credential can still be forbidden when its direction does not grant the
-requested operation. Re-enroll instead of widening or copying a token by hand.
+Read the full degraded-host message in the hub. Forge preserves the peer's
+authorization reason instead of reducing it to an HTTP status.
+
+If the message says fleet authorization is inactive, inspect the spoke service's
+startup log and confirm it can resolve and reach the hub. An already active,
+sealed enrollment starts without a synchronous hub request and reconnects when
+the hub becomes reachable.
+
+If the peer rejects the hub identity, check that the enrollment is active and
+has not been revoked. Re-enroll instead of widening or copying a token by hand.
+A valid credential can still be forbidden when its direction does not grant the
+requested operation.
 
 ### A terminal does not open
 

--- a/docs/federated-fleet.md
+++ b/docs/federated-fleet.md
@@ -598,6 +598,13 @@ If the hub is temporarily unavailable, the spoke can use its last confirmed
 activation lease for up to 24 hours. Once that lease expires, hub requests are
 rejected until the spoke reaches the hub and renews it.
 
+The lease handshake is versioned separately from fleet snapshots. During a
+rolling upgrade, upgrade the hub first, then each spoke. A lease-unaware spoke
+is isolated from fleet reads and writes until it is upgraded and restarted;
+its existing enrollment is reused, so you do not need to re-enroll it. If a
+spoke was upgraded before its hub, upgrade the hub and restart that spoke so it
+can complete the lease handshake.
+
 If the peer rejects the hub identity, check that the enrollment is active and
 has not been revoked. Re-enroll instead of widening or copying a token by hand.
 A valid credential can still be forbidden when its direction does not grant the

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -26,7 +26,7 @@ raw markdown at /docs/<page>.md, and the docs index at /docs/index.md.
 - [Settings](https://forge.kenn.io/docs/settings.md): In-app settings for repositories, tokens, and modes
 - [Configuration](https://forge.kenn.io/docs/configuration.md): Config file reference and startup options
 - [Commands](https://forge.kenn.io/docs/commands.md): CLI command reference for the kenn-forge binary
-- [Federated fleet](https://forge.kenn.io/docs/federated-fleet.md): Hub-and-spoke federation across multiple machines
+- [Federated fleet](https://forge.kenn.io/docs/federated-fleet.md): Why to use a hub-and-spoke fleet, how ownership works, and how to set it up
 - [MCP companion](https://forge.kenn.io/docs/kenn-forge-mcp.md): Model Context Protocol server for agent access to the console
 - [Archive](https://forge.kenn.io/docs/archive.md): Historical activity archives beyond the live sync window
 - [Troubleshooting](https://forge.kenn.io/docs/troubleshooting.md): Startup, authentication, and sync problems

--- a/docs/site/docs-site.spec.ts
+++ b/docs/site/docs-site.spec.ts
@@ -205,21 +205,15 @@ test("links to the canonical kenn-forge downloads", async ({ browser }) => {
   await fallbackContext.close();
 });
 
-test("places Federated Forge under advanced and experimental navigation", async ({ page }) => {
+test("keeps the federated fleet in first-level navigation", async ({ page }) => {
   await page.goto("/docs/");
 
   const primaryNav = page.locator(".md-sidebar--primary nav[data-md-level='0']");
-  const advancedLabel = primaryNav.locator("label.md-nav__link", {
-    hasText: "Advanced / experimental",
-  });
-  await expect(advancedLabel).toBeVisible();
-
-  const advancedItem = advancedLabel.locator("xpath=ancestor::li[1]");
-  await expect(advancedItem.getByRole("link", { name: "Federated Forge" })).toHaveAttribute(
-    "href",
-    /federated-fleet\/$/,
-  );
-  await expect(primaryNav.locator(":scope > ul > li > a.md-nav__link", { hasText: "Fleet" })).toHaveCount(0);
+  await expect(
+    primaryNav.locator(":scope > ul > li > a.md-nav__link", {
+      hasText: "Federated fleet",
+    }),
+  ).toHaveAttribute("href", /federated-fleet\/$/);
 });
 
 test("applies the browser theme before the runtime bundle", async ({ browser }) => {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -20,6 +20,98 @@
   font-size: 0.78rem;
 }
 
+.md-typeset figure.fleet-diagram {
+  margin: 1.75rem 0;
+  overflow-x: auto;
+}
+
+.md-typeset .fleet-diagram svg {
+  display: block;
+  width: 100%;
+  min-width: 700px;
+  height: auto;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--md-default-bg-color) 94%, var(--md-accent-fg-color));
+}
+
+.md-typeset .fleet-diagram figcaption {
+  margin-top: 0.5rem;
+  color: var(--md-default-fg-color--light);
+  font-size: 0.78rem;
+}
+
+.fleet-diagram__node {
+  fill: var(--md-default-bg-color);
+  stroke: var(--md-default-fg-color--lighter);
+  stroke-width: 2;
+}
+
+.fleet-diagram__node--hub {
+  fill: color-mix(in srgb, var(--md-default-bg-color) 88%, var(--md-accent-fg-color));
+  stroke: var(--md-accent-fg-color);
+  stroke-width: 3;
+}
+
+.fleet-diagram__title,
+.fleet-diagram__body,
+.fleet-diagram__eyebrow,
+.fleet-diagram__label,
+.fleet-diagram__command,
+.fleet-diagram__step-number {
+  fill: var(--md-default-fg-color);
+  font-family: var(--md-text-font);
+}
+
+.fleet-diagram__title {
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.fleet-diagram__body,
+.fleet-diagram__label {
+  font-size: 16px;
+}
+
+.fleet-diagram__eyebrow {
+  fill: var(--md-accent-fg-color);
+  font-size: 14px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+}
+
+.fleet-diagram__command {
+  fill: var(--md-default-fg-color--light);
+  font-family: var(--md-code-font);
+  font-size: 14px;
+}
+
+.fleet-diagram__line {
+  fill: none;
+  stroke: var(--md-accent-fg-color);
+  stroke-linecap: round;
+  stroke-width: 3;
+}
+
+.fleet-diagram__line--secondary {
+  stroke: var(--md-default-fg-color--light);
+  stroke-dasharray: 7 7;
+}
+
+.fleet-diagram__arrowhead {
+  fill: var(--md-accent-fg-color);
+}
+
+.fleet-diagram__step {
+  fill: var(--md-accent-fg-color);
+}
+
+.fleet-diagram__step-number {
+  fill: var(--md-primary-bg-color);
+  font-size: 18px;
+  font-weight: 800;
+}
+
 .md-typeset figure.workflow-shot {
   margin: 1.5rem 0;
 }

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -132,9 +132,13 @@ pull and publish, and Kata reference behavior.
 
 ## Use a fleet
 
-A hub combines snapshots from enrolled Forge spokes. Supported
-actions route back to the machine that owns the resource, and terminal traffic
-uses the spoke's WebSocket API.
+A hub combines snapshots from enrolled Forge spokes. Its workspace list shows
+which node owns each workspace, and **New workspace** can create repository
+work on the hub or a writable spoke. A spoke keeps workspace creation and its
+workspace list local.
+
+Supported actions route back to the machine that owns the resource, and
+terminal traffic uses the spoke's WebSocket API.
 
 Each daemon must have a reachable HTTPS origin. Forge does not use SSH for
 fleet transport or daemon startup. See [Federated fleet](federated-fleet.md).

--- a/docs/workflows/workspaces.md
+++ b/docs/workflows/workspaces.md
@@ -24,6 +24,22 @@ Choose an agent from the create menu when you want to create the workspace and
 launch that agent in one step. Creating the same item or ad-hoc branch again
 reopens the existing workspace instead of making a duplicate.
 
+### Choose a machine in a fleet
+
+On a fleet hub, **New workspace** includes a **Run on** selector. Choose the hub
+or any spoke that currently allows workspace writes. An unavailable machine
+stays in the list with the reason it cannot be selected. The chosen machine
+owns the worktree, Git commands, agent processes, and tmux sessions.
+
+The hub workspace list adds a node badge to every row, so local and remote
+workspaces are easy to tell apart. A spoke shows only its local workspaces and
+creates new workspaces on itself.
+
+The workspace buttons on pull requests and issues create work on the Forge UI
+you opened. Use the hub's **New workspace** dialog when you need to choose a
+different execution machine. See [Federated fleet](../federated-fleet.md) for
+the complete ownership model and setup workflow.
+
 ## Use the workspace view
 
 The workspace sidebar can search, sort, and group workspaces. Rows show the

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -22,12 +22,12 @@ nav = [
     {"Work in local sessions" = "workflows/workspaces.md"},
     {"Read and edit Docs" = "workflows/docs.md"},
   ]},
+  {"Federated fleet" = "federated-fleet.md"},
   {"Integrations" = "integrations.md"},
   {"Settings" = "settings.md"},
   {"Configuration" = "configuration.md"},
   {"Commands" = "commands.md"},
   {"Advanced / experimental" = [
-    {"Federated Forge" = "federated-fleet.md"},
     {"MCP companion" = "kenn-forge-mcp.md"},
   ]},
   {"Archive" = "archive.md"},

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -11568,6 +11568,57 @@ paths:
       summary: Create issue workspace on fleet host
       tags:
         - Fleet
+  /fleet/hosts/{host_key}/host/{platform_host}/repo/{provider}/{owner}/{name}/workspaces:
+    post:
+      operationId: create-fleet-repo-workspace-on-platform-host
+      parameters:
+        - in: path
+          name: host_key
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: platform_host
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: true
+              type: object
+        description: JSON payload forwarded to the owning host.
+        required: true
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Response returned by the owning fleet host.
+      summary: Create repository workspace on fleet host
+      tags:
+        - Fleet
   /fleet/hosts/{host_key}/issues/{provider}/{owner}/{name}/{number}/workspace:
     post:
       operationId: create-fleet-issue-workspace
@@ -12233,6 +12284,52 @@ paths:
                 $ref: "#/components/schemas/ProblemError"
           description: Response returned by the owning fleet host.
       summary: Set project worktree session backend on fleet host
+      tags:
+        - Fleet
+  /fleet/hosts/{host_key}/repo/{provider}/{owner}/{name}/workspaces:
+    post:
+      operationId: create-fleet-repo-workspace
+      parameters:
+        - in: path
+          name: host_key
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: true
+              type: object
+        description: JSON payload forwarded to the owning host.
+        required: true
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Response returned by the owning fleet host.
+      summary: Create repository workspace on fleet host
       tags:
         - Fleet
   /fleet/hosts/{host_key}/runtime/sessions:

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -41,6 +41,9 @@ components:
           format: uri
           readOnly: true
           type: string
+        activation_lease_version:
+          format: int64
+          type: integer
         preparation_seal:
           type: string
         protocol_version:
@@ -48,6 +51,7 @@ components:
           type: integer
       required:
         - protocol_version
+        - activation_lease_version
         - preparation_seal
       type: object
     Activity:
@@ -2308,6 +2312,9 @@ components:
           format: uri
           readOnly: true
           type: string
+        activation_lease_version:
+          format: int64
+          type: integer
         activation_valid_until:
           format: date-time
           type: string
@@ -4351,6 +4358,9 @@ components:
           format: uri
           readOnly: true
           type: string
+        activation_lease_version:
+          format: int64
+          type: integer
         activation_valid_until:
           format: date-time
           type: string

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -2308,6 +2308,9 @@ components:
           format: uri
           readOnly: true
           type: string
+        activation_valid_until:
+          format: date-time
+          type: string
         created_at:
           format: date-time
           type: string
@@ -4347,6 +4350,9 @@ components:
             - /api/v1/schemas/LocalEnrollment.json
           format: uri
           readOnly: true
+          type: string
+        activation_valid_until:
+          format: date-time
           type: string
         enrollment_id:
           type: string

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -718,8 +718,8 @@
     navigate(buildMobileWorkspaceRoute(workspaceId, hostKey), mobileWorkspaceHistoryState("list"));
   }
 
-  function openCreatedMobileWorkspace(workspaceId: string): void {
-    navigate(buildMobileWorkspaceRoute(workspaceId));
+  function openCreatedMobileWorkspace(workspaceId: string, hostKey?: string): void {
+    navigate(buildMobileWorkspaceRoute(workspaceId, hostKey));
   }
 
   function openMobileWorkspaceItemFromList(workspaceId: string, hostKey?: string): void {
@@ -1477,9 +1477,13 @@
         seedRepo={getNewWorkspaceSeedRepo()}
         initialSource={getNewWorkspaceSource()}
         onClose={closeNewWorkspaceDialog}
-        onCreated={(workspaceId) => {
-          if (isMobilePage(getPage())) openCreatedMobileWorkspace(workspaceId);
-          else navigate(`/terminal/${encodeURIComponent(workspaceId)}`);
+        onCreated={(workspaceId, hostKey) => {
+          if (isMobilePage(getPage())) openCreatedMobileWorkspace(workspaceId, hostKey);
+          else if (hostKey) {
+            navigate(`/terminal/fleet/${encodeURIComponent(hostKey)}/${encodeURIComponent(workspaceId)}`);
+          } else {
+            navigate(`/terminal/${encodeURIComponent(workspaceId)}`);
+          }
         }}
       />
     {/if}

--- a/frontend/src/WorkspaceCreateSplitButton.browser.svelte.ts
+++ b/frontend/src/WorkspaceCreateSplitButton.browser.svelte.ts
@@ -81,7 +81,7 @@ describe("workspace create split button in the New workspace dialog", () => {
     expect(item.element() === hit || item.element().contains(hit)).toBe(true);
 
     await item.click();
-    await vi.waitFor(() => expect(onCreated).toHaveBeenCalledWith("ws-new"));
+    await vi.waitFor(() => expect(onCreated).toHaveBeenCalledWith("ws-new", undefined));
   });
 
   it("uses kit-ui primary colors for both solid segments", async () => {
@@ -186,6 +186,6 @@ describe("workspace create split button in the New workspace dialog", () => {
     await dialog.getByRole("button", { name: "Create or open workspace options" }).click();
     await page.getByRole("menuitem", { name: "Codex" }).click();
 
-    await vi.waitFor(() => expect(onCreated).toHaveBeenCalledWith("ws-kata"));
+    await vi.waitFor(() => expect(onCreated).toHaveBeenCalledWith("ws-kata", undefined));
   });
 });

--- a/frontend/src/lib/api/generated/schema.ts
+++ b/frontend/src/lib/api/generated/schema.ts
@@ -6157,6 +6157,8 @@ export interface components {
              */
             readonly $schema?: string;
             /** Format: date-time */
+            activation_valid_until?: string;
+            /** Format: date-time */
             created_at: string;
             /** Format: date-time */
             expires_at: string;
@@ -7072,6 +7074,8 @@ export interface components {
              * @example /api/v1/schemas/LocalEnrollment.json
              */
             readonly $schema?: string;
+            /** Format: date-time */
+            activation_valid_until?: string;
             enrollment_id: string;
             /** Format: date-time */
             expires_at: string;

--- a/frontend/src/lib/api/generated/schema.ts
+++ b/frontend/src/lib/api/generated/schema.ts
@@ -809,6 +809,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/fleet/hosts/{host_key}/host/{platform_host}/repo/{provider}/{owner}/{name}/workspaces": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create repository workspace on fleet host */
+        post: operations["create-fleet-repo-workspace-on-platform-host"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/fleet/hosts/{host_key}/issues/{provider}/{owner}/{name}/{number}/workspace": {
         parameters: {
             query?: never;
@@ -1094,6 +1111,23 @@ export interface paths {
         /** Set project worktree session backend on fleet host */
         put: operations["set-fleet-project-worktree-session-backend"];
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/fleet/hosts/{host_key}/repo/{provider}/{owner}/{name}/workspaces": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create repository workspace on fleet host */
+        post: operations["create-fleet-repo-workspace"];
         delete?: never;
         options?: never;
         head?: never;
@@ -11245,6 +11279,42 @@ export interface operations {
             };
         };
     };
+    "create-fleet-repo-workspace-on-platform-host": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                host_key: string;
+                platform_host: string;
+                provider: string;
+                owner: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        /** @description JSON payload forwarded to the owning host. */
+        requestBody: {
+            content: {
+                "application/json": {
+                    [key: string]: unknown;
+                };
+            };
+        };
+        responses: {
+            /** @description Response returned by the owning fleet host. */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
     "create-fleet-issue-workspace": {
         parameters: {
             query?: never;
@@ -11789,6 +11859,41 @@ export interface operations {
                 host_key: string;
                 project_id: string;
                 worktree_id: string;
+            };
+            cookie?: never;
+        };
+        /** @description JSON payload forwarded to the owning host. */
+        requestBody: {
+            content: {
+                "application/json": {
+                    [key: string]: unknown;
+                };
+            };
+        };
+        responses: {
+            /** @description Response returned by the owning fleet host. */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "create-fleet-repo-workspace": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                host_key: string;
+                provider: string;
+                owner: string;
+                name: string;
             };
             cookie?: never;
         };

--- a/frontend/src/lib/api/generated/schema.ts
+++ b/frontend/src/lib/api/generated/schema.ts
@@ -5099,6 +5099,8 @@ export interface components {
              * @example /api/v1/schemas/ActivateEnrollmentInputBody.json
              */
             readonly $schema?: string;
+            /** Format: int64 */
+            activation_lease_version: number;
             preparation_seal: string;
             /** Format: int64 */
             protocol_version: number;
@@ -6156,6 +6158,8 @@ export interface components {
              * @example /api/v1/schemas/Enrollment.json
              */
             readonly $schema?: string;
+            /** Format: int64 */
+            activation_lease_version?: number;
             /** Format: date-time */
             activation_valid_until?: string;
             /** Format: date-time */
@@ -7074,6 +7078,8 @@ export interface components {
              * @example /api/v1/schemas/LocalEnrollment.json
              */
             readonly $schema?: string;
+            /** Format: int64 */
+            activation_lease_version?: number;
             /** Format: date-time */
             activation_valid_until?: string;
             enrollment_id: string;

--- a/frontend/src/lib/components/terminal/NewWorkspaceDialog.svelte
+++ b/frontend/src/lib/components/terminal/NewWorkspaceDialog.svelte
@@ -6,6 +6,7 @@
     Button,
     SearchInput,
     SelectDropdown,
+    type SelectDropdownOption,
     TextInput,
     Typeahead,
     type TypeaheadOption,
@@ -19,6 +20,8 @@
     type TransientTransportError,
   } from "../../api/effect-errors.js";
   import { executeGeneratedApiRequest } from "../../api/generated-api.js";
+  import { executeOpaqueGeneratedApiRequest } from "../../api/generated-api.js";
+  import { loadFleetSnapshot, type HostSummary } from "../../api/fleet-snapshot.js";
   import type { ProblemBody } from "../../api/problems.js";
   import type { AppExecution } from "../../app/runtime.js";
   import { getAppRuntime } from "../../app/runtime-context.js";
@@ -58,7 +61,7 @@
     initialSource?: NewWorkspaceSource;
     // Overridable so callers embedding this dialog outside the app shell (and
     // tests) can observe the created workspace instead of navigating.
-    onCreated?: ((workspaceId: string) => void) | undefined;
+    onCreated?: ((workspaceId: string, hostKey?: string) => void) | undefined;
   }
 
   const {
@@ -80,6 +83,11 @@
     label: string;
   };
 
+  type CreatedWorkspacePayload = {
+    id?: string;
+    status?: string;
+  };
+
   let repos = $state<RepoOption[]>([]);
   let reposLoading = $state(false);
   let reposError = $state<string | null>(null);
@@ -89,6 +97,8 @@
   let error = $state<string | null>(null);
   let suggestedBranch = $state<string | null>(null);
   let pendingLaunchTargetKey = $state<string | null>(null);
+  let workspaceHosts = $state.raw<HostSummary[]>([]);
+  let selectedWorkspaceHostKey = $state("");
   let source = $state<NewWorkspaceSource>("repository");
   const kataDaemons = createKataDaemonsStore();
   let selectedDaemonID = $state("");
@@ -102,9 +112,48 @@
   let kataSearchGeneration = 0;
   let activeSession: object | null = null;
   let repoLoadExecution: AppExecution<void, ApiProblemError | TransientTransportError> | null = null;
+  let fleetLoadExecution: AppExecution<
+    void,
+    ApiProblemError | InvalidExternalPayload | TransientTransportError
+  > | null = null;
 
   function clearPendingLaunch(): void {
     pendingLaunchTargetKey = null;
+  }
+
+  function loadWorkspaceHosts(session: object): void {
+    fleetLoadExecution?.interrupt();
+    const execution = runtime.runCommand(
+      loadFleetSnapshot().pipe(
+        Effect.tap((snapshot) =>
+          Effect.sync(() => {
+            if (activeSession !== session) return;
+            const hosts = snapshot.hosts ?? [];
+            const self = hosts.find((host) => host.kind === "self");
+            workspaceHosts = self?.federationRole === "hub"
+              ? hosts
+              : self
+                ? [self]
+                : hosts.filter((host) => host.operationAvailability.workspaceWrite?.available === true);
+            selectedWorkspaceHostKey =
+              workspaceHosts.find((host) => host.kind === "self")?.configKey ??
+              workspaceHosts[0]?.configKey ??
+              "";
+          }),
+        ),
+        Effect.asVoid,
+      ),
+      {
+        operation: "load workspace execution hosts",
+        safeContext: {},
+        onFailure: () => {
+          if (activeSession !== session) return;
+          workspaceHosts = [];
+          selectedWorkspaceHostKey = "";
+        },
+      },
+    );
+    fleetLoadExecution = execution;
   }
 
   function cancelKataSearch(): void {
@@ -145,6 +194,15 @@
     return `${canonicalProvider(seed.provider)}/${seed.platformHost}/${seed.owner}/${seed.name}`;
   }
 
+  function normalizeCreatedWorkspace(value: unknown): CreatedWorkspacePayload {
+    if (typeof value !== "object" || value === null) return {};
+    const record = value as Record<string, unknown>;
+    return {
+      ...(typeof record.id === "string" ? { id: record.id } : {}),
+      ...(typeof record.status === "string" ? { status: record.status } : {}),
+    };
+  }
+
   // An explicit seed is a promise about which repository the workspace
   // targets. When it cannot be resolved (for example a repository hidden
   // from the UI), require a choice instead of silently diverting to another
@@ -168,6 +226,8 @@
       activeSession = null;
       repoLoadExecution?.interrupt();
       repoLoadExecution = null;
+      fleetLoadExecution?.interrupt();
+      fleetLoadExecution = null;
       kataRosterController?.abort();
       resetKataSelection();
       return;
@@ -180,6 +240,8 @@
     error = null;
     suggestedBranch = null;
     pendingLaunchTargetKey = null;
+    workspaceHosts = [];
+    selectedWorkspaceHostKey = "";
     submitting = false;
     repos = [];
     selectedKey = "";
@@ -200,6 +262,7 @@
         if (activeSession === session) activeSession = null;
       };
     }
+    loadWorkspaceHosts(session);
     const execution = runtime.runCommand(
       executeGeneratedApiRequest("load repositories", (client, signal) => client.GET("/repos", { signal })).pipe(
         Effect.flatMap((loaded) =>
@@ -236,6 +299,8 @@
     clearPendingLaunch();
     repoLoadExecution?.interrupt();
     repoLoadExecution = null;
+    fleetLoadExecution?.interrupt();
+    fleetLoadExecution = null;
     resetKataSelection();
     source = nextSource;
     branch = "";
@@ -257,6 +322,7 @@
       });
       return;
     }
+    loadWorkspaceHosts(session);
     reposLoading = true;
     const execution = runtime.runCommand(
       executeGeneratedApiRequest("load repositories", (client, signal) => client.GET("/repos", { signal })).pipe(
@@ -288,6 +354,28 @@
   );
 
   const selected = $derived(repos.find((repo) => repo.key === selectedKey) ?? null);
+  const selectedWorkspaceHost = $derived(
+    workspaceHosts.find((host) => host.configKey === selectedWorkspaceHostKey) ?? null,
+  );
+  const remoteWorkspaceHostKey = $derived(
+    source !== "repository" || selectedWorkspaceHost?.kind === "self"
+      ? undefined
+      : selectedWorkspaceHost?.configKey,
+  );
+  const workspaceHostOptions = $derived<SelectDropdownOption[]>(
+    workspaceHosts.map((host) => {
+      const writeAvailability = host.operationAvailability.workspaceWrite;
+      const unavailableReason = writeAvailability?.unavailableReason || "Workspace creation is unavailable.";
+      return {
+        value: host.configKey,
+        label: `${host.name.trim() || host.hostname?.trim() || host.configKey}${host.kind === "self" ? " (this machine)" : ""}`,
+        disabled: writeAvailability?.available !== true,
+        ...(writeAvailability?.available === true
+          ? {}
+          : { indicator: { tone: "danger" as const, title: unavailableReason } }),
+      };
+    }),
+  );
 
   const selectedDaemon = $derived(
     kataDaemons.daemons().find((daemon) => daemon.id === selectedDaemonID) ?? null,
@@ -413,10 +501,10 @@
     if (kataWorkspaceIdentity) {
       const created = createdKataWorkspaceRef(kataWorkspaceIdentity);
       if (created) {
-        if (launchTargetKey) queueWorkspaceLaunch(created.id, launchTargetKey, undefined);
+        if (launchTargetKey) queueWorkspaceLaunch(created.id, launchTargetKey, remoteWorkspaceHostKey);
         pendingLaunchTargetKey = null;
         onClose();
-        if (onCreated) onCreated(created.id);
+        if (onCreated) onCreated(created.id, remoteWorkspaceHostKey);
         else navigate(`/terminal/${created.id}`);
         return;
       }
@@ -434,13 +522,27 @@
             name: repo.name,
             repoPath: `${repo.owner}/${repo.name}`,
           };
+          const repoPath = providerRepoPath(ref, "/workspaces");
+          const routeParams = providerRouteParams(ref);
+          if (remoteWorkspaceHostKey) {
+            const fleetPath = repoPath.startsWith("/host/")
+              ? "/fleet/hosts/{host_key}/host/{platform_host}/repo/{provider}/{owner}/{name}/workspaces" as const
+              : "/fleet/hosts/{host_key}/repo/{provider}/{owner}/{name}/workspaces" as const;
+            return executeOpaqueGeneratedApiRequest("create fleet workspace", (client, signal) =>
+              client.POST(fleetPath, {
+                params: { path: { host_key: remoteWorkspaceHostKey, ...routeParams } },
+                body: requested ? { branch: requested } : {},
+                signal,
+              }),
+            ).pipe(Effect.map(normalizeCreatedWorkspace));
+          }
           return executeGeneratedApiRequest("create workspace", (client, signal) =>
-            client.POST(providerRepoPath(ref, "/workspaces"), {
-              params: { path: providerRouteParams(ref) },
+            client.POST(repoPath, {
+              params: { path: routeParams },
               body: requested ? { branch: requested } : {},
               signal,
             }),
-          );
+          ).pipe(Effect.map(normalizeCreatedWorkspace));
         })()
       : Effect.tryPromise({
           try: () => createOrOpenKataWorkspace({
@@ -453,7 +555,7 @@
             ...(kataReference!.title ? { title: kataReference!.title } : {}),
           }),
           catch: (cause) => cause,
-        });
+        }).pipe(Effect.map(normalizeCreatedWorkspace));
     const program = createProgram.pipe(
       Effect.tap((created) =>
         Effect.sync(() => {
@@ -476,7 +578,7 @@
       ),
       Effect.tap((workspaceId) =>
         Effect.sync(() => {
-          if (launchTargetKey) queueWorkspaceLaunch(workspaceId, launchTargetKey, undefined);
+          if (launchTargetKey) queueWorkspaceLaunch(workspaceId, launchTargetKey, remoteWorkspaceHostKey);
           // The workspace exists either way, so it stays the last-used repo; only
           // the navigation is abandoned when the user moved on.
           if (requestedSource === "repository" && repo) rememberNewWorkspaceRepoKey(repo.key);
@@ -487,8 +589,12 @@
           if (!open || activeSession !== session) return;
           pendingLaunchTargetKey = null;
           onClose();
-          if (onCreated) onCreated(workspaceId);
-          else navigate(`/terminal/${workspaceId}`);
+          if (onCreated) onCreated(workspaceId, remoteWorkspaceHostKey);
+          else if (remoteWorkspaceHostKey) {
+            navigate(`/terminal/fleet/${encodeURIComponent(remoteWorkspaceHostKey)}/${encodeURIComponent(workspaceId)}`);
+          } else {
+            navigate(`/terminal/${encodeURIComponent(workspaceId)}`);
+          }
         }),
       ),
       Effect.ensuring(
@@ -509,6 +615,7 @@
           platformHost: repo.platformHost,
           owner: repo.owner,
           name: repo.name,
+          remote: remoteWorkspaceHostKey !== undefined,
         } : { daemonId: daemonID }),
       },
       onFailure: (failure) => {
@@ -600,6 +707,23 @@
           Branches from the repository's default branch in a new worktree.
         </small>
       </label>
+
+      {#if workspaceHostOptions.length > 1}
+        <label class="field">
+          <span class="field-label">Run on</span>
+          <SelectDropdown
+            value={selectedWorkspaceHostKey}
+            options={workspaceHostOptions}
+            onchange={(hostKey) => {
+              clearPendingLaunch();
+              selectedWorkspaceHostKey = hostKey;
+            }}
+            title="Workspace machine"
+            disabled={submitting}
+          />
+          <small class="field-hint">The selected Forge owns the worktree and runtime sessions.</small>
+        </label>
+      {/if}
     {:else}
       <label class="field">
         <span class="field-label">Kata daemon</span>

--- a/frontend/src/lib/components/terminal/NewWorkspaceDialog.test.ts
+++ b/frontend/src/lib/components/terminal/NewWorkspaceDialog.test.ts
@@ -338,6 +338,58 @@ describe("NewWorkspaceDialog", () => {
     expect(options.params.path.platform_host).toBe("git.example.test");
   });
 
+  it("creates and opens repository workspaces on the selected spoke", async () => {
+    mockGet.mockImplementation((path: string) => {
+      if (path === "/repos") return Promise.resolve({ data: [repoFixture("acme", "widget")] });
+      if (path === "/snapshot") {
+        return Promise.resolve({
+          data: {
+            hosts: [
+              {
+                configKey: "hub-node",
+                federationRole: "hub",
+                kind: "self",
+                name: "Studio hub",
+                operationAvailability: { workspaceWrite: { available: true } },
+              },
+              {
+                configKey: "build-node",
+                federationRole: "spoke",
+                kind: "remote",
+                name: "Build spoke",
+                operationAvailability: { workspaceWrite: { available: true } },
+              },
+            ],
+          },
+        });
+      }
+      throw new Error(`unexpected GET ${path}`);
+    });
+    await renderDialog();
+
+    const machine = await screen.findByRole("combobox", {
+      name: "Workspace machine: Studio hub (this machine)",
+    });
+    await fireEvent.click(machine);
+    await fireEvent.click(screen.getByRole("option", { name: "Build spoke" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Create workspace" }));
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
+    const [path, options] = mockPost.mock.calls[0] as [
+      string,
+      { params: { path: Record<string, string> }; body: Record<string, string> },
+    ];
+    expect(path).toBe("/fleet/hosts/{host_key}/repo/{provider}/{owner}/{name}/workspaces");
+    expect(options.params.path).toEqual({
+      host_key: "build-node",
+      provider: "github",
+      owner: "acme",
+      name: "widget",
+    });
+    expect(options.body).toEqual({});
+    expect(mockNavigate).toHaveBeenCalledWith("/terminal/fleet/build-node/ws-new");
+  });
+
   it("offers the suggested branch when the requested one already exists", async () => {
     mockPost.mockResolvedValue({
       error: {
@@ -429,7 +481,7 @@ describe("NewWorkspaceDialog", () => {
     expect(discardWorkspaceLaunch("ws-stale", undefined)).toBe("codex");
 
     await fireEvent.click(screen.getByRole("button", { name: "Create workspace" }));
-    await waitFor(() => expect(onCreated).toHaveBeenCalledWith("ws-new"));
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith("ws-new", undefined));
     expect(discardWorkspaceLaunch("ws-new", undefined)).toBeNull();
   });
 

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -307,6 +307,10 @@
   const fleetDegraded = $derived(
     fleetError !== null || Object.keys(fleetPeerErrors).length > 0,
   );
+  const showWorkspaceHostBadges = $derived(
+    fleetHosts.length > 1 &&
+      fleetHosts.find((host) => host.kind === "self")?.federationRole === "hub",
+  );
 
   // Flat ordering for timestamp sorts. The org/repo mode keeps
   // the API order (created_at DESC) inside each repo group.
@@ -390,6 +394,10 @@
   function fleetHostName(hostKey: string): string {
     const name = fleetHosts.find((host) => host.configKey === hostKey)?.name.trim();
     return name || hostKey;
+  }
+
+  function workspaceHostName(ws: Workspace): string {
+    return ws.fleet_host_name?.trim() || workspaceHost(ws)?.name.trim() || ws.fleet_host_key || "This machine";
   }
 
   const repoLabelFormatter = $derived.by(() =>
@@ -1379,6 +1387,12 @@
                   size={6}
                 />
                 <span class="ws-name">{displayName(ws)}</span>
+                {#if showWorkspaceHostBadges}
+                  <span
+                    class="workspace-host-badge"
+                    title={`Runs on ${workspaceHostName(ws)}`}
+                  >{workspaceHostName(ws)}</span>
+                {/if}
                 {#if ws.status === "deleting" || ws.status === "deletion_failed"}
                   <span
                     class={["workspace-lifecycle-state", `workspace-lifecycle-state--${ws.status}`]}
@@ -1902,6 +1916,24 @@
 
   .ws-row.selected .ws-name {
     font-weight: 600;
+  }
+
+  .workspace-host-badge {
+    flex: 0 1 auto;
+    min-width: 0;
+    max-width: 38%;
+    overflow: hidden;
+    padding: 1px 5px;
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-sm);
+    background: var(--bg-subtle);
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-2xs);
+    font-weight: 600;
+    line-height: 1.35;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .workspace-lifecycle-state {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -257,7 +257,7 @@ describe("WorkspaceListSidebar", () => {
     expect(screen.getByText("Workspaces")).toBeTruthy();
   });
 
-  it("does not repeat fleet hosts in the workspace list", async () => {
+  it("labels workspace rows with their execution machine on the hub", async () => {
     mockGet.mockImplementation((path: string) => {
       if (path === "/snapshot") {
         return Promise.resolve({
@@ -268,7 +268,8 @@ describe("WorkspaceListSidebar", () => {
                 diagnostics: [],
                 id: "hub",
                 kind: "self",
-                name: "hub",
+                name: "Studio hub",
+                federationRole: "hub",
                 operationAvailability: {},
                 platform: "darwin",
                 preferredTransport: "local",
@@ -281,6 +282,7 @@ describe("WorkspaceListSidebar", () => {
                 id: "79e90262-7426-4dd5-9ef1-0d511af84e12",
                 kind: "remote",
                 name: "Build spoke",
+                federationRole: "spoke",
                 operationAvailability: {},
                 platform: "linux",
                 preferredTransport: "http",
@@ -289,6 +291,15 @@ describe("WorkspaceListSidebar", () => {
               },
             ],
             workspaces: [
+              workspaceFixture({
+                id: "local-ws",
+                provider: "github",
+                platformHost: "github.com",
+                owner: "acme",
+                name: "service",
+                number: 11,
+                title: "Local workspace",
+              }),
               {
                 ...workspaceFixture({
                   id: "remote-ws",
@@ -313,7 +324,9 @@ describe("WorkspaceListSidebar", () => {
     });
 
     await screen.findByText("Remote workspace");
-    expect(screen.queryByText("Build spoke")).toBeNull();
+    expect(screen.getByTitle("Runs on Studio hub")).toBeTruthy();
+    expect(screen.getByText("Build spoke")).toBeTruthy();
+    expect(screen.getByTitle("Runs on Build spoke")).toBeTruthy();
     expect(screen.queryByLabelText("Fleet hosts")).toBeNull();
     expect(screen.queryByText("79e90262-7426-4dd5-9ef1-0d511af84e12")).toBeNull();
   });

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.host-visible.browser.svelte.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.host-visible.browser.svelte.ts
@@ -245,6 +245,7 @@ describe("WorkspaceTerminalView hostVisible", () => {
 
     let hostVisible = $state(true);
     const target = document.createElement("div");
+    target.tabIndex = -1;
     document.body.appendChild(target);
     const settingsStore = createSettingsStore();
     const instance = mount(WorkspaceTerminalView, {
@@ -262,11 +263,18 @@ describe("WorkspaceTerminalView hostVisible", () => {
     });
 
     try {
-      await vi.waitFor(() => expect(target.querySelector(".xterm-helper-textarea")).not.toBeNull(), WAIT);
-      const terminalInput = target.querySelector<HTMLElement>(".xterm-helper-textarea");
-      if (terminalInput === null) throw new Error("agent terminal focus target was not created");
+      const workflowTab = await vi.waitFor(() => {
+        const element = target.querySelector<HTMLElement>(".workspace-stage [data-tabbed-panel-tab-key] [role='tab']");
+        expect(element).not.toBeNull();
+        return element!;
+      }, WAIT);
 
-      terminalInput.focus();
+      // Move focus outside the pane first so the workflow tab always emits the
+      // focus event that establishes ownership.
+      target.focus();
+      expect(document.activeElement).toBe(target);
+      workflowTab.focus();
+      expect(document.activeElement).toBe(workflowTab);
       await vi.waitFor(() => expect(target.querySelectorAll(".workspace-stage .input-active")).toHaveLength(1), WAIT);
 
       hostVisible = false;

--- a/frontend/tests/e2e-full/roborev-e2e.spec.ts
+++ b/frontend/tests/e2e-full/roborev-e2e.spec.ts
@@ -920,9 +920,9 @@ test.describe.serial("Roborev", () => {
       }).toPass({ timeout: 10_000 });
     });
 
-    test("a committed comment with a lost response is reconciled without replay", async ({ page }) => {
+    test("a committed comment with a lost response is reconciled without replay", async ({ page }, testInfo) => {
       await openDrawer(page, 72);
-      const comment = "Lost response reconciliation comment";
+      const comment = `Lost response reconciliation comment (attempt ${testInfo.retry})`;
       await page.route(
         "**/api/roborev/api/comment",
         async (route) => {

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -5816,6 +5816,9 @@ type ValidateFleetFilesystemRepoParams struct {
 // CreateFleetIssueWorkspaceOnPlatformHostJSONBody defines parameters for CreateFleetIssueWorkspaceOnPlatformHost.
 type CreateFleetIssueWorkspaceOnPlatformHostJSONBody map[string]interface{}
 
+// CreateFleetRepoWorkspaceOnPlatformHostJSONBody defines parameters for CreateFleetRepoWorkspaceOnPlatformHost.
+type CreateFleetRepoWorkspaceOnPlatformHostJSONBody map[string]interface{}
+
 // CreateFleetIssueWorkspaceJSONBody defines parameters for CreateFleetIssueWorkspace.
 type CreateFleetIssueWorkspaceJSONBody map[string]interface{}
 
@@ -5842,6 +5845,9 @@ type LaunchFleetProjectWorktreeRuntimeSessionJSONBody map[string]interface{}
 
 // SetFleetProjectWorktreeSessionBackendJSONBody defines parameters for SetFleetProjectWorktreeSessionBackend.
 type SetFleetProjectWorktreeSessionBackendJSONBody map[string]interface{}
+
+// CreateFleetRepoWorkspaceJSONBody defines parameters for CreateFleetRepoWorkspace.
+type CreateFleetRepoWorkspaceJSONBody map[string]interface{}
 
 // LaunchFleetHostRuntimeSessionJSONBody defines parameters for LaunchFleetHostRuntimeSession.
 type LaunchFleetHostRuntimeSessionJSONBody map[string]interface{}
@@ -6432,6 +6438,9 @@ type CreateFleetEnrollmentTokenJSONRequestBody = CreateEnrollmentTokenInputBody
 // CreateFleetIssueWorkspaceOnPlatformHostJSONRequestBody defines body for CreateFleetIssueWorkspaceOnPlatformHost for application/json ContentType.
 type CreateFleetIssueWorkspaceOnPlatformHostJSONRequestBody CreateFleetIssueWorkspaceOnPlatformHostJSONBody
 
+// CreateFleetRepoWorkspaceOnPlatformHostJSONRequestBody defines body for CreateFleetRepoWorkspaceOnPlatformHost for application/json ContentType.
+type CreateFleetRepoWorkspaceOnPlatformHostJSONRequestBody CreateFleetRepoWorkspaceOnPlatformHostJSONBody
+
 // CreateFleetIssueWorkspaceJSONRequestBody defines body for CreateFleetIssueWorkspace for application/json ContentType.
 type CreateFleetIssueWorkspaceJSONRequestBody CreateFleetIssueWorkspaceJSONBody
 
@@ -6458,6 +6467,9 @@ type LaunchFleetProjectWorktreeRuntimeSessionJSONRequestBody LaunchFleetProjectW
 
 // SetFleetProjectWorktreeSessionBackendJSONRequestBody defines body for SetFleetProjectWorktreeSessionBackend for application/json ContentType.
 type SetFleetProjectWorktreeSessionBackendJSONRequestBody SetFleetProjectWorktreeSessionBackendJSONBody
+
+// CreateFleetRepoWorkspaceJSONRequestBody defines body for CreateFleetRepoWorkspace for application/json ContentType.
+type CreateFleetRepoWorkspaceJSONRequestBody CreateFleetRepoWorkspaceJSONBody
 
 // LaunchFleetHostRuntimeSessionJSONRequestBody defines body for LaunchFleetHostRuntimeSession for application/json ContentType.
 type LaunchFleetHostRuntimeSessionJSONRequestBody LaunchFleetHostRuntimeSessionJSONBody
@@ -7463,6 +7475,20 @@ type ClientInterface interface {
 	// Corresponds with POST /fleet/hosts/{host_key}/host/{platform_host}/issues/{provider}/{owner}/{name}/{number}/workspace (the `CreateFleetIssueWorkspaceOnPlatformHost` operationId).
 	CreateFleetIssueWorkspaceOnPlatformHost(ctx context.Context, hostKey string, platformHost string, provider string, owner string, name string, number string, body CreateFleetIssueWorkspaceOnPlatformHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// CreateFleetRepoWorkspaceOnPlatformHostWithBody Create repository workspace on fleet host
+	//
+	// Takes any type of body and a specified content type.
+	//
+	// Corresponds with POST /fleet/hosts/{host_key}/host/{platform_host}/repo/{provider}/{owner}/{name}/workspaces (the `CreateFleetRepoWorkspaceOnPlatformHost` operationId).
+	CreateFleetRepoWorkspaceOnPlatformHostWithBody(ctx context.Context, hostKey string, platformHost string, provider string, owner string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateFleetRepoWorkspaceOnPlatformHost Create repository workspace on fleet host
+	//
+	// Takes a body of the `application/json` content type.
+	//
+	// Corresponds with POST /fleet/hosts/{host_key}/host/{platform_host}/repo/{provider}/{owner}/{name}/workspaces (the `CreateFleetRepoWorkspaceOnPlatformHost` operationId).
+	CreateFleetRepoWorkspaceOnPlatformHost(ctx context.Context, hostKey string, platformHost string, provider string, owner string, name string, body CreateFleetRepoWorkspaceOnPlatformHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// CreateFleetIssueWorkspaceWithBody Create issue workspace on fleet host
 	//
 	// Takes any type of body and a specified content type.
@@ -7638,6 +7664,20 @@ type ClientInterface interface {
 	//
 	// Corresponds with PUT /fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/session-backend (the `SetFleetProjectWorktreeSessionBackend` operationId).
 	SetFleetProjectWorktreeSessionBackend(ctx context.Context, hostKey string, projectId string, worktreeId string, body SetFleetProjectWorktreeSessionBackendJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateFleetRepoWorkspaceWithBody Create repository workspace on fleet host
+	//
+	// Takes any type of body and a specified content type.
+	//
+	// Corresponds with POST /fleet/hosts/{host_key}/repo/{provider}/{owner}/{name}/workspaces (the `CreateFleetRepoWorkspace` operationId).
+	CreateFleetRepoWorkspaceWithBody(ctx context.Context, hostKey string, provider string, owner string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateFleetRepoWorkspace Create repository workspace on fleet host
+	//
+	// Takes a body of the `application/json` content type.
+	//
+	// Corresponds with POST /fleet/hosts/{host_key}/repo/{provider}/{owner}/{name}/workspaces (the `CreateFleetRepoWorkspace` operationId).
+	CreateFleetRepoWorkspace(ctx context.Context, hostKey string, provider string, owner string, name string, body CreateFleetRepoWorkspaceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// LaunchFleetHostRuntimeSessionWithBody Launch host runtime session on fleet host
 	//
@@ -11106,6 +11146,40 @@ func (c *Client) CreateFleetIssueWorkspaceOnPlatformHost(ctx context.Context, ho
 	return c.Client.Do(req)
 }
 
+// CreateFleetRepoWorkspaceOnPlatformHostWithBody Create repository workspace on fleet host
+//
+// Takes any type of body and a specified content type.
+//
+// Corresponds with POST /fleet/hosts/{host_key}/host/{platform_host}/repo/{provider}/{owner}/{name}/workspaces (the `CreateFleetRepoWorkspaceOnPlatformHost` operationId).
+func (c *Client) CreateFleetRepoWorkspaceOnPlatformHostWithBody(ctx context.Context, hostKey string, platformHost string, provider string, owner string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateFleetRepoWorkspaceOnPlatformHostRequestWithBody(c.Server, hostKey, platformHost, provider, owner, name, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// CreateFleetRepoWorkspaceOnPlatformHost Create repository workspace on fleet host
+//
+// Takes a body of the `application/json` content type.
+//
+// Corresponds with POST /fleet/hosts/{host_key}/host/{platform_host}/repo/{provider}/{owner}/{name}/workspaces (the `CreateFleetRepoWorkspaceOnPlatformHost` operationId).
+func (c *Client) CreateFleetRepoWorkspaceOnPlatformHost(ctx context.Context, hostKey string, platformHost string, provider string, owner string, name string, body CreateFleetRepoWorkspaceOnPlatformHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateFleetRepoWorkspaceOnPlatformHostRequest(c.Server, hostKey, platformHost, provider, owner, name, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 // CreateFleetIssueWorkspaceWithBody Create issue workspace on fleet host
 //
 // Takes any type of body and a specified content type.
@@ -11552,6 +11626,40 @@ func (c *Client) SetFleetProjectWorktreeSessionBackendWithBody(ctx context.Conte
 // Corresponds with PUT /fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/session-backend (the `SetFleetProjectWorktreeSessionBackend` operationId).
 func (c *Client) SetFleetProjectWorktreeSessionBackend(ctx context.Context, hostKey string, projectId string, worktreeId string, body SetFleetProjectWorktreeSessionBackendJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewSetFleetProjectWorktreeSessionBackendRequest(c.Server, hostKey, projectId, worktreeId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// CreateFleetRepoWorkspaceWithBody Create repository workspace on fleet host
+//
+// Takes any type of body and a specified content type.
+//
+// Corresponds with POST /fleet/hosts/{host_key}/repo/{provider}/{owner}/{name}/workspaces (the `CreateFleetRepoWorkspace` operationId).
+func (c *Client) CreateFleetRepoWorkspaceWithBody(ctx context.Context, hostKey string, provider string, owner string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateFleetRepoWorkspaceRequestWithBody(c.Server, hostKey, provider, owner, name, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// CreateFleetRepoWorkspace Create repository workspace on fleet host
+//
+// Takes a body of the `application/json` content type.
+//
+// Corresponds with POST /fleet/hosts/{host_key}/repo/{provider}/{owner}/{name}/workspaces (the `CreateFleetRepoWorkspace` operationId).
+func (c *Client) CreateFleetRepoWorkspace(ctx context.Context, hostKey string, provider string, owner string, name string, body CreateFleetRepoWorkspaceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateFleetRepoWorkspaceRequest(c.Server, hostKey, provider, owner, name, body)
 	if err != nil {
 		return nil, err
 	}
@@ -20298,6 +20406,81 @@ func NewCreateFleetIssueWorkspaceOnPlatformHostRequestWithBody(server string, ho
 	return req, nil
 }
 
+// NewCreateFleetRepoWorkspaceOnPlatformHostRequest calls the generic CreateFleetRepoWorkspaceOnPlatformHost builder with application/json body
+func NewCreateFleetRepoWorkspaceOnPlatformHostRequest(server string, hostKey string, platformHost string, provider string, owner string, name string, body CreateFleetRepoWorkspaceOnPlatformHostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateFleetRepoWorkspaceOnPlatformHostRequestWithBody(server, hostKey, platformHost, provider, owner, name, "application/json", bodyReader)
+}
+
+// NewCreateFleetRepoWorkspaceOnPlatformHostRequestWithBody constructs an http.Request for the CreateFleetRepoWorkspaceOnPlatformHost method, with any body, and a specified content type
+func NewCreateFleetRepoWorkspaceOnPlatformHostRequestWithBody(server string, hostKey string, platformHost string, provider string, owner string, name string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "host_key", hostKey, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "platform_host", platformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam4 string
+
+	pathParam4, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/fleet/hosts/%s/host/%s/repo/%s/%s/%s/workspaces", pathParam0, pathParam1, pathParam2, pathParam3, pathParam4)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewCreateFleetIssueWorkspaceRequest calls the generic CreateFleetIssueWorkspace builder with application/json body
 func NewCreateFleetIssueWorkspaceRequest(server string, hostKey string, provider string, owner string, name string, number string, body CreateFleetIssueWorkspaceJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -21276,6 +21459,74 @@ func NewSetFleetProjectWorktreeSessionBackendRequestWithBody(server string, host
 	}
 
 	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewCreateFleetRepoWorkspaceRequest calls the generic CreateFleetRepoWorkspace builder with application/json body
+func NewCreateFleetRepoWorkspaceRequest(server string, hostKey string, provider string, owner string, name string, body CreateFleetRepoWorkspaceJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateFleetRepoWorkspaceRequestWithBody(server, hostKey, provider, owner, name, "application/json", bodyReader)
+}
+
+// NewCreateFleetRepoWorkspaceRequestWithBody constructs an http.Request for the CreateFleetRepoWorkspace method, with any body, and a specified content type
+func NewCreateFleetRepoWorkspaceRequestWithBody(server string, hostKey string, provider string, owner string, name string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "host_key", hostKey, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/fleet/hosts/%s/repo/%s/%s/%s/workspaces", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
 	if err != nil {
 		return nil, err
 	}
@@ -38014,6 +38265,11 @@ type ClientWithResponsesInterface interface {
 
 	CreateFleetIssueWorkspaceOnPlatformHostWithResponse(ctx context.Context, hostKey string, platformHost string, provider string, owner string, name string, number string, body CreateFleetIssueWorkspaceOnPlatformHostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateFleetIssueWorkspaceOnPlatformHostResponse, error)
 
+	// CreateFleetRepoWorkspaceOnPlatformHostWithBodyWithResponse request with any body
+	CreateFleetRepoWorkspaceOnPlatformHostWithBodyWithResponse(ctx context.Context, hostKey string, platformHost string, provider string, owner string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateFleetRepoWorkspaceOnPlatformHostResponse, error)
+
+	CreateFleetRepoWorkspaceOnPlatformHostWithResponse(ctx context.Context, hostKey string, platformHost string, provider string, owner string, name string, body CreateFleetRepoWorkspaceOnPlatformHostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateFleetRepoWorkspaceOnPlatformHostResponse, error)
+
 	// CreateFleetIssueWorkspaceWithBodyWithResponse request with any body
 	CreateFleetIssueWorkspaceWithBodyWithResponse(ctx context.Context, hostKey string, provider string, owner string, name string, number string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateFleetIssueWorkspaceResponse, error)
 
@@ -38088,6 +38344,11 @@ type ClientWithResponsesInterface interface {
 	SetFleetProjectWorktreeSessionBackendWithBodyWithResponse(ctx context.Context, hostKey string, projectId string, worktreeId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetFleetProjectWorktreeSessionBackendResponse, error)
 
 	SetFleetProjectWorktreeSessionBackendWithResponse(ctx context.Context, hostKey string, projectId string, worktreeId string, body SetFleetProjectWorktreeSessionBackendJSONRequestBody, reqEditors ...RequestEditorFn) (*SetFleetProjectWorktreeSessionBackendResponse, error)
+
+	// CreateFleetRepoWorkspaceWithBodyWithResponse request with any body
+	CreateFleetRepoWorkspaceWithBodyWithResponse(ctx context.Context, hostKey string, provider string, owner string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateFleetRepoWorkspaceResponse, error)
+
+	CreateFleetRepoWorkspaceWithResponse(ctx context.Context, hostKey string, provider string, owner string, name string, body CreateFleetRepoWorkspaceJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateFleetRepoWorkspaceResponse, error)
 
 	// LaunchFleetHostRuntimeSessionWithBodyWithResponse request with any body
 	LaunchFleetHostRuntimeSessionWithBodyWithResponse(ctx context.Context, hostKey string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*LaunchFleetHostRuntimeSessionResponse, error)
@@ -40269,6 +40530,29 @@ func (r CreateFleetIssueWorkspaceOnPlatformHostResponse) StatusCode() int {
 	return 0
 }
 
+type CreateFleetRepoWorkspaceOnPlatformHostResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSONDefault                   *map[string]interface{}
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateFleetRepoWorkspaceOnPlatformHostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateFleetRepoWorkspaceOnPlatformHostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type CreateFleetIssueWorkspaceResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
@@ -40700,6 +40984,29 @@ func (r SetFleetProjectWorktreeSessionBackendResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r SetFleetProjectWorktreeSessionBackendResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CreateFleetRepoWorkspaceResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSONDefault                   *map[string]interface{}
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateFleetRepoWorkspaceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateFleetRepoWorkspaceResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -47394,6 +47701,23 @@ func (c *ClientWithResponses) CreateFleetIssueWorkspaceOnPlatformHostWithRespons
 	return ParseCreateFleetIssueWorkspaceOnPlatformHostResponse(rsp)
 }
 
+// CreateFleetRepoWorkspaceOnPlatformHostWithBodyWithResponse request with arbitrary body returning *CreateFleetRepoWorkspaceOnPlatformHostResponse
+func (c *ClientWithResponses) CreateFleetRepoWorkspaceOnPlatformHostWithBodyWithResponse(ctx context.Context, hostKey string, platformHost string, provider string, owner string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateFleetRepoWorkspaceOnPlatformHostResponse, error) {
+	rsp, err := c.CreateFleetRepoWorkspaceOnPlatformHostWithBody(ctx, hostKey, platformHost, provider, owner, name, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateFleetRepoWorkspaceOnPlatformHostResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateFleetRepoWorkspaceOnPlatformHostWithResponse(ctx context.Context, hostKey string, platformHost string, provider string, owner string, name string, body CreateFleetRepoWorkspaceOnPlatformHostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateFleetRepoWorkspaceOnPlatformHostResponse, error) {
+	rsp, err := c.CreateFleetRepoWorkspaceOnPlatformHost(ctx, hostKey, platformHost, provider, owner, name, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateFleetRepoWorkspaceOnPlatformHostResponse(rsp)
+}
+
 // CreateFleetIssueWorkspaceWithBodyWithResponse request with arbitrary body returning *CreateFleetIssueWorkspaceResponse
 func (c *ClientWithResponses) CreateFleetIssueWorkspaceWithBodyWithResponse(ctx context.Context, hostKey string, provider string, owner string, name string, number string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateFleetIssueWorkspaceResponse, error) {
 	rsp, err := c.CreateFleetIssueWorkspaceWithBody(ctx, hostKey, provider, owner, name, number, contentType, body, reqEditors...)
@@ -47635,6 +47959,23 @@ func (c *ClientWithResponses) SetFleetProjectWorktreeSessionBackendWithResponse(
 		return nil, err
 	}
 	return ParseSetFleetProjectWorktreeSessionBackendResponse(rsp)
+}
+
+// CreateFleetRepoWorkspaceWithBodyWithResponse request with arbitrary body returning *CreateFleetRepoWorkspaceResponse
+func (c *ClientWithResponses) CreateFleetRepoWorkspaceWithBodyWithResponse(ctx context.Context, hostKey string, provider string, owner string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateFleetRepoWorkspaceResponse, error) {
+	rsp, err := c.CreateFleetRepoWorkspaceWithBody(ctx, hostKey, provider, owner, name, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateFleetRepoWorkspaceResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateFleetRepoWorkspaceWithResponse(ctx context.Context, hostKey string, provider string, owner string, name string, body CreateFleetRepoWorkspaceJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateFleetRepoWorkspaceResponse, error) {
+	rsp, err := c.CreateFleetRepoWorkspace(ctx, hostKey, provider, owner, name, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateFleetRepoWorkspaceResponse(rsp)
 }
 
 // LaunchFleetHostRuntimeSessionWithBodyWithResponse request with arbitrary body returning *LaunchFleetHostRuntimeSessionResponse
@@ -52487,6 +52828,39 @@ func ParseCreateFleetIssueWorkspaceOnPlatformHostResponse(rsp *http.Response) (*
 	return response, nil
 }
 
+// ParseCreateFleetRepoWorkspaceOnPlatformHostResponse parses an HTTP response from a CreateFleetRepoWorkspaceOnPlatformHostWithResponse call
+func ParseCreateFleetRepoWorkspaceOnPlatformHostResponse(rsp *http.Response) (*CreateFleetRepoWorkspaceOnPlatformHostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateFleetRepoWorkspaceOnPlatformHostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.Header.Get("Content-Type") == "application/json" && true:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	case rsp.Header.Get("Content-Type") == "application/problem+json" && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseCreateFleetIssueWorkspaceResponse parses an HTTP response from a CreateFleetIssueWorkspaceWithResponse call
 func ParseCreateFleetIssueWorkspaceResponse(rsp *http.Response) (*CreateFleetIssueWorkspaceResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -53090,6 +53464,39 @@ func ParseSetFleetProjectWorktreeSessionBackendResponse(rsp *http.Response) (*Se
 	}
 
 	response := &SetFleetProjectWorktreeSessionBackendResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.Header.Get("Content-Type") == "application/json" && true:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	case rsp.Header.Get("Content-Type") == "application/problem+json" && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateFleetRepoWorkspaceResponse parses an HTTP response from a CreateFleetRepoWorkspaceWithResponse call
+func ParseCreateFleetRepoWorkspaceResponse(rsp *http.Response) (*CreateFleetRepoWorkspaceResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateFleetRepoWorkspaceResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -2294,22 +2294,23 @@ type Enrollment struct {
 	// Schema A URL to the JSON Schema for this object.
 	//
 	// Example: /api/v1/schemas/Enrollment.json
-	Schema             *string    `json:"$schema,omitempty"`
-	CreatedAt          time.Time  `json:"created_at"`
-	ExpiresAt          time.Time  `json:"expires_at"`
-	HubBaseUrl         string     `json:"hub_base_url"`
-	HubName            *string    `json:"hub_name,omitempty"`
-	HubNodeId          string     `json:"hub_node_id"`
-	Id                 string     `json:"id"`
-	NodeId             string     `json:"node_id"`
-	PreparationStarted *bool      `json:"preparation_started,omitempty"`
-	ProtocolVersion    int64      `json:"protocol_version"`
-	RevokedAt          *time.Time `json:"revoked_at,omitempty"`
-	SpokeBaseUrl       string     `json:"spoke_base_url"`
-	SpokeName          *string    `json:"spoke_name,omitempty"`
-	SpokePlatform      string     `json:"spoke_platform"`
-	State              string     `json:"state"`
-	UpdatedAt          time.Time  `json:"updated_at"`
+	Schema               *string    `json:"$schema,omitempty"`
+	ActivationValidUntil *time.Time `json:"activation_valid_until,omitempty"`
+	CreatedAt            time.Time  `json:"created_at"`
+	ExpiresAt            time.Time  `json:"expires_at"`
+	HubBaseUrl           string     `json:"hub_base_url"`
+	HubName              *string    `json:"hub_name,omitempty"`
+	HubNodeId            string     `json:"hub_node_id"`
+	Id                   string     `json:"id"`
+	NodeId               string     `json:"node_id"`
+	PreparationStarted   *bool      `json:"preparation_started,omitempty"`
+	ProtocolVersion      int64      `json:"protocol_version"`
+	RevokedAt            *time.Time `json:"revoked_at,omitempty"`
+	SpokeBaseUrl         string     `json:"spoke_base_url"`
+	SpokeName            *string    `json:"spoke_name,omitempty"`
+	SpokePlatform        string     `json:"spoke_platform"`
+	State                string     `json:"state"`
+	UpdatedAt            time.Time  `json:"updated_at"`
 }
 
 // EnrollmentToken defines model for EnrollmentToken.
@@ -3218,21 +3219,22 @@ type LocalEnrollment struct {
 	// Schema A URL to the JSON Schema for this object.
 	//
 	// Example: /api/v1/schemas/LocalEnrollment.json
-	Schema              *string               `json:"$schema,omitempty"`
-	EnrollmentId        string                `json:"enrollment_id"`
-	ExpiresAt           time.Time             `json:"expires_at"`
-	HubBaseUrl          string                `json:"hub_base_url"`
-	HubName             *string               `json:"hub_name,omitempty"`
-	HubNodeId           *string               `json:"hub_node_id,omitempty"`
-	NodeId              string                `json:"node_id"`
-	Preparation         *LocalPreparationSeal `json:"preparation,omitempty"`
-	PreparationRequired bool                  `json:"preparation_required"`
-	PreparationStarted  *bool                 `json:"preparation_started,omitempty"`
-	ProtocolVersion     int64                 `json:"protocol_version"`
-	SpokeBaseUrl        string                `json:"spoke_base_url"`
-	SpokeName           *string               `json:"spoke_name,omitempty"`
-	SpokePlatform       string                `json:"spoke_platform"`
-	State               string                `json:"state"`
+	Schema               *string               `json:"$schema,omitempty"`
+	ActivationValidUntil *time.Time            `json:"activation_valid_until,omitempty"`
+	EnrollmentId         string                `json:"enrollment_id"`
+	ExpiresAt            time.Time             `json:"expires_at"`
+	HubBaseUrl           string                `json:"hub_base_url"`
+	HubName              *string               `json:"hub_name,omitempty"`
+	HubNodeId            *string               `json:"hub_node_id,omitempty"`
+	NodeId               string                `json:"node_id"`
+	Preparation          *LocalPreparationSeal `json:"preparation,omitempty"`
+	PreparationRequired  bool                  `json:"preparation_required"`
+	PreparationStarted   *bool                 `json:"preparation_started,omitempty"`
+	ProtocolVersion      int64                 `json:"protocol_version"`
+	SpokeBaseUrl         string                `json:"spoke_base_url"`
+	SpokeName            *string               `json:"spoke_name,omitempty"`
+	SpokePlatform        string                `json:"spoke_platform"`
+	State                string                `json:"state"`
 }
 
 // LocalJoinInputBody defines model for LocalJoinInputBody.

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1193,9 +1193,10 @@ type ActivateEnrollmentInputBody struct {
 	// Schema A URL to the JSON Schema for this object.
 	//
 	// Example: /api/v1/schemas/ActivateEnrollmentInputBody.json
-	Schema          *string `json:"$schema,omitempty"`
-	PreparationSeal string  `json:"preparation_seal"`
-	ProtocolVersion int64   `json:"protocol_version"`
+	Schema                 *string `json:"$schema,omitempty"`
+	ActivationLeaseVersion int64   `json:"activation_lease_version"`
+	PreparationSeal        string  `json:"preparation_seal"`
+	ProtocolVersion        int64   `json:"protocol_version"`
 }
 
 // Activity defines model for Activity.
@@ -2294,23 +2295,24 @@ type Enrollment struct {
 	// Schema A URL to the JSON Schema for this object.
 	//
 	// Example: /api/v1/schemas/Enrollment.json
-	Schema               *string    `json:"$schema,omitempty"`
-	ActivationValidUntil *time.Time `json:"activation_valid_until,omitempty"`
-	CreatedAt            time.Time  `json:"created_at"`
-	ExpiresAt            time.Time  `json:"expires_at"`
-	HubBaseUrl           string     `json:"hub_base_url"`
-	HubName              *string    `json:"hub_name,omitempty"`
-	HubNodeId            string     `json:"hub_node_id"`
-	Id                   string     `json:"id"`
-	NodeId               string     `json:"node_id"`
-	PreparationStarted   *bool      `json:"preparation_started,omitempty"`
-	ProtocolVersion      int64      `json:"protocol_version"`
-	RevokedAt            *time.Time `json:"revoked_at,omitempty"`
-	SpokeBaseUrl         string     `json:"spoke_base_url"`
-	SpokeName            *string    `json:"spoke_name,omitempty"`
-	SpokePlatform        string     `json:"spoke_platform"`
-	State                string     `json:"state"`
-	UpdatedAt            time.Time  `json:"updated_at"`
+	Schema                 *string    `json:"$schema,omitempty"`
+	ActivationLeaseVersion *int64     `json:"activation_lease_version,omitempty"`
+	ActivationValidUntil   *time.Time `json:"activation_valid_until,omitempty"`
+	CreatedAt              time.Time  `json:"created_at"`
+	ExpiresAt              time.Time  `json:"expires_at"`
+	HubBaseUrl             string     `json:"hub_base_url"`
+	HubName                *string    `json:"hub_name,omitempty"`
+	HubNodeId              string     `json:"hub_node_id"`
+	Id                     string     `json:"id"`
+	NodeId                 string     `json:"node_id"`
+	PreparationStarted     *bool      `json:"preparation_started,omitempty"`
+	ProtocolVersion        int64      `json:"protocol_version"`
+	RevokedAt              *time.Time `json:"revoked_at,omitempty"`
+	SpokeBaseUrl           string     `json:"spoke_base_url"`
+	SpokeName              *string    `json:"spoke_name,omitempty"`
+	SpokePlatform          string     `json:"spoke_platform"`
+	State                  string     `json:"state"`
+	UpdatedAt              time.Time  `json:"updated_at"`
 }
 
 // EnrollmentToken defines model for EnrollmentToken.
@@ -3219,22 +3221,23 @@ type LocalEnrollment struct {
 	// Schema A URL to the JSON Schema for this object.
 	//
 	// Example: /api/v1/schemas/LocalEnrollment.json
-	Schema               *string               `json:"$schema,omitempty"`
-	ActivationValidUntil *time.Time            `json:"activation_valid_until,omitempty"`
-	EnrollmentId         string                `json:"enrollment_id"`
-	ExpiresAt            time.Time             `json:"expires_at"`
-	HubBaseUrl           string                `json:"hub_base_url"`
-	HubName              *string               `json:"hub_name,omitempty"`
-	HubNodeId            *string               `json:"hub_node_id,omitempty"`
-	NodeId               string                `json:"node_id"`
-	Preparation          *LocalPreparationSeal `json:"preparation,omitempty"`
-	PreparationRequired  bool                  `json:"preparation_required"`
-	PreparationStarted   *bool                 `json:"preparation_started,omitempty"`
-	ProtocolVersion      int64                 `json:"protocol_version"`
-	SpokeBaseUrl         string                `json:"spoke_base_url"`
-	SpokeName            *string               `json:"spoke_name,omitempty"`
-	SpokePlatform        string                `json:"spoke_platform"`
-	State                string                `json:"state"`
+	Schema                 *string               `json:"$schema,omitempty"`
+	ActivationLeaseVersion *int64                `json:"activation_lease_version,omitempty"`
+	ActivationValidUntil   *time.Time            `json:"activation_valid_until,omitempty"`
+	EnrollmentId           string                `json:"enrollment_id"`
+	ExpiresAt              time.Time             `json:"expires_at"`
+	HubBaseUrl             string                `json:"hub_base_url"`
+	HubName                *string               `json:"hub_name,omitempty"`
+	HubNodeId              *string               `json:"hub_node_id,omitempty"`
+	NodeId                 string                `json:"node_id"`
+	Preparation            *LocalPreparationSeal `json:"preparation,omitempty"`
+	PreparationRequired    bool                  `json:"preparation_required"`
+	PreparationStarted     *bool                 `json:"preparation_started,omitempty"`
+	ProtocolVersion        int64                 `json:"protocol_version"`
+	SpokeBaseUrl           string                `json:"spoke_base_url"`
+	SpokeName              *string               `json:"spoke_name,omitempty"`
+	SpokePlatform          string                `json:"spoke_platform"`
+	State                  string                `json:"state"`
 }
 
 // LocalJoinInputBody defines model for LocalJoinInputBody.

--- a/internal/federation/enrollment_store.go
+++ b/internal/federation/enrollment_store.go
@@ -277,9 +277,15 @@ func (s *Store) MarkLocalPreparationStarted(
 	})
 }
 
-func (s *Store) Activate(ctx context.Context, enrollmentID string) error {
+func (s *Store) Activate(
+	ctx context.Context, enrollmentID string, activationValidUntil time.Time,
+) error {
 	if err := ctx.Err(); err != nil {
 		return err
+	}
+	activationValidUntil = activationValidUntil.UTC()
+	if !activationValidUntil.After(s.now().UTC()) {
+		return errors.New("federation activation lease must expire in the future")
 	}
 	return s.mutate(func(state *persistedEnrollmentStore) error {
 		index := enrollmentIndexByID(state.Enrollments, enrollmentID)
@@ -291,6 +297,8 @@ func (s *Store) Activate(ctx context.Context, enrollmentID string) error {
 			return ErrEnrollmentRevoked
 		}
 		enrollment.State = EnrollmentActive
+		enrollment.ActivationLeaseVersion = ActivationLeaseVersion
+		enrollment.ActivationValidUntil = activationValidUntil
 		enrollment.UpdatedAt = s.now().UTC()
 		return nil
 	})
@@ -405,8 +413,42 @@ func (s *Store) MarkLocalActive(
 			state.Local.Preparation == nil {
 			return ErrPreparationSealMismatch
 		}
+		if state.Local.State == EnrollmentRevoked {
+			return ErrEnrollmentRevoked
+		}
 		state.Local.State = EnrollmentActive
 		state.Local.PreparationRequired = false
+		state.Local.ActivationLeaseVersion = ActivationLeaseVersion
+		state.Local.ActivationValidUntil = activationValidUntil
+		return nil
+	})
+}
+
+// RenewLocalActivationLease updates only the currently active lease. A stale
+// response cannot reactivate a local enrollment that was revoked while its
+// hub request was in flight.
+func (s *Store) RenewLocalActivationLease(
+	ctx context.Context, enrollmentID string, activationValidUntil time.Time,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	enrollmentID = strings.TrimSpace(enrollmentID)
+	activationValidUntil = activationValidUntil.UTC()
+	if !activationValidUntil.After(s.now().UTC()) {
+		return errors.New("federation activation lease must expire in the future")
+	}
+	return s.mutate(func(state *persistedEnrollmentStore) error {
+		if state.Local == nil || state.Local.EnrollmentID != enrollmentID {
+			return ErrEnrollmentConflict
+		}
+		if state.Local.State == EnrollmentRevoked {
+			return ErrEnrollmentRevoked
+		}
+		if state.Local.State != EnrollmentActive || state.Local.Preparation == nil ||
+			state.Local.ActivationLeaseVersion != ActivationLeaseVersion {
+			return ErrEnrollmentConflict
+		}
 		state.Local.ActivationValidUntil = activationValidUntil
 		return nil
 	})
@@ -573,6 +615,14 @@ func normalizeLocalEnrollmentVersioned(
 	if !local.ActivationValidUntil.IsZero() {
 		local.ActivationValidUntil = local.ActivationValidUntil.UTC()
 	}
+	if local.ActivationLeaseVersion != 0 &&
+		local.ActivationLeaseVersion != ActivationLeaseVersion {
+		return LocalEnrollment{}, errors.New("local federation enrollment has unsupported activation lease version")
+	}
+	if !local.ActivationValidUntil.IsZero() &&
+		local.ActivationLeaseVersion != ActivationLeaseVersion {
+		return LocalEnrollment{}, errors.New("local federation enrollment lease has no supported version")
+	}
 	var err error
 	local.SpokeBaseURL, err = CanonicalOrigin(local.SpokeBaseURL)
 	if err != nil {
@@ -734,7 +784,8 @@ func validateEnrollmentStore(state *persistedEnrollmentStore) error {
 	ids := make(map[string]struct{}, len(state.Enrollments))
 	nodeIDs := make(map[string]struct{}, len(state.Enrollments))
 	origins := make(map[string]struct{}, len(state.Enrollments))
-	for index, enrollment := range state.Enrollments {
+	for index := range state.Enrollments {
+		enrollment := &state.Enrollments[index]
 		if !validID(enrollment.ID) || !validID(enrollment.NodeID) || !validID(enrollment.HubID) {
 			return fmt.Errorf("federation enrollment %d has invalid identity", index)
 		}
@@ -744,6 +795,16 @@ func validateEnrollmentStore(state *persistedEnrollmentStore) error {
 		if enrollment.State != EnrollmentPending && enrollment.State != EnrollmentActive &&
 			enrollment.State != EnrollmentRevoked {
 			return fmt.Errorf("federation enrollment %d has invalid state %q", index, enrollment.State)
+		}
+		if enrollment.ActivationLeaseVersion != 0 &&
+			enrollment.ActivationLeaseVersion != ActivationLeaseVersion {
+			return fmt.Errorf("federation enrollment %d has unsupported activation lease version", index)
+		}
+		if !enrollment.ActivationValidUntil.IsZero() {
+			enrollment.ActivationValidUntil = enrollment.ActivationValidUntil.UTC()
+			if enrollment.ActivationLeaseVersion != ActivationLeaseVersion {
+				return fmt.Errorf("federation enrollment %d lease has no supported version", index)
+			}
 		}
 		spokeOrigin, err := CanonicalOrigin(enrollment.SpokeBaseURL)
 		if err != nil || spokeOrigin != enrollment.SpokeBaseURL {

--- a/internal/federation/enrollment_store.go
+++ b/internal/federation/enrollment_store.go
@@ -385,13 +385,21 @@ func (s *Store) SaveLocalPreparationSeal(
 	})
 }
 
-// MarkLocalActive records the hub's idempotent activation response.
-// It refuses to activate a different local enrollment.
-func (s *Store) MarkLocalActive(ctx context.Context, enrollmentID string) error {
+// MarkLocalActive records the hub's idempotent activation response and the
+// bounded lease during which the spoke may accept requests from that hub. It
+// refuses to activate a different local enrollment or persist an expired
+// lease.
+func (s *Store) MarkLocalActive(
+	ctx context.Context, enrollmentID string, activationValidUntil time.Time,
+) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 	enrollmentID = strings.TrimSpace(enrollmentID)
+	activationValidUntil = activationValidUntil.UTC()
+	if !activationValidUntil.After(s.now().UTC()) {
+		return errors.New("federation activation lease must expire in the future")
+	}
 	return s.mutate(func(state *persistedEnrollmentStore) error {
 		if state.Local == nil || state.Local.EnrollmentID != enrollmentID ||
 			state.Local.Preparation == nil {
@@ -399,6 +407,25 @@ func (s *Store) MarkLocalActive(ctx context.Context, enrollmentID string) error 
 		}
 		state.Local.State = EnrollmentActive
 		state.Local.PreparationRequired = false
+		state.Local.ActivationValidUntil = activationValidUntil
+		return nil
+	})
+}
+
+// InvalidateLocalActivationLease stops an active spoke from accepting hub
+// requests after the hub definitively rejects the enrollment.
+func (s *Store) InvalidateLocalActivationLease(
+	ctx context.Context, enrollmentID string,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	enrollmentID = strings.TrimSpace(enrollmentID)
+	return s.mutate(func(state *persistedEnrollmentStore) error {
+		if state.Local == nil || state.Local.EnrollmentID != enrollmentID {
+			return ErrEnrollmentConflict
+		}
+		state.Local.ActivationValidUntil = time.Time{}
 		return nil
 	})
 }
@@ -542,6 +569,9 @@ func normalizeLocalEnrollmentVersioned(
 	}
 	if !local.ExpiresAt.IsZero() {
 		local.ExpiresAt = local.ExpiresAt.UTC()
+	}
+	if !local.ActivationValidUntil.IsZero() {
+		local.ActivationValidUntil = local.ActivationValidUntil.UTC()
 	}
 	var err error
 	local.SpokeBaseURL, err = CanonicalOrigin(local.SpokeBaseURL)

--- a/internal/federation/enrollment_store_test.go
+++ b/internal/federation/enrollment_store_test.go
@@ -34,14 +34,16 @@ func TestEnrollmentActivationIsIdempotentAfterLostResponse(t *testing.T) {
 	resumed, err := store.Resume(t.Context(), first.ID, request.NodeID)
 	require.NoError(err)
 	assert.Equal(first, resumed)
-	require.NoError(store.Activate(t.Context(), first.ID))
-	require.NoError(store.Activate(t.Context(), first.ID))
+	require.NoError(store.Activate(t.Context(), first.ID, now.Add(time.Hour)))
+	require.NoError(store.Activate(t.Context(), first.ID, now.Add(time.Hour)))
 	_, err = store.Begin(t.Context(), token.Token, request)
 	require.ErrorIs(err, ErrEnrollmentTokenConsumed)
 
 	active, err := store.Resume(t.Context(), first.ID, request.NodeID)
 	require.NoError(err)
 	assert.Equal(EnrollmentActive, active.State)
+	assert.Equal(ActivationLeaseVersion, active.ActivationLeaseVersion)
+	assert.Equal(now.Add(time.Hour), active.ActivationValidUntil)
 	_, err = store.Begin(t.Context(), token.Token,
 		joinRequestForTest("22222222222222222222222222222222",
 			"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "https://spoke-b.example"))
@@ -311,13 +313,59 @@ func TestLocalPreparationSealIsBoundAndActivationIsIdempotent(t *testing.T) {
 	require.True(ok)
 	assert.Equal(EnrollmentActive, got.State)
 	assert.False(got.PreparationRequired)
+	assert.Equal(ActivationLeaseVersion, got.ActivationLeaseVersion)
 	assert.Equal(activationValidUntil.UTC(), got.ActivationValidUntil)
+	renewedUntil := activationValidUntil.Add(time.Hour)
+	require.NoError(reopened.RenewLocalActivationLease(
+		t.Context(), testEnrollmentID, renewedUntil,
+	))
+	got, ok = reopened.Local()
+	require.True(ok)
+	assert.Equal(renewedUntil.UTC(), got.ActivationValidUntil)
 	require.NoError(reopened.InvalidateLocalActivationLease(
 		t.Context(), testEnrollmentID,
 	))
 	got, ok = reopened.Local()
 	require.True(ok)
 	assert.True(got.ActivationValidUntil.IsZero())
+}
+
+func TestLocalActivationCannotResumeAfterRevocation(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	store := newEnrollmentStoreForTest(t, time.Now)
+	require.NoError(store.SaveLocal(t.Context(), LocalEnrollment{
+		EnrollmentID: testEnrollmentID, NodeID: testNodeID,
+		SpokePlatform: "linux", SpokeBaseURL: "https://spoke-a.example",
+		HubID: testHubID, HubURL: "https://hub.example",
+		ProtocolVersion: ProtocolVersion, State: EnrollmentActive,
+		ExpiresAt:              time.Now().Add(time.Hour),
+		PreparationStarted:     true,
+		ActivationLeaseVersion: ActivationLeaseVersion,
+		ActivationValidUntil:   time.Now().Add(time.Hour),
+		Preparation: &LocalPreparationSeal{
+			EnrollmentID: testEnrollmentID, NodeID: testNodeID,
+			HubID: testHubID, ProtocolVersion: ProtocolVersion,
+			PreparationDigest: "digest", Seal: "opaque-seal",
+		},
+	}))
+	local, ok := store.Local()
+	require.True(ok)
+	local.State = EnrollmentRevoked
+	require.NoError(store.SaveLocal(t.Context(), local))
+
+	validUntil := time.Now().Add(2 * time.Hour)
+	require.ErrorIs(
+		store.MarkLocalActive(t.Context(), testEnrollmentID, validUntil),
+		ErrEnrollmentRevoked,
+	)
+	require.ErrorIs(
+		store.RenewLocalActivationLease(t.Context(), testEnrollmentID, validUntil),
+		ErrEnrollmentRevoked,
+	)
+	local, ok = store.Local()
+	require.True(ok)
+	assert.Equal(EnrollmentRevoked, local.State)
 }
 
 func newEnrollmentStoreForTest(t *testing.T, now func() time.Time) *Store {

--- a/internal/federation/enrollment_store_test.go
+++ b/internal/federation/enrollment_store_test.go
@@ -300,12 +300,24 @@ func TestLocalPreparationSealIsBoundAndActivationIsIdempotent(t *testing.T) {
 	require.True(ok)
 	require.NotNil(detached.Preparation)
 	assert.Equal(seal.Seal, detached.Preparation.Seal)
-	require.NoError(reopened.MarkLocalActive(t.Context(), testEnrollmentID))
-	require.NoError(reopened.MarkLocalActive(t.Context(), testEnrollmentID))
+	activationValidUntil := time.Now().Add(time.Hour)
+	require.NoError(reopened.MarkLocalActive(
+		t.Context(), testEnrollmentID, activationValidUntil,
+	))
+	require.NoError(reopened.MarkLocalActive(
+		t.Context(), testEnrollmentID, activationValidUntil,
+	))
 	got, ok = reopened.Local()
 	require.True(ok)
 	assert.Equal(EnrollmentActive, got.State)
 	assert.False(got.PreparationRequired)
+	assert.Equal(activationValidUntil.UTC(), got.ActivationValidUntil)
+	require.NoError(reopened.InvalidateLocalActivationLease(
+		t.Context(), testEnrollmentID,
+	))
+	got, ok = reopened.Local()
+	require.True(ok)
+	assert.True(got.ActivationValidUntil.IsZero())
 }
 
 func newEnrollmentStoreForTest(t *testing.T, now func() time.Time) *Store {

--- a/internal/federation/protocol.go
+++ b/internal/federation/protocol.go
@@ -18,6 +18,11 @@ import (
 // an exact match; there is no version translation.
 const ProtocolVersion = 3
 
+// ActivationLeaseVersion identifies the lease handshake layered on the fleet
+// protocol. Keeping it distinct lets upgraded peers reject lease-unaware
+// activation without changing the snapshot and proxy wire contract.
+const ActivationLeaseVersion = 1
+
 // SpokeActivationLeaseDuration bounds how long a spoke may accept hub-issued
 // federation requests without successfully revalidating its enrollment.
 const SpokeActivationLeaseDuration = 24 * time.Hour
@@ -99,42 +104,44 @@ type JoinResponse struct {
 // Enrollment is the hub's durable membership record. Bearers are
 // deliberately absent and live only in federationauth.
 type Enrollment struct {
-	ID                   string          `json:"id"`
-	NodeID               string          `json:"node_id"`
-	SpokeName            string          `json:"spoke_name,omitempty"`
-	SpokePlatform        string          `json:"spoke_platform"`
-	SpokeBaseURL         string          `json:"spoke_base_url"`
-	HubID                string          `json:"hub_node_id"`
-	HubName              string          `json:"hub_name,omitempty"`
-	HubURL               string          `json:"hub_base_url"`
-	ProtocolVersion      int             `json:"protocol_version"`
-	State                EnrollmentState `json:"state"`
-	ExpiresAt            time.Time       `json:"expires_at"`
-	PreparationStarted   bool            `json:"preparation_started,omitempty"`
-	CreatedAt            time.Time       `json:"created_at"`
-	UpdatedAt            time.Time       `json:"updated_at"`
-	RevokedAt            time.Time       `json:"revoked_at,omitzero"`
-	ActivationValidUntil time.Time       `json:"activation_valid_until,omitzero"`
+	ID                     string          `json:"id"`
+	NodeID                 string          `json:"node_id"`
+	SpokeName              string          `json:"spoke_name,omitempty"`
+	SpokePlatform          string          `json:"spoke_platform"`
+	SpokeBaseURL           string          `json:"spoke_base_url"`
+	HubID                  string          `json:"hub_node_id"`
+	HubName                string          `json:"hub_name,omitempty"`
+	HubURL                 string          `json:"hub_base_url"`
+	ProtocolVersion        int             `json:"protocol_version"`
+	State                  EnrollmentState `json:"state"`
+	ExpiresAt              time.Time       `json:"expires_at"`
+	PreparationStarted     bool            `json:"preparation_started,omitempty"`
+	CreatedAt              time.Time       `json:"created_at"`
+	UpdatedAt              time.Time       `json:"updated_at"`
+	RevokedAt              time.Time       `json:"revoked_at,omitzero"`
+	ActivationLeaseVersion int             `json:"activation_lease_version,omitempty"`
+	ActivationValidUntil   time.Time       `json:"activation_valid_until,omitzero"`
 }
 
 // LocalEnrollment is the joining daemon's durable view of its pending or
 // active hub binding. It never contains either bearer credential.
 type LocalEnrollment struct {
-	EnrollmentID         string                `json:"enrollment_id"`
-	NodeID               string                `json:"node_id"`
-	SpokeName            string                `json:"spoke_name,omitempty"`
-	SpokePlatform        string                `json:"spoke_platform"`
-	SpokeBaseURL         string                `json:"spoke_base_url"`
-	HubID                string                `json:"hub_node_id,omitempty"`
-	HubName              string                `json:"hub_name,omitempty"`
-	HubURL               string                `json:"hub_base_url"`
-	ProtocolVersion      int                   `json:"protocol_version"`
-	State                EnrollmentState       `json:"state"`
-	ExpiresAt            time.Time             `json:"expires_at"`
-	PreparationStarted   bool                  `json:"preparation_started,omitempty"`
-	PreparationRequired  bool                  `json:"preparation_required"`
-	Preparation          *LocalPreparationSeal `json:"preparation,omitempty"`
-	ActivationValidUntil time.Time             `json:"activation_valid_until,omitzero"`
+	EnrollmentID           string                `json:"enrollment_id"`
+	NodeID                 string                `json:"node_id"`
+	SpokeName              string                `json:"spoke_name,omitempty"`
+	SpokePlatform          string                `json:"spoke_platform"`
+	SpokeBaseURL           string                `json:"spoke_base_url"`
+	HubID                  string                `json:"hub_node_id,omitempty"`
+	HubName                string                `json:"hub_name,omitempty"`
+	HubURL                 string                `json:"hub_base_url"`
+	ProtocolVersion        int                   `json:"protocol_version"`
+	State                  EnrollmentState       `json:"state"`
+	ExpiresAt              time.Time             `json:"expires_at"`
+	PreparationStarted     bool                  `json:"preparation_started,omitempty"`
+	PreparationRequired    bool                  `json:"preparation_required"`
+	Preparation            *LocalPreparationSeal `json:"preparation,omitempty"`
+	ActivationLeaseVersion int                   `json:"activation_lease_version,omitempty"`
+	ActivationValidUntil   time.Time             `json:"activation_valid_until,omitzero"`
 }
 
 // LocalPreparationSeal is the joining daemon's durable proof that the

--- a/internal/federation/protocol.go
+++ b/internal/federation/protocol.go
@@ -18,6 +18,10 @@ import (
 // an exact match; there is no version translation.
 const ProtocolVersion = 3
 
+// SpokeActivationLeaseDuration bounds how long a spoke may accept hub-issued
+// federation requests without successfully revalidating its enrollment.
+const SpokeActivationLeaseDuration = 24 * time.Hour
+
 // MaxCredentialLength bounds opaque federation bearers on the wire and disk.
 const MaxCredentialLength = 256
 
@@ -95,40 +99,42 @@ type JoinResponse struct {
 // Enrollment is the hub's durable membership record. Bearers are
 // deliberately absent and live only in federationauth.
 type Enrollment struct {
-	ID                 string          `json:"id"`
-	NodeID             string          `json:"node_id"`
-	SpokeName          string          `json:"spoke_name,omitempty"`
-	SpokePlatform      string          `json:"spoke_platform"`
-	SpokeBaseURL       string          `json:"spoke_base_url"`
-	HubID              string          `json:"hub_node_id"`
-	HubName            string          `json:"hub_name,omitempty"`
-	HubURL             string          `json:"hub_base_url"`
-	ProtocolVersion    int             `json:"protocol_version"`
-	State              EnrollmentState `json:"state"`
-	ExpiresAt          time.Time       `json:"expires_at"`
-	PreparationStarted bool            `json:"preparation_started,omitempty"`
-	CreatedAt          time.Time       `json:"created_at"`
-	UpdatedAt          time.Time       `json:"updated_at"`
-	RevokedAt          time.Time       `json:"revoked_at,omitzero"`
+	ID                   string          `json:"id"`
+	NodeID               string          `json:"node_id"`
+	SpokeName            string          `json:"spoke_name,omitempty"`
+	SpokePlatform        string          `json:"spoke_platform"`
+	SpokeBaseURL         string          `json:"spoke_base_url"`
+	HubID                string          `json:"hub_node_id"`
+	HubName              string          `json:"hub_name,omitempty"`
+	HubURL               string          `json:"hub_base_url"`
+	ProtocolVersion      int             `json:"protocol_version"`
+	State                EnrollmentState `json:"state"`
+	ExpiresAt            time.Time       `json:"expires_at"`
+	PreparationStarted   bool            `json:"preparation_started,omitempty"`
+	CreatedAt            time.Time       `json:"created_at"`
+	UpdatedAt            time.Time       `json:"updated_at"`
+	RevokedAt            time.Time       `json:"revoked_at,omitzero"`
+	ActivationValidUntil time.Time       `json:"activation_valid_until,omitzero"`
 }
 
 // LocalEnrollment is the joining daemon's durable view of its pending or
 // active hub binding. It never contains either bearer credential.
 type LocalEnrollment struct {
-	EnrollmentID        string                `json:"enrollment_id"`
-	NodeID              string                `json:"node_id"`
-	SpokeName           string                `json:"spoke_name,omitempty"`
-	SpokePlatform       string                `json:"spoke_platform"`
-	SpokeBaseURL        string                `json:"spoke_base_url"`
-	HubID               string                `json:"hub_node_id,omitempty"`
-	HubName             string                `json:"hub_name,omitempty"`
-	HubURL              string                `json:"hub_base_url"`
-	ProtocolVersion     int                   `json:"protocol_version"`
-	State               EnrollmentState       `json:"state"`
-	ExpiresAt           time.Time             `json:"expires_at"`
-	PreparationStarted  bool                  `json:"preparation_started,omitempty"`
-	PreparationRequired bool                  `json:"preparation_required"`
-	Preparation         *LocalPreparationSeal `json:"preparation,omitempty"`
+	EnrollmentID         string                `json:"enrollment_id"`
+	NodeID               string                `json:"node_id"`
+	SpokeName            string                `json:"spoke_name,omitempty"`
+	SpokePlatform        string                `json:"spoke_platform"`
+	SpokeBaseURL         string                `json:"spoke_base_url"`
+	HubID                string                `json:"hub_node_id,omitempty"`
+	HubName              string                `json:"hub_name,omitempty"`
+	HubURL               string                `json:"hub_base_url"`
+	ProtocolVersion      int                   `json:"protocol_version"`
+	State                EnrollmentState       `json:"state"`
+	ExpiresAt            time.Time             `json:"expires_at"`
+	PreparationStarted   bool                  `json:"preparation_started,omitempty"`
+	PreparationRequired  bool                  `json:"preparation_required"`
+	Preparation          *LocalPreparationSeal `json:"preparation,omitempty"`
+	ActivationValidUntil time.Time             `json:"activation_valid_until,omitzero"`
 }
 
 // LocalPreparationSeal is the joining daemon's durable proof that the

--- a/internal/federationauth/authenticator.go
+++ b/internal/federationauth/authenticator.go
@@ -42,6 +42,8 @@ var authorizedRoutes = []authorizedRoute{
 	{method: http.MethodPatch, path: "/api/v1/workspaces/{id}/runtime/sessions/{session_key}", scope: ScopeWorkspaceWrite},
 	{method: http.MethodDelete, path: "/api/v1/workspaces/{id}/runtime/sessions/{session_key}", scope: ScopeWorkspaceWrite},
 	{method: http.MethodGet, path: "/api/v1/workspaces/{id}/runtime/sessions/{session_key}/attach-spec", scope: ScopeTerminalAttach},
+	{method: http.MethodPost, path: "/api/v1/repo/{provider}/{owner}/{name}/workspaces", scope: ScopeWorkspaceWrite},
+	{method: http.MethodPost, path: "/api/v1/host/{platform_host}/repo/{provider}/{owner}/{name}/workspaces", scope: ScopeWorkspaceWrite},
 	{method: http.MethodPost, path: "/api/v1/issues/{provider}/{owner}/{name}/{number}/workspace", scope: ScopeWorkspaceWrite},
 	{method: http.MethodPost, path: "/api/v1/host/{platform_host}/issues/{provider}/{owner}/{name}/{number}/workspace", scope: ScopeWorkspaceWrite},
 	{method: http.MethodGet, path: "/api/v1/filesystem/complete", scope: ScopeWorkspaceRead},

--- a/internal/federationauth/authenticator_test.go
+++ b/internal/federationauth/authenticator_test.go
@@ -38,6 +38,11 @@ func TestFederationCredentialAuthorizationUsesExactRouteInventory(t *testing.T) 
 	require.True(listed)
 	assert.Equal(ScopeWorkspaceWrite, required)
 	required, listed = authenticator.RequiredScope(
+		http.MethodPost, "/api/v1/host/git.example.test/repo/gitlab/acme/widgets/workspaces",
+	)
+	require.True(listed)
+	assert.Equal(ScopeWorkspaceWrite, required)
+	required, listed = authenticator.RequiredScope(
 		http.MethodPost, "/api/v1/federation/workspaces/ws-1/cleanup",
 	)
 	require.True(listed)

--- a/internal/server/api_auth.go
+++ b/internal/server/api_auth.go
@@ -340,7 +340,10 @@ func (s *Server) authorizeFederationRequest(
 func (s *Server) allowsActivationLeaseHandshake(
 	r *http.Request, canonicalPath string, principal federationauth.Principal,
 ) bool {
-	if s.options.FederationEnrollments == nil ||
+	s.cfgMu.Lock()
+	fleetEnabled := s.cfg != nil && s.cfg.Fleet.Enabled
+	s.cfgMu.Unlock()
+	if !fleetEnabled || s.options.FederationEnrollments == nil ||
 		s.bootCfgSnapshot.FleetRole != config.FleetRoleHub {
 		return false
 	}

--- a/internal/server/api_auth.go
+++ b/internal/server/api_auth.go
@@ -207,6 +207,7 @@ func (s *Server) federationPrincipalEnrollmentState(
 		}
 		return federation.EnrollmentActive, s.options.FederationSpokeActive &&
 			local.State == federation.EnrollmentActive &&
+			local.ActivationValidUntil.After(s.now().UTC()) &&
 			hub.NodeID == principal.NodeID &&
 			local.HubID == principal.NodeID
 	}

--- a/internal/server/api_auth.go
+++ b/internal/server/api_auth.go
@@ -270,7 +270,7 @@ func (s *Server) authorizeFederationRequest(
 	}
 	canonicalPath := s.canonicalAPIPath(r)
 	enrollmentState, enrolled := s.federationPrincipalEnrollmentState(principal)
-	if !enrolled && s.allowsActivationLeaseRenewal(r, canonicalPath, principal) {
+	if !enrolled && s.allowsActivationLeaseHandshake(r, canonicalPath, principal) {
 		enrollmentState = federation.EnrollmentActive
 		enrolled = true
 	}
@@ -337,17 +337,22 @@ func (s *Server) authorizeFederationRequest(
 	return true
 }
 
-func (s *Server) allowsActivationLeaseRenewal(
+func (s *Server) allowsActivationLeaseHandshake(
 	r *http.Request, canonicalPath string, principal federationauth.Principal,
 ) bool {
-	if r.Method != http.MethodPost || s.options.FederationEnrollments == nil ||
+	if s.options.FederationEnrollments == nil ||
 		s.bootCfgSnapshot.FleetRole != config.FleetRoleHub {
 		return false
 	}
 	enrollment, ok := s.options.FederationEnrollments.EnrollmentForSpoke(principal.NodeID)
-	return ok && enrollment.State == federation.EnrollmentActive &&
-		canonicalPath == "/api/v1/federation/enrollments/"+
-			url.PathEscape(enrollment.ID)+"/activate"
+	if !ok || enrollment.State != federation.EnrollmentActive {
+		return false
+	}
+	if r.Method == http.MethodGet && canonicalPath == "/api/v1/federation/identity" {
+		return true
+	}
+	return r.Method == http.MethodPost && canonicalPath ==
+		"/api/v1/federation/enrollments/"+url.PathEscape(enrollment.ID)+"/activate"
 }
 
 func (s *Server) allowsSpokeEnrollmentRevocation(

--- a/internal/server/api_auth.go
+++ b/internal/server/api_auth.go
@@ -207,6 +207,7 @@ func (s *Server) federationPrincipalEnrollmentState(
 		}
 		return federation.EnrollmentActive, s.options.FederationSpokeActive &&
 			local.State == federation.EnrollmentActive &&
+			local.ActivationLeaseVersion == federation.ActivationLeaseVersion &&
 			local.ActivationValidUntil.After(s.now().UTC()) &&
 			hub.NodeID == principal.NodeID &&
 			local.HubID == principal.NodeID
@@ -220,7 +221,9 @@ func (s *Server) federationPrincipalEnrollmentState(
 		return federation.EnrollmentPending,
 			enrollment.PreparationStarted || enrollment.ExpiresAt.After(s.now().UTC())
 	}
-	if enrollment.State != federation.EnrollmentActive {
+	if enrollment.State != federation.EnrollmentActive ||
+		enrollment.ActivationLeaseVersion != federation.ActivationLeaseVersion ||
+		!enrollment.ActivationValidUntil.After(s.now().UTC()) {
 		return "", false
 	}
 	for _, member := range members {
@@ -267,7 +270,11 @@ func (s *Server) authorizeFederationRequest(
 	}
 	canonicalPath := s.canonicalAPIPath(r)
 	enrollmentState, enrolled := s.federationPrincipalEnrollmentState(principal)
-	if !enrolled && s.allowsRevokedSpokeRevocation(r, canonicalPath, principal) {
+	if !enrolled && s.allowsActivationLeaseRenewal(r, canonicalPath, principal) {
+		enrollmentState = federation.EnrollmentActive
+		enrolled = true
+	}
+	if !enrolled && s.allowsSpokeEnrollmentRevocation(r, canonicalPath, principal) {
 		enrollmentState = federation.EnrollmentRevoked
 		enrolled = true
 	}
@@ -330,14 +337,28 @@ func (s *Server) authorizeFederationRequest(
 	return true
 }
 
-func (s *Server) allowsRevokedSpokeRevocation(
+func (s *Server) allowsActivationLeaseRenewal(
+	r *http.Request, canonicalPath string, principal federationauth.Principal,
+) bool {
+	if r.Method != http.MethodPost || s.options.FederationEnrollments == nil ||
+		s.bootCfgSnapshot.FleetRole != config.FleetRoleHub {
+		return false
+	}
+	enrollment, ok := s.options.FederationEnrollments.EnrollmentForSpoke(principal.NodeID)
+	return ok && enrollment.State == federation.EnrollmentActive &&
+		canonicalPath == "/api/v1/federation/enrollments/"+
+			url.PathEscape(enrollment.ID)+"/activate"
+}
+
+func (s *Server) allowsSpokeEnrollmentRevocation(
 	r *http.Request, canonicalPath string, principal federationauth.Principal,
 ) bool {
 	if r.Method != http.MethodDelete || s.options.FederationEnrollments == nil {
 		return false
 	}
 	local, ok := s.options.FederationEnrollments.Local()
-	if !ok || local.State != federation.EnrollmentRevoked ||
+	if !ok || (local.State != federation.EnrollmentActive &&
+		local.State != federation.EnrollmentRevoked) ||
 		local.HubID != principal.NodeID {
 		return false
 	}

--- a/internal/server/api_auth_test.go
+++ b/internal/server/api_auth_test.go
@@ -781,10 +781,27 @@ func TestLeaseUnawareHubEnrollmentCredentialIsInactive(t *testing.T) {
 	t.Cleanup(ts.Close)
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
 
-	identityResponse := authGet(t, ts, "/api/v1/federation/identity", func(r *http.Request) {
-		r.Header.Set("Authorization", "Bearer "+token)
-		r.Header.Set(federationauth.NodeIDHeader, nodeID)
-	})
+	requestIdentity := func() *http.Response {
+		return authGet(t, ts, "/api/v1/federation/identity", func(r *http.Request) {
+			r.Header.Set("Authorization", "Bearer "+token)
+			r.Header.Set(federationauth.NodeIDHeader, nodeID)
+		})
+	}
+	requestActivation := func() *http.Response {
+		request, requestErr := http.NewRequest(
+			http.MethodPost,
+			ts.URL+"/api/v1/federation/enrollments/"+enrollmentID+"/activate",
+			strings.NewReader(`{"protocol_version":3,"preparation_seal":"legacy"}`),
+		)
+		require.NoError(requestErr)
+		request.Header.Set("Authorization", "Bearer "+token)
+		request.Header.Set("Content-Type", "application/json")
+		response, requestErr := ts.Client().Do(request)
+		require.NoError(requestErr)
+		return response
+	}
+
+	identityResponse := requestIdentity()
 	identityResponse.Body.Close()
 	require.Equal(http.StatusOK, identityResponse.StatusCode,
 		"lease-unaware peers need identity preflight access before activation")
@@ -795,19 +812,20 @@ func TestLeaseUnawareHubEnrollmentCredentialIsInactive(t *testing.T) {
 	defer response.Body.Close()
 	require.Equal(http.StatusForbidden, response.StatusCode)
 
-	activationRequest, err := http.NewRequest(
-		http.MethodPost,
-		ts.URL+"/api/v1/federation/enrollments/"+enrollmentID+"/activate",
-		strings.NewReader(`{"protocol_version":3,"preparation_seal":"legacy"}`),
-	)
-	require.NoError(err)
-	activationRequest.Header.Set("Authorization", "Bearer "+token)
-	activationRequest.Header.Set("Content-Type", "application/json")
-	activationResponse, err := ts.Client().Do(activationRequest)
-	require.NoError(err)
-	defer activationResponse.Body.Close()
+	activationResponse := requestActivation()
+	activationResponse.Body.Close()
 	require.Equal(http.StatusUnprocessableEntity, activationResponse.StatusCode,
 		"lease-unaware peers may reach only the activation handshake")
+
+	srv.cfgMu.Lock()
+	srv.cfg.Fleet.Enabled = false
+	srv.cfgMu.Unlock()
+	identityResponse = requestIdentity()
+	identityResponse.Body.Close()
+	require.Equal(http.StatusForbidden, identityResponse.StatusCode)
+	activationResponse = requestActivation()
+	activationResponse.Body.Close()
+	require.Equal(http.StatusForbidden, activationResponse.StatusCode)
 }
 
 func TestActiveHubCredentialRequiresActiveSpokeStartup(t *testing.T) {

--- a/internal/server/api_auth_test.go
+++ b/internal/server/api_auth_test.go
@@ -509,7 +509,9 @@ func TestRemovedFleetMemberCredentialFailsOnNextRequest(t *testing.T) {
 		HubCredential:   "hub-credential",
 	})
 	require.NoError(err)
-	require.NoError(enrollments.Activate(t.Context(), enrollmentID))
+	require.NoError(enrollments.Activate(
+		t.Context(), enrollmentID, time.Now().Add(time.Hour),
+	))
 
 	credentials, err := federationauth.Open(
 		filepath.Join(t.TempDir(), "credentials.json"),
@@ -731,6 +733,75 @@ func TestPendingSpokeCredentialCannotRevokeSiblingEnrollment(t *testing.T) {
 	assert.Equal(t, federation.EnrollmentPending, sibling.State)
 }
 
+func TestLeaseUnawareHubEnrollmentCredentialIsInactive(t *testing.T) {
+	require := require.New(t)
+	const (
+		hubID        = "0123456789abcdef0123456789abcdef"
+		nodeID       = "fedcba9876543210fedcba9876543210"
+		enrollmentID = "11111111111111111111111111111111"
+	)
+	path := filepath.Join(t.TempDir(), "enrollments.json")
+	contents, err := json.Marshal(map[string]any{
+		"version": 1, "tokens": []any{},
+		"enrollments": []federation.Enrollment{{
+			ID: enrollmentID, NodeID: nodeID,
+			SpokePlatform: "linux", SpokeBaseURL: "https://spoke.example",
+			HubID: hubID, HubURL: "https://hub.example",
+			ProtocolVersion: federation.ProtocolVersion,
+			State:           federation.EnrollmentActive,
+			ExpiresAt:       time.Now().Add(time.Hour),
+		}},
+	})
+	require.NoError(err)
+	require.NoError(os.WriteFile(path, contents, 0o600))
+	enrollments, err := federation.Open(path, federation.StoreOptions{})
+	require.NoError(err)
+	credentials, err := federationauth.Open(filepath.Join(t.TempDir(), "credentials.json"))
+	require.NoError(err)
+	token, err := credentials.MintInbound(
+		nodeID, []federationauth.Scope{
+			federationauth.ScopeSnapshotRead,
+			federationauth.ScopeEnrollmentActivate,
+		},
+	)
+	require.NoError(err)
+	cfg := &config.Config{Fleet: config.Fleet{
+		Enabled: true, Role: config.FleetRoleHub,
+		Members: []config.FleetMember{{
+			NodeID: nodeID, BaseURL: "https://spoke.example",
+			State: federation.EnrollmentActive,
+		}},
+	}}
+	srv := New(dbtest.Open(t), nil, nil, "/", cfg, ServerOptions{
+		DaemonAccess:          DaemonAccessOptions{Token: "local-secret", RequireAPIAuth: true},
+		FederationCredentials: credentials, FederationEnrollments: enrollments,
+		FederationSpokeID: hubID,
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+
+	response := authGet(t, ts, "/api/v1/snapshot/raw", func(r *http.Request) {
+		r.Header.Set("Authorization", "Bearer "+token)
+	})
+	defer response.Body.Close()
+	require.Equal(http.StatusForbidden, response.StatusCode)
+
+	activationRequest, err := http.NewRequest(
+		http.MethodPost,
+		ts.URL+"/api/v1/federation/enrollments/"+enrollmentID+"/activate",
+		strings.NewReader(`{"protocol_version":3,"preparation_seal":"legacy"}`),
+	)
+	require.NoError(err)
+	activationRequest.Header.Set("Authorization", "Bearer "+token)
+	activationRequest.Header.Set("Content-Type", "application/json")
+	activationResponse, err := ts.Client().Do(activationRequest)
+	require.NoError(err)
+	defer activationResponse.Body.Close()
+	require.Equal(http.StatusUnprocessableEntity, activationResponse.StatusCode,
+		"lease-unaware peers may reach only the activation handshake")
+}
+
 func TestActiveHubCredentialRequiresActiveSpokeStartup(t *testing.T) {
 	const (
 		hubID        = "0123456789abcdef0123456789abcdef"
@@ -740,20 +811,28 @@ func TestActiveHubCredentialRequiresActiveSpokeStartup(t *testing.T) {
 	for _, test := range []struct {
 		name            string
 		nodeActive      bool
+		leaseVersion    int
 		leaseValidUntil time.Time
 		wantDenied      bool
 	}{
 		{
 			name: "validated startup with current lease", nodeActive: true,
+			leaseVersion:    federation.ActivationLeaseVersion,
 			leaseValidUntil: time.Now().Add(time.Hour),
 		},
 		{
 			name: "validated startup with expired lease", nodeActive: true,
+			leaseVersion:    federation.ActivationLeaseVersion,
 			leaseValidUntil: time.Now().Add(-time.Hour), wantDenied: true,
 		},
 		{
 			name: "local-only startup", leaseValidUntil: time.Now().Add(time.Hour),
-			wantDenied: true,
+			leaseVersion: federation.ActivationLeaseVersion,
+			wantDenied:   true,
+		},
+		{
+			name: "lease-unaware enrollment", nodeActive: true,
+			leaseValidUntil: time.Time{}, wantDenied: true,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -768,8 +847,9 @@ func TestActiveHubCredentialRequiresActiveSpokeStartup(t *testing.T) {
 				SpokePlatform: "linux", SpokeBaseURL: "https://spoke.example",
 				HubID: hubID, HubURL: "https://hub.example",
 				ProtocolVersion: federation.ProtocolVersion, State: federation.EnrollmentActive,
-				ExpiresAt:            time.Now().Add(time.Hour),
-				ActivationValidUntil: test.leaseValidUntil,
+				ActivationLeaseVersion: test.leaseVersion,
+				ExpiresAt:              time.Now().Add(time.Hour),
+				ActivationValidUntil:   test.leaseValidUntil,
 			}))
 			credentials, err := federationauth.Open(filepath.Join(t.TempDir(), "credentials.json"))
 			require.NoError(err)
@@ -829,8 +909,9 @@ func TestFederationAuthenticationKeepsBootTopologyUntilRestart(t *testing.T) {
 		SpokePlatform: "linux", SpokeBaseURL: "https://spoke.example",
 		HubID: hubID, HubURL: "https://hub.example",
 		ProtocolVersion: federation.ProtocolVersion, State: federation.EnrollmentActive,
-		ExpiresAt:            time.Now().Add(time.Hour),
-		ActivationValidUntil: time.Now().Add(time.Hour),
+		ActivationLeaseVersion: federation.ActivationLeaseVersion,
+		ExpiresAt:              time.Now().Add(time.Hour),
+		ActivationValidUntil:   time.Now().Add(time.Hour),
 	}))
 	credentials, err := federationauth.Open(filepath.Join(t.TempDir(), "credentials.json"))
 	require.NoError(err)

--- a/internal/server/api_auth_test.go
+++ b/internal/server/api_auth_test.go
@@ -738,12 +738,23 @@ func TestActiveHubCredentialRequiresActiveSpokeStartup(t *testing.T) {
 		enrollmentID = "11111111111111111111111111111111"
 	)
 	for _, test := range []struct {
-		name       string
-		nodeActive bool
-		wantDenied bool
+		name            string
+		nodeActive      bool
+		leaseValidUntil time.Time
+		wantDenied      bool
 	}{
-		{name: "validated startup", nodeActive: true},
-		{name: "local-only startup", wantDenied: true},
+		{
+			name: "validated startup with current lease", nodeActive: true,
+			leaseValidUntil: time.Now().Add(time.Hour),
+		},
+		{
+			name: "validated startup with expired lease", nodeActive: true,
+			leaseValidUntil: time.Now().Add(-time.Hour), wantDenied: true,
+		},
+		{
+			name: "local-only startup", leaseValidUntil: time.Now().Add(time.Hour),
+			wantDenied: true,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			assert := assert.New(t)
@@ -757,7 +768,8 @@ func TestActiveHubCredentialRequiresActiveSpokeStartup(t *testing.T) {
 				SpokePlatform: "linux", SpokeBaseURL: "https://spoke.example",
 				HubID: hubID, HubURL: "https://hub.example",
 				ProtocolVersion: federation.ProtocolVersion, State: federation.EnrollmentActive,
-				ExpiresAt: time.Now().Add(time.Hour),
+				ExpiresAt:            time.Now().Add(time.Hour),
+				ActivationValidUntil: test.leaseValidUntil,
 			}))
 			credentials, err := federationauth.Open(filepath.Join(t.TempDir(), "credentials.json"))
 			require.NoError(err)
@@ -817,7 +829,8 @@ func TestFederationAuthenticationKeepsBootTopologyUntilRestart(t *testing.T) {
 		SpokePlatform: "linux", SpokeBaseURL: "https://spoke.example",
 		HubID: hubID, HubURL: "https://hub.example",
 		ProtocolVersion: federation.ProtocolVersion, State: federation.EnrollmentActive,
-		ExpiresAt: time.Now().Add(time.Hour),
+		ExpiresAt:            time.Now().Add(time.Hour),
+		ActivationValidUntil: time.Now().Add(time.Hour),
 	}))
 	credentials, err := federationauth.Open(filepath.Join(t.TempDir(), "credentials.json"))
 	require.NoError(err)

--- a/internal/server/api_auth_test.go
+++ b/internal/server/api_auth_test.go
@@ -781,6 +781,14 @@ func TestLeaseUnawareHubEnrollmentCredentialIsInactive(t *testing.T) {
 	t.Cleanup(ts.Close)
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
 
+	identityResponse := authGet(t, ts, "/api/v1/federation/identity", func(r *http.Request) {
+		r.Header.Set("Authorization", "Bearer "+token)
+		r.Header.Set(federationauth.NodeIDHeader, nodeID)
+	})
+	identityResponse.Body.Close()
+	require.Equal(http.StatusOK, identityResponse.StatusCode,
+		"lease-unaware peers need identity preflight access before activation")
+
 	response := authGet(t, ts, "/api/v1/snapshot/raw", func(r *http.Request) {
 		r.Header.Set("Authorization", "Bearer "+token)
 	})

--- a/internal/server/federation_events.go
+++ b/internal/server/federation_events.go
@@ -71,7 +71,7 @@ func (l *hubEventLifecycle) Run(ctx context.Context) {
 		l.mu.Lock()
 		enabled := l.enabled
 		changed := l.changed
-		var runCtx context.Context
+		runCtx := ctx
 		if enabled {
 			var cancel context.CancelFunc
 			runCtx, cancel = context.WithCancel(ctx)

--- a/internal/server/federation_events.go
+++ b/internal/server/federation_events.go
@@ -18,18 +18,32 @@ import (
 const maxFederationCursorLength = 32
 
 type hubEventLifecycle struct {
-	mu           sync.Mutex
-	run          func(context.Context)
-	enabled      bool
-	changed      chan struct{}
-	activeCancel context.CancelFunc
+	mu                   sync.Mutex
+	run                  func(context.Context)
+	restartOnCleanReturn bool
+	enabled              bool
+	changed              chan struct{}
+	activeCancel         context.CancelFunc
 }
 
 func newHubEventLifecycle(
 	enabled bool, run func(context.Context),
 ) *hubEventLifecycle {
+	return newHubEventLifecycleWithRestart(enabled, run, true)
+}
+
+func newHubEventLifecycleStoppingOnCleanReturn(
+	enabled bool, run func(context.Context),
+) *hubEventLifecycle {
+	return newHubEventLifecycleWithRestart(enabled, run, false)
+}
+
+func newHubEventLifecycleWithRestart(
+	enabled bool, run func(context.Context), restartOnCleanReturn bool,
+) *hubEventLifecycle {
 	return &hubEventLifecycle{
-		run: run, enabled: enabled, changed: make(chan struct{}),
+		run: run, restartOnCleanReturn: restartOnCleanReturn,
+		enabled: enabled, changed: make(chan struct{}),
 	}
 }
 
@@ -74,9 +88,13 @@ func (l *hubEventLifecycle) Run(ctx context.Context) {
 			}
 		}
 		l.run(runCtx)
+		cleanReturn := runCtx.Err() == nil
 		l.mu.Lock()
 		l.activeCancel = nil
 		l.mu.Unlock()
+		if cleanReturn && !l.restartOnCleanReturn {
+			return
+		}
 	}
 }
 

--- a/internal/server/federation_events_test.go
+++ b/internal/server/federation_events_test.go
@@ -342,6 +342,17 @@ func TestHubEventLifecyclePausesUntilFleetIsEnabled(t *testing.T) {
 	}, time.Second, time.Millisecond)
 }
 
+func TestHubEventLifecycleCanStopAfterCleanReturn(t *testing.T) {
+	runs := 0
+	lifecycle := newHubEventLifecycleStoppingOnCleanReturn(true, func(context.Context) {
+		runs++
+	})
+
+	lifecycle.Run(t.Context())
+
+	assert.Equal(t, 1, runs)
+}
+
 func TestDisabledFederationSpokeSeedsDisconnectedStateForFreshSubscriber(t *testing.T) {
 	const hubID = "66666666666666666666666666666666"
 	require := require.New(t)

--- a/internal/server/federation_events_test.go
+++ b/internal/server/federation_events_test.go
@@ -204,7 +204,9 @@ func TestEnrollmentRevocationClosesExistingFederationEventStream(t *testing.T) {
 		HubCredential:   "hub-credential",
 	})
 	require.NoError(err)
-	require.NoError(enrollments.Activate(t.Context(), enrollmentID))
+	require.NoError(enrollments.Activate(
+		t.Context(), enrollmentID, time.Now().Add(time.Hour),
+	))
 
 	credentials, err := federationauth.Open(filepath.Join(dir, "credentials.json"))
 	require.NoError(err)

--- a/internal/server/fleetapi/fleet_enrollment.go
+++ b/internal/server/fleetapi/fleet_enrollment.go
@@ -497,6 +497,9 @@ func (h *Handler) activateEnrollment(
 		); err != nil {
 			return nil, httpapi.Internal("activate hub credential: " + err.Error())
 		}
+		enrollment.ActivationValidUntil = h.now().UTC().Add(
+			federation.SpokeActivationLeaseDuration,
+		)
 		return &activateEnrollmentOutput{Body: enrollment}, nil
 	}
 	if enrollment.State == federation.EnrollmentRevoked {
@@ -546,6 +549,9 @@ func (h *Handler) activateEnrollment(
 	if err != nil {
 		return nil, enrollmentProblem(err)
 	}
+	enrollment.ActivationValidUntil = h.now().UTC().Add(
+		federation.SpokeActivationLeaseDuration,
+	)
 	return &activateEnrollmentOutput{Body: enrollment}, nil
 }
 

--- a/internal/server/fleetapi/fleet_enrollment.go
+++ b/internal/server/fleetapi/fleet_enrollment.go
@@ -60,8 +60,9 @@ type localJoinOutput = httpapi.BodyOutput[federation.LocalEnrollment]
 type activateEnrollmentInput struct {
 	EnrollmentID string `path:"enrollment_id"`
 	Body         struct {
-		ProtocolVersion int    `json:"protocol_version"`
-		PreparationSeal string `json:"preparation_seal"`
+		ProtocolVersion        int    `json:"protocol_version"`
+		ActivationLeaseVersion int    `json:"activation_lease_version"`
+		PreparationSeal        string `json:"preparation_seal"`
 	}
 }
 
@@ -482,57 +483,53 @@ func (h *Handler) activateEnrollment(
 			federation.ProtocolVersion, input.Body.ProtocolVersion,
 		))
 	}
+	if input.Body.ActivationLeaseVersion != federation.ActivationLeaseVersion {
+		return nil, enrollmentProblem(fmt.Errorf(
+			"%w: activation lease expected %d, got %d",
+			federation.ErrProtocolMismatch,
+			federation.ActivationLeaseVersion,
+			input.Body.ActivationLeaseVersion,
+		))
+	}
 	enrollment, err := h.enrollments.Resume(ctx, input.EnrollmentID, principal.NodeID)
 	if err != nil {
 		return nil, enrollmentProblem(err)
 	}
-	if enrollment.State == federation.EnrollmentActive {
-		if err := h.credentials.UpdateInboundScopes(
-			enrollment.NodeID, federationauth.SpokeToHubScopes(),
-		); err != nil {
-			return nil, httpapi.Internal("activate spoke credential: " + err.Error())
-		}
-		if err := h.credentials.UpdateOutboundScopes(
-			enrollment.NodeID, federationauth.HubToSpokeScopes(),
-		); err != nil {
-			return nil, httpapi.Internal("activate hub credential: " + err.Error())
-		}
-		enrollment.ActivationValidUntil = h.now().UTC().Add(
-			federation.SpokeActivationLeaseDuration,
-		)
-		return &activateEnrollmentOutput{Body: enrollment}, nil
-	}
 	if enrollment.State == federation.EnrollmentRevoked {
 		return nil, enrollmentProblem(federation.ErrEnrollmentRevoked)
 	}
-	if enrollment.State != federation.EnrollmentPending {
+	if enrollment.State != federation.EnrollmentPending &&
+		enrollment.State != federation.EnrollmentActive {
 		return nil, enrollmentProblem(federation.ErrEnrollmentConflict)
 	}
-	if h.db == nil {
-		return nil, httpapi.ServiceUnavailable("spoke preparation seal store unavailable")
+	if enrollment.State == federation.EnrollmentPending {
+		if h.db == nil {
+			return nil, httpapi.ServiceUnavailable("spoke preparation seal store unavailable")
+		}
+		seal, err := h.db.GetSpokePreparationSeal(ctx, enrollment.ID)
+		if err != nil {
+			return nil, httpapi.Internal("read spoke preparation seal: " + err.Error())
+		}
+		presented := strings.TrimSpace(input.Body.PreparationSeal)
+		if seal == nil || presented == "" ||
+			seal.NodeID != principal.NodeID || seal.NodeID != enrollment.NodeID ||
+			seal.HubNodeID != h.nodeID ||
+			seal.ProtocolVersion != federation.ProtocolVersion ||
+			subtle.ConstantTimeCompare([]byte(seal.Seal), []byte(presented)) != 1 {
+			return nil, enrollmentProblem(federation.ErrPreparationRequired)
+		}
+		if h.persistMember == nil {
+			return nil, httpapi.ServiceUnavailable("fleet membership persistence unavailable")
+		}
+		if err := h.persistMember(ctx, config.FleetMember{
+			NodeID: enrollment.NodeID, Name: enrollment.SpokeName,
+			BaseURL: enrollment.SpokeBaseURL, State: federation.EnrollmentActive,
+		}); err != nil {
+			return nil, httpapi.Internal("persist active fleet member: " + err.Error())
+		}
 	}
-	seal, err := h.db.GetSpokePreparationSeal(ctx, enrollment.ID)
-	if err != nil {
-		return nil, httpapi.Internal("read spoke preparation seal: " + err.Error())
-	}
-	presented := strings.TrimSpace(input.Body.PreparationSeal)
-	if seal == nil || presented == "" ||
-		seal.NodeID != principal.NodeID || seal.NodeID != enrollment.NodeID ||
-		seal.HubNodeID != h.nodeID ||
-		seal.ProtocolVersion != federation.ProtocolVersion ||
-		subtle.ConstantTimeCompare([]byte(seal.Seal), []byte(presented)) != 1 {
-		return nil, enrollmentProblem(federation.ErrPreparationRequired)
-	}
-	if h.persistMember == nil {
-		return nil, httpapi.ServiceUnavailable("fleet membership persistence unavailable")
-	}
-	if err := h.persistMember(ctx, config.FleetMember{
-		NodeID: enrollment.NodeID, Name: enrollment.SpokeName,
-		BaseURL: enrollment.SpokeBaseURL, State: federation.EnrollmentActive,
-	}); err != nil {
-		return nil, httpapi.Internal("persist active fleet member: " + err.Error())
-	}
-	if err := h.enrollments.Activate(ctx, enrollment.ID); err != nil {
+	validUntil := h.now().UTC().Add(federation.SpokeActivationLeaseDuration)
+	if err := h.enrollments.Activate(ctx, enrollment.ID, validUntil); err != nil {
 		return nil, enrollmentProblem(err)
 	}
 	if err := h.credentials.UpdateInboundScopes(
@@ -549,9 +546,6 @@ func (h *Handler) activateEnrollment(
 	if err != nil {
 		return nil, enrollmentProblem(err)
 	}
-	enrollment.ActivationValidUntil = h.now().UTC().Add(
-		federation.SpokeActivationLeaseDuration,
-	)
 	return &activateEnrollmentOutput{Body: enrollment}, nil
 }
 

--- a/internal/server/fleetapi/fleet_enrollment_test.go
+++ b/internal/server/fleetapi/fleet_enrollment_test.go
@@ -544,12 +544,22 @@ func TestEnrollmentActivationRequiresPreparationAndIsIdempotent(t *testing.T) {
 	require.NoError(json.NewDecoder(active.Body).Decode(&enrollment))
 	active.Body.Close()
 	assert.Equal(federation.EnrollmentActive, enrollment.State)
+	assert.WithinDuration(
+		time.Now().Add(federation.SpokeActivationLeaseDuration),
+		enrollment.ActivationValidUntil, time.Second,
+	)
 	require.Len(persisted, 1)
 	assert.Equal(enrollmentNodeID, persisted[0].NodeID)
 
 	retried := activate()
-	assert.Equal(http.StatusOK, retried.StatusCode)
+	require.Equal(http.StatusOK, retried.StatusCode)
+	var retriedEnrollment federation.Enrollment
+	require.NoError(json.NewDecoder(retried.Body).Decode(&retriedEnrollment))
 	retried.Body.Close()
+	assert.WithinDuration(
+		time.Now().Add(federation.SpokeActivationLeaseDuration),
+		retriedEnrollment.ActivationValidUntil, time.Second,
+	)
 	assert.Len(persisted, 1, "an already-active retry does not persist membership twice")
 
 	replayedJoin := postEnrollmentRequest(

--- a/internal/server/fleetapi/fleet_enrollment_test.go
+++ b/internal/server/fleetapi/fleet_enrollment_test.go
@@ -516,12 +516,24 @@ func TestEnrollmentActivationRequiresPreparationAndIsIdempotent(t *testing.T) {
 			t, server.Client(), http.MethodPost,
 			server.URL+"/api/v1/federation/enrollments/"+enrollmentRequestID+"/activate",
 			map[string]any{
-				"protocol_version": federation.ProtocolVersion,
-				"preparation_seal": preparationSeal,
+				"protocol_version":         federation.ProtocolVersion,
+				"activation_lease_version": federation.ActivationLeaseVersion,
+				"preparation_seal":         preparationSeal,
 			},
 			joinResponse.SpokeCredential,
 		)
 	}
+	leaseUnaware := doEnrollmentJSON(
+		t, server.Client(), http.MethodPost,
+		server.URL+"/api/v1/federation/enrollments/"+enrollmentRequestID+"/activate",
+		map[string]any{
+			"protocol_version": federation.ProtocolVersion,
+			"preparation_seal": preparationSeal,
+		},
+		joinResponse.SpokeCredential,
+	)
+	assert.Equal(http.StatusUnprocessableEntity, leaseUnaware.StatusCode)
+	leaseUnaware.Body.Close()
 	blocked := activate()
 	assert.Equal(http.StatusConflict, blocked.StatusCode)
 	blocked.Body.Close()
@@ -544,10 +556,15 @@ func TestEnrollmentActivationRequiresPreparationAndIsIdempotent(t *testing.T) {
 	require.NoError(json.NewDecoder(active.Body).Decode(&enrollment))
 	active.Body.Close()
 	assert.Equal(federation.EnrollmentActive, enrollment.State)
+	assert.Equal(federation.ActivationLeaseVersion, enrollment.ActivationLeaseVersion)
 	assert.WithinDuration(
 		time.Now().Add(federation.SpokeActivationLeaseDuration),
 		enrollment.ActivationValidUntil, time.Second,
 	)
+	storedEnrollment, err := fixture.enrollments.Get(t.Context(), enrollmentRequestID)
+	require.NoError(err)
+	assert.Equal(federation.ActivationLeaseVersion, storedEnrollment.ActivationLeaseVersion)
+	assert.Equal(enrollment.ActivationValidUntil, storedEnrollment.ActivationValidUntil)
 	require.Len(persisted, 1)
 	assert.Equal(enrollmentNodeID, persisted[0].NodeID)
 
@@ -727,7 +744,9 @@ func TestEnrollmentRevocationRecoversAfterPartialHubCleanup(t *testing.T) {
 	var joinResponse federation.JoinResponse
 	require.NoError(json.NewDecoder(joined.Body).Decode(&joinResponse))
 	joined.Body.Close()
-	require.NoError(hub.enrollments.Activate(t.Context(), enrollmentRequestID))
+	require.NoError(hub.enrollments.Activate(
+		t.Context(), enrollmentRequestID, time.Now().Add(time.Hour),
+	))
 	require.NoError(hub.credentials.UpdateInboundScopes(
 		enrollmentNodeID, federationauth.SpokeToHubScopes(),
 	))

--- a/internal/server/fleetapi/fleet_hub.go
+++ b/internal/server/fleetapi/fleet_hub.go
@@ -3,6 +3,7 @@ package fleetapi
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,7 +17,10 @@ import (
 	"go.kenn.io/forge/internal/fleet"
 )
 
-const maxFederationSnapshotBytes = 32 << 20
+const (
+	maxFederationSnapshotBytes = 32 << 20
+	maxFederationProblemBytes  = 64 << 10
+)
 
 // buildFleetSnapshot projects one observer-relative view. Hubs build
 // the neutral aggregate from member raw snapshots; nodes consume that one
@@ -238,7 +242,7 @@ func (s *Handler) fetchFederationJSON(
 	}
 	defer response.Body.Close()
 	if response.StatusCode/100 != 2 {
-		return fmt.Errorf("peer returned HTTP %d", response.StatusCode)
+		return federationPeerResponseError(response)
 	}
 	body, err := io.ReadAll(io.LimitReader(
 		response.Body, maxFederationSnapshotBytes+1,
@@ -253,6 +257,43 @@ func (s *Handler) fetchFederationJSON(
 		return fmt.Errorf("decode federation snapshot: %w", err)
 	}
 	return nil
+}
+
+func federationPeerResponseError(response *http.Response) error {
+	body, err := io.ReadAll(io.LimitReader(
+		response.Body, maxFederationProblemBytes+1,
+	))
+	if err != nil || len(body) > maxFederationProblemBytes {
+		return fmt.Errorf("peer returned HTTP %d", response.StatusCode)
+	}
+	var problem struct {
+		Detail  string `json:"detail"`
+		Details struct {
+			Reason string `json:"reason"`
+		} `json:"details"`
+	}
+	if json.Unmarshal(body, &problem) != nil {
+		return fmt.Errorf("peer returned HTTP %d", response.StatusCode)
+	}
+	detail := strings.Join(strings.Fields(problem.Detail), " ")
+	switch problem.Details.Reason {
+	case "federationEnrollmentInactive":
+		return errors.New(
+			"peer fleet authorization is inactive; check its service startup logs and hub connectivity",
+		)
+	case "federationSubjectMismatch":
+		return errors.New("peer rejected the hub identity; check its fleet enrollment")
+	}
+	if detail == "" {
+		return fmt.Errorf("peer returned HTTP %d", response.StatusCode)
+	}
+	if problem.Details.Reason != "" {
+		return fmt.Errorf(
+			"peer returned HTTP %d: %s (%s)",
+			response.StatusCode, detail, problem.Details.Reason,
+		)
+	}
+	return fmt.Errorf("peer returned HTTP %d: %s", response.StatusCode, detail)
 }
 
 func neutralSnapshotContainsNode(

--- a/internal/server/fleetapi/fleet_hub_test.go
+++ b/internal/server/fleetapi/fleet_hub_test.go
@@ -63,6 +63,45 @@ func TestBuildFleetSnapshotMergesMemberAndDegrades(t *testing.T) {
 	assert.Equal(1, down, "want 1 unreachable (epyc)")
 }
 
+func TestBuildFleetSnapshotExplainsInactivePeerFederation(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	peer := httptest.NewTLSServer(http.HandlerFunc(func(
+		writer http.ResponseWriter, _ *http.Request,
+	) {
+		writer.Header().Set("Content-Type", "application/problem+json")
+		writer.WriteHeader(http.StatusForbidden)
+		_, _ = writer.Write([]byte(`{
+			"title":"Forbidden",
+			"status":403,
+			"detail":"federation credential is not attached to an authorized enrollment",
+			"code":"forbidden",
+			"details":{"reason":"federationEnrollmentInactive"}
+		}`))
+	}))
+	t.Cleanup(peer.Close)
+
+	server := New(Deps{DB: dbtest.Open(t)})
+	configureTestMembers(t, server, testTLSClient(t, peer), config.FleetMember{
+		NodeID: testMemberNodeID, Name: "member", BaseURL: peer.URL,
+	})
+
+	snapshot, err := server.buildFleetSnapshot(t.Context(), true)
+	require.NoError(err)
+	for _, host := range snapshot.Hosts {
+		if host.ConfigKey != testMemberNodeID {
+			continue
+		}
+		require.NotNil(host.Error)
+		assert.Equal(
+			"peer fleet authorization is inactive; check its service startup logs and hub connectivity",
+			*host.Error,
+		)
+		return
+	}
+	require.FailNow("member host missing from hub projection")
+}
+
 func TestBuildFleetSnapshotSkipsMembersWhenFederationDisabled(t *testing.T) {
 	peerRequests := 0
 	peer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/fleetapi/fleet_proxy.go
+++ b/internal/server/fleetapi/fleet_proxy.go
@@ -1006,6 +1006,8 @@ func (s *Handler) resolveEnrolledSpoke(
 ) (fleetHostTarget, bool) {
 	enrollment, ok := s.enrollments.EnrollmentForSpoke(member.NodeID)
 	if !ok || enrollment.State != federation.EnrollmentActive ||
+		enrollment.ActivationLeaseVersion != federation.ActivationLeaseVersion ||
+		!enrollment.ActivationValidUntil.After(s.now().UTC()) ||
 		enrollment.SpokeBaseURL != member.BaseURL {
 		return fleetHostTarget{}, false
 	}

--- a/internal/server/fleetapi/fleet_proxy.go
+++ b/internal/server/fleetapi/fleet_proxy.go
@@ -75,6 +75,34 @@ func (s *Handler) registerFleetOperationRoutes(api huma.API) {
 			},
 		},
 		{
+			operationID: "create-fleet-repo-workspace",
+			method:      http.MethodPost,
+			path:        "/fleet/hosts/{host_key}/repo/{provider}/{owner}/{name}/workspaces",
+			summary:     "Create repository workspace on fleet host",
+			pathParams:  []string{"host_key", "provider", "owner", "name"},
+			body:        true,
+			targetPath: func(r *http.Request) string {
+				return "/api/v1/repo/" +
+					escapePath(r.PathValue("provider")) + "/" +
+					escapePath(r.PathValue("owner")) + "/" +
+					escapePath(r.PathValue("name")) + "/workspaces"
+			},
+		},
+		{
+			operationID: "create-fleet-repo-workspace-on-platform-host",
+			method:      http.MethodPost,
+			path:        "/fleet/hosts/{host_key}/host/{platform_host}/repo/{provider}/{owner}/{name}/workspaces",
+			summary:     "Create repository workspace on fleet host",
+			pathParams:  []string{"host_key", "platform_host", "provider", "owner", "name"},
+			body:        true,
+			targetPath: func(r *http.Request) string {
+				return "/api/v1/host/" + escapePath(r.PathValue("platform_host")) +
+					"/repo/" + escapePath(r.PathValue("provider")) + "/" +
+					escapePath(r.PathValue("owner")) + "/" +
+					escapePath(r.PathValue("name")) + "/workspaces"
+			},
+		},
+		{
 			operationID: "create-fleet-issue-workspace",
 			method:      http.MethodPost,
 			path:        "/fleet/hosts/{host_key}/issues/{provider}/{owner}/{name}/{number}/workspace",

--- a/internal/server/fleetapi/fleet_proxy_test.go
+++ b/internal/server/fleetapi/fleet_proxy_test.go
@@ -35,6 +35,47 @@ func (b *closeTrackingBody) Close() error {
 	return nil
 }
 
+func TestFleetRepositoryWorkspaceCreateRoutesToOwningHost(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	type receivedRequest struct {
+		path string
+		body string
+		err  error
+	}
+	received := make(chan receivedRequest, 1)
+	peer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		received <- receivedRequest{path: r.URL.Path, body: string(body), err: err}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"id":"remote-workspace"}`))
+	}))
+	t.Cleanup(peer.Close)
+
+	srv, _ := setupTestServer(t)
+	configureTestMembers(t, srv, testTLSClient(t, peer), config.FleetMember{
+		NodeID: testMemberNodeID, BaseURL: peer.URL,
+	})
+	hub := httptest.NewServer(srv.localHandler())
+	t.Cleanup(hub.Close)
+
+	resp := httpDo(
+		t,
+		hub,
+		http.MethodPost,
+		"/api/v1/fleet/hosts/"+testMemberNodeID+"/repo/github/acme/widgets/workspaces",
+		[]byte(`{"branch":"fleet-ux"}`),
+	)
+	defer resp.Body.Close()
+	require.Equal(http.StatusAccepted, resp.StatusCode)
+
+	request := <-received
+	require.NoError(request.err)
+	assert.Equal("/api/v1/repo/github/acme/widgets/workspaces", request.path)
+	assert.JSONEq(`{"branch":"fleet-ux"}`, request.body)
+}
+
 func TestFleetWebSocketProxyNegotiatesContextTakeoverOnBothLegs(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/server/fleetapi/fleet_routes_test.go
+++ b/internal/server/fleetapi/fleet_routes_test.go
@@ -39,6 +39,8 @@ func TestSnapshotRoutesRegistered(t *testing.T) {
 		{http.MethodGet, "/snapshot"},
 		{http.MethodGet, "/snapshot/raw"},
 		{http.MethodPost, "/fleet/hosts/{host_key}/workspaces"},
+		{http.MethodPost, "/fleet/hosts/{host_key}/repo/{provider}/{owner}/{name}/workspaces"},
+		{http.MethodPost, "/fleet/hosts/{host_key}/host/{platform_host}/repo/{provider}/{owner}/{name}/workspaces"},
 		{http.MethodPost, "/fleet/hosts/{host_key}/issues/{provider}/{owner}/{name}/{number}/workspace"},
 		{http.MethodPost, "/fleet/hosts/{host_key}/host/{platform_host}/issues/{provider}/{owner}/{name}/{number}/workspace"},
 		{http.MethodPost, "/fleet/hosts/{host_key}/workspaces/{id}/runtime/sessions"},

--- a/internal/server/fleetapi/test_helpers_test.go
+++ b/internal/server/fleetapi/test_helpers_test.go
@@ -83,7 +83,9 @@ func configureTestMembers(
 			},
 		)
 		require.NoError(t, beginErr)
-		require.NoError(t, enrollments.Activate(t.Context(), enrollment.ID))
+		require.NoError(t, enrollments.Activate(
+			t.Context(), enrollment.ID, time.Now().Add(time.Hour),
+		))
 		tokens[member.NodeID] = token
 	}
 	h.nodeID = testHubNodeID

--- a/internal/server/provider_descriptors_test.go
+++ b/internal/server/provider_descriptors_test.go
@@ -284,6 +284,80 @@ func TestDiffDescriptorRoundTripSeedsNodeRepositoryCatalog(t *testing.T) {
 	assert.Nil(nodePull, "descriptors must not become a spoke-side provider item cache")
 }
 
+func TestRemoteAdHocWorkspaceCreationSeedsSpokeRepositoryCatalog(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	hubDB := dbtest.Open(t)
+	repoID, err := hubDB.UpsertRepo(t.Context(), db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-acme-widget", Owner: "acme", Name: "widget",
+	})
+	require.NoError(err)
+	require.NoError(hubDB.UpdateRepoProviderMetadata(
+		t.Context(), repoID, db.RepoProviderMetadata{
+			PlatformRepoID: "repo-acme-widget",
+			CloneURL:       "https://github.com/acme/widget.git",
+			DefaultBranch:  "main",
+		},
+	))
+
+	hubCredentials, err := federationauth.Open(
+		filepath.Join(t.TempDir(), "hub-credentials.json"),
+	)
+	require.NoError(err)
+	token, err := hubCredentials.MintInbound(
+		proxyTestNodeID, federationauth.SpokeToHubScopes(),
+	)
+	require.NoError(err)
+	hubServer := New(hubDB, nil, nil, "/", nil, ServerOptions{
+		DaemonAccess: DaemonAccessOptions{
+			Token: "hub-local-secret", RequireAPIAuth: true,
+		},
+		FederationSpokeID:                  proxyTestHubID,
+		FederationCredentials:              hubCredentials,
+		DisableWorkspaceBackgroundMonitors: true,
+	})
+	t.Cleanup(func() { gracefulShutdown(t, hubServer) })
+	hub := httptest.NewTLSServer(hubServer)
+	t.Cleanup(hub.Close)
+
+	spokeCredentials, err := federationauth.Open(
+		filepath.Join(t.TempDir(), "spoke-credentials.json"),
+	)
+	require.NoError(err)
+	require.NoError(spokeCredentials.StoreOutbound(
+		proxyTestHubID, token, federationauth.SpokeToHubScopes(),
+	))
+	spokeDB := dbtest.Open(t)
+	spokeConfig := &config.Config{Fleet: config.Fleet{
+		Enabled: true, Role: config.FleetRoleSpoke,
+		Hub: &config.FleetHub{NodeID: proxyTestHubID, BaseURL: hub.URL},
+	}}
+	spokeServer := New(spokeDB, nil, nil, "/", spokeConfig, ServerOptions{
+		FederationSpokeID:                  proxyTestNodeID,
+		FederationSpokeActive:              true,
+		FederationCredentials:              spokeCredentials,
+		FederationHTTPClient:               hub.Client(),
+		WorktreeDir:                        t.TempDir(),
+		DisableWorkspaceBackgroundMonitors: true,
+	})
+	t.Cleanup(func() { gracefulShutdown(t, spokeServer) })
+
+	response := doJSON(
+		t, spokeServer, http.MethodPost,
+		"/api/v1/host/github.com/repo/github/acme/widget/workspaces",
+		map[string]any{"branch": "work/remote-create"},
+	)
+	require.Equal(http.StatusAccepted, response.Code, response.Body.String())
+	observed, err := spokeDB.GetRepositoryByProviderID(
+		t.Context(), "github", "github.com", "repo-acme-widget",
+	)
+	require.NoError(err)
+	require.NotNil(observed)
+	assert.Equal("acme", observed.Repository.Owner)
+	assert.Equal("widget", observed.Repository.Name)
+}
+
 func TestRepositoryDescriptorOrdersObservationTimeWithRepositoryIdentity(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/provider_route_policy.go
+++ b/internal/server/provider_route_policy.go
@@ -54,6 +54,8 @@ var providerRouteDeclarations = []ProviderRouteRule{
 	{OperationID: "create-fleet-enrollment-token", Owner: NodeLocal},
 	{OperationID: "create-fleet-issue-workspace", Owner: NodeLocal},
 	{OperationID: "create-fleet-issue-workspace-on-platform-host", Owner: NodeLocal},
+	{OperationID: "create-fleet-repo-workspace", Owner: NodeLocal},
+	{OperationID: "create-fleet-repo-workspace-on-platform-host", Owner: NodeLocal},
 	{OperationID: "create-fleet-project-worktree", Owner: NodeLocal},
 	{OperationID: "create-fleet-project-worktree-from-merge-request", Owner: NodeLocal},
 	{OperationID: "create-fleet-workspace", Owner: NodeLocal},

--- a/internal/server/provider_sources.go
+++ b/internal/server/provider_sources.go
@@ -237,7 +237,7 @@ func (s *hubProviderSource) GetRepositoryDescriptor(
 	return descriptor, nil
 }
 
-func (s *hubProviderSource) ResolveProjectRepository(
+func (s *hubProviderSource) ResolveRepositoryRoute(
 	ctx context.Context, route providerplane.RepositoryRoute,
 ) (*db.Repo, error) {
 	descriptor, err := s.GetRepositoryDescriptor(ctx, route)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -881,7 +881,7 @@ func newServer(
 		}
 		if options.FederationSpokeActive &&
 			options.MaintainFederationSpokeActivation != nil {
-			s.spokeActivationLease = newHubEventLifecycle(
+			s.spokeActivationLease = newHubEventLifecycleStoppingOnCleanReturn(
 				cfg.Fleet.Enabled, options.MaintainFederationSpokeActivation,
 			)
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -73,6 +73,7 @@ type ServerOptions struct {
 	FederationSpokeID                  string
 	FederationSpokeActive              bool
 	FederationSpokeUnavailableReason   string
+	MaintainFederationSpokeActivation  func(context.Context)
 	FederationHTTPClient               *http.Client
 	ProviderWriteGate                  *providerplane.ProviderWriteGate
 	MCPURL                             string
@@ -239,6 +240,7 @@ type Server struct {
 	providerSource         *hubProviderSource
 	providerProxy          *providerProxy
 	hubEvents              *hubEventLifecycle
+	spokeActivationLease   *hubEventLifecycle
 	providerRouteSpoke     bool
 	providerWriteGate      *providerplane.ProviderWriteGate
 	// activityAfterItemsForTest pauses Activity between its two identity reads
@@ -755,6 +757,9 @@ func (s *Server) applyFleetConfigLocked() {
 	if s.hubEvents != nil {
 		s.hubEvents.SetEnabled(active.Fleet.Enabled)
 	}
+	if s.spokeActivationLease != nil {
+		s.spokeActivationLease.SetEnabled(active.Fleet.Enabled)
+	}
 }
 
 func (s *Server) activeFleetConfigSnapshotLocked() fleetapi.ConfigSnapshot {
@@ -873,6 +878,12 @@ func newServer(
 		s.providerRouteSpoke = true
 		s.providerSource = &hubProviderSource{
 			db: database, clones: clones, enabled: s.federationEnabled,
+		}
+		if options.FederationSpokeActive &&
+			options.MaintainFederationSpokeActivation != nil {
+			s.spokeActivationLease = newHubEventLifecycle(
+				cfg.Fleet.Enabled, options.MaintainFederationSpokeActivation,
+			)
 		}
 		if options.FederationSpokeActive && cfg.Fleet.Hub != nil {
 			client, err := providerplane.NewClient(providerplane.Options{
@@ -1126,14 +1137,14 @@ func newServer(
 	}
 	var providerWorkspaceAutomation workspaceapi.ProviderWorkspaceAutomation
 	var mergeRequestWorktreeSource workspaceapi.MergeRequestWorktreeSource
-	var resolveProjectRepository func(
+	var resolveRepository func(
 		context.Context, providerplane.RepositoryRoute,
 	) (*db.Repo, error)
 	if s.providerSource != nil {
 		providerWorkspaceAutomation = s.providerSource
 		mergeRequestWorktreeSource = s.providerSource
 		if s.providerSource.client != nil {
-			resolveProjectRepository = s.providerSource.ResolveProjectRepository
+			resolveRepository = s.providerSource.ResolveRepositoryRoute
 		}
 	}
 	s.workspaceAPI = workspaceapi.New(workspaceapi.Deps{
@@ -1159,7 +1170,7 @@ func newServer(
 		RefreshWorktreeStats:        s.fleetAPI.RefreshWorktreeStats,
 		RefreshProjectInventory:     s.fleetAPI.RefreshProjectInventory,
 		LookupRepo:                  repoResolver.LookupRoute,
-		ResolveProjectRepository:    resolveProjectRepository,
+		ResolveRepository:           resolveRepository,
 		EnqueueDetailSync:           s.enqueueDetailSyncWithCompletion,
 		ProviderWriteGate:           s.providerWriteGate,
 		LaunchSpecResolver:          launchSpecResolver,
@@ -1298,6 +1309,9 @@ func newServer(
 	)
 	if s.hubEvents != nil {
 		s.runWorkspaceDependent(s.hubEvents.Run)
+	}
+	if s.spokeActivationLease != nil {
+		s.runWorkspaceDependent(s.spokeActivationLease.Run)
 	}
 	if clones != nil {
 		// Seed even when background refresh is disabled: startup also adopts

--- a/internal/server/workspaceapi/handler.go
+++ b/internal/server/workspaceapi/handler.go
@@ -90,11 +90,11 @@ type Deps struct {
 	Subscribe          func(context.Context, bool) (<-chan RecordedEvent, <-chan struct{})
 	Generation         func() uint64
 
-	RecomputeWorktreeLinks   func(context.Context)
-	RefreshWorktreeStats     func(context.Context, string, string) error
-	RefreshProjectInventory  func(context.Context, string) error
-	LookupRepo               func(context.Context, string, string, string, string) (*db.Repo, error)
-	ResolveProjectRepository func(
+	RecomputeWorktreeLinks  func(context.Context)
+	RefreshWorktreeStats    func(context.Context, string, string) error
+	RefreshProjectInventory func(context.Context, string) error
+	LookupRepo              func(context.Context, string, string, string, string) (*db.Repo, error)
+	ResolveRepository       func(
 		context.Context, providerplane.RepositoryRoute,
 	) (*db.Repo, error)
 	EnqueueDetailSync func(
@@ -129,7 +129,7 @@ type Handler struct {
 	refreshWorktreeStats           func(context.Context, string, string) error
 	refreshProjectInventory        func(context.Context, string) error
 	lookupRepo                     func(context.Context, string, string, string, string) (*db.Repo, error)
-	resolveProjectRepository       func(context.Context, providerplane.RepositoryRoute) (*db.Repo, error)
+	resolveRepository              func(context.Context, providerplane.RepositoryRoute) (*db.Repo, error)
 	enqueueDetailSync              func(string, []any, func(context.Context) error, func(context.Context)) bool
 	providerWriteGate              providerplane.WriteAdmitter
 	launchSpecResolver             providerplane.WorkspaceLaunchSpecResolver
@@ -204,7 +204,7 @@ func New(deps Deps) *Handler {
 		refreshWorktreeStats:           deps.RefreshWorktreeStats,
 		refreshProjectInventory:        deps.RefreshProjectInventory,
 		lookupRepo:                     deps.LookupRepo,
-		resolveProjectRepository:       deps.ResolveProjectRepository,
+		resolveRepository:              deps.ResolveRepository,
 		enqueueDetailSync:              deps.EnqueueDetailSync,
 		providerWriteGate:              deps.ProviderWriteGate,
 		launchSpecResolver:             deps.LaunchSpecResolver,

--- a/internal/server/workspaceapi/projects_handlers.go
+++ b/internal/server/workspaceapi/projects_handlers.go
@@ -381,8 +381,8 @@ func (s *Handler) registerProjectAtPath(
 	var repoID sql.NullInt64
 	if identity != nil {
 		var id int64
-		if s.resolveProjectRepository != nil {
-			repository, resolveErr := s.resolveProjectRepository(ctx, providerplane.RepositoryRoute{
+		if s.resolveRepository != nil {
+			repository, resolveErr := s.resolveRepository(ctx, providerplane.RepositoryRoute{
 				Provider: identity.Platform, PlatformHost: identity.Host,
 				Owner: identity.Owner, Name: identity.Name,
 			})

--- a/internal/server/workspaceapi/projects_handlers_test.go
+++ b/internal/server/workspaceapi/projects_handlers_test.go
@@ -36,7 +36,7 @@ func TestRegisterProjectUsesHubRepositoryIdentity(t *testing.T) {
 	observedAt := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
 	handler := New(Deps{
 		DB: database,
-		ResolveProjectRepository: func(
+		ResolveRepository: func(
 			ctx context.Context, route providerplane.RepositoryRoute,
 		) (*db.Repo, error) {
 			entry, _, err := database.ReconcileRepositoryObservation(ctx, db.RepoIdentity{

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -819,6 +819,14 @@ func (s *Handler) createAdHocWorkspace(
 func (s *Handler) CreateAdHocWorkspaceService(
 	ctx context.Context, req CreateAdHocWorkspaceRequest,
 ) (WorkspaceResult, error) {
+	if s.resolveRepository != nil {
+		if _, err := s.resolveRepository(ctx, providerplane.RepositoryRoute{
+			Provider: req.Provider, PlatformHost: req.PlatformHost,
+			Owner: req.Owner, Name: req.Name,
+		}); err != nil {
+			return WorkspaceResult{}, err
+		}
+	}
 	input := &createAdHocWorkspaceInput{
 		Provider: req.Provider, PlatformHost: req.PlatformHost,
 		Owner: req.Owner, Name: req.Name,

--- a/internal/server/workspaceapi/services_test.go
+++ b/internal/server/workspaceapi/services_test.go
@@ -11,6 +11,7 @@ import (
 	"go.kenn.io/forge/internal/db"
 	ghclient "go.kenn.io/forge/internal/github"
 	"go.kenn.io/forge/internal/platform"
+	"go.kenn.io/forge/internal/providerplane"
 	"go.kenn.io/forge/internal/server/httpapi"
 	"go.kenn.io/forge/internal/testutil/dbtest"
 	"go.kenn.io/forge/internal/workspace"
@@ -19,6 +20,64 @@ import (
 
 type recordingWorkspaceAutomation struct {
 	requests []ProviderWorkspaceItemRequest
+}
+
+func TestCreateAdHocWorkspaceResolvesMissingRepositoryBeforeLocalCreate(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	manager := workspace.NewManager(database, t.TempDir())
+	resolved := false
+	handler := New(Deps{
+		DB: database,
+		Resolver: httpapi.NewRepositoryResolver(httpapi.RepositoryResolverDeps{
+			DB: database,
+		}),
+		Workspaces: manager,
+		ResolveRepository: func(
+			ctx context.Context, route providerplane.RepositoryRoute,
+		) (*db.Repo, error) {
+			resolved = true
+			assert.Equal(providerplane.RepositoryRoute{
+				Provider: "github", PlatformHost: "github.com",
+				Owner: "acme", Name: "widget",
+			}, route)
+			entry, _, err := database.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+				Platform: route.Provider, PlatformHost: route.PlatformHost,
+				PlatformRepoID: "stable-provider-id",
+				Owner:          route.Owner, Name: route.Name,
+			}, time.Now().UTC())
+			if err != nil {
+				return nil, err
+			}
+			return &entry.Repository, nil
+		},
+		EnrichmentDisabled: true,
+	})
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(handler.Shutdown(ctx))
+	})
+	branch := "work/remote-create"
+
+	result, err := handler.CreateAdHocWorkspaceService(
+		t.Context(), CreateAdHocWorkspaceRequest{
+			Provider: "github", PlatformHost: "github.com",
+			Owner: "acme", Name: "widget", Branch: &branch,
+		},
+	)
+
+	require.NoError(err)
+	assert.True(resolved)
+	assert.NotEmpty(result.Workspace.ID)
+	entry, err := database.GetRepositoryByProviderID(
+		t.Context(), "github", "github.com", "stable-provider-id",
+	)
+	require.NoError(err)
+	require.NotNil(entry)
+	assert.Equal("acme", entry.Repository.Owner)
+	assert.Equal("widget", entry.Repository.Name)
 }
 
 func (a *recordingWorkspaceAutomation) AutoAssignWorkspaceItem(

--- a/internal/testutil/federationtest/enrollment.go
+++ b/internal/testutil/federationtest/enrollment.go
@@ -59,6 +59,9 @@ func SeedActiveSpokeEnrollment(
 		ProtocolVersion: federation.ProtocolVersion,
 		State:           federation.EnrollmentActive,
 		ExpiresAt:       enrollment.ExpiresAt,
+		ActivationValidUntil: time.Now().UTC().Add(
+			federation.SpokeActivationLeaseDuration,
+		),
 	}); err != nil {
 		return fmt.Errorf("save active spoke enrollment: %w", err)
 	}

--- a/internal/testutil/federationtest/enrollment.go
+++ b/internal/testutil/federationtest/enrollment.go
@@ -34,10 +34,13 @@ func SeedActiveHubEnrollment(
 	if err != nil {
 		return federation.Enrollment{}, fmt.Errorf("begin enrollment: %w", err)
 	}
-	if err := store.Activate(ctx, enrollment.ID); err != nil {
+	activationValidUntil := time.Now().UTC().Add(federation.SpokeActivationLeaseDuration)
+	if err := store.Activate(ctx, enrollment.ID, activationValidUntil); err != nil {
 		return federation.Enrollment{}, fmt.Errorf("activate enrollment: %w", err)
 	}
 	enrollment.State = federation.EnrollmentActive
+	enrollment.ActivationLeaseVersion = federation.ActivationLeaseVersion
+	enrollment.ActivationValidUntil = activationValidUntil
 	return enrollment, nil
 }
 
@@ -48,17 +51,18 @@ func SeedActiveSpokeEnrollment(
 	enrollment federation.Enrollment,
 ) error {
 	if err := store.SaveLocal(ctx, federation.LocalEnrollment{
-		EnrollmentID:    enrollment.ID,
-		NodeID:          enrollment.NodeID,
-		SpokeName:       enrollment.SpokeName,
-		SpokePlatform:   enrollment.SpokePlatform,
-		SpokeBaseURL:    enrollment.SpokeBaseURL,
-		HubID:           enrollment.HubID,
-		HubName:         enrollment.HubName,
-		HubURL:          enrollment.HubURL,
-		ProtocolVersion: federation.ProtocolVersion,
-		State:           federation.EnrollmentActive,
-		ExpiresAt:       enrollment.ExpiresAt,
+		EnrollmentID:           enrollment.ID,
+		NodeID:                 enrollment.NodeID,
+		SpokeName:              enrollment.SpokeName,
+		SpokePlatform:          enrollment.SpokePlatform,
+		SpokeBaseURL:           enrollment.SpokeBaseURL,
+		HubID:                  enrollment.HubID,
+		HubName:                enrollment.HubName,
+		HubURL:                 enrollment.HubURL,
+		ProtocolVersion:        federation.ProtocolVersion,
+		State:                  federation.EnrollmentActive,
+		ExpiresAt:              enrollment.ExpiresAt,
+		ActivationLeaseVersion: federation.ActivationLeaseVersion,
 		ActivationValidUntil: time.Now().UTC().Add(
 			federation.SpokeActivationLeaseDuration,
 		),

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: ${ROBOREV_SRC:?Set ROBOREV_SRC}
       dockerfile: ${COMPOSE_DIR:?Set COMPOSE_DIR}/roborev/Dockerfile
+      additional_contexts:
+        forge: ${COMPOSE_DIR}/../..
       args:
         ROBOREV_REF: ${ROBOREV_REF:-main}
     ports:

--- a/tests/integration/roborev/Dockerfile
+++ b/tests/integration/roborev/Dockerfile
@@ -6,8 +6,15 @@ RUN git checkout ${ROBOREV_REF} && \
     go build -o /roborev ./cmd/roborev/
 
 FROM debian:bookworm-slim
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl git socat && \
+RUN apt-get \
+      -o Acquire::Retries=5 \
+      -o Acquire::http::Timeout=10 \
+      -o APT::Update::Error-Mode=any \
+      update && \
+    apt-get \
+      -o Acquire::Retries=5 \
+      -o Acquire::http::Timeout=10 \
+      install -y --no-install-recommends curl git socat && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=builder /roborev /usr/local/bin/roborev
 RUN mkdir -p /data

--- a/tests/integration/roborev/Dockerfile
+++ b/tests/integration/roborev/Dockerfile
@@ -6,12 +6,12 @@ RUN git checkout ${ROBOREV_REF} && \
     go build -o /roborev ./cmd/roborev/
 
 FROM debian:bookworm-slim
-RUN apt-get \
+RUN timeout --signal=TERM --kill-after=5s 2m apt-get \
       -o Acquire::Retries=5 \
       -o Acquire::http::Timeout=10 \
       -o APT::Update::Error-Mode=any \
       update && \
-    apt-get \
+    timeout --signal=TERM --kill-after=5s 2m apt-get \
       -o Acquire::Retries=5 \
       -o Acquire::http::Timeout=10 \
       install -y --no-install-recommends curl git socat && \

--- a/tests/integration/roborev/Dockerfile
+++ b/tests/integration/roborev/Dockerfile
@@ -4,27 +4,21 @@ COPY . /src
 WORKDIR /src
 RUN git checkout ${ROBOREV_REF} && \
     go build -o /roborev ./cmd/roborev/
+COPY --from=forge tests/integration/roborev/tcp-forward.go /tcp-forward.go
+RUN go build -o /tcp-forward /tcp-forward.go
 
-FROM debian:bookworm-slim
-RUN timeout --signal=TERM --kill-after=5s 2m apt-get \
-      -o Acquire::Retries=5 \
-      -o Acquire::http::Timeout=10 \
-      -o APT::Update::Error-Mode=any \
-      update && \
-    timeout --signal=TERM --kill-after=5s 2m apt-get \
-      -o Acquire::Retries=5 \
-      -o Acquire::http::Timeout=10 \
-      install -y --no-install-recommends curl git socat && \
-    rm -rf /var/lib/apt/lists/*
+FROM golang:1.27.0
+RUN command -v git && command -v curl
 COPY --from=builder /roborev /usr/local/bin/roborev
+COPY --from=builder /tcp-forward /usr/local/bin/tcp-forward
 RUN mkdir -p /data
 ENV ROBOREV_DATA_DIR=/data
 
 # The daemon enforces loopback-only bind addresses.
 # Docker port mapping requires 0.0.0.0 inside the container.
-# Workaround: bind daemon to 127.0.0.1:7374 and use socat
+# Workaround: bind daemon to 127.0.0.1:7374 and use a small Go proxy
 # to relay 0.0.0.0:7373 -> 127.0.0.1:7374.
 EXPOSE 7373
 ENTRYPOINT ["/bin/sh", "-c", "\
-  socat TCP-LISTEN:7373,fork,reuseaddr,bind=0.0.0.0 TCP:127.0.0.1:7374 & \
+  tcp-forward & \
   exec roborev \"$@\"" , "--"]

--- a/tests/integration/roborev/tcp-forward.go
+++ b/tests/integration/roborev/tcp-forward.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"io"
+	"log"
+	"net"
+)
+
+func main() {
+	listener, err := net.Listen("tcp", "0.0.0.0:7373")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for {
+		client, err := listener.Accept()
+		if err != nil {
+			log.Printf("accept connection: %v", err)
+			continue
+		}
+		go forward(client)
+	}
+}
+
+func forward(client net.Conn) {
+	defer client.Close()
+
+	server, err := net.Dial("tcp", "127.0.0.1:7374")
+	if err != nil {
+		log.Printf("connect to Roborev: %v", err)
+		return
+	}
+	defer server.Close()
+
+	done := make(chan struct{}, 2)
+	go copyConnection(server, client, done)
+	go copyConnection(client, server, done)
+	<-done
+}
+
+func copyConnection(dst, src net.Conn, done chan<- struct{}) {
+	_, _ = io.Copy(dst, src)
+	if tcp, ok := dst.(*net.TCPConn); ok {
+		_ = tcp.CloseWrite()
+	}
+	done <- struct{}{}
+}


### PR DESCRIPTION
Forge fleets now make workspace ownership visible and let hub users place new repository work on the right machine. Previously, remote workspaces appeared in the aggregate list without a clear owner, and repository creation always targeted the UI's local node.

The hub now shows an execution-node badge and a **Run on** selector with unavailable-node reasons. A spoke keeps the simpler local-only flow. Pull-request and issue workspace actions also remain local to the Forge UI that was opened, because those shortcuts represent “work here”; explicit cross-node placement belongs in the workspace dialog.

Remote creation resolves the hub's stable repository descriptor into the selected spoke before its normal local create. This covers repositories that the hub knows about but the spoke has not yet discovered.

Federation startup now balances outage tolerance with revocation:

- both peers persist and enforce a versioned 24-hour activation lease, renewed by the spoke every six hours;
- a transient hub outage may use an unexpired cached lease, with one-minute renewal backoff;
- a stale renewal response cannot reactivate a revoked enrollment, and definitive rejection removes broad credential grants and stops renewal until restart;
- the lease handshake is versioned separately from fleet snapshots, so a rolling upgrade is hub first, then spoke restart, without re-enrollment.

Lease-unaware or expired peers can reach only the narrow activation/revocation recovery routes, not normal fleet reads, writes, workspace operations, or terminal attachment.

The Zensical guide is promoted to first-level navigation and explains the topology, ownership model, setup sequence, placement behavior, activation lease, rolling upgrades, and troubleshooting flow with accessible SVG diagrams. No database migration is required; lease metadata is additive in the existing enrollment document.

Verification includes `make lint-check`, generated API and context checks, 3,657 frontend unit tests, 18 rendered documentation browser checks, focused race-enabled startup/auth/routing tests, and an integration test that creates a workspace from an initially empty spoke repository catalog. The formerly failing shuffled `TestGitHubAppSplitAuthE2E` seed passes locally and the replacement GitHub race job passed; that earlier CI failure did not report a data race.
