### PR TITLE
fix: treat vanished tmux tasks as absent during test cleanup

### DIFF
--- a/internal/testutil/testtmux/process_start_proc.go
+++ b/internal/testutil/testtmux/process_start_proc.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"syscall"
 )
 
 func readProcessStatFromProc(
@@ -13,6 +14,12 @@ func readProcessStatFromProc(
 ) ([]byte, error) {
 	content, err := readFile(fmt.Sprintf("/proc/%d/stat", pid))
 	if err != nil {
+		// The kernel reports ESRCH from the read itself when the task exits
+		// between opening and reading its stat file; that is a definitive
+		// absence, so no liveness probe is needed.
+		if errors.Is(err, syscall.ESRCH) {
+			return nil, fmt.Errorf("%w: process %d", errProcessAbsent, pid)
+		}
 		if errors.Is(err, os.ErrNotExist) &&
 			errors.Is(probeProcess(pid), errProcessAbsent) {
 			return nil, fmt.Errorf("%w: process %d", errProcessAbsent, pid)

--- a/internal/testutil/testtmux/process_start_proc_test.go
+++ b/internal/testutil/testtmux/process_start_proc_test.go
@@ -2,6 +2,7 @@ package testtmux
 
 import (
 	"os"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -37,4 +38,23 @@ func TestReadProcessStatFromProcPreservesMissingStatAsIndeterminate(t *testing.T
 	)
 	require.Same(t, statErr, err)
 	require.NotErrorIs(t, err, errProcessAbsent)
+}
+
+func TestReadProcessStatFromProcTreatsVanishedTaskAsMissing(t *testing.T) {
+	statErr := &os.PathError{
+		Op:   "read",
+		Path: "/proc/31415/stat",
+		Err:  syscall.ESRCH,
+	}
+	_, err := readProcessStatFromProc(
+		31415,
+		func(string) ([]byte, error) {
+			return nil, statErr
+		},
+		func(int) error {
+			require.Fail(t, "probe must not run when the kernel already reported the task gone")
+			return nil
+		},
+	)
+	require.ErrorIs(t, err, errProcessAbsent)
 }


### PR DESCRIPTION
- Fixes the main-branch CI failure in `TestOwnerCleanupRetainsSharedRoot`, where a tmux process listed by `ps` exited before its `/proc/<pid>/stat` was read.
- On Linux that read fails with ESRCH rather than ENOENT, so cleanup treated the dead process as indeterminate and aborted. It is now treated as absent.

Failed run: https://github.com/kenn-io/forge/actions/runs/33630242018/job/100247693994

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sup>generated by a clanker</sup>