### PR TITLE
fix: exclude locked pull requests from open lists

### DIFF
--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -252,7 +252,8 @@ registry helpers return typed errors for missing providers or capabilities.
   or GitLab/Gitea/Forgejo repository metadata confirmation. (`internal/platform/gitlab/feature_disabled.go::Client.repositoryFeatureError`, `internal/platform/gitealike/feature_disabled.go::Provider.ClassifyRepositoryFeatureError`)
 - Locked pull requests retain their upstream state for detail and sync, but list
   filters and repository counts classify them as closed because they cannot enter
-  an open interaction workflow. (`internal/db/queries.go::DB.ListMergeRequests`)
+  an open interaction workflow; detail presents only the Locked chip, not the
+  upstream Open chip. (`internal/db/queries.go::DB.ListMergeRequests`, `frontend/src/lib/components/detail/PullDetail.svelte`)
 - Mutation routes must check provider capabilities before posting comments,
   changing state, merging, requesting review, or approving workflows.
   Server handlers translate these typed platform errors into the stable problem

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -250,6 +250,9 @@ registry helpers return typed errors for missing providers or capabilities.
 - Every issue or merge-request read boundary that can receive a disabled-feature
   candidate must route through definitive classification: GitHub's disabled 410,
   or GitLab/Gitea/Forgejo repository metadata confirmation. (`internal/platform/gitlab/feature_disabled.go::Client.repositoryFeatureError`, `internal/platform/gitealike/feature_disabled.go::Provider.ClassifyRepositoryFeatureError`)
+- Locked pull requests retain their upstream state for detail and sync, but list
+  filters and repository counts classify them as closed because they cannot enter
+  an open interaction workflow. (`internal/db/queries.go::DB.ListMergeRequests`)
 - Mutation routes must check provider capabilities before posting comments,
   changing state, merging, requesting review, or approving workflows.
   Server handlers translate these typed platform errors into the stable problem

--- a/frontend/src/App.provider-capabilities.browser.svelte.ts
+++ b/frontend/src/App.provider-capabilities.browser.svelte.ts
@@ -246,7 +246,10 @@ describe("provider capabilities: locked PR chip", () => {
     });
 
     await expect.element(page.getByText("Locked pull request")).toBeVisible();
-    await vi.waitFor(() => expect(chipsRowText()).toContain("Locked"), WAIT);
+    await vi.waitFor(() => {
+      expect(chipsRowText()).toContain("Locked");
+      expect(chipsRowText()).not.toContain("Open");
+    }, WAIT);
   });
 });
 

--- a/frontend/src/lib/components/detail/PullDetail.svelte
+++ b/frontend/src/lib/components/detail/PullDetail.svelte
@@ -2200,7 +2200,7 @@
       </div>
 
       <div class="chips-row">
-        {#if true}
+        {#if !(pr.IsLocked && lockedSupported)}
           {@const stateLabel = visiblePRStateLabel(pr)}
           {@const markDraftGate = operationGate(repoOperations?.mark_draft)}
           {@const canOpenStateMenu = pr.State === "open" && !pr.IsDraft && capabilities.draft_mutation}

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -2027,10 +2027,13 @@ func (d *DB) ListMergeRequests(ctx context.Context, opts ListMergeRequestsOpts) 
 	case "all":
 		// no state filter
 	case "closed":
-		conds = append(conds, "p.state IN ('closed', 'merged')")
+		conds = append(conds, "(p.state IN ('closed', 'merged') OR p.is_locked)")
 	default:
 		conds = append(conds, "p.state = ?")
 		args = append(args, state)
+		if state == "open" {
+			conds = append(conds, "NOT p.is_locked")
+		}
 	}
 
 	if opts.RepoID != 0 {

--- a/internal/db/queries_repo_summaries.go
+++ b/internal/db/queries_repo_summaries.go
@@ -47,8 +47,8 @@ func (d *DB) loadRepoSummaryStats(
 		WITH pr_stats AS (
 			SELECT repo_id,
 			       COUNT(*) AS cached_pr_count,
-			       SUM(CASE WHEN state = 'open' THEN 1 ELSE 0 END) AS open_pr_count,
-			       SUM(CASE WHEN state = 'open' AND is_draft THEN 1 ELSE 0 END) AS draft_pr_count,
+			       SUM(CASE WHEN state = 'open' AND NOT is_locked THEN 1 ELSE 0 END) AS open_pr_count,
+			       SUM(CASE WHEN state = 'open' AND NOT is_locked AND is_draft THEN 1 ELSE 0 END) AS draft_pr_count,
 			       MAX(last_activity_at) AS last_pr_activity_at
 			FROM forge_merge_requests
 			WHERE NOT EXISTS (

--- a/internal/db/queries_repo_summaries_test.go
+++ b/internal/db/queries_repo_summaries_test.go
@@ -82,6 +82,26 @@ func TestListRepoSummariesIncludesOverviewSnapshot(t *testing.T) {
 	assert.Equal(timelineUpdatedAt, *overview.TimelineUpdatedAt)
 }
 
+func TestListRepoSummariesExcludesLockedPullRequestsFromOpenCounts(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	repoID := insertTestRepo(t, d, "acme", "widgets")
+	insertTestMR(t, d, repoID, 1, "open", baseTime())
+	locked := testMR(repoID, 2)
+	locked.IsDraft = true
+	locked.IsLocked = true
+	_, err := d.UpsertMergeRequest(t.Context(), locked)
+	require.NoError(err)
+
+	summaries, err := d.ListRepoSummaries(t.Context())
+	require.NoError(err)
+	require.Len(summaries, 1)
+	assert.Equal(2, summaries[0].CachedPRCount)
+	assert.Equal(1, summaries[0].OpenPRCount)
+	assert.Zero(summaries[0].DraftPRCount)
+}
+
 func TestUpsertRepoOverviewClearsTimelineWhenReleaseChangesWithoutCloneData(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -1903,6 +1903,26 @@ func TestListPullRequests(t *testing.T) {
 	assert.Equal(t, []int{3, 2, 1}, []int{prs[0].Number, prs[1].Number, prs[2].Number})
 }
 
+func TestListPullRequestsTreatsLockedAsClosed(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	repoID := insertTestRepo(t, d, "owner", "repo")
+	locked := testMR(repoID, 1)
+	locked.IsLocked = true
+	_, err := d.UpsertMergeRequest(t.Context(), locked)
+	require.NoError(err)
+
+	open, err := d.ListMergeRequests(t.Context(), ListMergeRequestsOpts{State: "open"})
+	require.NoError(err)
+	assert.Empty(open)
+
+	closed, err := d.ListMergeRequests(t.Context(), ListMergeRequestsOpts{State: "closed"})
+	require.NoError(err)
+	require.Len(closed, 1)
+	assert.Equal(locked.Number, closed[0].Number)
+}
+
 func TestListPullRequestsFilterByRepo(t *testing.T) {
 	d := openTestDB(t)
 

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -131,7 +131,6 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 		Deletions:         30,
 		CommentCount:      3,
 		ReviewDecision:    "approved",
-		IsLocked:          true,
 		CIStatus:          "success",
 		CIChecksJSON:      string(ciChecksJSON),
 		CreatedAt:         w1Created,
@@ -280,6 +279,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 		Author:            "bob",
 		AuthorDisplayName: "Bob",
 		State:             "closed",
+		IsLocked:          true,
 		HeadBranch:        "experiment/new-api",
 		BaseBranch:        "main",
 		Additions:         900,
@@ -1117,7 +1117,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 			// real branch: a provider sync would otherwise rewrite the DB head
 			// branch to buildGHPR's placeholder and break workspace worktree
 			// provisioning against the git fixture.
-			setPRBranches(setPRLocked(setPRBody(setPRHeadSHA(setPRStats(buildGHPR("acme", "widgets", 1001, 1, "Add widget caching layer", "alice", "open", false, "", w1Created, now.Add(-2*time.Hour)), 240, 30), widgetsPR1HeadSHA), w1Body)), "feature/caching", "main"),
+			setPRBranches(setPRBody(setPRHeadSHA(setPRStats(buildGHPR("acme", "widgets", 1001, 1, "Add widget caching layer", "alice", "open", false, "", w1Created, now.Add(-2*time.Hour)), 240, 30), widgetsPR1HeadSHA), w1Body), "feature/caching", "main"),
 			setPRStats(buildGHPR("acme", "widgets", 1002, 2, "Fix race condition in event loop", "bob", "open", false, "dirty", w2Created, now.Add(-20*time.Hour)), 55, 12),
 			setPRStats(buildGHPR("acme", "widgets", 1006, 6, "WIP: new dashboard layout", "carol", "open", true, "", w6Created, now.Add(-12*time.Hour)), 150, 40),
 			setPRHeadSHA(setPRStats(buildGHPR("acme", "widgets", 1007, 7, "Bump lodash from 4.17.20 to 4.17.21", "dependabot[bot]", "open", false, "", w7Created, now.Add(-6*time.Hour)), 1, 1), widgetsPR7HeadSHA),
@@ -1136,11 +1136,11 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 			// real branch: a provider sync would otherwise rewrite the DB head
 			// branch to buildGHPR's placeholder and break workspace worktree
 			// provisioning against the git fixture.
-			setPRBranches(setPRLocked(setPRBody(setPRHeadSHA(setPRStats(buildGHPR("acme", "widgets", 1001, 1, "Add widget caching layer", "alice", "open", false, "", w1Created, now.Add(-2*time.Hour)), 240, 30), widgetsPR1HeadSHA), w1Body)), "feature/caching", "main"),
+			setPRBranches(setPRBody(setPRHeadSHA(setPRStats(buildGHPR("acme", "widgets", 1001, 1, "Add widget caching layer", "alice", "open", false, "", w1Created, now.Add(-2*time.Hour)), 240, 30), widgetsPR1HeadSHA), w1Body), "feature/caching", "main"),
 			setPRStats(buildGHPR("acme", "widgets", 1002, 2, "Fix race condition in event loop", "bob", "open", false, "dirty", w2Created, now.Add(-20*time.Hour)), 55, 12),
 			setPRStats(buildGHPR("acme", "widgets", 1003, 3, "Upgrade dependency versions", "carol", "merged", false, "", now.Add(-10*24*time.Hour), w3Merged), 80, 80),
 			setPRStats(buildGHPR("acme", "widgets", 1004, 4, "Refactor storage backend", "alice", "merged", false, "", now.Add(-30*24*time.Hour), w4Merged), 420, 310),
-			setPRStats(buildGHPR("acme", "widgets", 1005, 5, "Experimental new API", "bob", "closed", false, "", now.Add(-15*24*time.Hour), w5Closed), 900, 0),
+			setPRLocked(setPRStats(buildGHPR("acme", "widgets", 1005, 5, "Experimental new API", "bob", "closed", false, "", now.Add(-15*24*time.Hour), w5Closed), 900, 0)),
 			setPRStats(buildGHPR("acme", "widgets", 1006, 6, "WIP: new dashboard layout", "carol", "open", true, "", w6Created, now.Add(-12*time.Hour)), 150, 40),
 			setPRHeadSHA(setPRStats(buildGHPR("acme", "widgets", 1007, 7, "Bump lodash from 4.17.20 to 4.17.21", "dependabot[bot]", "open", false, "", w7Created, now.Add(-6*time.Hour)), 1, 1), widgetsPR7HeadSHA),
 		},


### PR DESCRIPTION
Locked pull requests could not take part in open review workflows, but Forge still listed and counted them as open.

- Exclude locked pull requests from open lists and repository open/draft counts.
- Include locked pull requests in closed lists while preserving their upstream state for detail views and sync.
- Show only the Locked chip in pull request detail instead of displaying Open and Locked together.
