### PR TITLE
feat: optional soft line breaks and markdown commit messages in detail views

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,6 +241,7 @@ api-generate: frontend-deps
 	mkdir -p internal/apiclient/spec
 	set -e; tmp="$$(mktemp)"; trap 'rm -f "$$tmp"' EXIT; go run ./cmd/kenn-forge-openapi -out "$$tmp" -version 3.0 -format json; if [ -f internal/apiclient/spec/openapi.json ] && cmp -s "$$tmp" internal/apiclient/spec/openapi.json; then rm "$$tmp"; else mv "$$tmp" internal/apiclient/spec/openapi.json; fi; trap - EXIT
 	set -e; tmp="$$(mktemp)"; trap 'rm -f "$$tmp"' EXIT; node frontend/node_modules/openapi-typescript/bin/cli.js frontend/openapi/openapi.yaml --enum-values -o "$$tmp"; if [ -f frontend/src/lib/api/generated/schema.ts ] && cmp -s "$$tmp" frontend/src/lib/api/generated/schema.ts; then rm "$$tmp"; else mv "$$tmp" frontend/src/lib/api/generated/schema.ts; fi; trap - EXIT
+	set -e; tmp="$$(mktemp)"; trap 'rm -f "$$tmp"' EXIT; node scripts/generate-schema-constraints.mjs internal/apiclient/spec/openapi.json "$$tmp"; if [ -f frontend/src/lib/api/generated/schema-constraints.ts ] && cmp -s "$$tmp" frontend/src/lib/api/generated/schema-constraints.ts; then rm "$$tmp"; else mv "$$tmp" frontend/src/lib/api/generated/schema-constraints.ts; fi; trap - EXIT
 	set -e; tmp="$$(mktemp)"; trap 'rm -f "$$tmp"' EXIT; printf '%s\n' \
 		'/**' \
 		' * This file was auto-generated from frontend/openapi/openapi.yaml.' \

--- a/context/config-persistence.md
+++ b/context/config-persistence.md
@@ -47,10 +47,13 @@ back to TOML.
   Omitted or zero values default to 50; explicit values must remain within 10-250
   in both config loading and settings writes (`internal/config/config.go::Detail`).
 - `detail.collapse_single_line_breaks` is a false-by-default PR/issue presentation opt-in
-  that renders descriptions, comments, and commit bodies with CommonMark soft breaks. It
-  never changes Docs mode or editor previews, and Detail settings writes replace the
+  that renders markdown descriptions, comments, and markdown-rendered commit bodies with
+  CommonMark soft breaks. It never changes plain text, Docs mode, or editor previews, and Detail settings writes replace the
   whole section, so the UI must send every Detail field
   (`internal/config/config.go::Detail`, `frontend/src/lib/utils/markdown.ts::getMarked`).
+- `detail.render_commit_messages_as_markdown` is a false-by-default opt-in that routes
+  timeline commit bodies through the comment markdown pipeline instead of plain text
+  (`internal/config/config.go::Detail`).
 - When zero is meaningful, represent the saved value as optional so TOML `omitempty` cannot turn explicit zero into an unset default; the round-trip test must cover zero (`internal/config/config.go::Terminal`).
 - Whole-file settings mutations must hold `configReloadMu` before `cfgMu` while applying and saving changes, or the watcher can restore a stale snapshot between writes (`internal/server/settings_handlers.go::updateSettings`).
 - Partial settings request objects must use pointer fields and merge only fields that were present; reusing persisted value structs collapses omission into zero values (`internal/server/settings_handlers.go::mcpSettingsUpdate`).

--- a/context/config-persistence.md
+++ b/context/config-persistence.md
@@ -46,6 +46,11 @@ back to TOML.
 - `detail.initial_timeline_entry_limit` is a global PR/issue presentation preference.
   Omitted or zero values default to 50; explicit values must remain within 10-250
   in both config loading and settings writes (`internal/config/config.go::Detail`).
+- `detail.collapse_single_line_breaks` is a false-by-default PR/issue presentation opt-in
+  that renders descriptions, comments, and commit bodies with CommonMark soft breaks. It
+  never changes Docs mode or editor previews, and Detail settings writes replace the
+  whole section, so the UI must send every Detail field
+  (`internal/config/config.go::Detail`, `frontend/src/lib/utils/markdown.ts::getMarked`).
 - When zero is meaningful, represent the saved value as optional so TOML `omitempty` cannot turn explicit zero into an unset default; the round-trip test must cover zero (`internal/config/config.go::Terminal`).
 - Whole-file settings mutations must hold `configReloadMu` before `cfgMu` while applying and saving changes, or the watcher can restore a stale snapshot between writes (`internal/server/settings_handlers.go::updateSettings`).
 - Partial settings request objects must use pointer fields and merge only fields that were present; reusing persisted value structs collapses omission into zero values (`internal/server/settings_handlers.go::mcpSettingsUpdate`).

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -264,10 +264,14 @@ Persisted controls must state their scope clearly.
   (`frontend/src/lib/stores/activity.svelte.ts::loadActivity`).
 - Server-backed settings belong in the API only when the preference should
   follow the user/config rather than one browser session.
-- Settings controls persist on change. Do not add a Save button or hold a dirty
-  draft for a setting; validate on change, persist, and reset the control to the
-  saved value when validation or the save fails
-  (`frontend/src/lib/components/settings/DetailSettings.svelte::saveLimit`).
+- Settings controls persist on change. Do not add a Save button, a dirty draft,
+  or a saving state that disables sibling controls; queue saves serially and
+  build each payload from the latest persisted values
+  (`frontend/src/lib/components/settings/DetailSettings.svelte::persist`).
+- Bounded numeric settings take their limits from the generated
+  `schema-constraints` module, never from hand-copied numbers, and show an inline
+  invalid state instead of sending a request the server would reject
+  (`scripts/generate-schema-constraints.mjs`, `frontend/src/lib/components/settings/DetailSettings.svelte::validateLimit`).
 - Detail timelines apply the server-backed entry limit after filtering and grouping,
   then make the remainder explicit and mount it in bounded idle batches; harnesses
   that require every fixture row pass a large limit. An explicit full-timeline request

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -264,6 +264,10 @@ Persisted controls must state their scope clearly.
   (`frontend/src/lib/stores/activity.svelte.ts::loadActivity`).
 - Server-backed settings belong in the API only when the preference should
   follow the user/config rather than one browser session.
+- Settings controls persist on change. Do not add a Save button or hold a dirty
+  draft for a setting; validate on change, persist, and reset the control to the
+  saved value when validation or the save fails
+  (`frontend/src/lib/components/settings/DetailSettings.svelte::saveLimit`).
 - Detail timelines apply the server-backed entry limit after filtering and grouping,
   then make the remainder explicit and mount it in bounded idle batches; harnesses
   that require every fixture row pass a large limit. An explicit full-timeline request

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -1609,6 +1609,8 @@ components:
     Detail:
       additionalProperties: false
       properties:
+        collapse_single_line_breaks:
+          type: boolean
         initial_timeline_entry_limit:
           format: int64
           maximum: 250
@@ -1616,6 +1618,7 @@ components:
           type: integer
       required:
         - initial_timeline_entry_limit
+        - collapse_single_line_breaks
       type: object
     DiffDescriptor:
       additionalProperties: false

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -1616,9 +1616,12 @@ components:
           maximum: 250
           minimum: 10
           type: integer
+        render_commit_messages_as_markdown:
+          type: boolean
       required:
         - initial_timeline_entry_limit
         - collapse_single_line_breaks
+        - render_commit_messages_as_markdown
       type: object
     DiffDescriptor:
       additionalProperties: false

--- a/frontend/src/lib/api/generated/schema-constraints.ts
+++ b/frontend/src/lib/api/generated/schema-constraints.ts
@@ -1,0 +1,43 @@
+/**
+ * This file was auto-generated from internal/apiclient/spec/openapi.json.
+ * Do not make direct changes to the file.
+ */
+
+export const schemaConstraints = {
+  CreateEnrollmentTokenInputBody: {
+    expires_in_seconds: { minimum: 1, maximum: 86400 },
+  },
+  CreateWorktreeFromMergeRequestInputBody: {
+    number: { minimum: 1 },
+  },
+  Detail: {
+    initial_timeline_entry_limit: { minimum: 10, maximum: 250 },
+  },
+  DiffDescriptor: {
+    snapshot_revision: { minimum: 0 },
+  },
+  FederationDiffDescriptorRequest: {
+    pull_number: { minimum: 1 },
+  },
+  NeutralHost: {
+    generation: { minimum: 0 },
+  },
+  NeutralSnapshot: {
+    generation: { minimum: 0 },
+  },
+  RawSnapshot: {
+    generation: { minimum: 0 },
+  },
+  RepositoryDescriptor: {
+    snapshot_revision: { minimum: 0 },
+  },
+  Snapshot: {
+    generation: { minimum: 0 },
+  },
+  WorkspaceLaunchPull: {
+    snapshot_revision: { minimum: 1 },
+  },
+  WorkspaceLaunchSpec: {
+    item_number: { minimum: 1 },
+  },
+} as const;

--- a/frontend/src/lib/api/generated/schema.ts
+++ b/frontend/src/lib/api/generated/schema.ts
@@ -5798,6 +5798,7 @@ export interface components {
             tmux: boolean;
         };
         Detail: {
+            collapse_single_line_breaks: boolean;
             /** Format: int64 */
             initial_timeline_entry_limit: number;
         };

--- a/frontend/src/lib/api/generated/schema.ts
+++ b/frontend/src/lib/api/generated/schema.ts
@@ -5801,6 +5801,7 @@ export interface components {
             collapse_single_line_breaks: boolean;
             /** Format: int64 */
             initial_timeline_entry_limit: number;
+            render_commit_messages_as_markdown: boolean;
         };
         DiffDescriptor: {
             /**

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -97,6 +97,7 @@ export const DEFAULT_PULL_REQUEST_SETTINGS: PullRequestSettings = {
 export const DEFAULT_DETAIL_SETTINGS: DetailSettings = {
   initial_timeline_entry_limit: 50,
   collapse_single_line_breaks: false,
+  render_commit_messages_as_markdown: false,
 };
 
 export type AgentSettings = components["schemas"]["Agent"];

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -96,6 +96,7 @@ export const DEFAULT_PULL_REQUEST_SETTINGS: PullRequestSettings = {
 
 export const DEFAULT_DETAIL_SETTINGS: DetailSettings = {
   initial_timeline_entry_limit: 50,
+  collapse_single_line_breaks: false,
 };
 
 export type AgentSettings = components["schemas"]["Agent"];

--- a/frontend/src/lib/components/detail/EventTimeline.svelte
+++ b/frontend/src/lib/components/detail/EventTimeline.svelte
@@ -23,6 +23,7 @@
   import { getAppRuntime } from "../../app/runtime-context.js";
   import { transientClipboardFeedback } from "../../browser/clipboard-feedback.js";
   import MarkdownHtml from "../shared/MarkdownHtml.svelte";
+  import { collapsePlainTextLineBreaks } from "../../utils/markdown.js";
   import {
     Button,
     Card,
@@ -130,6 +131,10 @@
   const stores = getStores() as StoreInstances | undefined;
   const runtime = getAppRuntime();
   const detailStore = stores?.detail;
+  const collapseSingleLineBreaks = $derived(
+    stores?.settings?.getDetailSettings().collapse_single_line_breaks ?? false,
+  );
+  const markdownOptions = $derived({ collapseSingleLineBreaks });
   const diffStore = stores?.diff;
   const diffReviewDraft = stores?.diffReviewDraft;
   const diff = $derived(diffStore?.getDiff() ?? null);
@@ -819,7 +824,8 @@
   }
 
   function commitDetailsBody(body: string): string {
-    return body.trim();
+    const trimmed = body.trim();
+    return collapseSingleLineBreaks ? collapsePlainTextLineBreaks(trimmed) : trimmed;
   }
 
   function systemEventLabel(eventType: string): string {
@@ -1676,7 +1682,7 @@
                   {#if block.type === "markdown"}
                     {#if block.text.trim().length > 0}
                       <div class="event-body-segment">
-                        <MarkdownHtml raw={block.text} repo={markdownRepo} />
+                        <MarkdownHtml raw={block.text} repo={markdownRepo} options={markdownOptions} />
                       </div>
                     {/if}
                   {:else if reviewThread}
@@ -1700,7 +1706,7 @@
                   {:else}
                     {@const fallback = "```suggestion\n" + block.replacement + "\n```"}
                     <div class="event-body-segment">
-                      <MarkdownHtml raw={fallback} repo={markdownRepo} />
+                      <MarkdownHtml raw={fallback} repo={markdownRepo} options={markdownOptions} />
                     </div>
                   {/if}
                 {/each}
@@ -1721,6 +1727,7 @@
               <MarkdownHtml
                 raw={event.Body}
                 repo={markdownRepo}
+                options={markdownOptions}
                 transformHtml={inlineReplyEntry
                   ? (html) => withInlineReplyButton(html, inlineReplyEntry)
                   : undefined}

--- a/frontend/src/lib/components/detail/EventTimeline.svelte
+++ b/frontend/src/lib/components/detail/EventTimeline.svelte
@@ -23,7 +23,6 @@
   import { getAppRuntime } from "../../app/runtime-context.js";
   import { transientClipboardFeedback } from "../../browser/clipboard-feedback.js";
   import MarkdownHtml from "../shared/MarkdownHtml.svelte";
-  import { collapsePlainTextLineBreaks } from "../../utils/markdown.js";
   import {
     Button,
     Card,
@@ -135,6 +134,9 @@
     stores?.settings?.getDetailSettings().collapse_single_line_breaks ?? false,
   );
   const markdownOptions = $derived({ collapseSingleLineBreaks });
+  const renderCommitMessagesAsMarkdown = $derived(
+    stores?.settings?.getDetailSettings().render_commit_messages_as_markdown ?? false,
+  );
   const diffStore = stores?.diff;
   const diffReviewDraft = stores?.diffReviewDraft;
   const diff = $derived(diffStore?.getDiff() ?? null);
@@ -824,8 +826,7 @@
   }
 
   function commitDetailsBody(body: string): string {
-    const trimmed = body.trim();
-    return collapseSingleLineBreaks ? collapsePlainTextLineBreaks(trimmed) : trimmed;
+    return body.trim();
   }
 
   function systemEventLabel(eventType: string): string {
@@ -1595,6 +1596,29 @@
   </div>
 {/snippet}
 
+{#snippet commitBody(body: string, animated: boolean)}
+  {#if animated}
+    <div
+      class={["event-body", "commit-body-details", { "markdown-body": renderCommitMessagesAsMarkdown }]}
+      transition:slide={{ duration: 100 }}
+    >
+      {#if renderCommitMessagesAsMarkdown}
+        <MarkdownHtml raw={body} repo={markdownRepo} options={markdownOptions} />
+      {:else}
+        {body}
+      {/if}
+    </div>
+  {:else}
+    <div class={["event-body", "commit-body-details", { "markdown-body": renderCommitMessagesAsMarkdown }]}>
+      {#if renderCommitMessagesAsMarkdown}
+        <MarkdownHtml raw={body} repo={markdownRepo} options={markdownOptions} />
+      {:else}
+        {body}
+      {/if}
+    </div>
+  {/if}
+{/snippet}
+
 {#snippet eventBody(
   event: PREvent | IssueEvent,
   nested = false,
@@ -1990,9 +2014,7 @@
             {#if (canExpandCompact && compactExpanded) || editingId === event.ID}
               <div class="compact-expanded-content">
                 {#if event.EventType === "commit"}
-                  <div class="event-body commit-body-details">
-                    {commitDetailsBody(event.Body)}
-                  </div>
+                  {@render commitBody(commitDetailsBody(event.Body), false)}
                 {:else}
                   {@render eventBody(event, false, entry.reviewThread, hasReplyOnlyAction ? entry : undefined)}
                 {/if}
@@ -2036,9 +2058,7 @@
                 <span class="event-time">{formatRelativeTime(event.CreatedAt)}</span>
               </div>
               {#if showCommitDetails && commitDetails}
-                <div class="event-body commit-body-details" transition:slide={{ duration: 100 }}>
-                  {commitDetails}
-                </div>
+                {@render commitBody(commitDetails, true)}
               {/if}
             </Card>
           {:else if event.EventType === "cross_referenced"}

--- a/frontend/src/lib/components/detail/EventTimeline.test.ts
+++ b/frontend/src/lib/components/detail/EventTimeline.test.ts
@@ -1836,6 +1836,38 @@ describe("EventTimeline", () => {
     expect(document.querySelector(".event-card--commit .event-time")?.textContent).toBe("4h ago");
   });
 
+  it("renders commit bodies as markdown when the detail setting is on", async () => {
+    renderTimeline({
+      props: {
+        events: [
+          makeEvent({
+            EventType: "commit",
+            Summary: "abcdef1234567890",
+            Body: "feat: add filters\n\nSee the **release notes**.",
+          }),
+        ],
+      },
+      context: new Map([
+        [
+          STORES_KEY,
+          {
+            settings: {
+              getDetailSettings: () => ({
+                initial_timeline_entry_limit: 50,
+                collapse_single_line_breaks: false,
+                render_commit_messages_as_markdown: true,
+              }),
+            },
+          },
+        ],
+      ]),
+    });
+
+    const details = document.querySelector(".commit-body-details");
+    expect(details?.classList.contains("markdown-body")).toBe(true);
+    await waitFor(() => expect(details?.querySelector("strong")?.textContent).toBe("release notes"));
+  });
+
   it("expands single-line commit messages when commit details are shown", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-06-01T16:00:00Z"));

--- a/frontend/src/lib/components/detail/IssueDetail.svelte
+++ b/frontend/src/lib/components/detail/IssueDetail.svelte
@@ -1513,7 +1513,10 @@
                 <MarkdownHtml
                   raw={issue.Body}
                   repo={{ provider, platformHost, owner, name, repoPath }}
-                  options={{ interactiveTasks: capabilities.state_mutation && !contentGate.unavailable }}
+                  options={{
+                    interactiveTasks: capabilities.state_mutation && !contentGate.unavailable,
+                    collapseSingleLineBreaks: settings.getDetailSettings().collapse_single_line_breaks,
+                  }}
                 />
               </div>
             </CollapsibleDescription>

--- a/frontend/src/lib/components/detail/PullDetail.svelte
+++ b/frontend/src/lib/components/detail/PullDetail.svelte
@@ -3058,7 +3058,10 @@
                 <MarkdownHtml
                   raw={pr.Body}
                   repo={{ provider, platformHost, owner, name, repoPath }}
-                  options={{ interactiveTasks: capabilities.state_mutation && !contentGate.unavailable }}
+                  options={{
+                    interactiveTasks: capabilities.state_mutation && !contentGate.unavailable,
+                    collapseSingleLineBreaks: settings.getDetailSettings().collapse_single_line_breaks,
+                  }}
                 />
               </div>
             </CollapsibleDescription>

--- a/frontend/src/lib/components/settings/DetailSettings.svelte
+++ b/frontend/src/lib/components/settings/DetailSettings.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Effect } from "effect";
-  import { Button } from "@kenn-io/kit-ui";
+  import { Button, Checkbox } from "@kenn-io/kit-ui";
   import type { DetailSettings as DetailSettingsType } from "../../api/types.js";
   import { getAppRuntime } from "../../app/runtime-context.js";
   import { getStores } from "../../context.js";
@@ -22,6 +22,7 @@
   const embedded = isEmbedded();
   let saving = $state(false);
   let draft = $derived(String(detail.initial_timeline_entry_limit));
+  let collapseDraft = $derived(detail.collapse_single_line_breaks);
   const parsedLimit = $derived(Number(draft));
   const valid = $derived(
     Number.isInteger(parsedLimit) && parsedLimit >= 10 && parsedLimit <= 250,
@@ -29,9 +30,18 @@
   const changed = $derived(valid && parsedLimit !== detail.initial_timeline_entry_limit);
 
   function save(): void {
-    if (embedded || saving || !changed) return;
+    if (!changed) return;
+    persist({ ...detail, initial_timeline_entry_limit: parsedLimit });
+  }
+
+  function toggleCollapseSingleLineBreaks(checked: boolean): void {
+    if (checked === detail.collapse_single_line_breaks) return;
+    persist({ ...detail, collapse_single_line_breaks: checked });
+  }
+
+  function persist(pending: DetailSettingsType): void {
+    if (embedded || saving) return;
     const previous = detail;
-    const pending = { initial_timeline_entry_limit: parsedLimit };
     saving = true;
     runtime.runCommand(
       Effect.gen(function* () {
@@ -43,6 +53,7 @@
             Effect.sync(() => {
               onUpdate(previous);
               draft = String(previous.initial_timeline_entry_limit);
+              collapseDraft = previous.collapse_single_line_breaks;
               showFlash(settingsErrorMessage(failure), { tone: "danger" });
             }),
           onSuccess: (settings) =>
@@ -96,7 +107,25 @@
   </div>
 </div>
 
+<Checkbox
+  class="toggle-row"
+  bind:checked={collapseDraft}
+  disabled={embedded || saving}
+  onchange={toggleCollapseSingleLineBreaks}
+  ariaLabel="Collapse single line breaks"
+>
+  <span class="setting-copy">
+    <span class="setting-label">Collapse single line breaks</span>
+    <span class="setting-description">
+      Render descriptions, comments, and commit messages with soft line breaks:
+      a single newline joins the paragraph and only a blank line starts a new one.
+    </span>
+  </span>
+</Checkbox>
+
 <style>
+  :global(.toggle-row) { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--space-5); }
+  :global(.toggle-row .kit-checkbox__box) { order: 2; margin-top: 2px; }
   .setting-row { display: flex; align-items: center; justify-content: space-between; gap: var(--space-5); min-height: 44px; }
   .setting-copy { display: flex; flex-direction: column; gap: 4px; }
   .setting-label { color: var(--text-secondary); font-size: var(--font-size-md); }

--- a/frontend/src/lib/components/settings/DetailSettings.svelte
+++ b/frontend/src/lib/components/settings/DetailSettings.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Effect } from "effect";
-  import { Button, Checkbox } from "@kenn-io/kit-ui";
+  import { Checkbox } from "@kenn-io/kit-ui";
   import type { DetailSettings as DetailSettingsType } from "../../api/types.js";
   import { getAppRuntime } from "../../app/runtime-context.js";
   import { getStores } from "../../context.js";
@@ -21,18 +21,21 @@
   const { settings: settingsStore } = getStores();
   const embedded = isEmbedded();
   let saving = $state(false);
-  let draft = $derived(String(detail.initial_timeline_entry_limit));
-  let collapseDraft = $derived(detail.collapse_single_line_breaks);
-  let commitMarkdownDraft = $derived(detail.render_commit_messages_as_markdown);
-  const parsedLimit = $derived(Number(draft));
-  const valid = $derived(
-    Number.isInteger(parsedLimit) && parsedLimit >= 10 && parsedLimit <= 250,
-  );
-  const changed = $derived(valid && parsedLimit !== detail.initial_timeline_entry_limit);
+  // Every control saves on change. The checkboxes keep local checked state
+  // so a failed save can flip them back to the persisted value.
+  let collapseSingleLineBreaks = $derived(detail.collapse_single_line_breaks);
+  let renderCommitMessagesAsMarkdown = $derived(detail.render_commit_messages_as_markdown);
 
-  function save(): void {
-    if (!changed) return;
-    persist({ ...detail, initial_timeline_entry_limit: parsedLimit });
+  function saveLimit(event: Event): void {
+    const input = event.currentTarget as HTMLInputElement;
+    const limit = Number(input.value);
+    if (!Number.isInteger(limit) || limit < 10 || limit > 250) {
+      input.value = String(detail.initial_timeline_entry_limit);
+      showFlash("Initial timeline entries must be between 10 and 250", { tone: "danger" });
+      return;
+    }
+    if (limit === detail.initial_timeline_entry_limit) return;
+    persist({ ...detail, initial_timeline_entry_limit: limit });
   }
 
   function toggleCollapseSingleLineBreaks(checked: boolean): void {
@@ -58,9 +61,8 @@
           onFailure: (failure) =>
             Effect.sync(() => {
               onUpdate(previous);
-              draft = String(previous.initial_timeline_entry_limit);
-              collapseDraft = previous.collapse_single_line_breaks;
-              commitMarkdownDraft = previous.render_commit_messages_as_markdown;
+              collapseSingleLineBreaks = previous.collapse_single_line_breaks;
+              renderCommitMessagesAsMarkdown = previous.render_commit_messages_as_markdown;
               showFlash(settingsErrorMessage(failure), { tone: "danger" });
             }),
           onSuccess: (settings) =>
@@ -98,25 +100,16 @@
       min="10"
       max="250"
       step="10"
-      bind:value={draft}
+      value={detail.initial_timeline_entry_limit}
       disabled={embedded || saving}
-      aria-invalid={!valid}
+      onchange={saveLimit}
     />
-    <Button
-      type="button"
-      size="sm"
-      disabled={embedded || saving || !changed}
-      onclick={save}
-      ariaLabel="Save timeline limit"
-    >
-      {saving ? "Saving..." : "Save"}
-    </Button>
   </div>
 </div>
 
 <Checkbox
   class="toggle-row"
-  bind:checked={collapseDraft}
+  bind:checked={collapseSingleLineBreaks}
   disabled={embedded || saving}
   onchange={toggleCollapseSingleLineBreaks}
   ariaLabel="Collapse single line breaks"
@@ -132,7 +125,7 @@
 
 <Checkbox
   class="toggle-row"
-  bind:checked={commitMarkdownDraft}
+  bind:checked={renderCommitMessagesAsMarkdown}
   disabled={embedded || saving}
   onchange={toggleCommitMarkdown}
   ariaLabel="Render commit messages as markdown"

--- a/frontend/src/lib/components/settings/DetailSettings.svelte
+++ b/frontend/src/lib/components/settings/DetailSettings.svelte
@@ -2,6 +2,7 @@
   import { Effect } from "effect";
   import { Checkbox } from "@kenn-io/kit-ui";
   import type { DetailSettings as DetailSettingsType } from "../../api/types.js";
+  import { schemaConstraints } from "../../api/generated/schema-constraints.js";
   import { getAppRuntime } from "../../app/runtime-context.js";
   import { getStores } from "../../context.js";
   import { isEmbedded } from "../../stores/embed-config.svelte.js";
@@ -20,67 +21,95 @@
   const runtime = getAppRuntime();
   const { settings: settingsStore } = getStores();
   const embedded = isEmbedded();
-  let saving = $state(false);
+  // The server's bounds come from the OpenAPI schema, so the input can reject
+  // an out-of-range limit before any request is sent.
+  const limitBounds = schemaConstraints.Detail.initial_timeline_entry_limit;
+  let limitValid = $state(true);
+  // Latest settings known to be persisted. Tracks the prop and advances on
+  // each successful save so a queued save builds on the previous result even
+  // before the parent has fed the new settings back through the prop.
+  let saved = $derived(detail);
   // Every control saves on change. The checkboxes keep local checked state
   // so a failed save can flip them back to the persisted value.
   let collapseSingleLineBreaks = $derived(detail.collapse_single_line_breaks);
   let renderCommitMessagesAsMarkdown = $derived(detail.render_commit_messages_as_markdown);
+  // Saves run one after another. Each builds its payload from the settings
+  // known when it starts, so a checkbox click that lands while a limit save
+  // is in flight neither clobbers that save nor gets dropped.
+  let queue: Promise<void> = Promise.resolve();
+
+  function validateLimit(input: HTMLInputElement): boolean {
+    const limit = Number(input.value);
+    limitValid =
+      input.validity.valid
+      && Number.isInteger(limit)
+      && limit >= limitBounds.minimum
+      && limit <= limitBounds.maximum;
+    return limitValid;
+  }
+
+  function onLimitInput(event: Event): void {
+    validateLimit(event.currentTarget as HTMLInputElement);
+  }
 
   function saveLimit(event: Event): void {
     const input = event.currentTarget as HTMLInputElement;
+    if (!validateLimit(input)) return;
     const limit = Number(input.value);
-    if (!Number.isInteger(limit) || limit < 10 || limit > 250) {
-      input.value = String(detail.initial_timeline_entry_limit);
-      showFlash("Initial timeline entries must be between 10 and 250", { tone: "danger" });
-      return;
-    }
-    if (limit === detail.initial_timeline_entry_limit) return;
-    persist({ ...detail, initial_timeline_entry_limit: limit });
+    persist((current) => (limit === current.initial_timeline_entry_limit ? null : { ...current, initial_timeline_entry_limit: limit }));
   }
 
   function toggleCollapseSingleLineBreaks(checked: boolean): void {
-    if (checked === detail.collapse_single_line_breaks) return;
-    persist({ ...detail, collapse_single_line_breaks: checked });
+    persist((current) => (checked === current.collapse_single_line_breaks ? null : { ...current, collapse_single_line_breaks: checked }));
   }
 
   function toggleCommitMarkdown(checked: boolean): void {
-    if (checked === detail.render_commit_messages_as_markdown) return;
-    persist({ ...detail, render_commit_messages_as_markdown: checked });
+    persist((current) =>
+      checked === current.render_commit_messages_as_markdown ? null : { ...current, render_commit_messages_as_markdown: checked },
+    );
   }
 
-  function persist(pending: DetailSettingsType): void {
-    if (embedded || saving) return;
-    const previous = detail;
-    saving = true;
-    runtime.runCommand(
-      Effect.gen(function* () {
-        const workflow = yield* SettingsWorkflow;
-        return yield* workflow.persist(() => ({ detail: pending }));
-      }).pipe(
-        Effect.matchEffect({
-          onFailure: (failure) =>
-            Effect.sync(() => {
-              onUpdate(previous);
-              collapseSingleLineBreaks = previous.collapse_single_line_breaks;
-              renderCommitMessagesAsMarkdown = previous.render_commit_messages_as_markdown;
-              showFlash(settingsErrorMessage(failure), { tone: "danger" });
-            }),
-          onSuccess: (settings) =>
-            Effect.sync(() => {
-              onUpdate(settings.detail);
-              settingsStore.setDetailSettings(settings.detail);
-            }),
-        }),
-        Effect.ensuring(Effect.sync(() => {
-          saving = false;
-        })),
-      ),
-      {
-        operation: "save detail settings",
-        safeContext: {},
-        onFailure: () => {},
-      },
-    );
+  function persist(build: (current: DetailSettingsType) => DetailSettingsType | null): void {
+    if (embedded) return;
+    queue = queue.then(() => {
+      const pending = build(saved);
+      if (pending === null) return;
+      return save(pending);
+    });
+  }
+
+  function save(pending: DetailSettingsType): Promise<void> {
+    const previous = saved;
+    return new Promise((resolve) => {
+      runtime.runCommand(
+        Effect.gen(function* () {
+          const workflow = yield* SettingsWorkflow;
+          return yield* workflow.persist(() => ({ detail: pending }));
+        }).pipe(
+          Effect.matchEffect({
+            onFailure: (failure) =>
+              Effect.sync(() => {
+                onUpdate(previous);
+                collapseSingleLineBreaks = previous.collapse_single_line_breaks;
+                renderCommitMessagesAsMarkdown = previous.render_commit_messages_as_markdown;
+                showFlash(settingsErrorMessage(failure), { tone: "danger" });
+              }),
+            onSuccess: (settings) =>
+              Effect.sync(() => {
+                saved = settings.detail;
+                onUpdate(settings.detail);
+                settingsStore.setDetailSettings(settings.detail);
+              }),
+          }),
+          Effect.ensuring(Effect.sync(resolve)),
+        ),
+        {
+          operation: "save detail settings",
+          safeContext: {},
+          onFailure: () => {},
+        },
+      );
+    });
   }
 </script>
 
@@ -97,20 +126,28 @@
     <input
       id="initial-timeline-entry-limit"
       type="number"
-      min="10"
-      max="250"
+      min={limitBounds.minimum}
+      max={limitBounds.maximum}
       step="10"
       value={detail.initial_timeline_entry_limit}
-      disabled={embedded || saving}
+      disabled={embedded}
+      aria-invalid={!limitValid}
+      aria-describedby={limitValid ? undefined : "initial-timeline-entry-limit-error"}
+      oninput={onLimitInput}
       onchange={saveLimit}
     />
+    {#if !limitValid}
+      <span id="initial-timeline-entry-limit-error" class="setting-error" role="alert">
+        Enter a whole number from {limitBounds.minimum} to {limitBounds.maximum}.
+      </span>
+    {/if}
   </div>
 </div>
 
 <Checkbox
   class="toggle-row"
   bind:checked={collapseSingleLineBreaks}
-  disabled={embedded || saving}
+  disabled={embedded}
   onchange={toggleCollapseSingleLineBreaks}
   ariaLabel="Collapse single line breaks"
 >
@@ -126,7 +163,7 @@
 <Checkbox
   class="toggle-row"
   bind:checked={renderCommitMessagesAsMarkdown}
-  disabled={embedded || saving}
+  disabled={embedded}
   onchange={toggleCommitMarkdown}
   ariaLabel="Render commit messages as markdown"
 >
@@ -146,6 +183,8 @@
   .setting-copy { display: flex; flex-direction: column; gap: 4px; }
   .setting-label { color: var(--text-secondary); font-size: var(--font-size-md); }
   .setting-description { max-width: 64ch; color: var(--text-muted); font-size: var(--font-size-sm); line-height: 1.4; }
-  .setting-control { display: flex; align-items: center; gap: var(--space-2); }
+  .setting-control { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; }
+  .setting-error { color: var(--accent-red); font-size: var(--font-size-sm); }
   input { width: 5.5rem; height: 28px; border: 1px solid var(--border-default); border-radius: var(--radius-sm); background: var(--bg-primary); color: var(--text-primary); font: inherit; font-size: var(--font-size-sm); padding: 0 8px; }
+  input[aria-invalid="true"] { border-color: var(--accent-red); }
 </style>

--- a/frontend/src/lib/components/settings/DetailSettings.svelte
+++ b/frontend/src/lib/components/settings/DetailSettings.svelte
@@ -23,6 +23,7 @@
   let saving = $state(false);
   let draft = $derived(String(detail.initial_timeline_entry_limit));
   let collapseDraft = $derived(detail.collapse_single_line_breaks);
+  let commitMarkdownDraft = $derived(detail.render_commit_messages_as_markdown);
   const parsedLimit = $derived(Number(draft));
   const valid = $derived(
     Number.isInteger(parsedLimit) && parsedLimit >= 10 && parsedLimit <= 250,
@@ -37,6 +38,11 @@
   function toggleCollapseSingleLineBreaks(checked: boolean): void {
     if (checked === detail.collapse_single_line_breaks) return;
     persist({ ...detail, collapse_single_line_breaks: checked });
+  }
+
+  function toggleCommitMarkdown(checked: boolean): void {
+    if (checked === detail.render_commit_messages_as_markdown) return;
+    persist({ ...detail, render_commit_messages_as_markdown: checked });
   }
 
   function persist(pending: DetailSettingsType): void {
@@ -54,6 +60,7 @@
               onUpdate(previous);
               draft = String(previous.initial_timeline_entry_limit);
               collapseDraft = previous.collapse_single_line_breaks;
+              commitMarkdownDraft = previous.render_commit_messages_as_markdown;
               showFlash(settingsErrorMessage(failure), { tone: "danger" });
             }),
           onSuccess: (settings) =>
@@ -117,8 +124,24 @@
   <span class="setting-copy">
     <span class="setting-label">Collapse single line breaks</span>
     <span class="setting-description">
-      Render descriptions, comments, and commit messages with soft line breaks:
-      a single newline joins the paragraph and only a blank line starts a new one.
+      Render markdown with soft line breaks: a single newline joins the paragraph
+      and only a blank line starts a new one.
+    </span>
+  </span>
+</Checkbox>
+
+<Checkbox
+  class="toggle-row"
+  bind:checked={commitMarkdownDraft}
+  disabled={embedded || saving}
+  onchange={toggleCommitMarkdown}
+  ariaLabel="Render commit messages as markdown"
+>
+  <span class="setting-copy">
+    <span class="setting-label">Render commit messages as markdown</span>
+    <span class="setting-description">
+      Show commit bodies in the timeline with the same markdown rendering as comments
+      instead of plain text.
     </span>
   </span>
 </Checkbox>

--- a/frontend/src/lib/components/settings/DetailSettings.svelte
+++ b/frontend/src/lib/components/settings/DetailSettings.svelte
@@ -38,10 +38,12 @@
   // is in flight neither clobbers that save nor gets dropped.
   let queue: Promise<void> = Promise.resolve();
 
+  // The browser's step check is deliberately ignored: step="10" only makes
+  // the spinner move in tens, while the API accepts any integer in range.
   function validateLimit(input: HTMLInputElement): boolean {
     const limit = Number(input.value);
     limitValid =
-      input.validity.valid
+      !input.validity.badInput
       && Number.isInteger(limit)
       && limit >= limitBounds.minimum
       && limit <= limitBounds.maximum;

--- a/frontend/src/lib/components/settings/DetailSettings.test.ts
+++ b/frontend/src/lib/components/settings/DetailSettings.test.ts
@@ -54,7 +54,7 @@ describe("DetailSettings", () => {
     expect(screen.getByText("Detail policy is managed by the fleet hub.")).toBeTruthy();
   });
 
-  it("saves the initial timeline entry limit", async () => {
+  it("saves the initial timeline entry limit when the input changes", async () => {
     const onUpdate = vi.fn();
     const saved = { ...initial, initial_timeline_entry_limit: 80 };
     mockPersistSettings.mockReturnValue(Effect.succeed({ detail: saved }));
@@ -65,13 +65,25 @@ describe("DetailSettings", () => {
     const input = screen.getByRole("spinbutton", { name: "Initial timeline entries" });
     expect(input.getAttribute("min")).toBe("10");
     expect(input.getAttribute("max")).toBe("250");
-    await fireEvent.input(input, { target: { value: "80" } });
-    await fireEvent.click(screen.getByRole("button", { name: "Save timeline limit" }));
+    expect(screen.queryByRole("button", { name: /save/i })).toBeNull();
+    await fireEvent.change(input, { target: { value: "80" } });
 
     await waitFor(() => expect(mockPersistSettings).toHaveBeenCalledOnce());
     expect(mockPersistSettings.mock.calls[0]?.[0]()).toEqual({ detail: saved });
     expect(onUpdate).toHaveBeenLastCalledWith(saved);
     expect(mockSetDetailSettings).toHaveBeenCalledWith(saved);
+  });
+
+  it("resets an out-of-range limit without saving", async () => {
+    render(SettingsRuntimeHarness, {
+      props: { component: DetailSettings, componentProps: { detail: initial, onUpdate: vi.fn() } },
+    });
+
+    const input = screen.getByRole("spinbutton", { name: "Initial timeline entries" }) as HTMLInputElement;
+    await fireEvent.change(input, { target: { value: "5" } });
+
+    expect(mockPersistSettings).not.toHaveBeenCalled();
+    expect(input.value).toBe("50");
   });
 
   it("restores the prior limit when saving fails", async () => {
@@ -84,8 +96,7 @@ describe("DetailSettings", () => {
     });
 
     const input = screen.getByRole("spinbutton", { name: "Initial timeline entries" });
-    await fireEvent.input(input, { target: { value: "90" } });
-    await fireEvent.click(screen.getByRole("button", { name: "Save timeline limit" }));
+    await fireEvent.change(input, { target: { value: "90" } });
 
     await waitFor(() => expect(onUpdate).toHaveBeenCalled());
     expect(onUpdate).toHaveBeenLastCalledWith(initial);

--- a/frontend/src/lib/components/settings/DetailSettings.test.ts
+++ b/frontend/src/lib/components/settings/DetailSettings.test.ts
@@ -30,7 +30,11 @@ vi.mock("../../stores/embed-config.svelte.js", async (importOriginal) => ({
 import DetailSettings from "./DetailSettings.svelte";
 import SettingsRuntimeHarness from "./SettingsRuntimeHarness.svelte";
 
-const initial = { initial_timeline_entry_limit: 50, collapse_single_line_breaks: false };
+const initial = {
+  initial_timeline_entry_limit: 50,
+  collapse_single_line_breaks: false,
+  render_commit_messages_as_markdown: false,
+};
 
 describe("DetailSettings", () => {
   afterEach(() => {
@@ -52,7 +56,7 @@ describe("DetailSettings", () => {
 
   it("saves the initial timeline entry limit", async () => {
     const onUpdate = vi.fn();
-    const saved = { initial_timeline_entry_limit: 80, collapse_single_line_breaks: false };
+    const saved = { ...initial, initial_timeline_entry_limit: 80 };
     mockPersistSettings.mockReturnValue(Effect.succeed({ detail: saved }));
     render(SettingsRuntimeHarness, {
       props: { component: DetailSettings, componentProps: { detail: initial, onUpdate } },
@@ -90,7 +94,7 @@ describe("DetailSettings", () => {
 
   it("persists the collapse single line breaks toggle alongside the current limit", async () => {
     const onUpdate = vi.fn();
-    const saved = { initial_timeline_entry_limit: 50, collapse_single_line_breaks: true };
+    const saved = { ...initial, collapse_single_line_breaks: true };
     mockPersistSettings.mockReturnValue(Effect.succeed({ detail: saved }));
     render(SettingsRuntimeHarness, {
       props: { component: DetailSettings, componentProps: { detail: initial, onUpdate } },
@@ -104,6 +108,21 @@ describe("DetailSettings", () => {
     expect(mockPersistSettings.mock.calls[0]?.[0]()).toEqual({ detail: saved });
     expect(onUpdate).toHaveBeenLastCalledWith(saved);
     expect(mockSetDetailSettings).toHaveBeenCalledWith(saved);
+  });
+
+  it("persists the commit markdown toggle", async () => {
+    const onUpdate = vi.fn();
+    const saved = { ...initial, render_commit_messages_as_markdown: true };
+    mockPersistSettings.mockReturnValue(Effect.succeed({ detail: saved }));
+    render(SettingsRuntimeHarness, {
+      props: { component: DetailSettings, componentProps: { detail: initial, onUpdate } },
+    });
+
+    await fireEvent.click(screen.getByRole("checkbox", { name: "Render commit messages as markdown" }));
+
+    await waitFor(() => expect(mockPersistSettings).toHaveBeenCalledOnce());
+    expect(mockPersistSettings.mock.calls[0]?.[0]()).toEqual({ detail: saved });
+    expect(onUpdate).toHaveBeenLastCalledWith(saved);
   });
 
   it("unchecks the toggle again when saving fails", async () => {

--- a/frontend/src/lib/components/settings/DetailSettings.test.ts
+++ b/frontend/src/lib/components/settings/DetailSettings.test.ts
@@ -30,7 +30,7 @@ vi.mock("../../stores/embed-config.svelte.js", async (importOriginal) => ({
 import DetailSettings from "./DetailSettings.svelte";
 import SettingsRuntimeHarness from "./SettingsRuntimeHarness.svelte";
 
-const initial = { initial_timeline_entry_limit: 50 };
+const initial = { initial_timeline_entry_limit: 50, collapse_single_line_breaks: false };
 
 describe("DetailSettings", () => {
   afterEach(() => {
@@ -52,7 +52,7 @@ describe("DetailSettings", () => {
 
   it("saves the initial timeline entry limit", async () => {
     const onUpdate = vi.fn();
-    const saved = { initial_timeline_entry_limit: 80 };
+    const saved = { initial_timeline_entry_limit: 80, collapse_single_line_breaks: false };
     mockPersistSettings.mockReturnValue(Effect.succeed({ detail: saved }));
     render(SettingsRuntimeHarness, {
       props: { component: DetailSettings, componentProps: { detail: initial, onUpdate } },
@@ -85,6 +85,41 @@ describe("DetailSettings", () => {
 
     await waitFor(() => expect(onUpdate).toHaveBeenCalled());
     expect(onUpdate).toHaveBeenLastCalledWith(initial);
+    expect(mockSetDetailSettings).not.toHaveBeenCalled();
+  });
+
+  it("persists the collapse single line breaks toggle alongside the current limit", async () => {
+    const onUpdate = vi.fn();
+    const saved = { initial_timeline_entry_limit: 50, collapse_single_line_breaks: true };
+    mockPersistSettings.mockReturnValue(Effect.succeed({ detail: saved }));
+    render(SettingsRuntimeHarness, {
+      props: { component: DetailSettings, componentProps: { detail: initial, onUpdate } },
+    });
+
+    const checkbox = screen.getByRole("checkbox", { name: "Collapse single line breaks" });
+    expect((checkbox as HTMLInputElement).checked).toBe(false);
+    await fireEvent.click(checkbox);
+
+    await waitFor(() => expect(mockPersistSettings).toHaveBeenCalledOnce());
+    expect(mockPersistSettings.mock.calls[0]?.[0]()).toEqual({ detail: saved });
+    expect(onUpdate).toHaveBeenLastCalledWith(saved);
+    expect(mockSetDetailSettings).toHaveBeenCalledWith(saved);
+  });
+
+  it("unchecks the toggle again when saving fails", async () => {
+    const onUpdate = vi.fn();
+    mockPersistSettings.mockReturnValue(
+      Effect.fail({ _tag: "TransientTransportError", operation: "save settings", cause: new Error("save failed") }),
+    );
+    render(SettingsRuntimeHarness, {
+      props: { component: DetailSettings, componentProps: { detail: initial, onUpdate } },
+    });
+
+    const checkbox = screen.getByRole("checkbox", { name: "Collapse single line breaks" });
+    await fireEvent.click(checkbox);
+
+    await waitFor(() => expect(onUpdate).toHaveBeenLastCalledWith(initial));
+    await waitFor(() => expect((checkbox as HTMLInputElement).checked).toBe(false));
     expect(mockSetDetailSettings).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/lib/components/settings/DetailSettings.test.ts
+++ b/frontend/src/lib/components/settings/DetailSettings.test.ts
@@ -74,6 +74,23 @@ describe("DetailSettings", () => {
     expect(mockSetDetailSettings).toHaveBeenCalledWith(saved);
   });
 
+  it("accepts any integer in range even when it is not a multiple of the spinner step", async () => {
+    const saved = { ...initial, initial_timeline_entry_limit: 11 };
+    mockPersistSettings.mockReturnValue(Effect.succeed({ detail: saved }));
+    render(SettingsRuntimeHarness, {
+      props: { component: DetailSettings, componentProps: { detail: initial, onUpdate: vi.fn() } },
+    });
+
+    const input = screen.getByRole("spinbutton", { name: "Initial timeline entries" }) as HTMLInputElement;
+    expect(input.getAttribute("step")).toBe("10");
+    await fireEvent.input(input, { target: { value: "11" } });
+    await fireEvent.change(input, { target: { value: "11" } });
+
+    expect(input.getAttribute("aria-invalid")).toBe("false");
+    await waitFor(() => expect(mockPersistSettings).toHaveBeenCalledOnce());
+    expect(mockPersistSettings.mock.calls[0]?.[0]()).toEqual({ detail: saved });
+  });
+
   it("flags an out-of-range limit inline and sends no request", async () => {
     render(SettingsRuntimeHarness, {
       props: { component: DetailSettings, componentProps: { detail: initial, onUpdate: vi.fn() } },

--- a/frontend/src/lib/components/settings/DetailSettings.test.ts
+++ b/frontend/src/lib/components/settings/DetailSettings.test.ts
@@ -74,16 +74,57 @@ describe("DetailSettings", () => {
     expect(mockSetDetailSettings).toHaveBeenCalledWith(saved);
   });
 
-  it("resets an out-of-range limit without saving", async () => {
+  it("flags an out-of-range limit inline and sends no request", async () => {
     render(SettingsRuntimeHarness, {
       props: { component: DetailSettings, componentProps: { detail: initial, onUpdate: vi.fn() } },
     });
 
     const input = screen.getByRole("spinbutton", { name: "Initial timeline entries" }) as HTMLInputElement;
+    expect(input.getAttribute("min")).toBe("10");
+    expect(input.getAttribute("max")).toBe("250");
+    await fireEvent.input(input, { target: { value: "5" } });
     await fireEvent.change(input, { target: { value: "5" } });
 
     expect(mockPersistSettings).not.toHaveBeenCalled();
-    expect(input.value).toBe("50");
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(screen.getByRole("alert").textContent).toContain("from 10 to 250");
+
+    await fireEvent.input(input, { target: { value: "50" } });
+    expect(input.getAttribute("aria-invalid")).toBe("false");
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("keeps a checkbox click that lands while a limit save is in flight", async () => {
+    const onUpdate = vi.fn();
+    const afterLimit = { ...initial, initial_timeline_entry_limit: 80 };
+    const afterToggle = { ...afterLimit, collapse_single_line_breaks: true };
+    let releaseLimit: (() => void) | undefined;
+    mockPersistSettings
+      .mockReturnValueOnce(
+        Effect.promise(
+          () =>
+            new Promise<{ detail: typeof afterLimit }>((resolve) => {
+              releaseLimit = () => resolve({ detail: afterLimit });
+            }),
+        ),
+      )
+      .mockReturnValueOnce(Effect.succeed({ detail: afterToggle }));
+    render(SettingsRuntimeHarness, {
+      props: { component: DetailSettings, componentProps: { detail: initial, onUpdate } },
+    });
+
+    const input = screen.getByRole("spinbutton", { name: "Initial timeline entries" });
+    await fireEvent.change(input, { target: { value: "80" } });
+    const checkbox = screen.getByRole("checkbox", { name: "Collapse single line breaks" }) as HTMLInputElement;
+    expect(checkbox.disabled).toBe(false);
+    await fireEvent.click(checkbox);
+
+    await waitFor(() => expect(mockPersistSettings).toHaveBeenCalledOnce());
+    releaseLimit?.();
+    await waitFor(() => expect(mockPersistSettings).toHaveBeenCalledTimes(2));
+    expect(mockPersistSettings.mock.calls[0]?.[0]()).toEqual({ detail: afterLimit });
+    expect(mockPersistSettings.mock.calls[1]?.[0]()).toEqual({ detail: afterToggle });
+    await waitFor(() => expect(onUpdate).toHaveBeenLastCalledWith(afterToggle));
   });
 
   it("restores the prior limit when saving fails", async () => {

--- a/frontend/src/lib/components/shared/MarkdownHtml.svelte
+++ b/frontend/src/lib/components/shared/MarkdownHtml.svelte
@@ -28,6 +28,7 @@
     raw: string;
     repoKey: string;
     interactiveTasks: boolean;
+    collapseSingleLineBreaks: boolean;
     transformHtml: ((html: string) => string) | undefined;
     html: string;
   }
@@ -39,17 +40,19 @@
       : `${repo.provider}\0${repo.platformHost ?? ""}\0${repo.owner}\0${repo.name}\0${repo.repoPath}`,
   );
   const interactiveTasks = $derived(options?.interactiveTasks ?? false);
+  const collapseSingleLineBreaks = $derived(options?.collapseSingleLineBreaks ?? false);
   const html = $derived.by(() => {
     if (
       resolved !== null
       && resolved.raw === raw
       && resolved.repoKey === repoKey
       && resolved.interactiveTasks === interactiveTasks
+      && resolved.collapseSingleLineBreaks === collapseSingleLineBreaks
       && resolved.transformHtml === transformHtml
     ) {
       return resolved.html;
     }
-    const fallback = renderMarkdownSync(raw, repo);
+    const fallback = renderMarkdownSync(raw, repo, { collapseSingleLineBreaks });
     return transformHtml?.(fallback) ?? fallback;
   });
 
@@ -58,15 +61,20 @@
     const currentRepo = repo;
     const currentRepoKey = repoKey;
     const currentInteractiveTasks = interactiveTasks;
+    const currentCollapse = collapseSingleLineBreaks;
     const currentTransform = transformHtml;
     const execution = untrack(() => runtime.runCommand(
-      renderMarkdownEffect(currentRaw, currentRepo, { interactiveTasks: currentInteractiveTasks }).pipe(
+      renderMarkdownEffect(currentRaw, currentRepo, {
+        interactiveTasks: currentInteractiveTasks,
+        collapseSingleLineBreaks: currentCollapse,
+      }).pipe(
         Effect.map((rendered) => currentTransform?.(rendered) ?? rendered),
         Effect.tap((rendered) => Effect.sync(() => {
           resolved = {
             raw: currentRaw,
             repoKey: currentRepoKey,
             interactiveTasks: currentInteractiveTasks,
+            collapseSingleLineBreaks: currentCollapse,
             transformHtml: currentTransform,
             html: rendered,
           };

--- a/frontend/src/lib/stores/settings-hydration.test.ts
+++ b/frontend/src/lib/stores/settings-hydration.test.ts
@@ -38,7 +38,7 @@ const settingsPayload = makeStartupSnapshot({
     },
   ],
   activity: activitySettings,
-  detail: { initial_timeline_entry_limit: 75 },
+  detail: { initial_timeline_entry_limit: 75, collapse_single_line_breaks: true },
   launch_targets: [codexTarget],
   workspaces: { auto_assign_on_create: false, default_sidebar_view: "item" },
   roborev: { init_managed_clones: true },
@@ -86,7 +86,10 @@ describe("applySettingsHydration", () => {
 
   it("hydrates the detail timeline limit into the settings store", () => {
     const { settingsStore } = hydrate();
-    expect(settingsStore.getDetailSettings()).toEqual({ initial_timeline_entry_limit: 75 });
+    expect(settingsStore.getDetailSettings()).toEqual({
+      initial_timeline_entry_limit: 75,
+      collapse_single_line_breaks: true,
+    });
   });
 
   it("clears stale launch targets when settings reports an empty inventory", () => {

--- a/frontend/src/lib/stores/settings-hydration.test.ts
+++ b/frontend/src/lib/stores/settings-hydration.test.ts
@@ -38,7 +38,11 @@ const settingsPayload = makeStartupSnapshot({
     },
   ],
   activity: activitySettings,
-  detail: { initial_timeline_entry_limit: 75, collapse_single_line_breaks: true },
+  detail: {
+    initial_timeline_entry_limit: 75,
+    collapse_single_line_breaks: true,
+    render_commit_messages_as_markdown: true,
+  },
   launch_targets: [codexTarget],
   workspaces: { auto_assign_on_create: false, default_sidebar_view: "item" },
   roborev: { init_managed_clones: true },
@@ -89,6 +93,7 @@ describe("applySettingsHydration", () => {
     expect(settingsStore.getDetailSettings()).toEqual({
       initial_timeline_entry_limit: 75,
       collapse_single_line_breaks: true,
+      render_commit_messages_as_markdown: true,
     });
   });
 

--- a/frontend/src/lib/utils/markdown.test.ts
+++ b/frontend/src/lib/utils/markdown.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import { buildCanonicalProviderItemURL } from "./item-reference.js";
-import { renderMarkdown, renderMarkdownBlocks } from "./markdown.js";
+import { collapsePlainTextLineBreaks, renderMarkdown, renderMarkdownBlocks, renderMarkdownSync } from "./markdown.js";
 
 describe("renderMarkdown task lists", () => {
   it("proxies private GitHub attachment images through the repo-scoped API", async () => {
@@ -491,5 +491,64 @@ describe("renderMarkdown details blocks", () => {
     expect(blocks[0]?.html).toContain("</details>");
     expect(blocks[0]?.html).not.toContain("Afterwards.");
     expect(blocks[1]?.html).toContain("<p>Afterwards.</p>");
+  });
+});
+
+describe("renderMarkdown line breaks", () => {
+  it("renders single newlines as hard breaks by default", async () => {
+    const html = await renderMarkdown("first line\nsecond line\n\nnext paragraph");
+    expect(html).toContain("first line<br>second line");
+    expect(html.match(/<p>/g)).toHaveLength(2);
+  });
+
+  it("joins single newlines into the paragraph when collapsing soft breaks", async () => {
+    const html = await renderMarkdown("first line\nsecond line\n\nnext paragraph", undefined, {
+      collapseSingleLineBreaks: true,
+    });
+    expect(html).not.toContain("<br>");
+    expect(html).toContain("first line\nsecond line");
+    expect(html.match(/<p>/g)).toHaveLength(2);
+  });
+
+  it("keeps collapsed and hard-break renders in separate caches", async () => {
+    const raw = "cache me\nplease";
+    const hard = await renderMarkdown(raw);
+    const soft = await renderMarkdown(raw, undefined, { collapseSingleLineBreaks: true });
+    expect(hard).toContain("<br>");
+    expect(soft).not.toContain("<br>");
+    expect(renderMarkdownSync(raw)).toContain("<br>");
+    expect(renderMarkdownSync(raw, undefined, { collapseSingleLineBreaks: true })).not.toContain("<br>");
+  });
+});
+
+describe("collapsePlainTextLineBreaks", () => {
+  it("joins wrapped lines but keeps paragraphs and list-like lines", () => {
+    const text = [
+      "fix: restrict tools",
+      "",
+      "Pi enables command execution by default, which let",
+      "reviews cross the boundary.",
+      "",
+      "Changes:",
+      "- restrict tools",
+      "- keep unsafe runs",
+      "",
+      "    indented block",
+      "    stays",
+    ].join("\n");
+    expect(collapsePlainTextLineBreaks(text)).toBe(
+      [
+        "fix: restrict tools",
+        "",
+        "Pi enables command execution by default, which let reviews cross the boundary.",
+        "",
+        "Changes:",
+        "- restrict tools",
+        "- keep unsafe runs",
+        "",
+        "    indented block",
+        "    stays",
+      ].join("\n"),
+    );
   });
 });

--- a/frontend/src/lib/utils/markdown.test.ts
+++ b/frontend/src/lib/utils/markdown.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import { buildCanonicalProviderItemURL } from "./item-reference.js";
-import { collapsePlainTextLineBreaks, renderMarkdown, renderMarkdownBlocks, renderMarkdownSync } from "./markdown.js";
+import { renderMarkdown, renderMarkdownBlocks, renderMarkdownSync } from "./markdown.js";
 
 describe("renderMarkdown task lists", () => {
   it("proxies private GitHub attachment images through the repo-scoped API", async () => {
@@ -518,37 +518,5 @@ describe("renderMarkdown line breaks", () => {
     expect(soft).not.toContain("<br>");
     expect(renderMarkdownSync(raw)).toContain("<br>");
     expect(renderMarkdownSync(raw, undefined, { collapseSingleLineBreaks: true })).not.toContain("<br>");
-  });
-});
-
-describe("collapsePlainTextLineBreaks", () => {
-  it("joins wrapped lines but keeps paragraphs and list-like lines", () => {
-    const text = [
-      "fix: restrict tools",
-      "",
-      "Pi enables command execution by default, which let",
-      "reviews cross the boundary.",
-      "",
-      "Changes:",
-      "- restrict tools",
-      "- keep unsafe runs",
-      "",
-      "    indented block",
-      "    stays",
-    ].join("\n");
-    expect(collapsePlainTextLineBreaks(text)).toBe(
-      [
-        "fix: restrict tools",
-        "",
-        "Pi enables command execution by default, which let reviews cross the boundary.",
-        "",
-        "Changes:",
-        "- restrict tools",
-        "- keep unsafe runs",
-        "",
-        "    indented block",
-        "    stays",
-      ].join("\n"),
-    );
   });
 });

--- a/frontend/src/lib/utils/markdown.ts
+++ b/frontend/src/lib/utils/markdown.ts
@@ -647,24 +647,3 @@ function renderMarkdownTokens(
   resetRenderState(opts, repo, highlightCode, highlightedCodeTokens);
   return sanitizeMarkdownHtml(marked.parser(tokens) as string);
 }
-
-// Plain-text counterpart of the collapseSingleLineBreaks render option for
-// bodies that are not rendered as markdown, such as commit messages. A
-// single newline joins the paragraph; blank lines still separate
-// paragraphs, and lines that look like list items, headings, quotes, or
-// indented blocks keep their own line.
-const PLAIN_TEXT_LINE_START = /^(\s|[-*+>#]|\d+[.)]\s)/;
-
-export function collapsePlainTextLineBreaks(text: string): string {
-  return text
-    .split(/\n{2,}/)
-    .map((paragraph) =>
-      paragraph.split("\n").reduce((joined, line, index) => {
-        if (index === 0) return line;
-        if (line.trim() === "") return joined;
-        if (PLAIN_TEXT_LINE_START.test(line)) return `${joined}\n${line}`;
-        return `${joined} ${line.trim()}`;
-      }, ""),
-    )
-    .join("\n\n");
-}

--- a/frontend/src/lib/utils/markdown.ts
+++ b/frontend/src/lib/utils/markdown.ts
@@ -160,6 +160,11 @@ export interface RenderMarkdownOpts {
   // caller is responsible for intercepting clicks and persisting state —
   // unhandled clicks toggle visually but do not save.
   interactiveTasks?: boolean;
+  // When true, a single newline inside a paragraph is a CommonMark soft
+  // break that joins the surrounding text; only a blank line separates
+  // paragraphs. When false (the default), newlines render as hard <br>
+  // breaks the way GitHub renders comments.
+  collapseSingleLineBreaks?: boolean;
 }
 
 // Per-render state for the custom checkbox renderer. Marked is single-
@@ -352,11 +357,12 @@ const taskListRenderer: RendererObject = {
   },
 };
 
-function getMarked(repo?: RepoContext): Marked {
-  const key = repo ? `${repo.provider}/${repo.platformHost ?? ""}/${repo.repoPath}` : "";
+function getMarked(repo?: RepoContext, opts: RenderMarkdownOpts = {}): Marked {
+  const collapse = !!opts.collapseSingleLineBreaks;
+  const key = `${collapse ? 1 : 0}\0${repo ? `${repo.provider}/${repo.platformHost ?? ""}/${repo.repoPath}` : ""}`;
   let instance = markedCache.get(key);
   if (!instance) {
-    instance = new Marked({ breaks: true, gfm: true });
+    instance = new Marked({ breaks: !collapse, gfm: true });
     instance.use({ extensions: [providerItemRefExtension(repo)] });
     instance.use({
       renderer: taskListRenderer,
@@ -583,8 +589,9 @@ export function extractMarkdownDefinitionLines(raw: string, repo?: RepoContext):
 export function renderMarkdown(raw: string, repo?: RepoContext, opts: RenderMarkdownOpts = {}): Promise<string> {
   if (!raw) return Promise.resolve("");
   const interactiveTasks = !!opts.interactiveTasks;
+  const collapse = !!opts.collapseSingleLineBreaks;
   const repoKey = repo ? `${repo.provider}/${repo.platformHost ?? ""}/${repo.repoPath}` : "";
-  const key = `${repoKey}\0${interactiveTasks ? 1 : 0}\0${raw}`;
+  const key = `${repoKey}\0${interactiveTasks ? 1 : 0}\0${collapse ? 1 : 0}\0${raw}`;
   const cached = htmlCache.get(key);
   if (cached !== undefined) return cached;
 
@@ -613,7 +620,7 @@ async function renderMarkdownUncached(
   repo: RepoContext | undefined,
   opts: RenderMarkdownOpts,
 ): Promise<string> {
-  const marked = getMarked(repo);
+  const marked = getMarked(repo, opts);
   const tokens = marked.lexer(raw) as Tokens.Generic[];
   // Mermaid fences render as diagram markup, so they never spend the
   // shared highlight budget.
@@ -624,7 +631,7 @@ async function renderMarkdownUncached(
 
 export function renderMarkdownSync(raw: string, repo?: RepoContext, opts: RenderMarkdownOpts = {}): string {
   if (!raw) return "";
-  const marked = getMarked(repo);
+  const marked = getMarked(repo, opts);
   const tokens = marked.lexer(raw) as Tokens.Generic[];
   return renderMarkdownTokens(marked, tokens, opts, repo, false);
 }
@@ -639,4 +646,25 @@ function renderMarkdownTokens(
 ): string {
   resetRenderState(opts, repo, highlightCode, highlightedCodeTokens);
   return sanitizeMarkdownHtml(marked.parser(tokens) as string);
+}
+
+// Plain-text counterpart of the collapseSingleLineBreaks render option for
+// bodies that are not rendered as markdown, such as commit messages. A
+// single newline joins the paragraph; blank lines still separate
+// paragraphs, and lines that look like list items, headings, quotes, or
+// indented blocks keep their own line.
+const PLAIN_TEXT_LINE_START = /^(\s|[-*+>#]|\d+[.)]\s)/;
+
+export function collapsePlainTextLineBreaks(text: string): string {
+  return text
+    .split(/\n{2,}/)
+    .map((paragraph) =>
+      paragraph.split("\n").reduce((joined, line, index) => {
+        if (index === 0) return line;
+        if (line.trim() === "") return joined;
+        if (PLAIN_TEXT_LINE_START.test(line)) return `${joined}\n${line}`;
+        return `${joined} ${line.trim()}`;
+      }, ""),
+    )
+    .join("\n\n");
 }

--- a/frontend/src/test/mockApiFetch.ts
+++ b/frontend/src/test/mockApiFetch.ts
@@ -290,6 +290,7 @@ export const mockSettings = {
   detail: {
     initial_timeline_entry_limit: 50,
     collapse_single_line_breaks: false,
+    render_commit_messages_as_markdown: false,
   },
   issues: {
     hide_bots: false,

--- a/frontend/src/test/mockApiFetch.ts
+++ b/frontend/src/test/mockApiFetch.ts
@@ -289,6 +289,7 @@ export const mockSettings = {
   },
   detail: {
     initial_timeline_entry_limit: 50,
+    collapse_single_line_breaks: false,
   },
   issues: {
     hide_bots: false,

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1944,6 +1944,7 @@ type DependencyCapabilities struct {
 
 // Detail defines model for Detail.
 type Detail struct {
+	CollapseSingleLineBreaks  bool  `json:"collapse_single_line_breaks"`
 	InitialTimelineEntryLimit int64 `json:"initial_timeline_entry_limit"`
 }
 

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1944,8 +1944,9 @@ type DependencyCapabilities struct {
 
 // Detail defines model for Detail.
 type Detail struct {
-	CollapseSingleLineBreaks  bool  `json:"collapse_single_line_breaks"`
-	InitialTimelineEntryLimit int64 `json:"initial_timeline_entry_limit"`
+	CollapseSingleLineBreaks       bool  `json:"collapse_single_line_breaks"`
+	InitialTimelineEntryLimit      int64 `json:"initial_timeline_entry_limit"`
+	RenderCommitMessagesAsMarkdown bool  `json:"render_commit_messages_as_markdown"`
 }
 
 // DiffDescriptor defines model for DiffDescriptor.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -710,6 +710,11 @@ type PullRequests struct {
 // Detail configures presentation shared by pull-request and issue detail.
 type Detail struct {
 	InitialTimelineEntryLimit int `toml:"initial_timeline_entry_limit,omitempty" json:"initial_timeline_entry_limit" minimum:"10" maximum:"250"`
+	// CollapseSingleLineBreaks renders descriptions, comments, and commit
+	// messages with CommonMark soft breaks: a single newline joins the
+	// paragraph and only a blank line separates paragraphs. False keeps
+	// GitHub comment-style hard breaks.
+	CollapseSingleLineBreaks bool `toml:"collapse_single_line_breaks,omitempty" json:"collapse_single_line_breaks"`
 }
 
 // Workspaces configures behavior shared by PR- and issue-backed workspaces.
@@ -1098,6 +1103,7 @@ default_branch_max_commits = 5000
 
 [detail]
 initial_timeline_entry_limit = 50
+collapse_single_line_breaks = false
 
 [terminal]
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -710,11 +710,13 @@ type PullRequests struct {
 // Detail configures presentation shared by pull-request and issue detail.
 type Detail struct {
 	InitialTimelineEntryLimit int `toml:"initial_timeline_entry_limit,omitempty" json:"initial_timeline_entry_limit" minimum:"10" maximum:"250"`
-	// CollapseSingleLineBreaks renders descriptions, comments, and commit
-	// messages with CommonMark soft breaks: a single newline joins the
-	// paragraph and only a blank line separates paragraphs. False keeps
-	// GitHub comment-style hard breaks.
+	// CollapseSingleLineBreaks renders markdown with CommonMark soft breaks:
+	// a single newline joins the paragraph and only a blank line separates
+	// paragraphs. False keeps GitHub comment-style hard breaks.
 	CollapseSingleLineBreaks bool `toml:"collapse_single_line_breaks,omitempty" json:"collapse_single_line_breaks"`
+	// RenderCommitMessagesAsMarkdown renders commit bodies in the timeline
+	// through the same markdown pipeline as comments instead of plain text.
+	RenderCommitMessagesAsMarkdown bool `toml:"render_commit_messages_as_markdown,omitempty" json:"render_commit_messages_as_markdown"`
 }
 
 // Workspaces configures behavior shared by PR- and issue-backed workspaces.
@@ -1104,6 +1106,7 @@ default_branch_max_commits = 5000
 [detail]
 initial_timeline_entry_limit = 50
 collapse_single_line_breaks = false
+render_commit_messages_as_markdown = false
 
 [terminal]
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2686,10 +2686,12 @@ name = "b"
 
 [detail]
 initial_timeline_entry_limit = 80
+collapse_single_line_breaks = true
 	`)
 	cfg, err := Load(path)
 	require.NoError(err)
 	assert.Equal(80, cfg.Detail.InitialTimelineEntryLimit)
+	assert.True(cfg.Detail.CollapseSingleLineBreaks)
 
 	savePath := filepath.Join(t.TempDir(), "saved.toml")
 	require.NoError(cfg.Save(savePath))
@@ -2697,6 +2699,7 @@ initial_timeline_entry_limit = 80
 	cfg2, err := Load(savePath)
 	require.NoError(err)
 	assert.Equal(80, cfg2.Detail.InitialTimelineEntryLimit)
+	assert.True(cfg2.Detail.CollapseSingleLineBreaks)
 }
 
 func TestRepositoryStableIdentitySurvivesConfigSave(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2687,11 +2687,13 @@ name = "b"
 [detail]
 initial_timeline_entry_limit = 80
 collapse_single_line_breaks = true
+render_commit_messages_as_markdown = true
 	`)
 	cfg, err := Load(path)
 	require.NoError(err)
 	assert.Equal(80, cfg.Detail.InitialTimelineEntryLimit)
 	assert.True(cfg.Detail.CollapseSingleLineBreaks)
+	assert.True(cfg.Detail.RenderCommitMessagesAsMarkdown)
 
 	savePath := filepath.Join(t.TempDir(), "saved.toml")
 	require.NoError(cfg.Save(savePath))
@@ -2700,6 +2702,7 @@ collapse_single_line_breaks = true
 	require.NoError(err)
 	assert.Equal(80, cfg2.Detail.InitialTimelineEntryLimit)
 	assert.True(cfg2.Detail.CollapseSingleLineBreaks)
+	assert.True(cfg2.Detail.RenderCommitMessagesAsMarkdown)
 }
 
 func TestRepositoryStableIdentitySurvivesConfigSave(t *testing.T) {

--- a/scripts/dev-backend-build.sh
+++ b/scripts/dev-backend-build.sh
@@ -8,6 +8,8 @@ frontend_spec="frontend/openapi/openapi.yaml"
 backend_spec="internal/apiclient/spec/openapi.json"
 frontend_schema="frontend/src/lib/api/generated/schema.ts"
 frontend_client="frontend/src/lib/api/generated/client.ts"
+frontend_constraints="frontend/src/lib/api/generated/schema-constraints.ts"
+constraints_generator="scripts/generate-schema-constraints.mjs"
 
 mkdir -p "$state_dir"
 
@@ -46,7 +48,7 @@ fi
 
 compute_inputs_hash() {
   {
-    printf '%s\n' "go.mod" "go.sum"
+    printf '%s\n' "go.mod" "go.sum" "$constraints_generator"
     find cmd/kenn-forge-openapi internal/server -type f -name '*.go' | sort
   } | while IFS= read -r path; do
     [ -f "$path" ] || continue
@@ -102,6 +104,12 @@ generate_api_artifacts() {
   fi
 
   write_if_changed "$backend_spec" "$tmp_backend_spec" >/dev/null 2>&1 || true
+
+  # Numeric bounds for frontend validation come from the backend JSON spec,
+  # so regenerate them alongside the other frontend artifacts.
+  tmp_constraints="$(mktemp "$state_dir/frontend-schema-constraints.XXXXXX")"
+  "$NODE_BIN" "$constraints_generator" "$backend_spec" "$tmp_constraints"
+  write_if_changed "$frontend_constraints" "$tmp_constraints" >/dev/null 2>&1 || true
 
   if [ "$frontend_changed" -eq 1 ]; then
     tmp_schema="$(mktemp "$state_dir/frontend-schema.XXXXXX")"

--- a/scripts/dev-backend-build.test.mjs
+++ b/scripts/dev-backend-build.test.mjs
@@ -2,6 +2,16 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { test } from "node:test";
 
+test("regenerates frontend schema constraints from the backend spec after writing it", async () => {
+  const script = await readFile(new URL("./dev-backend-build.sh", import.meta.url), "utf8");
+  const writeBackendSpec = script.indexOf('write_if_changed "$backend_spec" "$tmp_backend_spec"');
+  const generateConstraints = script.indexOf('"$NODE_BIN" "$constraints_generator" "$backend_spec"');
+  assert.notEqual(writeBackendSpec, -1);
+  assert.notEqual(generateConstraints, -1);
+  assert.ok(writeBackendSpec < generateConstraints);
+  assert.ok(script.includes('"$constraints_generator"') && script.includes("compute_inputs_hash"));
+});
+
 test("writes generated backend OpenAPI input before Go client generation", async () => {
   const script = await readFile("scripts/dev-backend-build.sh", "utf8");
 

--- a/scripts/generate-schema-constraints.mjs
+++ b/scripts/generate-schema-constraints.mjs
@@ -1,0 +1,57 @@
+// Emit numeric schema constraints from the generated OpenAPI document as a
+// TypeScript module. openapi-typescript keeps types but drops `minimum` and
+// `maximum`, so the frontend could not validate a bounded field without
+// duplicating the server's limits by hand. This module is the single source
+// the UI reads; regenerate it with `make api-generate`.
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+export function schemaConstraints(document) {
+  const schemas = document?.components?.schemas ?? {};
+  const out = {};
+  for (const schemaName of Object.keys(schemas).sort()) {
+    const properties = schemas[schemaName]?.properties ?? {};
+    const fields = {};
+    for (const propertyName of Object.keys(properties).sort()) {
+      const property = properties[propertyName] ?? {};
+      const constraint = {};
+      if (typeof property.minimum === "number") constraint.minimum = property.minimum;
+      if (typeof property.maximum === "number") constraint.maximum = property.maximum;
+      if (Object.keys(constraint).length > 0) fields[propertyName] = constraint;
+    }
+    if (Object.keys(fields).length > 0) out[schemaName] = fields;
+  }
+  return out;
+}
+
+export function renderModule(constraints) {
+  const lines = [
+    "/**",
+    " * This file was auto-generated from internal/apiclient/spec/openapi.json.",
+    " * Do not make direct changes to the file.",
+    " */",
+    "",
+    "export const schemaConstraints = {",
+  ];
+  for (const [schemaName, fields] of Object.entries(constraints)) {
+    lines.push(`  ${schemaName}: {`);
+    for (const [propertyName, constraint] of Object.entries(fields)) {
+      const parts = Object.entries(constraint).map(([key, value]) => `${key}: ${value}`);
+      lines.push(`    ${propertyName}: { ${parts.join(", ")} },`);
+    }
+    lines.push("  },");
+  }
+  lines.push("} as const;", "");
+  return lines.join("\n");
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (invokedDirectly) {
+  const [specPath, outPath] = process.argv.slice(2);
+  if (!specPath || !outPath) {
+    console.error("usage: generate-schema-constraints.mjs <openapi.json> <out.ts>");
+    process.exit(2);
+  }
+  const document = JSON.parse(readFileSync(specPath, "utf8"));
+  writeFileSync(outPath, renderModule(schemaConstraints(document)));
+}

--- a/scripts/generate-schema-constraints.test.mjs
+++ b/scripts/generate-schema-constraints.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { renderModule, schemaConstraints } from "./generate-schema-constraints.mjs";
+
+test("extracts only numeric bounds, sorted by schema and property", () => {
+  const constraints = schemaConstraints({
+    components: {
+      schemas: {
+        Zeta: { properties: { name: { type: "string" } } },
+        Alpha: {
+          properties: {
+            upper: { type: "integer", maximum: 5 },
+            both: { type: "integer", minimum: 10, maximum: 250 },
+            plain: { type: "boolean" },
+          },
+        },
+      },
+    },
+  });
+  assert.deepEqual(constraints, {
+    Alpha: { both: { minimum: 10, maximum: 250 }, upper: { maximum: 5 } },
+  });
+});
+
+test("renders a const module the frontend can import", () => {
+  const rendered = renderModule({ Alpha: { both: { minimum: 10, maximum: 250 } } });
+  assert.match(rendered, /export const schemaConstraints = \{/);
+  assert.match(rendered, /Alpha: \{\n    both: \{ minimum: 10, maximum: 250 \},\n  \},/);
+  assert.match(rendered, /\} as const;\n$/);
+});


### PR DESCRIPTION
Hard-wrapped descriptions, comments, and commit messages currently keep their narrow wrap width on screen, because Forge renders every newline as a hard line break the way GitHub renders comments. Two new opt-in settings under Settings > Detail change that:

- **Collapse single line breaks** renders markdown with CommonMark soft breaks. A single newline joins the paragraph and only a blank line starts a new one. Applies to pull request and issue descriptions and timeline comments. Docs mode and editor previews are unchanged.
- **Render commit messages as markdown** shows timeline commit bodies through the same renderer as comments instead of plain text. When both settings are on, commit messages collapse too.

Both persist to config under `detail` and default to off, so nothing changes until you turn them on.

Before, with both settings off:

![line-breaks-before.png](https://github.com/user-attachments/assets/d2b30fcb-03cc-460e-8709-14e65086405b)

After, with both settings on:

![line-breaks-after.png](https://github.com/user-attachments/assets/6165a10a-7d2e-4857-bea8-6551a4a6dd7a)

<sup>generated by a clanker</sup>
