### PR TITLE
feat: draw agent launch targets with harness glyphs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
         "@codemirror/view": "^6.43.0",
         "@effect/platform-browser": "4.0.0-beta.107",
         "@kenn-io/kata-ui": "github:kenn-io/kata#v0.14.3",
-        "@kenn-io/kit-ui": "github:kenn-io/kit-ui#b2c456a1213300af359befce4b271f48819376a1",
+        "@kenn-io/kit-ui": "github:kenn-io/kit-ui#8579c0c00eae233d8cd879a06f9effa9238321c8",
         "@lucide/svelte": "1.31.0",
         "@pierre/diffs": "1.3.5",
         "@pierre/trees": "1.0.0-beta.6",
@@ -228,7 +228,7 @@
 
     "@kenn-io/kata-ui": ["kata@github:kenn-io/kata#c668572", {}, "kenn-io-kata-c668572", "sha512-WiP4SeduGPD2HdCXRFflDNHv2EEOuoxIbSkVMxmwsT/6liW4kBwUI43oUMssdj8jygEsAlxkv7/u8VLPYZQQEQ=="],
 
-    "@kenn-io/kit-ui": ["@kenn-io/kit-ui@github:kenn-io/kit-ui#b2c456a", { "peerDependencies": { "@lucide/svelte": ">=1.0.0", "dompurify": "^3.2.0", "marked": "^18.0.0", "mermaid": ">=11.15.0 <12", "shiki": "^4.0.0", "svelte": "^5.29.0" }, "optionalPeers": ["mermaid"], "bin": { "kit-ui-check": "./bin/kit-ui-check.mjs" } }, "kenn-io-kit-ui-b2c456a", "sha512-aAx18nsPkqhwTfDpva3CyqkXmvGUUQbzfA5rNm6FxWz+jIDKFCHWioN010M8DF7AeIlzIzh9leJORJ8mE9XZZw=="],
+    "@kenn-io/kit-ui": ["@kenn-io/kit-ui@github:kenn-io/kit-ui#8579c0c", { "peerDependencies": { "@lucide/svelte": ">=1.0.0", "dompurify": "^3.2.0", "marked": "^18.0.0", "mermaid": ">=11.15.0 <12", "shiki": "^4.0.0", "svelte": "^5.29.0" }, "optionalPeers": ["mermaid"], "bin": { "kit-ui-check": "./bin/kit-ui-check.mjs" } }, "kenn-io-kit-ui-8579c0c", "sha512-8peFbyXvTx/0x99zIGY2wLj9uZWiuWkGn4dtNX0hQ9l+kVTRoEJW756UNAUoieY03gPlksRzpyQGQMlJ2lCHsA=="],
 
     "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
         "@codemirror/view": "^6.43.0",
         "@effect/platform-browser": "4.0.0-beta.107",
         "@kenn-io/kata-ui": "github:kenn-io/kata#v0.14.3",
-        "@kenn-io/kit-ui": "github:kenn-io/kit-ui#8579c0c00eae233d8cd879a06f9effa9238321c8",
+        "@kenn-io/kit-ui": "github:kenn-io/kit-ui#f5f200a4a96ac153c19d553e57154484804d0d9f",
         "@lucide/svelte": "1.31.0",
         "@pierre/diffs": "1.3.5",
         "@pierre/trees": "1.0.0-beta.6",
@@ -228,7 +228,7 @@
 
     "@kenn-io/kata-ui": ["kata@github:kenn-io/kata#c668572", {}, "kenn-io-kata-c668572", "sha512-WiP4SeduGPD2HdCXRFflDNHv2EEOuoxIbSkVMxmwsT/6liW4kBwUI43oUMssdj8jygEsAlxkv7/u8VLPYZQQEQ=="],
 
-    "@kenn-io/kit-ui": ["@kenn-io/kit-ui@github:kenn-io/kit-ui#8579c0c", { "peerDependencies": { "@lucide/svelte": ">=1.0.0", "dompurify": "^3.2.0", "marked": "^18.0.0", "mermaid": ">=11.15.0 <12", "shiki": "^4.0.0", "svelte": "^5.29.0" }, "optionalPeers": ["mermaid"], "bin": { "kit-ui-check": "./bin/kit-ui-check.mjs" } }, "kenn-io-kit-ui-8579c0c", "sha512-8peFbyXvTx/0x99zIGY2wLj9uZWiuWkGn4dtNX0hQ9l+kVTRoEJW756UNAUoieY03gPlksRzpyQGQMlJ2lCHsA=="],
+    "@kenn-io/kit-ui": ["@kenn-io/kit-ui@github:kenn-io/kit-ui#f5f200a", { "peerDependencies": { "@lucide/svelte": ">=1.0.0", "dompurify": "^3.2.0", "marked": "^18.0.0", "mermaid": ">=11.15.0 <12", "shiki": "^4.0.0", "svelte": "^5.29.0" }, "optionalPeers": ["mermaid"], "bin": { "kit-ui-check": "./bin/kit-ui-check.mjs" } }, "kenn-io-kit-ui-f5f200a", "sha512-TEXRjQsISZjZ17JzTWrAhXEZVwMzCSskS51x1LGn0XnVN1ixWdn36YSt9Ga8sXlaIuz6kkwFY8TUHUaOllWC0w=="],
 
     "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
         "@codemirror/view": "^6.43.0",
         "@effect/platform-browser": "4.0.0-beta.107",
         "@kenn-io/kata-ui": "github:kenn-io/kata#v0.14.3",
-        "@kenn-io/kit-ui": "github:kenn-io/kit-ui#f5f200a4a96ac153c19d553e57154484804d0d9f",
+        "@kenn-io/kit-ui": "github:kenn-io/kit-ui#5d93a31b3354d59cf505de4f3676f89278f73849",
         "@lucide/svelte": "1.31.0",
         "@pierre/diffs": "1.3.5",
         "@pierre/trees": "1.0.0-beta.6",
@@ -228,7 +228,7 @@
 
     "@kenn-io/kata-ui": ["kata@github:kenn-io/kata#c668572", {}, "kenn-io-kata-c668572", "sha512-WiP4SeduGPD2HdCXRFflDNHv2EEOuoxIbSkVMxmwsT/6liW4kBwUI43oUMssdj8jygEsAlxkv7/u8VLPYZQQEQ=="],
 
-    "@kenn-io/kit-ui": ["@kenn-io/kit-ui@github:kenn-io/kit-ui#f5f200a", { "peerDependencies": { "@lucide/svelte": ">=1.0.0", "dompurify": "^3.2.0", "marked": "^18.0.0", "mermaid": ">=11.15.0 <12", "shiki": "^4.0.0", "svelte": "^5.29.0" }, "optionalPeers": ["mermaid"], "bin": { "kit-ui-check": "./bin/kit-ui-check.mjs" } }, "kenn-io-kit-ui-f5f200a", "sha512-TEXRjQsISZjZ17JzTWrAhXEZVwMzCSskS51x1LGn0XnVN1ixWdn36YSt9Ga8sXlaIuz6kkwFY8TUHUaOllWC0w=="],
+    "@kenn-io/kit-ui": ["@kenn-io/kit-ui@github:kenn-io/kit-ui#5d93a31", { "peerDependencies": { "@lucide/svelte": ">=1.0.0", "dompurify": "^3.2.0", "marked": "^18.0.0", "mermaid": ">=11.15.0 <12", "shiki": "^4.0.0", "svelte": "^5.29.0" }, "optionalPeers": ["mermaid"], "bin": { "kit-ui-check": "./bin/kit-ui-check.mjs" } }, "kenn-io-kit-ui-5d93a31", "sha512-JbqfHbkKDRJl+FNWO3aGSkOHjJmWNuLCaq4WUBr1G1gzwmfTTt0sf+g/lIexLBRsNaE/kqMVTecF7se5bKMfFw=="],
 
     "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
 

--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -79,6 +79,10 @@ otherwise fails only in the Vitest/Playwright transform tier, not in
 - Chip: icons go in `children` (kit centers them), dropdown chevrons in
   `trailing`; no downstream `.kit-chip__label` overrides — repo chips
   depend on its ellipsis.
+- Agent launch targets draw kit `HarnessMark` wordmarks via `LaunchTargetName`
+  (key → harness by shared leading segments; `frontend/src/lib/components/terminal/agentHarness.ts::harnessForAgentKey`).
+  Marks are wide wordmarks, so they replace icon and label together; the label
+  stays as `kit-sr-only` for the accessible name unless it adds information.
 - Theme resolution: kit's theme store owns dark/light/system resolution
   and persistence (`kenn-forge-theme` key); `theme.svelte.ts` adapts it. A
   host-forced mode applies classes directly and never persists via

--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -79,10 +79,11 @@ otherwise fails only in the Vitest/Playwright transform tier, not in
 - Chip: icons go in `children` (kit centers them), dropdown chevrons in
   `trailing`; no downstream `.kit-chip__label` overrides — repo chips
   depend on its ellipsis.
-- Agent launch targets draw kit `HarnessMark` wordmarks via `LaunchTargetName`
-  (key → harness by shared leading segments; `frontend/src/lib/components/terminal/agentHarness.ts::harnessForAgentKey`).
-  Marks are wide wordmarks, so they replace icon and label together; the label
-  stays as `kit-sr-only` for the accessible name unless it adds information.
+- Agent launch targets draw their icon as a kit `HarnessIcon` via `LaunchTargetName`
+  (key → glyph by shared leading segments of the glyph id or its agent product
+  names, then a bare prefix of at least four characters;
+  `frontend/src/lib/components/terminal/agentHarness.ts::harnessForAgentKey`).
+  The glyph only replaces the generic kind icon; the target's own label always stays.
 - Theme resolution: kit's theme store owns dark/light/system resolution
   and persistence (`kenn-forge-theme` key); `theme.svelte.ts` adapts it. A
   host-forced mode applies classes directly and never persists via

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "@codemirror/view": "^6.43.0",
     "@effect/platform-browser": "4.0.0-beta.107",
     "@kenn-io/kata-ui": "github:kenn-io/kata#v0.14.3",
-    "@kenn-io/kit-ui": "github:kenn-io/kit-ui#b2c456a1213300af359befce4b271f48819376a1",
+    "@kenn-io/kit-ui": "github:kenn-io/kit-ui#8579c0c00eae233d8cd879a06f9effa9238321c8",
     "@lucide/svelte": "1.31.0",
     "@pierre/diffs": "1.3.5",
     "@pierre/trees": "1.0.0-beta.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "@codemirror/view": "^6.43.0",
     "@effect/platform-browser": "4.0.0-beta.107",
     "@kenn-io/kata-ui": "github:kenn-io/kata#v0.14.3",
-    "@kenn-io/kit-ui": "github:kenn-io/kit-ui#f5f200a4a96ac153c19d553e57154484804d0d9f",
+    "@kenn-io/kit-ui": "github:kenn-io/kit-ui#5d93a31b3354d59cf505de4f3676f89278f73849",
     "@lucide/svelte": "1.31.0",
     "@pierre/diffs": "1.3.5",
     "@pierre/trees": "1.0.0-beta.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "@codemirror/view": "^6.43.0",
     "@effect/platform-browser": "4.0.0-beta.107",
     "@kenn-io/kata-ui": "github:kenn-io/kata#v0.14.3",
-    "@kenn-io/kit-ui": "github:kenn-io/kit-ui#8579c0c00eae233d8cd879a06f9effa9238321c8",
+    "@kenn-io/kit-ui": "github:kenn-io/kit-ui#f5f200a4a96ac153c19d553e57154484804d0d9f",
     "@lucide/svelte": "1.31.0",
     "@pierre/diffs": "1.3.5",
     "@pierre/trees": "1.0.0-beta.6",

--- a/frontend/src/lib/components/mobile/MobileWorkspaceTerminal.svelte
+++ b/frontend/src/lib/components/mobile/MobileWorkspaceTerminal.svelte
@@ -939,7 +939,7 @@
       <div class="mobile-terminal-sheet__targets">
         {#each launchTargets as target (target.key)}
           <button type="button" disabled={!target.available || launchingTarget !== null || pendingLaunch !== null} title={target.disabled_reason} onclick={() => launch(target.key)}>
-            <span><strong><LaunchTargetName {target} label={target.kind === "plain_shell" ? "Shell" : target.label} markSize={16} /></strong><small>{target.available ? target.source : target.disabled_reason}</small></span>
+            <span><strong><LaunchTargetName {target} label={target.kind === "plain_shell" ? "Shell" : target.label} iconSize={16} /></strong><small>{target.available ? target.source : target.disabled_reason}</small></span>
             {#if launchingTarget === target.key}<Spinner size={16} />{:else}<PlusIcon size="18" aria-hidden="true" />{/if}
           </button>
         {/each}

--- a/frontend/src/lib/components/mobile/MobileWorkspaceTerminal.svelte
+++ b/frontend/src/lib/components/mobile/MobileWorkspaceTerminal.svelte
@@ -41,6 +41,7 @@
     sessionHostKey,
     type SessionHostKey,
   } from "../../stores/session-host.svelte.js";
+  import LaunchTargetName from "../terminal/LaunchTargetName.svelte";
   import SessionTerminalSlot from "../terminal/SessionTerminalSlot.svelte";
   import TerminalSettings from "../settings/TerminalSettings.svelte";
   import ConfirmDialog from "../shared/ConfirmDialog.svelte";
@@ -938,7 +939,7 @@
       <div class="mobile-terminal-sheet__targets">
         {#each launchTargets as target (target.key)}
           <button type="button" disabled={!target.available || launchingTarget !== null || pendingLaunch !== null} title={target.disabled_reason} onclick={() => launch(target.key)}>
-            <span><strong>{target.kind === "plain_shell" ? "Shell" : target.label}</strong><small>{target.available ? target.source : target.disabled_reason}</small></span>
+            <span><strong><LaunchTargetName {target} label={target.kind === "plain_shell" ? "Shell" : target.label} markSize={16} /></strong><small>{target.available ? target.source : target.disabled_reason}</small></span>
             {#if launchingTarget === target.key}<Spinner size={16} />{:else}<PlusIcon size="18" aria-hidden="true" />{/if}
           </button>
         {/each}

--- a/frontend/src/lib/components/terminal/LaunchMenu.svelte
+++ b/frontend/src/lib/components/terminal/LaunchMenu.svelte
@@ -2,9 +2,7 @@
   import type { LaunchTarget } from "../../api/types.js";
   import PlayIcon from "@lucide/svelte/icons/play";
   import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
-  import TerminalIcon from "@lucide/svelte/icons/terminal";
-  import SparklesIcon from "@lucide/svelte/icons/sparkles";
-  import BoxIcon from "@lucide/svelte/icons/box";
+  import LaunchTargetName from "./LaunchTargetName.svelte";
   import { isVisibleLaunchTarget } from "./launchTargets";
 
   interface LaunchMenuProps {
@@ -97,24 +95,13 @@
     <div class="launch-popover">
       <div class="popover-heading">Run configurations</div>
       {#each visibleTargets as target (target.key)}
-        {@const isShell = target.kind === "plain_shell"}
-        {@const isAgent = target.kind === "agent"}
         <button
           class="launch-option"
           disabled={disabled || !target.available || launchingKey === target.key}
           title={target.disabled_reason ?? targetLabel(target)}
           onclick={() => launch(target.key)}
         >
-          <span class="option-icon" aria-hidden="true">
-            {#if isShell}
-              <TerminalIcon size="13" strokeWidth="2" />
-            {:else if isAgent}
-              <SparklesIcon size="13" strokeWidth="2" />
-            {:else}
-              <BoxIcon size="13" strokeWidth="2" />
-            {/if}
-          </span>
-          <span class="option-label">{targetLabel(target)}</span>
+          <LaunchTargetName {target} label={targetLabel(target)} markSize={12} iconSize={13} />
         </button>
       {/each}
     </div>
@@ -190,10 +177,11 @@
   }
 
   .launch-option {
-    display: grid;
-    grid-template-columns: 16px 1fr;
+    --launch-target-gap: 8px;
+    --launch-target-icon-color: var(--text-muted);
+
+    display: flex;
     align-items: center;
-    gap: 8px;
     width: 100%;
     height: 26px;
     padding: 0 8px;
@@ -218,9 +206,9 @@
     outline: none;
   }
 
-  .launch-option:hover:not(:disabled) .option-icon,
-  .launch-option:focus-visible .option-icon {
-    color: var(--accent-blue);
+  .launch-option:hover:not(:disabled),
+  .launch-option:focus-visible {
+    --launch-target-icon-color: var(--accent-blue);
   }
 
   .launch-option:disabled {
@@ -229,17 +217,7 @@
     opacity: var(--opacity-disabled);
   }
 
-  .option-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--text-muted);
-  }
-
-  .option-label {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  .launch-option :global(.launch-target-label) {
     font-weight: 500;
   }
 

--- a/frontend/src/lib/components/terminal/LaunchMenu.svelte
+++ b/frontend/src/lib/components/terminal/LaunchMenu.svelte
@@ -101,7 +101,7 @@
           title={target.disabled_reason ?? targetLabel(target)}
           onclick={() => launch(target.key)}
         >
-          <LaunchTargetName {target} label={targetLabel(target)} markSize={12} iconSize={13} />
+          <LaunchTargetName {target} label={targetLabel(target)} iconSize={13} fallbackIcon />
         </button>
       {/each}
     </div>

--- a/frontend/src/lib/components/terminal/LaunchMenu.test.ts
+++ b/frontend/src/lib/components/terminal/LaunchMenu.test.ts
@@ -58,4 +58,35 @@ describe("LaunchMenu", () => {
     await fireEvent.click(codexOption);
     expect(onLaunch).toHaveBeenCalledWith("codex");
   });
+
+  it("draws a harness wordmark for agents whose key matches one and keeps the generic icon otherwise", async () => {
+    render(LaunchMenu, {
+      props: {
+        launchTargets: [
+          { key: "claude", label: "Claude", kind: "agent", source: "builtin", available: true },
+          { key: "codex-review", label: "Review Agent", kind: "agent", source: "config", available: true },
+          { key: "aider", label: "aider", kind: "agent", source: "builtin", available: true },
+        ],
+        onLaunch: vi.fn(),
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Launch" }));
+
+    // The Claude Code wordmark already names the built-in, so its label is only
+    // exposed to assistive tech; the button still reads "Claude".
+    const claude = screen.getByRole("button", { name: "Claude" });
+    expect(claude.querySelector(".kit-harness-mark--claude-code svg")).not.toBeNull();
+    expect(claude.querySelector(".launch-target-label")?.classList.contains("kit-sr-only")).toBe(true);
+
+    // A configured label that says more than the harness name stays visible
+    // beside the mark resolved from the key's leading segment.
+    const review = screen.getByRole("button", { name: "Review Agent" });
+    expect(review.querySelector(".kit-harness-mark--codex")).not.toBeNull();
+    expect(review.querySelector(".launch-target-label")?.classList.contains("kit-sr-only")).toBe(false);
+
+    const aider = screen.getByRole("button", { name: "aider" });
+    expect(aider.querySelector(".kit-harness-mark")).toBeNull();
+    expect(aider.querySelector(".launch-target-icon svg")).not.toBeNull();
+  });
 });

--- a/frontend/src/lib/components/terminal/LaunchMenu.test.ts
+++ b/frontend/src/lib/components/terminal/LaunchMenu.test.ts
@@ -59,13 +59,13 @@ describe("LaunchMenu", () => {
     expect(onLaunch).toHaveBeenCalledWith("codex");
   });
 
-  it("draws a harness wordmark for agents whose key matches one and keeps the generic icon otherwise", async () => {
+  it("draws a harness glyph for agents whose key matches one and keeps the generic icon otherwise", async () => {
     render(LaunchMenu, {
       props: {
         launchTargets: [
           { key: "claude", label: "Claude", kind: "agent", source: "builtin", available: true },
           { key: "codex-review", label: "Review Agent", kind: "agent", source: "config", available: true },
-          { key: "aider", label: "aider", kind: "agent", source: "builtin", available: true },
+          { key: "mystery", label: "mystery", kind: "agent", source: "config", available: true },
         ],
         onLaunch: vi.fn(),
       },
@@ -73,20 +73,17 @@ describe("LaunchMenu", () => {
 
     await fireEvent.click(screen.getByRole("button", { name: "Launch" }));
 
-    // The Claude Code wordmark already names the built-in, so its label is only
-    // exposed to assistive tech; the button still reads "Claude".
     const claude = screen.getByRole("button", { name: "Claude" });
-    expect(claude.querySelector(".kit-harness-mark--claude-code svg")).not.toBeNull();
-    expect(claude.querySelector(".launch-target-label")?.classList.contains("kit-sr-only")).toBe(true);
+    expect(claude.querySelector(".kit-harness-icon--claude svg")).not.toBeNull();
+    expect(claude.querySelector(".launch-target-label")?.textContent).toBe("Claude");
 
-    // A configured label that says more than the harness name stays visible
-    // beside the mark resolved from the key's leading segment.
+    // The glyph comes from the key's leading segment; the configured label is untouched.
     const review = screen.getByRole("button", { name: "Review Agent" });
-    expect(review.querySelector(".kit-harness-mark--codex")).not.toBeNull();
-    expect(review.querySelector(".launch-target-label")?.classList.contains("kit-sr-only")).toBe(false);
+    expect(review.querySelector(".kit-harness-icon--openai")).not.toBeNull();
+    expect(review.querySelector(".launch-target-label")?.textContent).toBe("Review Agent");
 
-    const aider = screen.getByRole("button", { name: "aider" });
-    expect(aider.querySelector(".kit-harness-mark")).toBeNull();
-    expect(aider.querySelector(".launch-target-icon svg")).not.toBeNull();
+    const mystery = screen.getByRole("button", { name: "mystery" });
+    expect(mystery.querySelector(".kit-harness-icon")).toBeNull();
+    expect(mystery.querySelector(".launch-target-icon svg")).not.toBeNull();
   });
 });

--- a/frontend/src/lib/components/terminal/LaunchTargetName.svelte
+++ b/frontend/src/lib/components/terminal/LaunchTargetName.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import { HarnessMark } from "@kenn-io/kit-ui";
+  import BoxIcon from "@lucide/svelte/icons/box";
+  import SparklesIcon from "@lucide/svelte/icons/sparkles";
+  import TerminalIcon from "@lucide/svelte/icons/terminal";
+
+  import type { LaunchTarget } from "../../api/types.js";
+  import { launchTargetMark } from "./agentHarness";
+
+  /**
+   * A launch target's visible name: the kit-ui harness wordmark when the
+   * target's key resolves to one, otherwise a generic kind icon beside the
+   * label. The label text is always in the DOM so the enclosing button keeps
+   * its accessible name; it is only hidden visually when the wordmark already
+   * says the same thing.
+   */
+  interface Props {
+    target: Pick<LaunchTarget, "kind" | "key" | "label">;
+    label: string;
+    /** Wordmark height in px. */
+    markSize?: number;
+    /** Generic icon size in px for targets without a mark; omit to render text only. */
+    iconSize?: number | null;
+  }
+
+  const { target, label, markSize = 14, iconSize = null }: Props = $props();
+
+  const mark = $derived(launchTargetMark(target));
+</script>
+
+<span class="launch-target-name">
+  {#if mark}
+    <HarnessMark harness={mark.harness} size={markSize} decorative class="launch-target-mark" />
+    <span class={["launch-target-label", !mark.showLabel && "kit-sr-only"]}>{label}</span>
+  {:else}
+    {#if iconSize !== null}
+      <span class="launch-target-icon" aria-hidden="true">
+        {#if target.kind === "plain_shell"}
+          <TerminalIcon size={iconSize} strokeWidth="2" />
+        {:else if target.kind === "agent"}
+          <SparklesIcon size={iconSize} strokeWidth="2" />
+        {:else}
+          <BoxIcon size={iconSize} strokeWidth="2" />
+        {/if}
+      </span>
+    {/if}
+    <span class="launch-target-label">{label}</span>
+  {/if}
+</span>
+
+<style>
+  .launch-target-name {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--launch-target-gap, 8px);
+    min-width: 0;
+  }
+
+  .launch-target-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    color: var(--launch-target-icon-color, var(--text-muted));
+    transition: color 80ms ease;
+  }
+
+  .launch-target-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+</style>

--- a/frontend/src/lib/components/terminal/LaunchTargetName.svelte
+++ b/frontend/src/lib/components/terminal/LaunchTargetName.svelte
@@ -1,51 +1,46 @@
 <script lang="ts">
-  import { HarnessMark } from "@kenn-io/kit-ui";
+  import { HarnessIcon } from "@kenn-io/kit-ui";
   import BoxIcon from "@lucide/svelte/icons/box";
   import SparklesIcon from "@lucide/svelte/icons/sparkles";
   import TerminalIcon from "@lucide/svelte/icons/terminal";
 
   import type { LaunchTarget } from "../../api/types.js";
-  import { launchTargetMark } from "./agentHarness";
+  import { launchTargetHarness } from "./agentHarness";
 
   /**
-   * A launch target's visible name: the kit-ui harness wordmark when the
-   * target's key resolves to one, otherwise a generic kind icon beside the
-   * label. The label text is always in the DOM so the enclosing button keeps
-   * its accessible name; it is only hidden visually when the wordmark already
-   * says the same thing.
+   * A launch target's icon and label. The icon is the kit-ui harness glyph
+   * when the target's key resolves to one, otherwise the generic kind icon.
+   * The label is always the target's own.
    */
   interface Props {
-    target: Pick<LaunchTarget, "kind" | "key" | "label">;
+    target: Pick<LaunchTarget, "kind" | "key">;
     label: string;
-    /** Wordmark height in px. */
-    markSize?: number;
-    /** Generic icon size in px for targets without a mark; omit to render text only. */
-    iconSize?: number | null;
+    /** Icon size in px, for the harness glyph and the generic fallback alike. */
+    iconSize?: number;
+    /** Render the generic kind icon when no glyph matches; off by default. */
+    fallbackIcon?: boolean;
   }
 
-  const { target, label, markSize = 14, iconSize = null }: Props = $props();
+  const { target, label, iconSize = 14, fallbackIcon = false }: Props = $props();
 
-  const mark = $derived(launchTargetMark(target));
+  const harness = $derived(launchTargetHarness(target));
 </script>
 
 <span class="launch-target-name">
-  {#if mark}
-    <HarnessMark harness={mark.harness} size={markSize} decorative class="launch-target-mark" />
-    <span class={["launch-target-label", !mark.showLabel && "kit-sr-only"]}>{label}</span>
-  {:else}
-    {#if iconSize !== null}
-      <span class="launch-target-icon" aria-hidden="true">
-        {#if target.kind === "plain_shell"}
-          <TerminalIcon size={iconSize} strokeWidth="2" />
-        {:else if target.kind === "agent"}
-          <SparklesIcon size={iconSize} strokeWidth="2" />
-        {:else}
-          <BoxIcon size={iconSize} strokeWidth="2" />
-        {/if}
-      </span>
-    {/if}
-    <span class="launch-target-label">{label}</span>
+  {#if harness}
+    <HarnessIcon {harness} size={iconSize} decorative class="launch-target-icon" />
+  {:else if fallbackIcon}
+    <span class="launch-target-icon" aria-hidden="true">
+      {#if target.kind === "plain_shell"}
+        <TerminalIcon size={iconSize} strokeWidth="2" />
+      {:else if target.kind === "agent"}
+        <SparklesIcon size={iconSize} strokeWidth="2" />
+      {:else}
+        <BoxIcon size={iconSize} strokeWidth="2" />
+      {/if}
+    </span>
   {/if}
+  <span class="launch-target-label">{label}</span>
 </span>
 
 <style>

--- a/frontend/src/lib/components/terminal/WorkspaceHome.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceHome.svelte
@@ -107,7 +107,7 @@
           aria-label={targetLabel(target)}
           onclick={() => onLaunch?.(target.key)}
         >
-          <LaunchTargetName {target} label={targetLabel(target)} markSize={13} iconSize={14} />
+          <LaunchTargetName {target} label={targetLabel(target)} iconSize={14} fallbackIcon />
           {#if isLaunching}
             <span class="card-status">starting…</span>
           {/if}

--- a/frontend/src/lib/components/terminal/WorkspaceHome.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceHome.svelte
@@ -6,9 +6,7 @@
   import GitBranchIcon from "@lucide/svelte/icons/git-branch";
   import FolderIcon from "@lucide/svelte/icons/folder";
   import PlayIcon from "@lucide/svelte/icons/play";
-  import TerminalIcon from "@lucide/svelte/icons/terminal";
-  import SparklesIcon from "@lucide/svelte/icons/sparkles";
-  import BoxIcon from "@lucide/svelte/icons/box";
+  import LaunchTargetName from "./LaunchTargetName.svelte";
   import { isVisibleLaunchTarget } from "./launchTargets";
 
   interface WorkspaceHomeWorkspace {
@@ -101,8 +99,6 @@
     </div>
     <div class="launch-grid">
       {#each visibleTargets as target (target.key)}
-        {@const isShell = target.kind === "plain_shell"}
-        {@const isAgent = target.kind === "agent"}
         {@const isLaunching = launchingKey === target.key}
         <button
           class="launch-card"
@@ -111,16 +107,7 @@
           aria-label={targetLabel(target)}
           onclick={() => onLaunch?.(target.key)}
         >
-          <span class="card-icon" aria-hidden="true">
-            {#if isShell}
-              <TerminalIcon size="14" strokeWidth="2" />
-            {:else if isAgent}
-              <SparklesIcon size="14" strokeWidth="2" />
-            {:else}
-              <BoxIcon size="14" strokeWidth="2" />
-            {/if}
-          </span>
-          <span class="card-label">{targetLabel(target)}</span>
+          <LaunchTargetName {target} label={targetLabel(target)} markSize={13} iconSize={14} />
           {#if isLaunching}
             <span class="card-status">starting…</span>
           {/if}
@@ -282,8 +269,11 @@
   }
 
   .launch-card {
+    --launch-target-gap: 8px;
+    --launch-target-icon-color: var(--text-secondary);
+
     display: grid;
-    grid-template-columns: 16px 1fr;
+    grid-template-columns: minmax(0, 1fr);
     align-items: center;
     gap: 4px 8px;
     /* min-height instead of fixed height: when a card flips into the
@@ -313,8 +303,8 @@
     );
   }
 
-  .launch-card:hover:not(:disabled) .card-icon {
-    color: var(--accent-blue);
+  .launch-card:hover:not(:disabled) {
+    --launch-target-icon-color: var(--accent-blue);
   }
 
   .launch-card:disabled {
@@ -323,18 +313,7 @@
     opacity: var(--opacity-disabled);
   }
 
-  .card-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--text-secondary);
-    transition: color 80ms ease;
-  }
-
-  .card-label {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  .launch-card :global(.launch-target-label) {
     font-weight: 600;
     letter-spacing: 0.005em;
   }

--- a/frontend/src/lib/components/terminal/WorkspaceHome.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceHome.test.ts
@@ -94,8 +94,7 @@ describe("WorkspaceHome", () => {
     }) as HTMLButtonElement;
     expect(codexLaunchButton.disabled).toBe(false);
     expect(codexLaunchButton.textContent?.trim()).toBe("Codex");
-    expect(codexLaunchButton.querySelector(".kit-harness-mark--codex")).not.toBeNull();
-    expect(codexLaunchButton.querySelector(".launch-target-icon")).toBeNull();
+    expect(codexLaunchButton.querySelector(".kit-harness-icon--openai")).not.toBeNull();
     expect(
       (
         screen.getByRole("button", {
@@ -111,7 +110,7 @@ describe("WorkspaceHome", () => {
       name: "Shell",
     }) as HTMLButtonElement;
     expect(shellLaunchButton.textContent?.trim()).toBe("Shell");
-    expect(shellLaunchButton.querySelector(".kit-harness-mark")).toBeNull();
+    expect(shellLaunchButton.querySelector(".kit-harness-icon")).toBeNull();
     expect(shellLaunchButton.querySelector(".launch-target-icon svg")).not.toBeNull();
 
     await fireEvent.click(codexLaunchButton);

--- a/frontend/src/lib/components/terminal/WorkspaceHome.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceHome.test.ts
@@ -94,6 +94,8 @@ describe("WorkspaceHome", () => {
     }) as HTMLButtonElement;
     expect(codexLaunchButton.disabled).toBe(false);
     expect(codexLaunchButton.textContent?.trim()).toBe("Codex");
+    expect(codexLaunchButton.querySelector(".kit-harness-mark--codex")).not.toBeNull();
+    expect(codexLaunchButton.querySelector(".launch-target-icon")).toBeNull();
     expect(
       (
         screen.getByRole("button", {
@@ -109,6 +111,8 @@ describe("WorkspaceHome", () => {
       name: "Shell",
     }) as HTMLButtonElement;
     expect(shellLaunchButton.textContent?.trim()).toBe("Shell");
+    expect(shellLaunchButton.querySelector(".kit-harness-mark")).toBeNull();
+    expect(shellLaunchButton.querySelector(".launch-target-icon svg")).not.toBeNull();
 
     await fireEvent.click(codexLaunchButton);
     expect(onLaunch).toHaveBeenCalledWith("codex");

--- a/frontend/src/lib/components/terminal/agentHarness.test.ts
+++ b/frontend/src/lib/components/terminal/agentHarness.test.ts
@@ -1,62 +1,48 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { harnessForAgentKey, launchTargetMark } from "./agentHarness";
+import { harnessForAgentKey, launchTargetHarness } from "./agentHarness";
 
 describe("harnessForAgentKey", () => {
-  it("matches built-in agent keys to the harness sharing their leading segment", () => {
-    expect(harnessForAgentKey("claude")).toBe("claude-code");
-    expect(harnessForAgentKey("codex")).toBe("codex");
+  it("matches built-in agent keys to a glyph by brand id or agent product name", () => {
+    expect(harnessForAgentKey("claude")).toBe("claude");
+    expect(harnessForAgentKey("codex")).toBe("openai");
     expect(harnessForAgentKey("gemini")).toBe("gemini");
     expect(harnessForAgentKey("opencode")).toBe("opencode");
     expect(harnessForAgentKey("pi")).toBe("pi");
+    expect(harnessForAgentKey("aider")).toBe("aider");
   });
 
-  it("matches configured keys that extend a harness id", () => {
-    expect(harnessForAgentKey("claude-code")).toBe("claude-code");
-    expect(harnessForAgentKey("claude-fast")).toBe("claude-code");
-    expect(harnessForAgentKey("codex_review")).toBe("codex");
+  it("matches configured keys that extend a name", () => {
+    expect(harnessForAgentKey("claude-code")).toBe("claude");
+    expect(harnessForAgentKey("claude-fast")).toBe("claude");
+    expect(harnessForAgentKey("codex_review")).toBe("openai");
     expect(harnessForAgentKey("Cursor Agent")).toBe("cursor");
-    expect(harnessForAgentKey("vscode")).toBe("vscode-copilot");
+    expect(harnessForAgentKey("cortex-code")).toBe("snowflake");
   });
 
-  it("only matches whole segments", () => {
+  it("falls back to a bare string prefix for names long enough to be unambiguous", () => {
+    expect(harnessForAgentKey("claudex")).toBe("claude");
+    expect(harnessForAgentKey("codexy-fast")).toBe("openai");
+    expect(harnessForAgentKey("geminiwrap")).toBe("gemini");
+  });
+
+  it("never lets a short name swallow an unrelated key", () => {
     expect(harnessForAgentKey("pixel")).toBeNull();
-    expect(harnessForAgentKey("aider")).toBeNull();
+    expect(harnessForAgentKey("zebra")).toBeNull();
     expect(harnessForAgentKey("")).toBeNull();
     expect(harnessForAgentKey("---")).toBeNull();
   });
 });
 
-describe("launchTargetMark", () => {
+describe("launchTargetHarness", () => {
   it("ignores shells and unmatched agents", () => {
-    expect(launchTargetMark({ kind: "plain_shell", key: "plain_shell", label: "Plain shell" })).toBeNull();
-    expect(launchTargetMark({ kind: "shell", key: "shell", label: "Shell" })).toBeNull();
-    expect(launchTargetMark({ kind: "agent", key: "aider", label: "aider" })).toBeNull();
+    expect(launchTargetHarness({ kind: "plain_shell", key: "plain_shell" })).toBeNull();
+    expect(launchTargetHarness({ kind: "shell", key: "shell" })).toBeNull();
+    expect(launchTargetHarness({ kind: "agent", key: "totally-unknown" })).toBeNull();
   });
 
-  it("hides the label when the harness name already covers it", () => {
-    expect(launchTargetMark({ kind: "agent", key: "claude", label: "Claude" })).toEqual({
-      harness: "claude-code",
-      showLabel: false,
-    });
-    expect(launchTargetMark({ kind: "agent", key: "opencode", label: "opencode" })).toEqual({
-      harness: "opencode",
-      showLabel: false,
-    });
-    expect(launchTargetMark({ kind: "agent", key: "codex", label: "  " })).toEqual({
-      harness: "codex",
-      showLabel: false,
-    });
-  });
-
-  it("keeps a label that says more than the harness name", () => {
-    expect(launchTargetMark({ kind: "agent", key: "codex-review", label: "Review Agent" })).toEqual({
-      harness: "codex",
-      showLabel: true,
-    });
-    expect(launchTargetMark({ kind: "agent", key: "claude", label: "Claude fast" })).toEqual({
-      harness: "claude-code",
-      showLabel: true,
-    });
+  it("resolves agent keys", () => {
+    expect(launchTargetHarness({ kind: "agent", key: "claude" })).toBe("claude");
+    expect(launchTargetHarness({ kind: "agent", key: "codex-review" })).toBe("openai");
   });
 });

--- a/frontend/src/lib/components/terminal/agentHarness.test.ts
+++ b/frontend/src/lib/components/terminal/agentHarness.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { harnessForAgentKey, launchTargetMark } from "./agentHarness";
+
+describe("harnessForAgentKey", () => {
+  it("matches built-in agent keys to the harness sharing their leading segment", () => {
+    expect(harnessForAgentKey("claude")).toBe("claude-code");
+    expect(harnessForAgentKey("codex")).toBe("codex");
+    expect(harnessForAgentKey("gemini")).toBe("gemini");
+    expect(harnessForAgentKey("opencode")).toBe("opencode");
+    expect(harnessForAgentKey("pi")).toBe("pi");
+  });
+
+  it("matches configured keys that extend a harness id", () => {
+    expect(harnessForAgentKey("claude-code")).toBe("claude-code");
+    expect(harnessForAgentKey("claude-fast")).toBe("claude-code");
+    expect(harnessForAgentKey("codex_review")).toBe("codex");
+    expect(harnessForAgentKey("Cursor Agent")).toBe("cursor");
+    expect(harnessForAgentKey("vscode")).toBe("vscode-copilot");
+  });
+
+  it("only matches whole segments", () => {
+    expect(harnessForAgentKey("pixel")).toBeNull();
+    expect(harnessForAgentKey("aider")).toBeNull();
+    expect(harnessForAgentKey("")).toBeNull();
+    expect(harnessForAgentKey("---")).toBeNull();
+  });
+});
+
+describe("launchTargetMark", () => {
+  it("ignores shells and unmatched agents", () => {
+    expect(launchTargetMark({ kind: "plain_shell", key: "plain_shell", label: "Plain shell" })).toBeNull();
+    expect(launchTargetMark({ kind: "shell", key: "shell", label: "Shell" })).toBeNull();
+    expect(launchTargetMark({ kind: "agent", key: "aider", label: "aider" })).toBeNull();
+  });
+
+  it("hides the label when the harness name already covers it", () => {
+    expect(launchTargetMark({ kind: "agent", key: "claude", label: "Claude" })).toEqual({
+      harness: "claude-code",
+      showLabel: false,
+    });
+    expect(launchTargetMark({ kind: "agent", key: "opencode", label: "opencode" })).toEqual({
+      harness: "opencode",
+      showLabel: false,
+    });
+    expect(launchTargetMark({ kind: "agent", key: "codex", label: "  " })).toEqual({
+      harness: "codex",
+      showLabel: false,
+    });
+  });
+
+  it("keeps a label that says more than the harness name", () => {
+    expect(launchTargetMark({ kind: "agent", key: "codex-review", label: "Review Agent" })).toEqual({
+      harness: "codex",
+      showLabel: true,
+    });
+    expect(launchTargetMark({ kind: "agent", key: "claude", label: "Claude fast" })).toEqual({
+      harness: "claude-code",
+      showLabel: true,
+    });
+  });
+});

--- a/frontend/src/lib/components/terminal/agentHarness.ts
+++ b/frontend/src/lib/components/terminal/agentHarness.ts
@@ -1,26 +1,20 @@
-import { HARNESSES, harnessInfo, type HarnessId } from "@kenn-io/kit-ui";
+import { HARNESS_ICONS, type HarnessIconId } from "@kenn-io/kit-ui";
 
 import type { LaunchTarget } from "../../api/types.js";
 
 /**
- * The kit-ui harness wordmark a launch target should be drawn with.
+ * The kit-ui harness glyph a launch target should be drawn with.
  *
  * Agent launch targets are keyed by the maintainer (built-ins such as `claude`
- * and `codex`, or config entries like `codex-review`), while kit-ui's harness
- * ids follow the agentsview naming (`claude-code`). The two are matched on a
- * shared leading prefix, segment by segment, so `claude`, `claude-code` and
- * `claude-fast` all resolve to the Claude Code mark and `codex-review` to
- * Codex, but `pixel` never resolves to `pi`.
+ * and `codex`, or config entries like `codex-review`), while kit-ui's glyphs
+ * are keyed by brand (`openai` for Codex, `snowflake` for Cortex Code). Each
+ * glyph therefore matches on its own id and on the agent products kit-ui lists
+ * for it, both slugged the same way as the key: first segment by segment, so
+ * `codex-review` resolves to the OpenAI glyph and `claude-fast` to Claude;
+ * then, for names long enough to be unambiguous, as a plain string prefix of
+ * the key's first segment, so a `claudex` wrapper still gets the Claude glyph
+ * while `pixel` never resolves to `pi`.
  */
-export interface LaunchTargetMark {
-  harness: HarnessId;
-  /**
-   * Whether the target's own label still adds information beside the
-   * wordmark. A built-in `Claude` under the `Claude Code` mark does not; a
-   * config `Review Agent` under the Codex mark does.
-   */
-  showLabel: boolean;
-}
 
 function segments(value: string): string[] {
   return value
@@ -29,32 +23,50 @@ function segments(value: string): string[] {
     .filter((segment) => segment !== "");
 }
 
-/** Resolve an agent launch-target key to the harness whose id shares its prefix. */
-export function harnessForAgentKey(key: string): HarnessId | null {
+/** Shortest name segment that may match a key as a bare string prefix. */
+const LOOSE_PREFIX_MIN_LENGTH = 4;
+
+interface Candidate {
+  id: HarnessIconId;
+  segments: string[];
+}
+
+const CANDIDATES: readonly Candidate[] = HARNESS_ICONS.flatMap((icon) =>
+  [icon.id, ...icon.agents].map((name) => ({ id: icon.id, segments: segments(name) })),
+);
+
+/** Resolve an agent launch-target key to the glyph whose name shares its prefix. */
+export function harnessForAgentKey(key: string): HarnessIconId | null {
   const keySegments = segments(key);
-  if (keySegments.length === 0) return null;
-  let best: { id: HarnessId; matched: number } | null = null;
-  for (const harness of HARNESSES) {
-    const idSegments = segments(harness.id);
-    if (idSegments[0] !== keySegments[0]) continue;
+  const keyHead = keySegments[0];
+  if (keyHead === undefined) return null;
+  let best: { id: HarnessIconId; matched: number } | null = null;
+  for (const candidate of CANDIDATES) {
+    if (candidate.segments[0] !== keyHead) continue;
     let matched = 0;
     while (
-      matched < idSegments.length &&
+      matched < candidate.segments.length &&
       matched < keySegments.length &&
-      idSegments[matched] === keySegments[matched]
+      candidate.segments[matched] === keySegments[matched]
     ) {
       matched += 1;
     }
-    if (best === null || matched > best.matched) best = { id: harness.id, matched };
+    if (best === null || matched > best.matched) best = { id: candidate.id, matched };
   }
-  return best?.id ?? null;
+  if (best !== null) return best.id;
+
+  let loose: { id: HarnessIconId; length: number } | null = null;
+  for (const candidate of CANDIDATES) {
+    const head = candidate.segments[0];
+    if (head === undefined || head.length < LOOSE_PREFIX_MIN_LENGTH) continue;
+    if (!keyHead.startsWith(head)) continue;
+    if (loose === null || head.length > loose.length) loose = { id: candidate.id, length: head.length };
+  }
+  return loose?.id ?? null;
 }
 
-export function launchTargetMark(target: Pick<LaunchTarget, "kind" | "key" | "label">): LaunchTargetMark | null {
+/** The glyph for a launch target, or null for shells and unmatched agents. */
+export function launchTargetHarness(target: Pick<LaunchTarget, "kind" | "key">): HarnessIconId | null {
   if (target.kind !== "agent") return null;
-  const harness = harnessForAgentKey(target.key);
-  if (harness === null) return null;
-  const label = target.label.trim().toLowerCase();
-  const harnessLabel = harnessInfo(harness).label.toLowerCase();
-  return { harness, showLabel: label !== "" && !harnessLabel.startsWith(label) };
+  return harnessForAgentKey(target.key);
 }

--- a/frontend/src/lib/components/terminal/agentHarness.ts
+++ b/frontend/src/lib/components/terminal/agentHarness.ts
@@ -1,0 +1,60 @@
+import { HARNESSES, harnessInfo, type HarnessId } from "@kenn-io/kit-ui";
+
+import type { LaunchTarget } from "../../api/types.js";
+
+/**
+ * The kit-ui harness wordmark a launch target should be drawn with.
+ *
+ * Agent launch targets are keyed by the maintainer (built-ins such as `claude`
+ * and `codex`, or config entries like `codex-review`), while kit-ui's harness
+ * ids follow the agentsview naming (`claude-code`). The two are matched on a
+ * shared leading prefix, segment by segment, so `claude`, `claude-code` and
+ * `claude-fast` all resolve to the Claude Code mark and `codex-review` to
+ * Codex, but `pixel` never resolves to `pi`.
+ */
+export interface LaunchTargetMark {
+  harness: HarnessId;
+  /**
+   * Whether the target's own label still adds information beside the
+   * wordmark. A built-in `Claude` under the `Claude Code` mark does not; a
+   * config `Review Agent` under the Codex mark does.
+   */
+  showLabel: boolean;
+}
+
+function segments(value: string): string[] {
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((segment) => segment !== "");
+}
+
+/** Resolve an agent launch-target key to the harness whose id shares its prefix. */
+export function harnessForAgentKey(key: string): HarnessId | null {
+  const keySegments = segments(key);
+  if (keySegments.length === 0) return null;
+  let best: { id: HarnessId; matched: number } | null = null;
+  for (const harness of HARNESSES) {
+    const idSegments = segments(harness.id);
+    if (idSegments[0] !== keySegments[0]) continue;
+    let matched = 0;
+    while (
+      matched < idSegments.length &&
+      matched < keySegments.length &&
+      idSegments[matched] === keySegments[matched]
+    ) {
+      matched += 1;
+    }
+    if (best === null || matched > best.matched) best = { id: harness.id, matched };
+  }
+  return best?.id ?? null;
+}
+
+export function launchTargetMark(target: Pick<LaunchTarget, "kind" | "key" | "label">): LaunchTargetMark | null {
+  if (target.kind !== "agent") return null;
+  const harness = harnessForAgentKey(target.key);
+  if (harness === null) return null;
+  const label = target.label.trim().toLowerCase();
+  const harnessLabel = harnessInfo(harness).label.toLowerCase();
+  return { harness, showLabel: label !== "" && !harnessLabel.startsWith(label) };
+}

--- a/frontend/src/lib/components/workspace/WorkspaceCreateSplitButton.svelte
+++ b/frontend/src/lib/components/workspace/WorkspaceCreateSplitButton.svelte
@@ -7,6 +7,7 @@
   } from "@kenn-io/kit-ui";
   import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
   import PackagePlusIcon from "@lucide/svelte/icons/package-plus";
+  import LaunchTargetName from "../terminal/LaunchTargetName.svelte";
   import { Effect } from "effect";
   import { tick } from "svelte";
   import type { LaunchTarget } from "../../api/types.js";
@@ -231,7 +232,7 @@
             onclick={() => selectTarget(target.key)}
             onkeydown={handleItemKeydown}
           >
-            {target.label}
+            <LaunchTargetName {target} label={target.label} markSize={12} />
           </button>
         </li>
       {/each}

--- a/frontend/src/lib/components/workspace/WorkspaceCreateSplitButton.svelte
+++ b/frontend/src/lib/components/workspace/WorkspaceCreateSplitButton.svelte
@@ -232,7 +232,7 @@
             onclick={() => selectTarget(target.key)}
             onkeydown={handleItemKeydown}
           >
-            <LaunchTargetName {target} label={target.label} markSize={12} />
+            <LaunchTargetName {target} label={target.label} iconSize={12} />
           </button>
         </li>
       {/each}

--- a/skills/kenn-forge-ephemeral-dev/SKILL.md
+++ b/skills/kenn-forge-ephemeral-dev/SKILL.md
@@ -30,7 +30,7 @@ Use `make dev-ephemeral` when the user wants a local kenn-forge dev stack withou
 
    ```sh
    make dev-ephemeral ARGS="-work-dir tmp/my-run"
-   make dev-ephemeral ARGS="-backend-port 19091 -frontend-port 15174"
+   make dev-ephemeral ARGS="-backend-port 19091 -frontend-port 15174 -mcp-port 19092"
    ```
 
 4. Use a fresh empty DB only when requested:
@@ -44,6 +44,10 @@ Use `make dev-ephemeral` when the user wants a local kenn-forge dev stack withou
 - The launcher starts both backend and frontend.
 - The backend disables provider sync by default; `-sync` explicitly enables it.
 - It writes a generated config at `<work-dir>/config.toml`.
+- When the source config enables MCP, the generated config moves the MCP
+  listener to a free port (or `-mcp-port`) so the ephemeral backend never
+  fights the live daemon for the configured one; the status JSON reports it as
+  `mcp_port` and `mcp_url`, omitted when MCP is disabled.
 - It copies the configured source SQLite DB by default into `<work-dir>/data/forge.db`.
 - It passes `KENN_FORGE_CONFIG=<work-dir>/config.toml` to both processes.
 - It passes `KENN_FORGE_API_URL=<backend-url>` to the frontend.
@@ -62,10 +66,12 @@ Read `<work-dir>/dev-ephemeral.json` when another tool or response needs process
   "frontend_pid": 1003,
   "backend_port": 19091,
   "frontend_port": 15174,
+  "mcp_port": 19092,
   "config_path": "tmp/my-run/config.toml",
   "data_dir": "tmp/my-run/data",
   "backend_url": "http://127.0.0.1:19091",
-  "frontend_url": "http://127.0.0.1:15174"
+  "frontend_url": "http://127.0.0.1:15174",
+  "mcp_url": "http://127.0.0.1:19092"
 }
 ```
 

--- a/tools/devephemeral/main.go
+++ b/tools/devephemeral/main.go
@@ -42,6 +42,7 @@ type ephemeralOptions struct {
 	workDir          string
 	backendPort      int
 	frontendPort     int
+	mcpPort          int
 	freshDB          bool
 }
 
@@ -52,8 +53,11 @@ type ephemeralRun struct {
 	logDir       string
 	backendURL   string
 	frontendURL  string
+	mcpURL       string
 	backendPort  int
 	frontendPort int
+	// mcpPort is zero when the source config leaves the MCP listener disabled.
+	mcpPort int
 }
 
 type ephemeralStatus struct {
@@ -65,10 +69,12 @@ type ephemeralStatus struct {
 	FrontendStartedAt string `json:"frontend_started_at,omitempty"`
 	BackendPort       int    `json:"backend_port"`
 	FrontendPort      int    `json:"frontend_port"`
+	MCPPort           int    `json:"mcp_port,omitempty"`
 	ConfigPath        string `json:"config_path"`
 	DataDir           string `json:"data_dir"`
 	BackendURL        string `json:"backend_url"`
 	FrontendURL       string `json:"frontend_url"`
+	MCPURL            string `json:"mcp_url,omitempty"`
 }
 
 type processRef struct {
@@ -107,6 +113,7 @@ func run(ctx context.Context, args []string) error {
 	stop := fs.Bool("stop", false, "stop an ephemeral dev stack using its status JSON")
 	backendPort := fs.Int("backend-port", 0, "backend port (0 selects a free port)")
 	frontendPort := fs.Int("frontend-port", 0, "frontend port (0 selects a free port)")
+	mcpPort := fs.Int("mcp-port", 0, "MCP listener port when the source config enables MCP (0 selects a free port)")
 	freshDB := fs.Bool("fresh-db", false, "start with an empty ephemeral database instead of copying the source database")
 	syncEnabled := fs.Bool("sync", false, "enable provider synchronization")
 	if err := fs.Parse(args); err != nil {
@@ -142,8 +149,12 @@ func run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("resolve frontend port: %w", err)
 	}
-	if resolvedBackendPort == resolvedFrontendPort {
-		return fmt.Errorf("backend and frontend ports both resolved to %d", resolvedBackendPort)
+	resolvedMCPPort, err := resolvePort(*mcpPort)
+	if err != nil {
+		return fmt.Errorf("resolve mcp port: %w", err)
+	}
+	if err := requireDistinctPorts(resolvedBackendPort, resolvedFrontendPort, resolvedMCPPort); err != nil {
+		return err
 	}
 
 	releaseLock, err := lockEphemeralWorkDir(resolvedWorkDir)
@@ -179,6 +190,7 @@ func run(ctx context.Context, args []string) error {
 		workDir:          resolvedWorkDir,
 		backendPort:      resolvedBackendPort,
 		frontendPort:     resolvedFrontendPort,
+		mcpPort:          resolvedMCPPort,
 		freshDB:          *freshDB,
 	})
 	if err != nil {
@@ -228,10 +240,12 @@ func run(ctx context.Context, args []string) error {
 		FrontendStartedAt: frontendStartedAt,
 		BackendPort:       prepared.backendPort,
 		FrontendPort:      prepared.frontendPort,
+		MCPPort:           prepared.mcpPort,
 		ConfigPath:        prepared.configPath,
 		DataDir:           prepared.dataDir,
 		BackendURL:        prepared.backendURL,
 		FrontendURL:       prepared.frontendURL,
+		MCPURL:            prepared.mcpURL,
 	}
 	if err := writeStatusFile(prepared.statusPath, status); err != nil {
 		return errors.Join(err, errors.Join(stopStartedCommands(frontend, backend)...))
@@ -260,6 +274,11 @@ func prepareEphemeralConfig(opts ephemeralOptions) (ephemeralRun, error) {
 	}
 	if err := validatePort(opts.frontendPort); err != nil {
 		return ephemeralRun{}, fmt.Errorf("frontend port: %w", err)
+	}
+	if opts.mcpPort != 0 {
+		if err := validatePort(opts.mcpPort); err != nil {
+			return ephemeralRun{}, fmt.Errorf("mcp port: %w", err)
+		}
 	}
 	if err := os.MkdirAll(opts.workDir, 0o700); err != nil {
 		return ephemeralRun{}, fmt.Errorf("create work directory: %w", err)
@@ -290,6 +309,19 @@ func prepareEphemeralConfig(opts ephemeralOptions) (ephemeralRun, error) {
 	cfg.Port = opts.backendPort
 	cfg.DataDir = dataDir
 	cfg.TrustReverseProxy = false
+	// The source config's MCP port belongs to the developer's live daemon, so
+	// the ephemeral backend must never inherit it. The launcher resolves a free
+	// port; a zero here keeps the config's implicit backend+1.
+	mcpPort := 0
+	mcpURL := ""
+	if cfg.MCP.Enabled {
+		cfg.MCP.Port = opts.mcpPort
+		mcpPort = cfg.MCPPort()
+		mcpURL, err = serverURL(cfg.Host, mcpPort, "/")
+		if err != nil {
+			return ephemeralRun{}, err
+		}
+	}
 
 	configPath := filepath.Join(opts.workDir, "config.toml")
 	if err := cfg.Save(configPath); err != nil {
@@ -312,8 +344,10 @@ func prepareEphemeralConfig(opts ephemeralOptions) (ephemeralRun, error) {
 		logDir:       logDir,
 		backendURL:   backendURL,
 		frontendURL:  frontendURL,
+		mcpURL:       mcpURL,
 		backendPort:  opts.backendPort,
 		frontendPort: opts.frontendPort,
+		mcpPort:      mcpPort,
 	}, nil
 }
 
@@ -425,6 +459,9 @@ func writeStatusFile(path string, status ephemeralStatus) error {
 func printStatus(status ephemeralStatus, statusPath string) {
 	fmt.Printf("backend:  %s pid=%d\n", status.BackendURL, status.BackendPID)
 	fmt.Printf("frontend: %s pid=%d\n", status.FrontendURL, status.FrontendPID)
+	if status.MCPURL != "" {
+		fmt.Printf("mcp:      %s\n", status.MCPURL)
+	}
 	fmt.Printf("config:   %s\n", status.ConfigPath)
 	fmt.Printf("status:   %s\n", statusPath)
 }
@@ -973,6 +1010,20 @@ func resolvePort(port int) (int, error) {
 		return 0, fmt.Errorf("unexpected address type %T", listener.Addr())
 	}
 	return addr.Port, nil
+}
+
+// requireDistinctPorts rejects a free-port resolution that handed two
+// listeners the same port; a fixed port that repeats is a user error either way.
+func requireDistinctPorts(backend, frontend, mcp int) error {
+	switch {
+	case backend == frontend:
+		return fmt.Errorf("backend and frontend ports both resolved to %d", backend)
+	case backend == mcp:
+		return fmt.Errorf("backend and mcp ports both resolved to %d", backend)
+	case frontend == mcp:
+		return fmt.Errorf("frontend and mcp ports both resolved to %d", frontend)
+	}
+	return nil
 }
 
 func validatePort(port int) error {

--- a/tools/devephemeral/main_test.go
+++ b/tools/devephemeral/main_test.go
@@ -69,6 +69,91 @@ func TestPrepareEphemeralConfigOverridesPortAndDataDir(t *testing.T) {
 	assert.Equal(sourceDataDir, source.DataDir)
 }
 
+func TestPrepareEphemeralConfigMovesEnabledMCPListenerOffTheSourcePort(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.toml")
+	workDir := filepath.Join(dir, "run")
+	require.NoError(os.MkdirAll(workDir, 0o700))
+
+	source := config.Config{
+		SyncInterval:        "5m",
+		GitHubTokenEnv:      "KENN_FORGE_GITHUB_TOKEN",
+		DefaultPlatformHost: "github.com",
+		Host:                "127.0.0.1",
+		Port:                8091,
+		DataDir:             filepath.Join(dir, "source-data"),
+		Activity:            config.Activity{ViewMode: "threaded", TimeRange: "7d"},
+		MCP:                 config.MCP{Enabled: true, Port: 6661},
+	}
+	require.NoError(source.Save(sourcePath))
+
+	prepared, err := prepareEphemeralConfig(ephemeralOptions{
+		sourceConfigPath: sourcePath,
+		workDir:          workDir,
+		backendPort:      39101,
+		frontendPort:     39102,
+		mcpPort:          39103,
+		freshDB:          true,
+	})
+	require.NoError(err)
+
+	reloaded, err := config.Load(prepared.configPath)
+	require.NoError(err)
+	assert.True(reloaded.MCP.Enabled)
+	assert.Equal(39103, reloaded.MCP.Port)
+	assert.Equal("127.0.0.1:39103", reloaded.MCPListenAddr())
+	assert.Equal(39103, prepared.mcpPort)
+	assert.Equal("http://127.0.0.1:39103", prepared.mcpURL)
+}
+
+func TestPrepareEphemeralConfigLeavesDisabledMCPAlone(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.toml")
+	workDir := filepath.Join(dir, "run")
+	require.NoError(os.MkdirAll(workDir, 0o700))
+
+	source := config.Config{
+		SyncInterval:        "5m",
+		GitHubTokenEnv:      "KENN_FORGE_GITHUB_TOKEN",
+		DefaultPlatformHost: "github.com",
+		Host:                "127.0.0.1",
+		Port:                8091,
+		DataDir:             filepath.Join(dir, "source-data"),
+		Activity:            config.Activity{ViewMode: "threaded", TimeRange: "7d"},
+	}
+	require.NoError(source.Save(sourcePath))
+
+	prepared, err := prepareEphemeralConfig(ephemeralOptions{
+		sourceConfigPath: sourcePath,
+		workDir:          workDir,
+		backendPort:      39101,
+		frontendPort:     39102,
+		mcpPort:          39103,
+		freshDB:          true,
+	})
+	require.NoError(err)
+
+	reloaded, err := config.Load(prepared.configPath)
+	require.NoError(err)
+	assert.False(reloaded.MCP.Enabled)
+	assert.Empty(reloaded.MCPListenAddr())
+	assert.Equal(0, prepared.mcpPort)
+	assert.Empty(prepared.mcpURL)
+}
+
+func TestRequireDistinctPortsRejectsAnyCollision(t *testing.T) {
+	require := require.New(t)
+
+	require.NoError(requireDistinctPorts(1, 2, 3))
+	require.Error(requireDistinctPorts(1, 1, 3))
+	require.Error(requireDistinctPorts(1, 2, 1))
+	require.Error(requireDistinctPorts(1, 2, 2))
+}
+
 func TestPrepareEphemeralConfigForcesBackendToLoopback(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -471,10 +556,12 @@ func TestWriteStatusFileRecordsPIDsAndPortsNextToConfig(t *testing.T) {
 		FrontendPID:  1003,
 		BackendPort:  39401,
 		FrontendPort: 39402,
+		MCPPort:      39403,
 		ConfigPath:   filepath.Join(dir, "config.toml"),
 		DataDir:      filepath.Join(dir, "data"),
 		BackendURL:   "http://127.0.0.1:39401",
 		FrontendURL:  "http://127.0.0.1:39402",
+		MCPURL:       "http://127.0.0.1:39403",
 	})
 	require.NoError(err)
 
@@ -488,6 +575,8 @@ func TestWriteStatusFileRecordsPIDsAndPortsNextToConfig(t *testing.T) {
 	assert.Equal(1003, got.FrontendPID)
 	assert.Equal(39401, got.BackendPort)
 	assert.Equal(39402, got.FrontendPort)
+	assert.Equal(39403, got.MCPPort)
+	assert.Equal("http://127.0.0.1:39403", got.MCPURL)
 	assert.Equal(filepath.Join(dir, "config.toml"), got.ConfigPath)
 }
 


### PR DESCRIPTION
Every agent in the launch surfaces used the same generic sparkles icon, so a row of Claude, Codex, Gemini, and opencode entries read as identical items. Launch targets now draw the coding-agent glyph kit-ui ships as `HarnessIcon`, with the target's own label unchanged beside it.

- The launch popover, workspace home cards, the create-and-launch split menu, and the phone launch sheet show the glyph in the icon slot. Agents with no matching glyph keep the sparkles icon; shells keep the terminal icon.
- A target is matched by the leading segments of its key against kit-ui's glyph ids and the agent products listed for them, then by a bare prefix of at least four characters. `claude`, `claude-fast`, and a `claudex` wrapper all get the Claude glyph; `codex-review` gets the OpenAI one; `pixel` never picks up `pi`.
- kit-ui is pinned to the commit that replaced the wordmarks with the AgentsView glyph set (kenn-io/kit-ui#54).

Also included: the ephemeral dev launcher no longer inherits the source config's MCP port, which belongs to the live daemon and made the ephemeral backend fail to start. It resolves a free port (or `-mcp-port`) and reports `mcp_port` and `mcp_url` in its status JSON.

<sup>generated by a clanker</sup>
