### PR TITLE
fix: reconnect terminals after silent transport failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,7 @@ jobs:
       - name: Run tests
         run: |
           mkdir -p tmp
-          go tool gotestsum --format pkgname-and-test-fails --jsonfile=tmp/test-output.json -- ./... -shuffle=on -parallel=4
+          go tool gotestsum --format pkgname-and-test-fails --jsonfile=tmp/test-output.json -- ./... -shuffle=on -parallel=4 -timeout 20m
 
       - name: Publish unit test report
         if: ${{ !cancelled() && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) }}

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -299,9 +299,9 @@ stale tabs.
   (`frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::presentRuntimeMutation`).
 - Workspace terminals use xterm.js exclusively; there is no renderer setting
   or alternate renderer path (`frontend/src/lib/components/terminal/TerminalPane.svelte`).
-- Terminal clients must replace silent half-open sockets without a page reload;
-  round-trip liveness must traverse Fleet bridges so idle tmux output is not required for recovery
-  (`frontend/src/lib/components/terminal/terminal-session.ts::makeTerminalSessionController`, `internal/server/workspaceapi/workspace_runtime_terminal.go::bridgeRuntimeAttachment`).
+- Terminal clients must replace silent half-open sockets without a page reload; every local terminal backend must answer the shared round-trip heartbeat, and Fleet bridges must pass it through so idle output is not required for recovery
+  (`frontend/src/lib/components/terminal/terminal-session.ts::makeTerminalSessionController`,
+  `internal/terminalwebsocket/terminalwebsocket.go::WriteHeartbeat`).
 - Own every non-empty browser text paste at the terminal container boundary,
   sanitize and send it once, and do not delegate single-line paste to xterm;
   this event path must remain usable on insecure HTTP origins without the async

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -299,6 +299,9 @@ stale tabs.
   (`frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::presentRuntimeMutation`).
 - Workspace terminals use xterm.js exclusively; there is no renderer setting
   or alternate renderer path (`frontend/src/lib/components/terminal/TerminalPane.svelte`).
+- Terminal clients must replace silent half-open sockets without a page reload;
+  round-trip liveness must traverse Fleet bridges so idle tmux output is not required for recovery
+  (`frontend/src/lib/components/terminal/terminal-session.ts::makeTerminalSessionController`, `internal/server/workspaceapi/workspace_runtime_terminal.go::bridgeRuntimeAttachment`).
 - Own every non-empty browser text paste at the terminal container boundary,
   sanitize and send it once, and do not delegate single-line paste to xterm;
   this event path must remain usable on insecure HTTP origins without the async

--- a/frontend/src/lib/components/terminal/terminal-session.test.ts
+++ b/frontend/src/lib/components/terminal/terminal-session.test.ts
@@ -188,6 +188,37 @@ it.layer(makeTerminalSocketTest())("terminal socket reconnect", (it) => {
     }),
   );
 
+  it.effect("replaces a socket that stops answering heartbeat round trips", () =>
+    Effect.gen(function* () {
+      const probe = yield* TerminalSocketProbe;
+      probe.sockets.length = 0;
+      const controller = makeTerminalSessionController({
+        url: () => "wss://example.invalid/terminal",
+        onMessage: () => "continue",
+      });
+      const fiber = yield* Effect.forkChild(Effect.scoped(controller.program));
+      yield* Effect.repeat(Effect.yieldNow, { times: 5 });
+      probe.sockets[0]?.open();
+      yield* Effect.repeat(Effect.yieldNow, { times: 5 });
+
+      assert.include(probe.sockets[0]?.sent ?? [], '{"type":"heartbeat"}');
+      yield* TestClock.adjust("44 seconds");
+      probe.sockets[0]?.message('{"type":"heartbeat"}');
+      yield* Effect.yieldNow;
+      yield* TestClock.adjust("44 seconds");
+      assert.isTrue(controller.isConnected());
+      yield* TestClock.adjust("16 seconds");
+      yield* Effect.repeat(Effect.yieldNow, { times: 5 });
+      assert.isFalse(controller.isConnected());
+      assert.strictEqual(probe.sockets[0]?.closeCount, 1);
+      yield* TestClock.adjust("1 second");
+      yield* Effect.repeat(Effect.yieldNow, { times: 5 });
+      assert.lengthOf(probe.sockets, 2);
+
+      yield* Fiber.interrupt(fiber);
+    }),
+  );
+
   it.effect("does not drop outbound frames while the socket is connected", () =>
     Effect.gen(function* () {
       const probe = yield* TerminalSocketProbe;
@@ -206,7 +237,8 @@ it.layer(makeTerminalSocketTest())("terminal socket reconnect", (it) => {
         controller.send(`frame-${index}`);
       }
       yield* Effect.repeat(Effect.yieldNow, { times: 300 });
-      assert.lengthOf(probe.sockets[0]?.sent ?? [], 300);
+      const dataFrames = probe.sockets[0]?.sent.filter((frame) => String(frame).startsWith("frame-"));
+      assert.lengthOf(dataFrames ?? [], 300);
 
       yield* Fiber.interrupt(fiber);
     }),

--- a/frontend/src/lib/components/terminal/terminal-session.ts
+++ b/frontend/src/lib/components/terminal/terminal-session.ts
@@ -37,6 +37,9 @@ class TerminalDisconnected extends Data.TaggedError("TerminalDisconnected")<{
 const terminalReconnectSchedule = Schedule.exponential("1 second").pipe(
   Schedule.modifyDelay(({ duration }) => Effect.succeed(Duration.min(duration, Duration.seconds(30)))),
 );
+const terminalHeartbeatInterval = Duration.seconds(15);
+const terminalLivenessTimeout = Duration.seconds(45);
+const terminalHeartbeatMessage = '{"type":"heartbeat"}';
 
 function isAttachableInitialStatus(status: string | undefined): boolean {
   return status === undefined || status === "running" || status === "starting";
@@ -70,6 +73,7 @@ export function makeTerminalSessionController(options: TerminalSessionOptions): 
     const inbound = yield* Queue.unbounded<
       { readonly kind: "frame"; readonly data: string | Uint8Array } | { readonly kind: "done" }
     >();
+    const heartbeatReplies = yield* Queue.unbounded<void>();
     let opened = false;
     yield* Effect.addFinalizer(() =>
       Effect.sync(() => {
@@ -77,6 +81,7 @@ export function makeTerminalSessionController(options: TerminalSessionOptions): 
       }).pipe(
         Effect.andThen(Queue.shutdown(outbound)),
         Effect.andThen(Queue.shutdown(inbound)),
+        Effect.andThen(Queue.shutdown(heartbeatReplies)),
         Effect.andThen(
           Effect.sync(() => {
             connected = false;
@@ -97,7 +102,11 @@ export function makeTerminalSessionController(options: TerminalSessionOptions): 
     const receiveLoop = socket.runRaw(
       (data) => {
         const frame = normalizeTerminalFrame(data);
-        if (frame !== null) Queue.offerUnsafe(inbound, { kind: "frame", data: frame });
+        if (frame === terminalHeartbeatMessage) {
+          Queue.offerUnsafe(heartbeatReplies, undefined);
+        } else if (frame !== null) {
+          Queue.offerUnsafe(inbound, { kind: "frame", data: frame });
+        }
       },
       {
         onOpen: Effect.sync(() => {
@@ -121,8 +130,27 @@ export function makeTerminalSessionController(options: TerminalSessionOptions): 
       yield* messageLoop;
       yield* Fiber.join(receiver);
     });
+    const heartbeatLoop = Effect.forever(
+      Queue.offer(outbound, terminalHeartbeatMessage).pipe(
+        Effect.andThen(
+          Queue.take(heartbeatReplies).pipe(
+            Effect.timeoutOrElse({
+              duration: terminalLivenessTimeout,
+              orElse: () =>
+                Effect.fail(
+                  new TerminalDisconnected({
+                    cause: new Error("terminal heartbeat timed out"),
+                    opened,
+                  }),
+                ),
+            }),
+          ),
+        ),
+        Effect.andThen(Effect.sleep(terminalHeartbeatInterval)),
+      ),
+    );
 
-    return yield* Effect.raceFirst(readLoop, writeLoop).pipe(
+    return yield* Effect.raceAllFirst([readLoop, writeLoop, heartbeatLoop]).pipe(
       Effect.andThen(
         Effect.suspend(() =>
           Effect.fail(new TerminalDisconnected({ cause: new Error("terminal socket closed"), opened })),

--- a/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
+++ b/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
@@ -2428,7 +2428,9 @@ test.describe("inline workspace pane continuity", () => {
             this.addEventListener("message", (event) => {
               if (typeof event.data !== "string") return;
               try {
-                entry.replayReady = (JSON.parse(event.data) as { type?: string }).type === "replay_ready";
+                if ((JSON.parse(event.data) as { type?: string }).type === "replay_ready") {
+                  entry.replayReady = true;
+                }
               } catch {
                 // Non-JSON text frame; the renderer ignores it too.
               }

--- a/internal/server/fleetapi/fleet_proxy_test.go
+++ b/internal/server/fleetapi/fleet_proxy_test.go
@@ -17,6 +17,7 @@ import (
 
 	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/server/httpapi"
+	"go.kenn.io/forge/internal/terminalwebsocket"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -98,13 +99,15 @@ func TestFleetWebSocketProxyNegotiatesContextTakeoverOnBothLegs(t *testing.T) {
 			peerExtensions <- w.Header().Get("Sec-WebSocket-Extensions")
 			peerHeaders <- r.Header.Clone()
 
-			typ, payload, err := conn.Read(r.Context())
-			if err != nil {
-				peerErrors <- err
-				return
-			}
-			if err := conn.Write(r.Context(), typ, payload); err != nil {
-				peerErrors <- err
+			for {
+				typ, payload, err := conn.Read(r.Context())
+				if err != nil {
+					return
+				}
+				if err := conn.Write(r.Context(), typ, payload); err != nil {
+					peerErrors <- err
+					return
+				}
 			}
 		},
 	))
@@ -175,6 +178,14 @@ func TestFleetWebSocketProxyNegotiatesContextTakeoverOnBothLegs(t *testing.T) {
 	require.NoError(err)
 	assert.Equal(websocket.MessageBinary, typ)
 	assert.Equal(want, got)
+
+	require.NoError(conn.Write(
+		ctx, websocket.MessageText, []byte(terminalwebsocket.HeartbeatMessage),
+	))
+	typ, got, err = conn.Read(ctx)
+	require.NoError(err)
+	assert.Equal(websocket.MessageText, typ)
+	assert.JSONEq(terminalwebsocket.HeartbeatMessage, string(got))
 }
 
 func TestFleetProxyUsesOnlyDestinationCredentialAndRefusesRedirects(t *testing.T) {

--- a/internal/server/workspaceapi/workspace_runtime_terminal.go
+++ b/internal/server/workspaceapi/workspace_runtime_terminal.go
@@ -309,9 +309,16 @@ func bridgeRuntimeAttachment(
 					return
 				}
 			case websocket.MessageText:
-				if err := handleRuntimeTerminalControl(ctx, attachment, data); err != nil {
+				heartbeat, err := handleRuntimeTerminalControl(ctx, attachment, data)
+				if err != nil {
 					slog.Warn("runtime terminal control failed", "err", err)
 					return
+				}
+				if heartbeat {
+					if err := conn.Write(ctx, websocket.MessageText, []byte(`{"type":"heartbeat"}`)); err != nil {
+						logWebsocketDebug("runtime terminal heartbeat write ended", "err", err)
+						return
+					}
 				}
 			}
 		}
@@ -423,14 +430,16 @@ func handleRuntimeTerminalControl(
 	ctx context.Context,
 	attachment *localruntime.Attachment,
 	data []byte,
-) error {
+) (bool, error) {
 	var msg runtimeTerminalControlMsg
 	if err := json.Unmarshal(data, &msg); err != nil {
 		slog.Warn("bad runtime terminal control message", "err", err)
-		return nil
+		return false, nil
 	}
 	info := attachment.Info()
 	switch msg.Type {
+	case "heartbeat":
+		return true, nil
 	case "claim_resize":
 		settle, err := attachment.ClaimResize(ptysize.Geometry{
 			Cols:        msg.Cols,
@@ -439,23 +448,23 @@ func handleRuntimeTerminalControl(
 			PixelHeight: msg.PixelHeight,
 		})
 		if err != nil {
-			return err
+			return false, err
 		}
 		if !settle {
-			return nil
+			return false, nil
 		}
 		refreshCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
 		if err := attachment.Refresh(refreshCtx); err != nil {
-			return err
+			return false, err
 		}
 		attachment.ResizeSettled()
-		return nil
+		return false, nil
 	case "resize_active":
 		if msg.Active != nil {
 			attachment.SetResizeActive(*msg.Active)
 		}
-		return nil
+		return false, nil
 	case "refresh":
 		logWebsocketDebug(
 			"runtime terminal refresh requested",
@@ -481,7 +490,7 @@ func handleRuntimeTerminalControl(
 		if err := attachment.Refresh(refreshCtx); err != nil {
 			slog.Warn("runtime terminal refresh", "err", err)
 		}
-		return nil
+		return false, nil
 	case "resize":
 		logWebsocketDebug(
 			"runtime terminal resize requested",
@@ -501,7 +510,7 @@ func handleRuntimeTerminalControl(
 			slog.Warn("runtime terminal resize", "err", err)
 		}
 	}
-	return nil
+	return false, nil
 }
 
 func writeRuntimeExit(

--- a/internal/server/workspaceapi/workspace_runtime_terminal.go
+++ b/internal/server/workspaceapi/workspace_runtime_terminal.go
@@ -315,7 +315,7 @@ func bridgeRuntimeAttachment(
 					return
 				}
 				if heartbeat {
-					if err := conn.Write(ctx, websocket.MessageText, []byte(`{"type":"heartbeat"}`)); err != nil {
+					if err := terminalwebsocket.WriteHeartbeat(ctx, conn); err != nil {
 						logWebsocketDebug("runtime terminal heartbeat write ended", "err", err)
 						return
 					}

--- a/internal/server/workspaceapi/workspace_runtime_terminal_test.go
+++ b/internal/server/workspaceapi/workspace_runtime_terminal_test.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"go.kenn.io/forge/internal/ptysize"
+	"go.kenn.io/forge/internal/terminalwebsocket"
 	"go.kenn.io/forge/internal/workspace/localruntime"
 )
 
@@ -63,11 +64,14 @@ func TestServeRuntimeTerminalAnswersHeartbeat(t *testing.T) {
 	defer cancel()
 	conn, _, err := websocket.Dial(ctx, wsURL, nil)
 	require.NoError(err)
-	require.NoError(conn.Write(ctx, websocket.MessageText, []byte(`{"type":"heartbeat"}`)))
+	require.NoError(conn.Write(
+		ctx, websocket.MessageText,
+		[]byte(terminalwebsocket.HeartbeatMessage),
+	))
 	typ, data, err := conn.Read(ctx)
 	require.NoError(err)
 	require.Equal(websocket.MessageText, typ)
-	require.JSONEq(`{"type":"heartbeat"}`, string(data))
+	require.JSONEq(terminalwebsocket.HeartbeatMessage, string(data))
 
 	require.NoError(conn.Close(websocket.StatusNormalClosure, "done"))
 	select {

--- a/internal/server/workspaceapi/workspace_runtime_terminal_test.go
+++ b/internal/server/workspaceapi/workspace_runtime_terminal_test.go
@@ -49,6 +49,34 @@ func TestServeRuntimeTerminalNegotiatesCompression(t *testing.T) {
 	}
 }
 
+func TestServeRuntimeTerminalAnswersHeartbeat(t *testing.T) {
+	require := require.New(t)
+	attachment := localruntime.NewAttachmentForTesting(
+		localruntime.AttachmentForTestingOptions{
+			Output: make(chan []byte),
+			Done:   make(chan struct{}),
+		},
+	)
+	wsURL, handlerDone := runtimeTerminalTestServer(t, attachment)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(err)
+	require.NoError(conn.Write(ctx, websocket.MessageText, []byte(`{"type":"heartbeat"}`)))
+	typ, data, err := conn.Read(ctx)
+	require.NoError(err)
+	require.Equal(websocket.MessageText, typ)
+	require.JSONEq(`{"type":"heartbeat"}`, string(data))
+
+	require.NoError(conn.Close(websocket.StatusNormalClosure, "done"))
+	select {
+	case <-handlerDone:
+	case <-ctx.Done():
+		require.Fail("terminal handler did not return")
+	}
+}
+
 func TestServeRuntimeTerminalForwardsBufferedReplayBeforeRefresh(t *testing.T) {
 	require := require.New(t)
 	replay := []byte("buffered replay")
@@ -232,11 +260,13 @@ func TestHandleRuntimeTerminalControlAcknowledgesResizeClaimBeforeReturning(t *t
 		},
 	)
 
-	require.NoError(handleRuntimeTerminalControl(
+	heartbeat, err := handleRuntimeTerminalControl(
 		context.Background(),
 		attachment,
 		[]byte(`{"type":"claim_resize","cols":132,"rows":43,"pixel_width":1056,"pixel_height":688}`),
-	))
+	)
+	require.NoError(err)
+	require.False(heartbeat)
 	events = append(events, "next input")
 
 	require.Equal([]string{"claim", "refresh", "settled", "next input"}, events)

--- a/internal/terminal/bridge.go
+++ b/internal/terminal/bridge.go
@@ -12,6 +12,7 @@ import (
 	"github.com/coder/websocket"
 
 	"go.kenn.io/forge/internal/ptysize"
+	"go.kenn.io/forge/internal/terminalwebsocket"
 )
 
 type controlMsg struct {
@@ -77,6 +78,13 @@ func wsToPTY(
 			var msg controlMsg
 			if jsonErr := json.Unmarshal(data, &msg); jsonErr != nil {
 				slog.Warn("bad control message", "err", jsonErr)
+				continue
+			}
+			if msg.Type == "heartbeat" {
+				if wErr := terminalwebsocket.WriteHeartbeat(ctx, conn); wErr != nil {
+					logWebsocketDebug("terminal heartbeat write ended", "err", wErr)
+					return
+				}
 				continue
 			}
 			handleControl(ptmx, &msg)

--- a/internal/terminal/handler.go
+++ b/internal/terminal/handler.go
@@ -360,6 +360,13 @@ func bridgePtyOwnerAttachment(
 					slog.Warn("bad pty owner terminal control message", "err", err)
 					continue
 				}
+				if msg.Type == "heartbeat" {
+					if err := terminalwebsocket.WriteHeartbeat(ctx, conn); err != nil {
+						logWebsocketDebug("pty owner terminal heartbeat write ended", "err", err)
+						return
+					}
+					continue
+				}
 				if msg.Type == "resize" || msg.Type == "claim_resize" {
 					_ = attachment.Resize(ptysize.Geometry{
 						Cols:        msg.Cols,

--- a/internal/terminal/handler_test.go
+++ b/internal/terminal/handler_test.go
@@ -16,6 +16,7 @@ import (
 
 	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/ptyowner"
+	"go.kenn.io/forge/internal/terminalwebsocket"
 	"go.kenn.io/forge/internal/testutil/dbtest"
 	"go.kenn.io/forge/internal/workspace"
 )
@@ -184,6 +185,20 @@ func TestHandlerAttachesPtyOwnerTerminal(t *testing.T) {
 	require.Contains(readWebSocketUntil(t, conn, "ready"), "ready")
 	require.NoError(conn.Write(
 		t.Context(), websocket.MessageText,
+		[]byte(terminalwebsocket.HeartbeatMessage),
+	))
+	heartbeatCtx, cancelHeartbeat := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancelHeartbeat()
+	for {
+		typ, data, err := conn.Read(heartbeatCtx)
+		require.NoError(err)
+		if typ == websocket.MessageText {
+			require.JSONEq(terminalwebsocket.HeartbeatMessage, string(data))
+			break
+		}
+	}
+	require.NoError(conn.Write(
+		t.Context(), websocket.MessageText,
 		[]byte(`{"type":"claim_resize","cols":101,"rows":33}`),
 	))
 	require.NoError(conn.Write(
@@ -217,6 +232,46 @@ func TestHandleControlAppliesResizeClaim(t *testing.T) {
 		X:    824,
 		Y:    560,
 	}, size)
+}
+
+func TestWSToPTYAnswersHeartbeat(t *testing.T) {
+	require := require.New(t)
+	ptmx, tty, err := pty.Open()
+	require.NoError(err)
+	t.Cleanup(func() {
+		_ = ptmx.Close()
+		_ = tty.Close()
+	})
+
+	handlerDone := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, acceptErr := terminalwebsocket.Accept(w, r)
+		if acceptErr != nil {
+			handlerDone <- acceptErr
+			return
+		}
+		defer conn.CloseNow()
+		wsToPTY(r.Context(), ptmx, conn)
+		handlerDone <- nil
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(
+		ctx, "ws"+strings.TrimPrefix(server.URL, "http"), nil,
+	)
+	require.NoError(err)
+	require.NoError(conn.Write(
+		ctx, websocket.MessageText,
+		[]byte(terminalwebsocket.HeartbeatMessage),
+	))
+	typ, data, err := conn.Read(ctx)
+	require.NoError(err)
+	require.Equal(websocket.MessageText, typ)
+	require.JSONEq(terminalwebsocket.HeartbeatMessage, string(data))
+	require.NoError(conn.Close(websocket.StatusNormalClosure, "done"))
+	require.NoError(<-handlerDone)
 }
 
 func TestProcessExitCode(t *testing.T) {

--- a/internal/terminalwebsocket/terminalwebsocket.go
+++ b/internal/terminalwebsocket/terminalwebsocket.go
@@ -8,6 +8,14 @@ import (
 	"github.com/coder/websocket"
 )
 
+// HeartbeatMessage is the terminal liveness probe and reply payload.
+const HeartbeatMessage = `{"type":"heartbeat"}`
+
+// WriteHeartbeat acknowledges a terminal liveness probe.
+func WriteHeartbeat(ctx context.Context, conn *websocket.Conn) error {
+	return conn.Write(ctx, websocket.MessageText, []byte(HeartbeatMessage))
+}
+
 // Accept upgrades a terminal connection with compression suited to repetitive
 // terminal repaint streams.
 func Accept(w http.ResponseWriter, r *http.Request) (*websocket.Conn, error) {


### PR DESCRIPTION
Forge terminals now recover from silent, half-open WebSocket paths without requiring a page reload.

- Send an end-to-end heartbeat through local and Fleet terminal routes; only the echoed reply proves browser-to-runtime round-trip liveness.
- Close and reconnect after 45 seconds without a reply, using the existing reconnect and replay handling so tmux state returns in browser and desktop shells.
- Cover client timeout/reconnect and server heartbeat echo, and document the transport invariant.
