### PR TITLE
perf: wake the archive worker on demand instead of polling every second

### DIFF
--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -436,10 +436,11 @@ fallback repository listing.
   any other infrastructure error still surfaces — an empty pass reported as
   success would hide a dead worker. (`internal/archive/scheduler.go::RunPass`,
   `internal/archive/service.go::resolveRepositoriesTolerant`)
-- The archive worker is wake-driven, not a ticker: each pass reports the earliest
-  eligibility time (deferral deadlines, feature cooldowns, maintenance due, hydration
-  retries) and the loop sleeps until then, capped at five minutes; only a pass that
-  attempted work or failed re-runs on the pacing interval. (`internal/github/sync.go::archiveWait`)
+- The archive worker backs off while idle instead of ticking every second: after a pass
+  that attempted no work the wait doubles from the pacing interval to a five-minute cap,
+  and a pass that worked or failed, or a wake, returns it to the pacing interval. Every
+  completed sync run wakes it, since a sync can clear a feature cooldown and make archive
+  work eligible. (`internal/github/sync.go::runArchiveLoop`, `internal/github/sync.go::runOnceWithSlot`)
 - Initial issue and pull-request inventory includes all states in stable created-time ascending order; issue enumeration excludes PR-shaped rows. (`internal/github/pages.go::ListIssuesPage`, `internal/github/pages.go::ListMergeRequestsPage`)
 - GitHub issue-only repositories return pulls API 404; normal and archive paths
   classify it as feature-disabled only for explicit `has_pull_requests=false`;

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -441,9 +441,13 @@ fallback repository listing.
   and a pass that worked or failed, or a wake, returns it to the pacing interval. Every
   completed sync run wakes it, since a sync can clear a feature cooldown and make archive
   work eligible. (`internal/github/sync.go::runArchiveLoop`, `internal/github/sync.go::runOnceWithSlot`)
-- A pass "worked" only when a unit reached the provider or failed; an admission deferral
-  before any provider request is idle, so a long live sync backs the worker off instead of
-  writing a one-second deferral every second. (`internal/archive/scheduler.go::finishWork`)
+- A pass "worked" when a unit reached the provider, including a provider-answered feature
+  deferral or a preempted request, or failed; only an admission denial before any provider
+  request is idle, so a long live sync backs the worker off instead of writing a one-second
+  deferral every second. (`internal/archive/scheduler.go::finishWork`)
+- Releasing the last live provider operation on a host wakes the archive worker, so work
+  denied behind a notification refresh or active-detail fetch resumes when the host frees
+  rather than after its backoff. (`internal/github/sync.go::beginProviderWork`)
 - Initial issue and pull-request inventory includes all states in stable created-time ascending order; issue enumeration excludes PR-shaped rows. (`internal/github/pages.go::ListIssuesPage`, `internal/github/pages.go::ListMergeRequestsPage`)
 - GitHub issue-only repositories return pulls API 404; normal and archive paths
   classify it as feature-disabled only for explicit `has_pull_requests=false`;

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -441,6 +441,9 @@ fallback repository listing.
   and a pass that worked or failed, or a wake, returns it to the pacing interval. Every
   completed sync run wakes it, since a sync can clear a feature cooldown and make archive
   work eligible. (`internal/github/sync.go::runArchiveLoop`, `internal/github/sync.go::runOnceWithSlot`)
+- A pass "worked" only when a unit reached the provider or failed; an admission deferral
+  before any provider request is idle, so a long live sync backs the worker off instead of
+  writing a one-second deferral every second. (`internal/archive/scheduler.go::finishWork`)
 - Initial issue and pull-request inventory includes all states in stable created-time ascending order; issue enumeration excludes PR-shaped rows. (`internal/github/pages.go::ListIssuesPage`, `internal/github/pages.go::ListMergeRequestsPage`)
 - GitHub issue-only repositories return pulls API 404; normal and archive paths
   classify it as feature-disabled only for explicit `has_pull_requests=false`;

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -427,15 +427,19 @@ fallback repository listing.
   While an unresolvable ref persists in config, genuinely removed repos keep
   collecting; the recurring deferral warning is the operator signal.
   (`internal/archive/service.go::EnsureConfigured`)
-- The archive worker poll resolves configured repositories tolerantly: a ref
+- The archive worker pass resolves configured repositories tolerantly: a ref
   that seeding skipped stays in the syncer's tracked set, so an all-or-nothing
-  resolve would fail every one-second pass and starve archive work for all
+  resolve would fail every pass and starve archive work for all
   healthy repositories. Only provider-classified failures (invalid ref,
   provider not configured, missing capability) are dropped as
   repository-scoped (debug-logged; seeding already warned); a broken store or
   any other infrastructure error still surfaces — an empty pass reported as
-  success would hide a dead worker. (`internal/archive/scheduler.go::RunEligible`,
+  success would hide a dead worker. (`internal/archive/scheduler.go::RunPass`,
   `internal/archive/service.go::resolveRepositoriesTolerant`)
+- The archive worker is wake-driven, not a ticker: each pass reports the earliest
+  eligibility time (deferral deadlines, feature cooldowns, maintenance due, hydration
+  retries) and the loop sleeps until then, capped at five minutes; only a pass that
+  attempted work or failed re-runs on the pacing interval. (`internal/github/sync.go::archiveWait`)
 - Initial issue and pull-request inventory includes all states in stable created-time ascending order; issue enumeration excludes PR-shaped rows. (`internal/github/pages.go::ListIssuesPage`, `internal/github/pages.go::ListMergeRequestsPage`)
 - GitHub issue-only repositories return pulls API 404; normal and archive paths
   classify it as feature-disabled only for explicit `has_pull_requests=false`;

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -448,6 +448,10 @@ fallback repository listing.
 - Releasing the last live provider operation on a host wakes the archive worker only when
   that host denied or preempted an archive request; a normal sync's stream of releases
   must not trigger denied passes and deferral writes. (`internal/github/sync.go::beginProviderWork`)
+- Archive scheduling is eventually consistent by maintainer decision: a missed or late wake
+  that only delays eligible archive work until the next backoff pass (five minutes at most)
+  is accepted behavior, not a defect. Do not add wake bookkeeping or atomicity for it.
+  (`internal/github/sync.go::runArchiveLoop`)
 - Initial issue and pull-request inventory includes all states in stable created-time ascending order; issue enumeration excludes PR-shaped rows. (`internal/github/pages.go::ListIssuesPage`, `internal/github/pages.go::ListMergeRequestsPage`)
 - GitHub issue-only repositories return pulls API 404; normal and archive paths
   classify it as feature-disabled only for explicit `has_pull_requests=false`;

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -445,9 +445,9 @@ fallback repository listing.
   deferral or a preempted request, or failed; only an admission denial before any provider
   request is idle, so a long live sync backs the worker off instead of writing a one-second
   deferral every second. (`internal/archive/scheduler.go::finishWork`)
-- Releasing the last live provider operation on a host wakes the archive worker, so work
-  denied behind a notification refresh or active-detail fetch resumes when the host frees
-  rather than after its backoff. (`internal/github/sync.go::beginProviderWork`)
+- Releasing the last live provider operation on a host wakes the archive worker only when
+  that host denied or preempted an archive request; a normal sync's stream of releases
+  must not trigger denied passes and deferral writes. (`internal/github/sync.go::beginProviderWork`)
 - Initial issue and pull-request inventory includes all states in stable created-time ascending order; issue enumeration excludes PR-shaped rows. (`internal/github/pages.go::ListIssuesPage`, `internal/github/pages.go::ListMergeRequestsPage`)
 - GitHub issue-only repositories return pulls API 404; normal and archive paths
   classify it as feature-disabled only for explicit `has_pull_requests=false`;

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -350,7 +350,9 @@ registry helpers return typed errors for missing providers or capabilities.
   boundary; using the later promotion time can skip items updated after inventory
   completed. (`internal/db/queries_archive.go::StartFullArchives`)
 - Configuration reconciliation pauses omitted repositories with a durable `configuration_removed` reason while retaining archive content and progress. Re-adding the same full identity clears only that automatic pause; an operator pause stays paused. (`internal/db/queries_archive.go::ReconcileDiscoveryArchives`, `internal/db/queries_archive.go::EnsureDiscoveryArchives`)
-- Reconcile configured repositories only at startup or configuration reload; idle scheduler polls must remain read-only unless they claim actual work. (`internal/github/sync.go::SetReposWithContext`, `internal/archive/scheduler.go::RunEligible`)
+- Reconcile configured repositories only at startup or configuration reload; idle scheduler passes must remain read-only unless they claim actual work. (`internal/github/sync.go::SetReposWithContext`, `internal/archive/scheduler.go::RunPass`)
+- The worker caches resolved repositories keyed on configured refs plus the store's repository reconciliation generation; archive lifecycle changes invalidate explicitly, so an unchanged pass runs no resolution queries. (`internal/archive/service.go::workerRepositories`)
+- An idle pass reads only archive repo states and one hydration due summary; claims run only for repositories the summary reports due, and both share one pending-lookup predicate so they cannot disagree. (`internal/db/queries_archive.go::SummarizeArchiveItemsDue`)
 - Startup reconciliation reopens completed legacy known-item lookups once when
   lifecycle details are missing, independent of historical inventory coverage;
   a close actor is current only when the latest authored close event matches

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -351,8 +351,7 @@ registry helpers return typed errors for missing providers or capabilities.
   completed. (`internal/db/queries_archive.go::StartFullArchives`)
 - Configuration reconciliation pauses omitted repositories with a durable `configuration_removed` reason while retaining archive content and progress. Re-adding the same full identity clears only that automatic pause; an operator pause stays paused. (`internal/db/queries_archive.go::ReconcileDiscoveryArchives`, `internal/db/queries_archive.go::EnsureDiscoveryArchives`)
 - Reconcile configured repositories only at startup or configuration reload; idle scheduler passes must remain read-only unless they claim actual work. (`internal/github/sync.go::SetReposWithContext`, `internal/archive/scheduler.go::RunPass`)
-- The worker caches resolved repositories keyed on configured refs plus the store's repository reconciliation generation; archive lifecycle changes invalidate explicitly, so an unchanged pass runs no resolution queries. (`internal/archive/service.go::workerRepositories`)
-- An idle pass reads only archive repo states and one hydration due summary; claims run only for repositories the summary reports due, and both share one pending-lookup predicate so they cannot disagree. (`internal/db/queries_archive.go::SummarizeArchiveItemsDue`)
+- The worker caches resolved repositories keyed on configured refs plus the store's repository reconciliation generation, which every catalog write advances, so an unchanged pass runs no resolution queries. (`internal/archive/service.go::workerRepositories`)
 - Startup reconciliation reopens completed legacy known-item lookups once when
   lifecycle details are missing, independent of historical inventory coverage;
   a close actor is current only when the latest authored close event matches

--- a/context/retries-and-backoffs.md
+++ b/context/retries-and-backoffs.md
@@ -68,6 +68,10 @@ Steady background cadence is scheduling policy, not transient retry. Do not
 migrate ticker-driven sync or refresh loops into `backoff/v5`
 (`internal/github/sync.go::Syncer.Start`).
 
+The archive worker is the exception: it sleeps until the earliest eligibility time
+its last pass reported (five-minute cap) and is woken by `archiveWake`
+(`internal/github/sync.go::archiveWait`).
+
 ## Long-lived stream recovery
 
 Hub event-stream recovery is connection lifecycle policy, not a retry

--- a/context/retries-and-backoffs.md
+++ b/context/retries-and-backoffs.md
@@ -68,9 +68,9 @@ Steady background cadence is scheduling policy, not transient retry. Do not
 migrate ticker-driven sync or refresh loops into `backoff/v5`
 (`internal/github/sync.go::Syncer.Start`).
 
-The archive worker is the exception: it sleeps until the earliest eligibility time
-its last pass reported (five-minute cap) and is woken by `archiveWake`
-(`internal/github/sync.go::archiveWait`).
+The archive worker uses the backoff schedule type only as an idle delay calculator,
+not as a retry wrapper: idle passes double up to a five-minute cap and any wake or
+worked pass resets it (`internal/github/sync.go::runArchiveLoop`).
 
 ## Long-lived stream recovery
 

--- a/internal/archive/hydrate.go
+++ b/internal/archive/hydrate.go
@@ -33,7 +33,7 @@ func (s *Service) hydrateItem(
 	preempted := archivePreempted(ctx, requestCtx)
 	deferred := complete(syncErr, syncResult.ProviderAttempted)
 	if preempted {
-		return errAdmissionDeferred
+		return errRequestPreempted
 	}
 	if deferred != nil {
 		return &featureDeferredError{FeatureDeferral: *deferred, providerAttempted: true}

--- a/internal/archive/inventory.go
+++ b/internal/archive/inventory.go
@@ -59,7 +59,7 @@ func (s *Service) inventoryPage(ctx context.Context, repo resolvedRepository, st
 			}
 			if err != nil {
 				if preempted {
-					return errAdmissionDeferred
+					return errRequestPreempted
 				}
 				return s.recordScanFailure(ctx, repo, kind, scan.Generation, fmt.Errorf(
 					"list historical issues for %s: %w", archiveRepoIdentityKey(repo.Ref), err,
@@ -85,7 +85,7 @@ func (s *Service) inventoryPage(ctx context.Context, repo resolvedRepository, st
 			}
 			if err != nil {
 				if preempted {
-					return errAdmissionDeferred
+					return errRequestPreempted
 				}
 				return s.recordScanFailure(ctx, repo, kind, scan.Generation, fmt.Errorf(
 					"list historical merge requests for %s: %w", archiveRepoIdentityKey(repo.Ref), err,

--- a/internal/archive/maintenance.go
+++ b/internal/archive/maintenance.go
@@ -182,6 +182,18 @@ func (s *Service) promptPages(
 	}
 }
 
+// nextPromptMaintenanceAt reports when a repository's next maintenance pass
+// becomes due, or nil when maintenance is not scheduled (initial archive
+// incomplete) or is already due.
+func nextPromptMaintenanceAt(state db.ArchiveRepoState, interval time.Duration) *time.Time {
+	if state.InitialCompletedAt == nil ||
+		state.MaintenanceWatermark == nil || state.MaintenanceSucceededAt == nil {
+		return nil
+	}
+	due := state.MaintenanceSucceededAt.Add(interval).UTC()
+	return &due
+}
+
 func promptMaintenanceDue(state db.ArchiveRepoState, now time.Time, interval time.Duration) bool {
 	if state.InitialCompletedAt == nil {
 		return false

--- a/internal/archive/maintenance.go
+++ b/internal/archive/maintenance.go
@@ -126,7 +126,7 @@ func (s *Service) promptPages(
 			}
 			if err != nil {
 				if preempted {
-					return errAdmissionDeferred
+					return errRequestPreempted
 				}
 				return s.recordScanFailure(ctx, repo, kind, scan.Generation, fmt.Errorf(
 					"list updated issues for %s: %w", archiveRepoIdentityKey(repo.Ref), err,
@@ -152,7 +152,7 @@ func (s *Service) promptPages(
 			}
 			if err != nil {
 				if preempted {
-					return errAdmissionDeferred
+					return errRequestPreempted
 				}
 				return s.recordScanFailure(ctx, repo, kind, scan.Generation, fmt.Errorf(
 					"list updated merge requests for %s: %w", archiveRepoIdentityKey(repo.Ref), err,

--- a/internal/archive/maintenance.go
+++ b/internal/archive/maintenance.go
@@ -182,18 +182,6 @@ func (s *Service) promptPages(
 	}
 }
 
-// nextPromptMaintenanceAt reports when a repository's next maintenance pass
-// becomes due, or nil when maintenance is not scheduled (initial archive
-// incomplete) or is already due.
-func nextPromptMaintenanceAt(state db.ArchiveRepoState, interval time.Duration) *time.Time {
-	if state.InitialCompletedAt == nil ||
-		state.MaintenanceWatermark == nil || state.MaintenanceSucceededAt == nil {
-		return nil
-	}
-	due := state.MaintenanceSucceededAt.Add(interval).UTC()
-	return &due
-}
-
 func promptMaintenanceDue(state db.ArchiveRepoState, now time.Time, interval time.Duration) bool {
 	if state.InitialCompletedAt == nil {
 		return false

--- a/internal/archive/scheduler.go
+++ b/internal/archive/scheduler.go
@@ -65,6 +65,11 @@ func (s *Scheduler) Run(
 
 var errAdmissionDeferred = errors.New("archive request deferred by admission")
 
+// errRequestPreempted marks an admitted provider request that live work
+// canceled mid-flight. It is an admission deferral for retry purposes, but the
+// provider was reached, so the pass counts as work.
+var errRequestPreempted = fmt.Errorf("archive request preempted by live work: %w", errAdmissionDeferred)
+
 type featureDeferredError struct {
 	FeatureDeferral
 	providerAttempted bool
@@ -252,13 +257,20 @@ func (s *Service) runNextInventoryWork(
 	}
 }
 
-// finishWork converts a work unit's outcome into the pass result. An
-// admission deferral is not attempted work: nothing reached the provider and
-// the deferral names when to look again, so the worker may back off. A
-// completed or failed unit did reach the provider and is reported as work so
-// the loop keeps its pacing interval while work flows.
+// finishWork converts a work unit's outcome into the pass result. A unit that
+// reached the provider is work, even when the provider answered with a feature
+// deferral or live work preempted the request: other repositories on the host
+// may be eligible right now, so the loop keeps its pacing interval. Only an
+// admission denial before any provider request is idle: nothing was attempted
+// and the deferral names when to look again, so the worker may back off.
 func (s *Service) finishWork(err error) (bool, error) {
-	if errors.Is(err, errAdmissionDeferred) {
+	var deferred *featureDeferredError
+	switch {
+	case errors.As(err, &deferred):
+		return deferred.providerAttempted, nil
+	case errors.Is(err, errRequestPreempted):
+		return true, nil
+	case errors.Is(err, errAdmissionDeferred):
 		return false, nil
 	}
 	return true, err

--- a/internal/archive/scheduler.go
+++ b/internal/archive/scheduler.go
@@ -66,38 +66,114 @@ func featureDeferredBeforeProvider(err error) bool {
 	return errors.As(err, &deferred) && deferred != nil && !deferred.providerAttempted
 }
 
+// NextWake tells the worker loop when to run its next pass.
+type NextWake struct {
+	// At is the earliest moment known archive work can become eligible. It is
+	// zero when nothing is scheduled: every configured repository is paused,
+	// complete, or waiting on an explicit action such as a credential retry.
+	At time.Time
+	// Worked reports that this pass attempted provider work, so more work may
+	// be eligible right away and the loop should pace by its work interval
+	// rather than sleep until At.
+	Worked bool
+}
+
+// wakeCollector gathers the eligibility times one provider-host pass learns
+// about while it looks for work: deferral deadlines, feature cooldowns,
+// maintenance due times, and hydration retry times.
+type wakeCollector struct {
+	at time.Time
+}
+
+func (c *wakeCollector) add(at time.Time) {
+	if at.IsZero() {
+		return
+	}
+	if c.at.IsZero() || at.Before(c.at) {
+		c.at = at
+	}
+}
+
+func (c *wakeCollector) addPtr(at *time.Time) {
+	if at != nil {
+		c.add(at.UTC())
+	}
+}
+
+func (c *wakeCollector) addDeferral(err error) {
+	var deferred *featureDeferredError
+	if errors.As(err, &deferred) && deferred != nil {
+		c.add(deferred.RetryAt.UTC())
+	}
+}
+
+// RunEligible performs one worker pass and discards the wake computation. Tests
+// and one-shot callers use it; the worker loop calls RunPass.
 func (s *Service) RunEligible(ctx context.Context) error {
-	if s.configured == nil {
-		return errors.New("run eligible archives: configured repository source is required")
-	}
-	refs, err := s.configured.ConfiguredRepositories(ctx)
+	_, err := s.RunPass(ctx)
+	return err
+}
+
+// RunPass performs one worker pass over every configured repository grouped by
+// provider host and reports when the next pass can find work. A pass with
+// unchanged configuration performs no repository resolution queries, and a
+// pass that finds no eligible work reads only the archive repository states
+// and one hydration due summary.
+func (s *Service) RunPass(ctx context.Context) (NextWake, error) {
+	resolved, err := s.workerRepositories(ctx)
 	if err != nil {
-		return fmt.Errorf("list configured archive repositories: %w", err)
+		return NextWake{}, err
 	}
-	// Configuration reconciliation runs at startup and on configuration reload.
-	// The one-second worker poll must remain read-only when no work is eligible.
-	// Resolution failures are repository-scoped: a configured entry that seeding
-	// skipped must not block archive work for every healthy repository.
-	resolved, err := s.resolveRepositoriesTolerant(ctx, refs, true)
+	if len(resolved) == 0 {
+		return NextWake{}, nil
+	}
+	states, err := s.db.ListArchiveRepoStates(ctx, resolvedRepoIDs(resolved))
 	if err != nil {
-		return err
+		return NextWake{}, err
+	}
+	stateByID := make(map[int64]db.ArchiveRepoState, len(states))
+	for _, state := range states {
+		stateByID[state.RepoID] = state
 	}
 	groups := make(map[string][]resolvedRepository)
 	for _, repo := range resolved {
 		key := string(repo.Ref.Platform) + "\x00" + repo.Ref.Host
 		groups[key] = append(groups[key], repo)
 	}
-	return s.scheduler.Run(ctx, groups, s.runProviderHostWork)
+	var mu sync.Mutex
+	var next NextWake
+	err = s.scheduler.Run(ctx, groups, func(ctx context.Context, repos []resolvedRepository) error {
+		wake, err := s.runProviderHostWork(ctx, repos, stateByID)
+		mu.Lock()
+		defer mu.Unlock()
+		if wake.Worked {
+			next.Worked = true
+		}
+		if !wake.At.IsZero() && (next.At.IsZero() || wake.At.Before(next.At)) {
+			next.At = wake.At
+		}
+		return err
+	})
+	return next, err
 }
 
-func (s *Service) runProviderHostWork(ctx context.Context, repos []resolvedRepository) error {
-	states, err := s.db.ListArchiveRepoStates(ctx, resolvedRepoIDs(repos))
-	if err != nil {
-		return err
-	}
-	stateByID := make(map[int64]db.ArchiveRepoState, len(states))
-	for _, state := range states {
-		stateByID[state.RepoID] = state
+func (s *Service) runProviderHostWork(
+	ctx context.Context,
+	repos []resolvedRepository,
+	stateByID map[int64]db.ArchiveRepoState,
+) (NextWake, error) {
+	worked := NextWake{Worked: true}
+	var wake wakeCollector
+	now := s.now()
+	for _, repo := range repos {
+		state := stateByID[repo.ID]
+		if state.OperatorState == db.ArchiveOperatorStateActive &&
+			state.NextRetryAt != nil && state.NextRetryAt.After(now) {
+			// A deferred repository becomes eligible again at its retry time.
+			// Authentication and blocked repositories wait for an explicit
+			// retry, which wakes the worker itself.
+			wake.addPtr(state.NextRetryAt)
+		}
 	}
 
 	// Give both independent inventories their first bounded page before
@@ -105,21 +181,23 @@ func (s *Service) runProviderHostWork(ctx context.Context, repos []resolvedRepos
 	for _, repo := range repos {
 		state := stateByID[repo.ID]
 		if state.OperatorState != db.ArchiveOperatorStateActive ||
-			state.CollectionMode != db.ArchiveCollectionModeFull || archiveRepoDeferred(state, s.now()) {
+			state.CollectionMode != db.ArchiveCollectionModeFull || archiveRepoDeferred(state, now) {
 			continue
 		}
 		if archiveScanNotStarted(state.IssueInventory) {
 			err := s.inventoryPage(ctx, repo, state, db.ArchiveItemTypeIssue)
 			if !featureDeferredBeforeProvider(err) {
-				return s.swallowAdmissionDeferred(err)
+				return worked, s.swallowAdmissionDeferred(err)
 			}
+			wake.addDeferral(err)
 		}
 		if archiveScanNotStarted(state.MergeRequestInventory) {
 			err := s.inventoryPage(ctx, repo, state, db.ArchiveItemTypeMergeRequest)
 			if featureDeferredBeforeProvider(err) {
+				wake.addDeferral(err)
 				continue
 			}
-			return s.swallowAdmissionDeferred(err)
+			return worked, s.swallowAdmissionDeferred(err)
 		}
 	}
 
@@ -129,19 +207,20 @@ func (s *Service) runProviderHostWork(ctx context.Context, repos []resolvedRepos
 	// admitted request and indefinitely delay a persisted inventory cursor.
 	// The boundary only holds priority while it can actually advance: a
 	// boundary whose streams are all blocked stays durable for reporting but
-	// must not consume every poll and starve hydration and other
+	// must not consume every pass and starve hydration and other
 	// repositories on the same provider host.
 	for _, repo := range repos {
 		state := stateByID[repo.ID]
 		if state.CollectionMode == db.ArchiveCollectionModeFull &&
 			state.OperatorState == db.ArchiveOperatorStateActive &&
-			state.PromptScanStartedAt != nil && !archiveRepoDeferred(state, s.now()) &&
+			state.PromptScanStartedAt != nil && !archiveRepoDeferred(state, now) &&
 			maintenanceBoundaryActionable(state) {
 			err := s.promptMaintenance(ctx, repo, state)
 			if featureDeferredBeforeProvider(err) {
+				wake.addDeferral(err)
 				continue
 			}
-			return s.swallowAdmissionDeferred(err)
+			return worked, s.swallowAdmissionDeferred(err)
 		}
 	}
 
@@ -149,39 +228,44 @@ func (s *Service) runProviderHostWork(ctx context.Context, repos []resolvedRepos
 	for _, repo := range repos {
 		state := stateByID[repo.ID]
 		if state.CollectionMode == db.ArchiveCollectionModeFull &&
-			state.OperatorState == db.ArchiveOperatorStateActive && !archiveRepoDeferred(state, s.now()) {
+			state.OperatorState == db.ArchiveOperatorStateActive && !archiveRepoDeferred(state, now) {
 			fullIDs = append(fullIDs, repo.ID)
 		}
 	}
-	if handled, err := s.runNextHydrationWork(ctx, repos, fullIDs); handled || err != nil {
-		return err
+	if handled, err := s.runNextHydrationWork(ctx, repos, fullIDs, &wake); handled || err != nil {
+		return worked, err
 	}
 
 	if handled, err := s.runNextInventoryWork(
-		ctx, repos, stateByID, db.ArchiveCollectionModeFull,
+		ctx, repos, stateByID, db.ArchiveCollectionModeFull, &wake,
 	); handled || err != nil {
-		return err
+		return worked, err
 	}
 	for _, repo := range repos {
 		state := stateByID[repo.ID]
 		if state.CollectionMode != db.ArchiveCollectionModeFull ||
-			state.OperatorState != db.ArchiveOperatorStateActive || archiveRepoDeferred(state, s.now()) {
+			state.OperatorState != db.ArchiveOperatorStateActive || archiveRepoDeferred(state, now) {
 			continue
 		}
-		if promptMaintenanceDue(state, s.now(), s.maintenanceInterval) && maintenanceBoundaryActionable(state) {
+		if !maintenanceBoundaryActionable(state) {
+			continue
+		}
+		if promptMaintenanceDue(state, now, s.maintenanceInterval) {
 			err := s.promptMaintenance(ctx, repo, state)
 			if featureDeferredBeforeProvider(err) {
+				wake.addDeferral(err)
 				continue
 			}
-			return s.swallowAdmissionDeferred(err)
+			return worked, s.swallowAdmissionDeferred(err)
 		}
+		wake.addPtr(nextPromptMaintenanceAt(state, s.maintenanceInterval))
 	}
 	if handled, err := s.runNextInventoryWork(
-		ctx, repos, stateByID, db.ArchiveCollectionModeDiscovery,
+		ctx, repos, stateByID, db.ArchiveCollectionModeDiscovery, &wake,
 	); handled || err != nil {
-		return err
+		return worked, err
 	}
-	return nil
+	return NextWake{At: wake.at}, nil
 }
 
 type archiveInventoryScope struct {
@@ -189,15 +273,38 @@ type archiveInventoryScope struct {
 	itemType db.ArchiveItemType
 }
 
+// runNextHydrationWork claims and hydrates the oldest due item across the
+// eligible repositories. One due summary decides whether any claim is worth
+// making; when nothing is due it records the earliest item retry time so the
+// worker sleeps until then instead of re-checking every repository.
 func (s *Service) runNextHydrationWork(
 	ctx context.Context,
 	repos []resolvedRepository,
 	repoIDs []int64,
+	wake *wakeCollector,
 ) (bool, error) {
+	if len(repoIDs) == 0 {
+		return false, nil
+	}
+	summaries, err := s.db.SummarizeArchiveItemsDue(ctx, repoIDs, s.now())
+	if err != nil {
+		return false, err
+	}
+	dueIDs := make([]int64, 0, len(summaries))
+	for _, summary := range summaries {
+		if summary.Due > 0 {
+			dueIDs = append(dueIDs, summary.RepoID)
+			continue
+		}
+		wake.addPtr(summary.NextRetryAt)
+	}
+	if len(dueIDs) == 0 {
+		return false, nil
+	}
 	var excluded []db.ArchiveItemScope
 	for {
 		item, err := s.db.ClaimArchiveItem(ctx, db.ClaimArchiveItemOpts{
-			RepoIDs: repoIDs, Now: s.now(), ExcludedScopes: excluded,
+			RepoIDs: dueIDs, Now: s.now(), ExcludedScopes: excluded,
 		})
 		if err != nil {
 			return false, err
@@ -208,6 +315,7 @@ func (s *Service) runNextHydrationWork(
 		repo := resolvedRepoByID(repos, item.RepoID)
 		err = s.hydrateItem(ctx, repo, *item)
 		if featureDeferredBeforeProvider(err) {
+			wake.addDeferral(err)
 			excluded = append(excluded, db.ArchiveItemScope{
 				RepoID: item.RepoID, ItemType: item.ItemType,
 			})
@@ -222,6 +330,7 @@ func (s *Service) runNextInventoryWork(
 	repos []resolvedRepository,
 	states map[int64]db.ArchiveRepoState,
 	mode db.ArchiveCollectionMode,
+	wake *wakeCollector,
 ) (bool, error) {
 	skipped := make(map[archiveInventoryScope]struct{})
 	for {
@@ -233,6 +342,7 @@ func (s *Service) runNextInventoryWork(
 		}
 		err := s.inventoryPage(ctx, repo, state, itemType)
 		if featureDeferredBeforeProvider(err) {
+			wake.addDeferral(err)
 			skipped[archiveInventoryScope{repoID: repo.ID, itemType: itemType}] = struct{}{}
 			continue
 		}

--- a/internal/archive/scheduler.go
+++ b/internal/archive/scheduler.go
@@ -123,7 +123,7 @@ func (s *Service) runProviderHostWork(ctx context.Context, repos []resolvedRepos
 		if archiveScanNotStarted(state.IssueInventory) {
 			err := s.inventoryPage(ctx, repo, state, db.ArchiveItemTypeIssue)
 			if !featureDeferredBeforeProvider(err) {
-				return true, s.swallowAdmissionDeferred(err)
+				return s.finishWork(err)
 			}
 		}
 		if archiveScanNotStarted(state.MergeRequestInventory) {
@@ -131,7 +131,7 @@ func (s *Service) runProviderHostWork(ctx context.Context, repos []resolvedRepos
 			if featureDeferredBeforeProvider(err) {
 				continue
 			}
-			return true, s.swallowAdmissionDeferred(err)
+			return s.finishWork(err)
 		}
 	}
 
@@ -153,7 +153,7 @@ func (s *Service) runProviderHostWork(ctx context.Context, repos []resolvedRepos
 			if featureDeferredBeforeProvider(err) {
 				continue
 			}
-			return true, s.swallowAdmissionDeferred(err)
+			return s.finishWork(err)
 		}
 	}
 
@@ -185,7 +185,7 @@ func (s *Service) runProviderHostWork(ctx context.Context, repos []resolvedRepos
 			if featureDeferredBeforeProvider(err) {
 				continue
 			}
-			return true, s.swallowAdmissionDeferred(err)
+			return s.finishWork(err)
 		}
 	}
 	if handled, err := s.runNextInventoryWork(
@@ -225,7 +225,7 @@ func (s *Service) runNextHydrationWork(
 			})
 			continue
 		}
-		return true, s.swallowAdmissionDeferred(err)
+		return s.finishWork(err)
 	}
 }
 
@@ -248,15 +248,20 @@ func (s *Service) runNextInventoryWork(
 			skipped[archiveInventoryScope{repoID: repo.ID, itemType: itemType}] = struct{}{}
 			continue
 		}
-		return true, s.swallowAdmissionDeferred(err)
+		return s.finishWork(err)
 	}
 }
 
-func (s *Service) swallowAdmissionDeferred(err error) error {
+// finishWork converts a work unit's outcome into the pass result. An
+// admission deferral is not attempted work: nothing reached the provider and
+// the deferral names when to look again, so the worker may back off. A
+// completed or failed unit did reach the provider and is reported as work so
+// the loop keeps its pacing interval while work flows.
+func (s *Service) finishWork(err error) (bool, error) {
 	if errors.Is(err, errAdmissionDeferred) {
-		return nil
+		return false, nil
 	}
-	return err
+	return true, err
 }
 
 // archiveScanNotStarted reports a scan generation that has not committed any

--- a/internal/archive/scheduler.go
+++ b/internal/archive/scheduler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.kenn.io/forge/internal/db"
@@ -26,18 +27,29 @@ type Scheduler struct{}
 
 func NewScheduler() *Scheduler { return &Scheduler{} }
 
-func (s *Scheduler) Run(ctx context.Context, groups map[string][]resolvedRepository, work func(context.Context, []resolvedRepository) error) error {
+// Run executes work for every provider-host group concurrently and reports
+// whether any group attempted provider work.
+func (s *Scheduler) Run(
+	ctx context.Context,
+	groups map[string][]resolvedRepository,
+	work func(context.Context, []resolvedRepository) (bool, error),
+) (bool, error) {
 	keys := make([]string, 0, len(groups))
 	for key := range groups {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 	errCh := make(chan error, len(keys))
+	var worked atomic.Bool
 	var wg sync.WaitGroup
 	for _, key := range keys {
 		key, repos := key, groups[key]
 		wg.Go(func() {
-			if err := work(ctx, repos); err != nil {
+			handled, err := work(ctx, repos)
+			if handled {
+				worked.Store(true)
+			}
+			if err != nil {
 				errCh <- fmt.Errorf("archive provider worker %s: %w", key, err)
 			}
 		})
@@ -48,7 +60,7 @@ func (s *Scheduler) Run(ctx context.Context, groups map[string][]resolvedReposit
 	for err := range errCh {
 		errs = append(errs, err)
 	}
-	return errors.Join(errs...)
+	return worked.Load(), errors.Join(errs...)
 }
 
 var errAdmissionDeferred = errors.New("archive request deferred by admission")
@@ -66,114 +78,38 @@ func featureDeferredBeforeProvider(err error) bool {
 	return errors.As(err, &deferred) && deferred != nil && !deferred.providerAttempted
 }
 
-// NextWake tells the worker loop when to run its next pass.
-type NextWake struct {
-	// At is the earliest moment known archive work can become eligible. It is
-	// zero when nothing is scheduled: every configured repository is paused,
-	// complete, or waiting on an explicit action such as a credential retry.
-	At time.Time
-	// Worked reports that this pass attempted provider work, so more work may
-	// be eligible right away and the loop should pace by its work interval
-	// rather than sleep until At.
-	Worked bool
-}
-
-// wakeCollector gathers the eligibility times one provider-host pass learns
-// about while it looks for work: deferral deadlines, feature cooldowns,
-// maintenance due times, and hydration retry times.
-type wakeCollector struct {
-	at time.Time
-}
-
-func (c *wakeCollector) add(at time.Time) {
-	if at.IsZero() {
-		return
-	}
-	if c.at.IsZero() || at.Before(c.at) {
-		c.at = at
-	}
-}
-
-func (c *wakeCollector) addPtr(at *time.Time) {
-	if at != nil {
-		c.add(at.UTC())
-	}
-}
-
-func (c *wakeCollector) addDeferral(err error) {
-	var deferred *featureDeferredError
-	if errors.As(err, &deferred) && deferred != nil {
-		c.add(deferred.RetryAt.UTC())
-	}
-}
-
-// RunEligible performs one worker pass and discards the wake computation. Tests
-// and one-shot callers use it; the worker loop calls RunPass.
+// RunEligible performs one worker pass. Tests and one-shot callers use it;
+// the worker loop calls RunPass to learn whether the pass attempted work.
 func (s *Service) RunEligible(ctx context.Context) error {
 	_, err := s.RunPass(ctx)
 	return err
 }
 
 // RunPass performs one worker pass over every configured repository grouped by
-// provider host and reports when the next pass can find work. A pass with
-// unchanged configuration performs no repository resolution queries, and a
-// pass that finds no eligible work reads only the archive repository states
-// and one hydration due summary.
-func (s *Service) RunPass(ctx context.Context) (NextWake, error) {
+// provider host and reports whether any provider work was attempted, so the
+// loop can back off while nothing is eligible. A pass with unchanged
+// configuration performs no repository resolution queries.
+func (s *Service) RunPass(ctx context.Context) (bool, error) {
 	resolved, err := s.workerRepositories(ctx)
 	if err != nil {
-		return NextWake{}, err
-	}
-	if len(resolved) == 0 {
-		return NextWake{}, nil
-	}
-	states, err := s.db.ListArchiveRepoStates(ctx, resolvedRepoIDs(resolved))
-	if err != nil {
-		return NextWake{}, err
-	}
-	stateByID := make(map[int64]db.ArchiveRepoState, len(states))
-	for _, state := range states {
-		stateByID[state.RepoID] = state
+		return false, err
 	}
 	groups := make(map[string][]resolvedRepository)
 	for _, repo := range resolved {
 		key := string(repo.Ref.Platform) + "\x00" + repo.Ref.Host
 		groups[key] = append(groups[key], repo)
 	}
-	var mu sync.Mutex
-	var next NextWake
-	err = s.scheduler.Run(ctx, groups, func(ctx context.Context, repos []resolvedRepository) error {
-		wake, err := s.runProviderHostWork(ctx, repos, stateByID)
-		mu.Lock()
-		defer mu.Unlock()
-		if wake.Worked {
-			next.Worked = true
-		}
-		if !wake.At.IsZero() && (next.At.IsZero() || wake.At.Before(next.At)) {
-			next.At = wake.At
-		}
-		return err
-	})
-	return next, err
+	return s.scheduler.Run(ctx, groups, s.runProviderHostWork)
 }
 
-func (s *Service) runProviderHostWork(
-	ctx context.Context,
-	repos []resolvedRepository,
-	stateByID map[int64]db.ArchiveRepoState,
-) (NextWake, error) {
-	worked := NextWake{Worked: true}
-	var wake wakeCollector
-	now := s.now()
-	for _, repo := range repos {
-		state := stateByID[repo.ID]
-		if state.OperatorState == db.ArchiveOperatorStateActive &&
-			state.NextRetryAt != nil && state.NextRetryAt.After(now) {
-			// A deferred repository becomes eligible again at its retry time.
-			// Authentication and blocked repositories wait for an explicit
-			// retry, which wakes the worker itself.
-			wake.addPtr(state.NextRetryAt)
-		}
+func (s *Service) runProviderHostWork(ctx context.Context, repos []resolvedRepository) (bool, error) {
+	states, err := s.db.ListArchiveRepoStates(ctx, resolvedRepoIDs(repos))
+	if err != nil {
+		return false, err
+	}
+	stateByID := make(map[int64]db.ArchiveRepoState, len(states))
+	for _, state := range states {
+		stateByID[state.RepoID] = state
 	}
 
 	// Give both independent inventories their first bounded page before
@@ -181,23 +117,21 @@ func (s *Service) runProviderHostWork(
 	for _, repo := range repos {
 		state := stateByID[repo.ID]
 		if state.OperatorState != db.ArchiveOperatorStateActive ||
-			state.CollectionMode != db.ArchiveCollectionModeFull || archiveRepoDeferred(state, now) {
+			state.CollectionMode != db.ArchiveCollectionModeFull || archiveRepoDeferred(state, s.now()) {
 			continue
 		}
 		if archiveScanNotStarted(state.IssueInventory) {
 			err := s.inventoryPage(ctx, repo, state, db.ArchiveItemTypeIssue)
 			if !featureDeferredBeforeProvider(err) {
-				return worked, s.swallowAdmissionDeferred(err)
+				return true, s.swallowAdmissionDeferred(err)
 			}
-			wake.addDeferral(err)
 		}
 		if archiveScanNotStarted(state.MergeRequestInventory) {
 			err := s.inventoryPage(ctx, repo, state, db.ArchiveItemTypeMergeRequest)
 			if featureDeferredBeforeProvider(err) {
-				wake.addDeferral(err)
 				continue
 			}
-			return worked, s.swallowAdmissionDeferred(err)
+			return true, s.swallowAdmissionDeferred(err)
 		}
 	}
 
@@ -207,20 +141,19 @@ func (s *Service) runProviderHostWork(
 	// admitted request and indefinitely delay a persisted inventory cursor.
 	// The boundary only holds priority while it can actually advance: a
 	// boundary whose streams are all blocked stays durable for reporting but
-	// must not consume every pass and starve hydration and other
+	// must not consume every poll and starve hydration and other
 	// repositories on the same provider host.
 	for _, repo := range repos {
 		state := stateByID[repo.ID]
 		if state.CollectionMode == db.ArchiveCollectionModeFull &&
 			state.OperatorState == db.ArchiveOperatorStateActive &&
-			state.PromptScanStartedAt != nil && !archiveRepoDeferred(state, now) &&
+			state.PromptScanStartedAt != nil && !archiveRepoDeferred(state, s.now()) &&
 			maintenanceBoundaryActionable(state) {
 			err := s.promptMaintenance(ctx, repo, state)
 			if featureDeferredBeforeProvider(err) {
-				wake.addDeferral(err)
 				continue
 			}
-			return worked, s.swallowAdmissionDeferred(err)
+			return true, s.swallowAdmissionDeferred(err)
 		}
 	}
 
@@ -228,44 +161,39 @@ func (s *Service) runProviderHostWork(
 	for _, repo := range repos {
 		state := stateByID[repo.ID]
 		if state.CollectionMode == db.ArchiveCollectionModeFull &&
-			state.OperatorState == db.ArchiveOperatorStateActive && !archiveRepoDeferred(state, now) {
+			state.OperatorState == db.ArchiveOperatorStateActive && !archiveRepoDeferred(state, s.now()) {
 			fullIDs = append(fullIDs, repo.ID)
 		}
 	}
-	if handled, err := s.runNextHydrationWork(ctx, repos, fullIDs, &wake); handled || err != nil {
-		return worked, err
+	if handled, err := s.runNextHydrationWork(ctx, repos, fullIDs); handled || err != nil {
+		return handled, err
 	}
 
 	if handled, err := s.runNextInventoryWork(
-		ctx, repos, stateByID, db.ArchiveCollectionModeFull, &wake,
+		ctx, repos, stateByID, db.ArchiveCollectionModeFull,
 	); handled || err != nil {
-		return worked, err
+		return handled, err
 	}
 	for _, repo := range repos {
 		state := stateByID[repo.ID]
 		if state.CollectionMode != db.ArchiveCollectionModeFull ||
-			state.OperatorState != db.ArchiveOperatorStateActive || archiveRepoDeferred(state, now) {
+			state.OperatorState != db.ArchiveOperatorStateActive || archiveRepoDeferred(state, s.now()) {
 			continue
 		}
-		if !maintenanceBoundaryActionable(state) {
-			continue
-		}
-		if promptMaintenanceDue(state, now, s.maintenanceInterval) {
+		if promptMaintenanceDue(state, s.now(), s.maintenanceInterval) && maintenanceBoundaryActionable(state) {
 			err := s.promptMaintenance(ctx, repo, state)
 			if featureDeferredBeforeProvider(err) {
-				wake.addDeferral(err)
 				continue
 			}
-			return worked, s.swallowAdmissionDeferred(err)
+			return true, s.swallowAdmissionDeferred(err)
 		}
-		wake.addPtr(nextPromptMaintenanceAt(state, s.maintenanceInterval))
 	}
 	if handled, err := s.runNextInventoryWork(
-		ctx, repos, stateByID, db.ArchiveCollectionModeDiscovery, &wake,
+		ctx, repos, stateByID, db.ArchiveCollectionModeDiscovery,
 	); handled || err != nil {
-		return worked, err
+		return handled, err
 	}
-	return NextWake{At: wake.at}, nil
+	return false, nil
 }
 
 type archiveInventoryScope struct {
@@ -273,38 +201,15 @@ type archiveInventoryScope struct {
 	itemType db.ArchiveItemType
 }
 
-// runNextHydrationWork claims and hydrates the oldest due item across the
-// eligible repositories. One due summary decides whether any claim is worth
-// making; when nothing is due it records the earliest item retry time so the
-// worker sleeps until then instead of re-checking every repository.
 func (s *Service) runNextHydrationWork(
 	ctx context.Context,
 	repos []resolvedRepository,
 	repoIDs []int64,
-	wake *wakeCollector,
 ) (bool, error) {
-	if len(repoIDs) == 0 {
-		return false, nil
-	}
-	summaries, err := s.db.SummarizeArchiveItemsDue(ctx, repoIDs, s.now())
-	if err != nil {
-		return false, err
-	}
-	dueIDs := make([]int64, 0, len(summaries))
-	for _, summary := range summaries {
-		if summary.Due > 0 {
-			dueIDs = append(dueIDs, summary.RepoID)
-			continue
-		}
-		wake.addPtr(summary.NextRetryAt)
-	}
-	if len(dueIDs) == 0 {
-		return false, nil
-	}
 	var excluded []db.ArchiveItemScope
 	for {
 		item, err := s.db.ClaimArchiveItem(ctx, db.ClaimArchiveItemOpts{
-			RepoIDs: dueIDs, Now: s.now(), ExcludedScopes: excluded,
+			RepoIDs: repoIDs, Now: s.now(), ExcludedScopes: excluded,
 		})
 		if err != nil {
 			return false, err
@@ -315,7 +220,6 @@ func (s *Service) runNextHydrationWork(
 		repo := resolvedRepoByID(repos, item.RepoID)
 		err = s.hydrateItem(ctx, repo, *item)
 		if featureDeferredBeforeProvider(err) {
-			wake.addDeferral(err)
 			excluded = append(excluded, db.ArchiveItemScope{
 				RepoID: item.RepoID, ItemType: item.ItemType,
 			})
@@ -330,7 +234,6 @@ func (s *Service) runNextInventoryWork(
 	repos []resolvedRepository,
 	states map[int64]db.ArchiveRepoState,
 	mode db.ArchiveCollectionMode,
-	wake *wakeCollector,
 ) (bool, error) {
 	skipped := make(map[archiveInventoryScope]struct{})
 	for {
@@ -342,7 +245,6 @@ func (s *Service) runNextInventoryWork(
 		}
 		err := s.inventoryPage(ctx, repo, state, itemType)
 		if featureDeferredBeforeProvider(err) {
-			wake.addDeferral(err)
 			skipped[archiveInventoryScope{repoID: repo.ID, itemType: itemType}] = struct{}{}
 			continue
 		}

--- a/internal/archive/scheduler_test.go
+++ b/internal/archive/scheduler_test.go
@@ -22,7 +22,7 @@ func TestArchiveSchedulerDoesNotSerializeSameHostOutsideAdmission(t *testing.T) 
 	release := make(chan struct{})
 	var active atomic.Int32
 	var maximum atomic.Int32
-	work := func(context.Context, []resolvedRepository) error {
+	work := func(context.Context, []resolvedRepository) (bool, error) {
 		current := active.Add(1)
 		for {
 			observed := maximum.Load()
@@ -33,11 +33,11 @@ func TestArchiveSchedulerDoesNotSerializeSameHostOutsideAdmission(t *testing.T) 
 		entered <- struct{}{}
 		<-release
 		active.Add(-1)
-		return nil
+		return true, nil
 	}
 	errCh := make(chan error, 2)
-	go func() { errCh <- scheduler.Run(t.Context(), groups, work) }()
-	go func() { errCh <- scheduler.Run(t.Context(), groups, work) }()
+	go func() { _, err := scheduler.Run(t.Context(), groups, work); errCh <- err }()
+	go func() { _, err := scheduler.Run(t.Context(), groups, work); errCh <- err }()
 	require.Eventually(func() bool { return len(entered) == 2 }, time.Second, time.Millisecond)
 	release <- struct{}{}
 	release <- struct{}{}
@@ -58,7 +58,7 @@ func TestArchiveSchedulerRunsIndependentHostsConcurrently(t *testing.T) {
 	release := make(chan struct{})
 	var active atomic.Int32
 	var maximum atomic.Int32
-	work := func(context.Context, []resolvedRepository) error {
+	work := func(context.Context, []resolvedRepository) (bool, error) {
 		current := active.Add(1)
 		for {
 			observed := maximum.Load()
@@ -69,10 +69,10 @@ func TestArchiveSchedulerRunsIndependentHostsConcurrently(t *testing.T) {
 		entered <- struct{}{}
 		<-release
 		active.Add(-1)
-		return nil
+		return true, nil
 	}
 	done := make(chan error, 1)
-	go func() { done <- scheduler.Run(t.Context(), groups, work) }()
+	go func() { _, err := scheduler.Run(t.Context(), groups, work); done <- err }()
 	require.Eventually(func() bool { return len(entered) == 2 }, time.Second, time.Millisecond)
 	release <- struct{}{}
 	release <- struct{}{}

--- a/internal/archive/service.go
+++ b/internal/archive/service.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"go.kenn.io/forge/internal/db"
@@ -101,6 +103,19 @@ type Service struct {
 	scheduler           *Scheduler
 	maintenanceInterval time.Duration
 	wake                func()
+
+	reposMu sync.Mutex
+	repos   *resolvedRepositoryCache
+}
+
+// resolvedRepositoryCache remembers the worker's resolved configured
+// repositories so an idle pass performs no repository resolution queries. It
+// is valid only while the configured refs and the store's repository
+// reconciliation generation both match what it was built from.
+type resolvedRepositoryCache struct {
+	refKeys    []string
+	generation uint64
+	resolved   []resolvedRepository
 }
 
 type Status struct {
@@ -149,12 +164,63 @@ func (s *Service) SetMaintenanceInterval(interval time.Duration) {
 
 func (s *Service) SetWake(wake func()) { s.wake = wake }
 
+// InvalidateRepositories drops the worker's cached repository resolution so
+// the next pass resolves configured repositories again. Configuration
+// reconciliation and archive state changes call it; repository reconciliation
+// in the store is detected through its generation instead.
+func (s *Service) InvalidateRepositories() {
+	s.reposMu.Lock()
+	s.repos = nil
+	s.reposMu.Unlock()
+}
+
+// workerRepositories returns the configured repositories the worker should
+// schedule, resolving them only when the configuration or the store's
+// repository reconciliation generation changed since the cached resolution.
+func (s *Service) workerRepositories(ctx context.Context) ([]resolvedRepository, error) {
+	if s.configured == nil {
+		return nil, errors.New("run eligible archives: configured repository source is required")
+	}
+	refs, err := s.configured.ConfiguredRepositories(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list configured archive repositories: %w", err)
+	}
+	refKeys := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		refKeys = append(refKeys, archiveRepoIdentityKey(ref))
+	}
+	// Sample the generation before resolving: a reconciliation write that
+	// starts during resolution advances it, so the next pass re-resolves.
+	generation := s.db.RepositoryReconciliationGeneration()
+	s.reposMu.Lock()
+	cached := s.repos
+	s.reposMu.Unlock()
+	if cached != nil && cached.generation == generation && slices.Equal(cached.refKeys, refKeys) {
+		return cached.resolved, nil
+	}
+	// Configuration reconciliation runs at startup and on configuration reload.
+	// The worker pass must remain read-only when no work is eligible.
+	// Resolution failures are repository-scoped: a configured entry that seeding
+	// skipped must not block archive work for every healthy repository.
+	resolved, err := s.resolveRepositoriesTolerant(ctx, refs, true)
+	if err != nil {
+		return nil, err
+	}
+	s.reposMu.Lock()
+	s.repos = &resolvedRepositoryCache{
+		refKeys: refKeys, generation: generation, resolved: resolved,
+	}
+	s.reposMu.Unlock()
+	return resolved, nil
+}
+
 // EnsureConfigured seeds archive state for the configured repositories and
 // returns the refs that seeded successfully. Failures scoped to a single
 // repository are logged and skipped so one bad configured entry cannot block
 // the rest (or crash-loop the daemon at startup); only batch reconciliation
 // errors (a broken store) are returned.
 func (s *Service) EnsureConfigured(ctx context.Context, refs []platform.RepoRef) ([]platform.RepoRef, error) {
+	defer s.InvalidateRepositories()
 	seededRefs := make([]platform.RepoRef, 0, len(refs))
 	resolved := make([]resolvedRepository, 0, len(refs))
 	protectedIDs := make([]int64, 0, len(refs))
@@ -276,6 +342,7 @@ func (s *Service) seedArchiveRepository(ctx context.Context, ref platform.RepoRe
 // RetryAuthentication makes credential-blocked repositories eligible after a
 // config reload without resetting their durable archive progress.
 func (s *Service) RetryAuthentication(ctx context.Context, refs []platform.RepoRef) error {
+	defer s.InvalidateRepositories()
 	resolved, err := s.resolveRepositories(ctx, refs, false)
 	if err != nil {
 		return err
@@ -284,6 +351,7 @@ func (s *Service) RetryAuthentication(ctx context.Context, refs []platform.RepoR
 }
 
 func (s *Service) Start(ctx context.Context, refs []platform.RepoRef) ([]Status, error) {
+	defer s.InvalidateRepositories()
 	resolved, err := s.resolveRepositories(ctx, refs, true)
 	if err != nil {
 		return nil, err
@@ -318,6 +386,7 @@ func (s *Service) StartAll(ctx context.Context) ([]Status, error) {
 }
 
 func (s *Service) Pause(ctx context.Context, refs []platform.RepoRef) ([]Status, error) {
+	defer s.InvalidateRepositories()
 	resolved, err := s.resolveRepositories(ctx, refs, false)
 	if err != nil {
 		return nil, err
@@ -465,8 +534,9 @@ func (s *Service) resolveRepositories(ctx context.Context, refs []platform.RepoR
 // resolveRepositoriesTolerant resolves each reference independently and drops
 // the ones that fail, so a configured entry whose seeding was skipped cannot
 // starve archive work for every healthy repository. Failures are logged at
-// debug level: the worker polls every second and EnsureConfigured already
-// warns once per reconciliation for the same repositories.
+// debug level: the worker re-resolves after every configuration or
+// reconciliation change and EnsureConfigured already warns once per
+// reconciliation for the same repositories.
 func (s *Service) resolveRepositoriesTolerant(ctx context.Context, refs []platform.RepoRef, requireArchive bool) ([]resolvedRepository, error) {
 	resolved := make([]resolvedRepository, 0, len(refs))
 	seen := make(map[string]struct{}, len(refs))

--- a/internal/archive/service.go
+++ b/internal/archive/service.go
@@ -164,16 +164,6 @@ func (s *Service) SetMaintenanceInterval(interval time.Duration) {
 
 func (s *Service) SetWake(wake func()) { s.wake = wake }
 
-// InvalidateRepositories drops the worker's cached repository resolution so
-// the next pass resolves configured repositories again. Configuration
-// reconciliation and archive state changes call it; repository reconciliation
-// in the store is detected through its generation instead.
-func (s *Service) InvalidateRepositories() {
-	s.reposMu.Lock()
-	s.repos = nil
-	s.reposMu.Unlock()
-}
-
 // workerRepositories returns the configured repositories the worker should
 // schedule, resolving them only when the configuration or the store's
 // repository reconciliation generation changed since the cached resolution.
@@ -198,10 +188,12 @@ func (s *Service) workerRepositories(ctx context.Context) ([]resolvedRepository,
 	if cached != nil && cached.generation == generation && slices.Equal(cached.refKeys, refKeys) {
 		return cached.resolved, nil
 	}
-	// Configuration reconciliation runs at startup and on configuration reload.
-	// The worker pass must remain read-only when no work is eligible.
-	// Resolution failures are repository-scoped: a configured entry that seeding
-	// skipped must not block archive work for every healthy repository.
+	// Configuration reconciliation runs at startup and on configuration reload;
+	// its catalog writes advance the generation, so a seeded ref is resolved
+	// on the next pass. The pass itself stays read-only when nothing is
+	// eligible. Resolution failures are repository-scoped: a configured entry
+	// that seeding skipped must not block archive work for every healthy
+	// repository.
 	resolved, err := s.resolveRepositoriesTolerant(ctx, refs, true)
 	if err != nil {
 		return nil, err
@@ -220,7 +212,6 @@ func (s *Service) workerRepositories(ctx context.Context) ([]resolvedRepository,
 // the rest (or crash-loop the daemon at startup); only batch reconciliation
 // errors (a broken store) are returned.
 func (s *Service) EnsureConfigured(ctx context.Context, refs []platform.RepoRef) ([]platform.RepoRef, error) {
-	defer s.InvalidateRepositories()
 	seededRefs := make([]platform.RepoRef, 0, len(refs))
 	resolved := make([]resolvedRepository, 0, len(refs))
 	protectedIDs := make([]int64, 0, len(refs))
@@ -342,7 +333,6 @@ func (s *Service) seedArchiveRepository(ctx context.Context, ref platform.RepoRe
 // RetryAuthentication makes credential-blocked repositories eligible after a
 // config reload without resetting their durable archive progress.
 func (s *Service) RetryAuthentication(ctx context.Context, refs []platform.RepoRef) error {
-	defer s.InvalidateRepositories()
 	resolved, err := s.resolveRepositories(ctx, refs, false)
 	if err != nil {
 		return err
@@ -351,7 +341,6 @@ func (s *Service) RetryAuthentication(ctx context.Context, refs []platform.RepoR
 }
 
 func (s *Service) Start(ctx context.Context, refs []platform.RepoRef) ([]Status, error) {
-	defer s.InvalidateRepositories()
 	resolved, err := s.resolveRepositories(ctx, refs, true)
 	if err != nil {
 		return nil, err
@@ -386,7 +375,6 @@ func (s *Service) StartAll(ctx context.Context) ([]Status, error) {
 }
 
 func (s *Service) Pause(ctx context.Context, refs []platform.RepoRef) ([]Status, error) {
-	defer s.InvalidateRepositories()
 	resolved, err := s.resolveRepositories(ctx, refs, false)
 	if err != nil {
 		return nil, err

--- a/internal/archive/wake_test.go
+++ b/internal/archive/wake_test.go
@@ -1,11 +1,14 @@
 package archive
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/platform"
 	"go.kenn.io/forge/internal/testutil/dbtest"
 )
@@ -143,4 +146,64 @@ func TestRunPassReportsAdmissionDenialAsIdle(t *testing.T) {
 	worked, err = service.RunPass(t.Context())
 	require.NoError(err)
 	assert.True(worked)
+}
+
+// preemptingAdmission admits every request with an already-canceled context,
+// the shape live work leaves behind when it preempts an archive request.
+type preemptingAdmission struct{}
+
+func (preemptingAdmission) Admit(
+	context.Context,
+	platform.RepoRef,
+	db.ArchiveItemType,
+	int,
+) (AdmissionResult, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return AdmissionResult{
+		Allowed: true, Context: ctx,
+		Complete: func(error, bool) *FeatureDeferral { return nil },
+	}, nil
+}
+
+func TestRunPassReportsProviderAttemptedDeferralsAsWork(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	now := archiveTestTime()
+	ref := archiveServiceRef(platform.KindGitHub, "github.test", "repo")
+
+	t.Run("feature deferral after a provider request", func(t *testing.T) {
+		database := dbtest.Open(t)
+		archiveServiceSeedRepo(t, database, ref)
+		provider := newArchiveServiceProvider(ref.Platform, ref.Host)
+		provider.issueInventoryErr = errors.New("issues disabled for repository")
+		registry, err := platform.NewRegistry(provider)
+		require.NoError(err)
+		admission := &archiveTestAdmission{deferCompletedErrors: true, retryAt: now.Add(24 * time.Hour)}
+		service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, admission, now)
+		requireEnsureConfigured(t, service, []platform.RepoRef{ref})
+		_, err = service.Start(t.Context(), []platform.RepoRef{ref})
+		require.NoError(err)
+
+		worked, err := service.RunPass(t.Context())
+		require.NoError(err)
+		assert.True(worked, "the provider was contacted, so sibling work must not wait out a backoff")
+	})
+
+	t.Run("request preempted by live work", func(t *testing.T) {
+		database := dbtest.Open(t)
+		archiveServiceSeedRepo(t, database, ref)
+		provider := newArchiveServiceProvider(ref.Platform, ref.Host)
+		provider.issueInventoryErr = context.Canceled
+		registry, err := platform.NewRegistry(provider)
+		require.NoError(err)
+		service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, preemptingAdmission{}, now)
+		requireEnsureConfigured(t, service, []platform.RepoRef{ref})
+		_, err = service.Start(t.Context(), []platform.RepoRef{ref})
+		require.NoError(err)
+
+		worked, err := service.RunPass(t.Context())
+		require.NoError(err)
+		assert.True(worked, "a preempted request reached the provider and stays claimable")
+	})
 }

--- a/internal/archive/wake_test.go
+++ b/internal/archive/wake_test.go
@@ -1,0 +1,285 @@
+package archive
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/platform"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+)
+
+// runUntilIdle drives passes until one reports no attempted work and returns
+// that pass's wake computation.
+func runUntilIdle(t *testing.T, service *Service) NextWake {
+	t.Helper()
+	for range 20 {
+		wake, err := service.RunPass(t.Context())
+		require.NoError(t, err)
+		if !wake.Worked {
+			return wake
+		}
+	}
+	require.Fail(t, "archive worker did not become idle")
+	return NextWake{}
+}
+
+func TestRunPassIdleRepositoriesSleepUntilMaintenanceWithoutRepositoryResolution(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	now := archiveTestTime()
+	first := archiveServiceRef(platform.KindGitHub, "github.test", "first")
+	second := archiveServiceRef(platform.KindGitHub, "github.test", "second")
+	firstID := archiveServiceSeedRepo(t, database, first)
+	secondID := archiveServiceSeedRepo(t, database, second)
+	provider := newArchiveServiceProvider(first.Platform, first.Host)
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	service := newArchiveTestService(
+		t, database, registry, []platform.RepoRef{first, second}, &archiveTestAdmission{}, now,
+	)
+	requireEnsureConfigured(t, service, []platform.RepoRef{first, second})
+	_, err = service.Start(t.Context(), []platform.RepoRef{first, second})
+	require.NoError(err)
+
+	wake := runUntilIdle(t, service)
+	states, err := database.ListArchiveRepoStates(t.Context(), []int64{firstID, secondID})
+	require.NoError(err)
+	require.Len(states, 2)
+	for _, state := range states {
+		require.NotNil(state.InitialCompletedAt)
+		require.NotNil(state.MaintenanceSucceededAt)
+	}
+	assert.False(wake.Worked)
+	assert.Equal(states[0].MaintenanceSucceededAt.Add(service.maintenanceInterval), wake.At)
+
+	// Hide the repository catalog: any repository resolution query from the
+	// following idle passes now fails, so a clean pass proves the cached
+	// resolution was used.
+	_, err = database.WriteDB().ExecContext(t.Context(),
+		`ALTER TABLE forge_repos RENAME TO forge_repos_hidden`)
+	require.NoError(err)
+	for range 3 {
+		wake, err = service.RunPass(t.Context())
+		require.NoError(err)
+		assert.False(wake.Worked)
+		assert.Equal(states[0].MaintenanceSucceededAt.Add(service.maintenanceInterval), wake.At)
+	}
+
+	// A cold service must resolve and therefore fail, which proves the hidden
+	// catalog is what the cache avoided.
+	cold := newArchiveTestService(
+		t, database, registry, []platform.RepoRef{first, second}, &archiveTestAdmission{}, now,
+	)
+	_, err = cold.RunPass(t.Context())
+	require.Error(err)
+}
+
+func TestRunPassMaintenanceBecomesDueAtInterval(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	now := archiveTestTime()
+	ref := archiveServiceRef(platform.KindGitHub, "github.test", "repo")
+	archiveServiceSeedRepo(t, database, ref)
+	provider := newArchiveServiceProvider(ref.Platform, ref.Host)
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	service := newArchiveTestService(
+		t, database, registry, []platform.RepoRef{ref}, &archiveTestAdmission{}, now,
+	)
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
+	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
+	require.NoError(err)
+	idle := runUntilIdle(t, service)
+	require.Equal(now.Add(service.maintenanceInterval), idle.At)
+
+	before := len(provider.updatedIssueSince)
+	service.clock = fixedClock{value: idle.At}
+	wake, err := service.RunPass(t.Context())
+	require.NoError(err)
+	assert.True(wake.Worked, "maintenance must run once its interval elapses")
+	assert.Len(provider.updatedIssueSince, before+1)
+}
+
+func TestRunPassReportsRepositoryDeferralDeadline(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	now := archiveTestTime()
+	ref := archiveServiceRef(platform.KindGitHub, "github.test", "repo")
+	archiveServiceSeedRepo(t, database, ref)
+	provider := newArchiveServiceProvider(ref.Platform, ref.Host)
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	retryAt := now.Add(17 * time.Minute)
+	admission := &archiveTestAdmission{deny: true, retryAt: retryAt}
+	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, admission, now)
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
+	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
+	require.NoError(err)
+
+	wake, err := service.RunPass(t.Context())
+	require.NoError(err)
+	assert.True(wake.Worked, "a denied admission records the deferral as attempted work")
+
+	wake, err = service.RunPass(t.Context())
+	require.NoError(err)
+	assert.False(wake.Worked)
+	assert.Equal(retryAt, wake.At)
+	assert.Equal(1, admission.calls, "a deferred repository must not re-enter admission")
+}
+
+func TestRunPassReportsFeatureCooldownDeadline(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	now := archiveTestTime()
+	ref := archiveServiceRef(platform.KindGitHub, "github.test", "repo")
+	archiveServiceSeedRepo(t, database, ref)
+	provider := newArchiveServiceProvider(ref.Platform, ref.Host)
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	admission := &archiveFeatureDeferringAdmission{
+		enabled: true, repoName: ref.Name,
+		itemTypes: map[db.ArchiveItemType]bool{
+			db.ArchiveItemTypeIssue: true, db.ArchiveItemTypeMergeRequest: true,
+		},
+	}
+	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, admission, now)
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
+	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
+	require.NoError(err)
+
+	wake, err := service.RunPass(t.Context())
+	require.NoError(err)
+	assert.False(wake.Worked)
+	assert.Equal(archiveTestTime().Add(24*time.Hour), wake.At)
+}
+
+type retryAtClassifier struct{ retryAt time.Time }
+
+func (c retryAtClassifier) Classify(error, int, time.Time) RetryDecision {
+	retryAt := c.retryAt
+	return RetryDecision{Code: db.ArchiveErrorCodeTransient, RetryAt: &retryAt}
+}
+
+func TestRunPassReportsHydrationRetryTimeWithoutClaiming(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	now := archiveTestTime()
+	ref := archiveServiceRef(platform.KindGitHub, "github.test", "repo")
+	repoID := archiveServiceSeedRepo(t, database, ref)
+	provider := newArchiveServiceProvider(ref.Platform, ref.Host)
+	provider.historicalIssuePages = map[string]platform.Page[platform.Issue]{
+		"": {Items: []platform.Issue{archiveTestIssue(ref)}, Exhausted: true},
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	retryAt := now.Add(3 * time.Minute)
+	service, err := NewService(
+		database, registry, &archiveTestAdmission{},
+		archiveFailingItemSource{archiveTestSource{refs: []platform.RepoRef{ref}}},
+		retryAtClassifier{retryAt: retryAt}, fixedClock{value: now},
+	)
+	require.NoError(err)
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
+	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
+	require.NoError(err)
+
+	// Inventory both streams, then every hydration attempt fails and is
+	// scheduled for retry until nothing is due.
+	failures := 0
+	var wake NextWake
+	for range 10 {
+		wake, err = service.RunPass(t.Context())
+		if err != nil {
+			failures++
+			continue
+		}
+		if !wake.Worked {
+			break
+		}
+	}
+	require.Positive(failures, "hydration failures must surface from the pass")
+	require.False(wake.Worked)
+	assert.Equal(retryAt, wake.At)
+
+	summaries, err := database.SummarizeArchiveItemsDue(t.Context(), []int64{repoID}, now)
+	require.NoError(err)
+	require.Len(summaries, 1)
+	assert.Equal(0, summaries[0].Due)
+	require.NotNil(summaries[0].NextRetryAt)
+	assert.Equal(retryAt, *summaries[0].NextRetryAt)
+
+	service.clock = fixedClock{value: retryAt}
+	summaries, err = database.SummarizeArchiveItemsDue(t.Context(), []int64{repoID}, retryAt)
+	require.NoError(err)
+	require.Len(summaries, 1)
+	assert.Equal(failures, summaries[0].Due)
+	assert.Nil(summaries[0].NextRetryAt)
+	_, err = service.RunPass(t.Context())
+	require.Error(err, "the item must be claimed and retried once its retry time arrives")
+}
+
+func TestWorkerRepositoriesCacheFollowsConfigurationAndReconciliation(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	now := archiveTestTime()
+	first := archiveServiceRef(platform.KindGitHub, "github.test", "first")
+	second := archiveServiceRef(platform.KindGitHub, "github.test", "second")
+	archiveServiceSeedRepo(t, database, first)
+	provider := newArchiveServiceProvider(first.Platform, first.Host)
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	source := &archiveMutableSource{refs: []platform.RepoRef{first, second}}
+	service, err := NewService(database, registry, &archiveTestAdmission{}, source, nil, fixedClock{value: now})
+	require.NoError(err)
+
+	resolved, err := service.workerRepositories(t.Context())
+	require.NoError(err)
+	require.Len(resolved, 1, "an unseeded configured repository is skipped")
+	again, err := service.workerRepositories(t.Context())
+	require.NoError(err)
+	require.Len(again, 1)
+	assert.Same(&resolved[0], &again[0], "unchanged configuration reuses the cached resolution")
+
+	// Seeding the second repository is a repository reconciliation write and
+	// must make the next pass resolve it.
+	archiveServiceSeedRepo(t, database, second)
+	resolved, err = service.workerRepositories(t.Context())
+	require.NoError(err)
+	require.Len(resolved, 2)
+
+	// Dropping a configured repository takes effect without a store change.
+	source.refs = []platform.RepoRef{second}
+	resolved, err = service.workerRepositories(t.Context())
+	require.NoError(err)
+	require.Len(resolved, 1)
+	assert.Equal(second.Name, resolved[0].Ref.Name)
+
+	// Archive state changes invalidate explicitly.
+	_, err = service.workerRepositories(t.Context())
+	require.NoError(err)
+	service.InvalidateRepositories()
+	assert.Nil(service.repos)
+}
+
+func TestRunPassWithoutConfiguredRepositoriesSchedulesNothing(t *testing.T) {
+	require := require.New(t)
+	database := dbtest.Open(t)
+	provider := newArchiveServiceProvider(platform.KindGitHub, "github.test")
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	service := newArchiveTestService(t, database, registry, nil, &archiveTestAdmission{}, archiveTestTime())
+
+	wake, err := service.RunPass(context.Background())
+	require.NoError(err)
+	require.Equal(NextWake{}, wake)
+}

--- a/internal/archive/wake_test.go
+++ b/internal/archive/wake_test.go
@@ -1,33 +1,15 @@
 package archive
 
 import (
-	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/platform"
 	"go.kenn.io/forge/internal/testutil/dbtest"
 )
 
-// runUntilIdle drives passes until one reports no attempted work and returns
-// that pass's wake computation.
-func runUntilIdle(t *testing.T, service *Service) NextWake {
-	t.Helper()
-	for range 20 {
-		wake, err := service.RunPass(t.Context())
-		require.NoError(t, err)
-		if !wake.Worked {
-			return wake
-		}
-	}
-	require.Fail(t, "archive worker did not become idle")
-	return NextWake{}
-}
-
-func TestRunPassIdleRepositoriesSleepUntilMaintenanceWithoutRepositoryResolution(t *testing.T) {
+func TestRunPassIdleRepositoriesReportNoWorkWithoutRepositoryResolution(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	database := dbtest.Open(t)
@@ -46,16 +28,24 @@ func TestRunPassIdleRepositoriesSleepUntilMaintenanceWithoutRepositoryResolution
 	_, err = service.Start(t.Context(), []platform.RepoRef{first, second})
 	require.NoError(err)
 
-	wake := runUntilIdle(t, service)
+	// Drive passes until inventory, hydration, and the first maintenance
+	// scan are done and a pass reports no attempted work.
+	worked := true
+	for range 20 {
+		worked, err = service.RunPass(t.Context())
+		require.NoError(err)
+		if !worked {
+			break
+		}
+	}
+	require.False(worked, "archive worker did not become idle")
 	states, err := database.ListArchiveRepoStates(t.Context(), []int64{firstID, secondID})
 	require.NoError(err)
 	require.Len(states, 2)
 	for _, state := range states {
-		require.NotNil(state.InitialCompletedAt)
-		require.NotNil(state.MaintenanceSucceededAt)
+		assert.NotNil(state.InitialCompletedAt)
+		assert.NotNil(state.MaintenanceSucceededAt)
 	}
-	assert.False(wake.Worked)
-	assert.Equal(states[0].MaintenanceSucceededAt.Add(service.maintenanceInterval), wake.At)
 
 	// Hide the repository catalog: any repository resolution query from the
 	// following idle passes now fails, so a clean pass proves the cached
@@ -64,10 +54,9 @@ func TestRunPassIdleRepositoriesSleepUntilMaintenanceWithoutRepositoryResolution
 		`ALTER TABLE forge_repos RENAME TO forge_repos_hidden`)
 	require.NoError(err)
 	for range 3 {
-		wake, err = service.RunPass(t.Context())
+		worked, err = service.RunPass(t.Context())
 		require.NoError(err)
-		assert.False(wake.Worked)
-		assert.Equal(states[0].MaintenanceSucceededAt.Add(service.maintenanceInterval), wake.At)
+		assert.False(worked)
 	}
 
 	// A cold service must resolve and therefore fail, which proves the hidden
@@ -77,154 +66,6 @@ func TestRunPassIdleRepositoriesSleepUntilMaintenanceWithoutRepositoryResolution
 	)
 	_, err = cold.RunPass(t.Context())
 	require.Error(err)
-}
-
-func TestRunPassMaintenanceBecomesDueAtInterval(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	database := dbtest.Open(t)
-	now := archiveTestTime()
-	ref := archiveServiceRef(platform.KindGitHub, "github.test", "repo")
-	archiveServiceSeedRepo(t, database, ref)
-	provider := newArchiveServiceProvider(ref.Platform, ref.Host)
-	registry, err := platform.NewRegistry(provider)
-	require.NoError(err)
-	service := newArchiveTestService(
-		t, database, registry, []platform.RepoRef{ref}, &archiveTestAdmission{}, now,
-	)
-	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
-	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
-	require.NoError(err)
-	idle := runUntilIdle(t, service)
-	require.Equal(now.Add(service.maintenanceInterval), idle.At)
-
-	before := len(provider.updatedIssueSince)
-	service.clock = fixedClock{value: idle.At}
-	wake, err := service.RunPass(t.Context())
-	require.NoError(err)
-	assert.True(wake.Worked, "maintenance must run once its interval elapses")
-	assert.Len(provider.updatedIssueSince, before+1)
-}
-
-func TestRunPassReportsRepositoryDeferralDeadline(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	database := dbtest.Open(t)
-	now := archiveTestTime()
-	ref := archiveServiceRef(platform.KindGitHub, "github.test", "repo")
-	archiveServiceSeedRepo(t, database, ref)
-	provider := newArchiveServiceProvider(ref.Platform, ref.Host)
-	registry, err := platform.NewRegistry(provider)
-	require.NoError(err)
-	retryAt := now.Add(17 * time.Minute)
-	admission := &archiveTestAdmission{deny: true, retryAt: retryAt}
-	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, admission, now)
-	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
-	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
-	require.NoError(err)
-
-	wake, err := service.RunPass(t.Context())
-	require.NoError(err)
-	assert.True(wake.Worked, "a denied admission records the deferral as attempted work")
-
-	wake, err = service.RunPass(t.Context())
-	require.NoError(err)
-	assert.False(wake.Worked)
-	assert.Equal(retryAt, wake.At)
-	assert.Equal(1, admission.calls, "a deferred repository must not re-enter admission")
-}
-
-func TestRunPassReportsFeatureCooldownDeadline(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	database := dbtest.Open(t)
-	now := archiveTestTime()
-	ref := archiveServiceRef(platform.KindGitHub, "github.test", "repo")
-	archiveServiceSeedRepo(t, database, ref)
-	provider := newArchiveServiceProvider(ref.Platform, ref.Host)
-	registry, err := platform.NewRegistry(provider)
-	require.NoError(err)
-	admission := &archiveFeatureDeferringAdmission{
-		enabled: true, repoName: ref.Name,
-		itemTypes: map[db.ArchiveItemType]bool{
-			db.ArchiveItemTypeIssue: true, db.ArchiveItemTypeMergeRequest: true,
-		},
-	}
-	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, admission, now)
-	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
-	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
-	require.NoError(err)
-
-	wake, err := service.RunPass(t.Context())
-	require.NoError(err)
-	assert.False(wake.Worked)
-	assert.Equal(archiveTestTime().Add(24*time.Hour), wake.At)
-}
-
-type retryAtClassifier struct{ retryAt time.Time }
-
-func (c retryAtClassifier) Classify(error, int, time.Time) RetryDecision {
-	retryAt := c.retryAt
-	return RetryDecision{Code: db.ArchiveErrorCodeTransient, RetryAt: &retryAt}
-}
-
-func TestRunPassReportsHydrationRetryTimeWithoutClaiming(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	database := dbtest.Open(t)
-	now := archiveTestTime()
-	ref := archiveServiceRef(platform.KindGitHub, "github.test", "repo")
-	repoID := archiveServiceSeedRepo(t, database, ref)
-	provider := newArchiveServiceProvider(ref.Platform, ref.Host)
-	provider.historicalIssuePages = map[string]platform.Page[platform.Issue]{
-		"": {Items: []platform.Issue{archiveTestIssue(ref)}, Exhausted: true},
-	}
-	registry, err := platform.NewRegistry(provider)
-	require.NoError(err)
-	retryAt := now.Add(3 * time.Minute)
-	service, err := NewService(
-		database, registry, &archiveTestAdmission{},
-		archiveFailingItemSource{archiveTestSource{refs: []platform.RepoRef{ref}}},
-		retryAtClassifier{retryAt: retryAt}, fixedClock{value: now},
-	)
-	require.NoError(err)
-	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
-	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
-	require.NoError(err)
-
-	// Inventory both streams, then every hydration attempt fails and is
-	// scheduled for retry until nothing is due.
-	failures := 0
-	var wake NextWake
-	for range 10 {
-		wake, err = service.RunPass(t.Context())
-		if err != nil {
-			failures++
-			continue
-		}
-		if !wake.Worked {
-			break
-		}
-	}
-	require.Positive(failures, "hydration failures must surface from the pass")
-	require.False(wake.Worked)
-	assert.Equal(retryAt, wake.At)
-
-	summaries, err := database.SummarizeArchiveItemsDue(t.Context(), []int64{repoID}, now)
-	require.NoError(err)
-	require.Len(summaries, 1)
-	assert.Equal(0, summaries[0].Due)
-	require.NotNil(summaries[0].NextRetryAt)
-	assert.Equal(retryAt, *summaries[0].NextRetryAt)
-
-	service.clock = fixedClock{value: retryAt}
-	summaries, err = database.SummarizeArchiveItemsDue(t.Context(), []int64{repoID}, retryAt)
-	require.NoError(err)
-	require.Len(summaries, 1)
-	assert.Equal(failures, summaries[0].Due)
-	assert.Nil(summaries[0].NextRetryAt)
-	_, err = service.RunPass(t.Context())
-	require.Error(err, "the item must be claimed and retried once its retry time arrives")
 }
 
 func TestWorkerRepositoriesCacheFollowsConfigurationAndReconciliation(t *testing.T) {
@@ -263,23 +104,4 @@ func TestWorkerRepositoriesCacheFollowsConfigurationAndReconciliation(t *testing
 	require.NoError(err)
 	require.Len(resolved, 1)
 	assert.Equal(second.Name, resolved[0].Ref.Name)
-
-	// Archive state changes invalidate explicitly.
-	_, err = service.workerRepositories(t.Context())
-	require.NoError(err)
-	service.InvalidateRepositories()
-	assert.Nil(service.repos)
-}
-
-func TestRunPassWithoutConfiguredRepositoriesSchedulesNothing(t *testing.T) {
-	require := require.New(t)
-	database := dbtest.Open(t)
-	provider := newArchiveServiceProvider(platform.KindGitHub, "github.test")
-	registry, err := platform.NewRegistry(provider)
-	require.NoError(err)
-	service := newArchiveTestService(t, database, registry, nil, &archiveTestAdmission{}, archiveTestTime())
-
-	wake, err := service.RunPass(context.Background())
-	require.NoError(err)
-	require.Equal(NextWake{}, wake)
 }

--- a/internal/archive/wake_test.go
+++ b/internal/archive/wake_test.go
@@ -2,6 +2,7 @@ package archive
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -104,4 +105,42 @@ func TestWorkerRepositoriesCacheFollowsConfigurationAndReconciliation(t *testing
 	require.NoError(err)
 	require.Len(resolved, 1)
 	assert.Equal(second.Name, resolved[0].Ref.Name)
+}
+
+func TestRunPassReportsAdmissionDenialAsIdle(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	now := archiveTestTime()
+	ref := archiveServiceRef(platform.KindGitHub, "github.test", "repo")
+	repoID := archiveServiceSeedRepo(t, database, ref)
+	provider := newArchiveServiceProvider(ref.Platform, ref.Host)
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	retryAt := now.Add(time.Second)
+	admission := &archiveTestAdmission{deny: true, retryAt: retryAt}
+	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, admission, now)
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
+	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
+	require.NoError(err)
+
+	// Live sync holding the provider denies admission before any request is
+	// made. That is not work: the loop must back off rather than re-run at
+	// the pacing interval for the whole sync.
+	worked, err := service.RunPass(t.Context())
+	require.NoError(err)
+	assert.False(worked)
+	states, err := database.ListArchiveRepoStates(t.Context(), []int64{repoID})
+	require.NoError(err)
+	require.Len(states, 1)
+	require.NotNil(states[0].NextRetryAt)
+	assert.Equal(retryAt, *states[0].NextRetryAt)
+	assert.Equal(1, admission.calls)
+
+	// Once admission opens again the pass reaches the provider and reports work.
+	admission.deny = false
+	service.clock = fixedClock{value: retryAt}
+	worked, err = service.RunPass(t.Context())
+	require.NoError(err)
+	assert.True(worked)
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"go.kenn.io/forge/internal/db/dbupgrade"
 	_ "modernc.org/sqlite"
@@ -19,6 +20,11 @@ type DB struct {
 	mrReconcileGate   sync.Mutex
 	mrSnapshotLocksMu sync.Mutex
 	mrSnapshotLocks   map[mergeRequestSnapshotLockKey]*mergeRequestSnapshotLock
+
+	// repositoryReconciliationGeneration counts repository reconciliation
+	// writes so caches keyed on repository identity can detect that a
+	// repository row, route, or replacement may have changed.
+	repositoryReconciliationGeneration atomic.Uint64
 
 	beforeRepositoryReconciliationWriteLock func()
 }
@@ -234,7 +240,17 @@ func (d *DB) lockRepositoryReconciliationWrite() func() {
 	}
 	d.mrReconcileMu.Lock()
 	d.mrReconcileGate.Unlock()
+	d.repositoryReconciliationGeneration.Add(1)
 	return d.mrReconcileMu.Unlock
+}
+
+// RepositoryReconciliationGeneration reports a process-local counter that
+// advances whenever a repository reconciliation write begins. A reader that
+// samples it before resolving repository identity and finds it unchanged later
+// knows no reconciliation write started in between, so cached repository rows
+// resolved under the reconciliation read lock are still current.
+func (d *DB) RepositoryReconciliationGeneration() uint64 {
+	return d.repositoryReconciliationGeneration.Load()
 }
 
 // SetBeforeRepositoryReconciliationWriteLockForTest installs a hook after

--- a/internal/db/queries_archive.go
+++ b/internal/db/queries_archive.go
@@ -826,85 +826,21 @@ func (d *DB) claimArchiveItem(
 	return &oldest, nil
 }
 
-// pendingArchiveItemsFrom selects every hydration lookup that is still open
-// for an active, unblocked full-archive repository, regardless of whether its
-// own retry time has arrived. Claiming and the due summary share it so the
-// worker's "is anything due" answer and the claim it then makes agree.
-const pendingArchiveItemsFrom = `
+const dueArchiveItemsQuery = `
+	SELECT ai.repo_id, ai.item_type, ai.item_number, ai.provider_created_at,
+		p.scan_generation, p.attempt_count
 	FROM forge_archive_dataset_progress p
 	JOIN forge_archive_items ai
 	  ON ai.repo_id = p.repo_id AND ai.item_type = p.item_type AND ai.item_number = p.item_number
 	JOIN forge_archive_repos ar ON ar.repo_id = p.repo_id
-	WHERE ar.collection_mode = 'full'
+	WHERE p.repo_id = ?
+	  AND ar.collection_mode = 'full'
 	  AND ar.operator_state = 'active'
 	  AND (ar.next_retry_at IS NULL OR ar.next_retry_at <= ?)
 	  AND ai.lifecycle_state = 'active'
 	  AND p.dataset = 'lookup'
-	  AND p.status IN ('pending', 'running', 'failed')`
-
-const dueArchiveItemsQuery = `
-	SELECT ai.repo_id, ai.item_type, ai.item_number, ai.provider_created_at,
-		p.scan_generation, p.attempt_count` + pendingArchiveItemsFrom + `
-	  AND p.repo_id = ?
+	  AND p.status IN ('pending', 'running', 'failed')
 	  AND (p.next_retry_at IS NULL OR p.next_retry_at <= ?)`
-
-// ArchiveItemDueSummary reports, for one repository, how many hydration
-// lookups are due now and the earliest retry time among those that are not.
-type ArchiveItemDueSummary struct {
-	RepoID      int64
-	Due         int
-	NextRetryAt *time.Time
-}
-
-// SummarizeArchiveItemsDue answers in one statement whether any hydration
-// lookup is claimable now for the given repositories and, when none is, the
-// earliest moment one becomes claimable. Repositories with no open lookups
-// are omitted. The worker uses it to skip per-repository claims on idle passes
-// and to sleep until the next retry instead of polling.
-func (d *DB) SummarizeArchiveItemsDue(
-	ctx context.Context,
-	repoIDs []int64,
-	now time.Time,
-) ([]ArchiveItemDueSummary, error) {
-	repoIDs = normalizedArchiveRepoIDs(repoIDs)
-	if len(repoIDs) == 0 {
-		return nil, nil
-	}
-	now = now.UTC()
-	dueAt := formatDatasetProgressTime(now)
-	query := `
-	SELECT p.repo_id,
-		SUM(CASE WHEN p.next_retry_at IS NULL OR p.next_retry_at <= ? THEN 1 ELSE 0 END),
-		MIN(CASE WHEN p.next_retry_at > ? THEN p.next_retry_at END)` +
-		pendingArchiveItemsFrom + `
-	  AND p.repo_id IN (` + sqlPlaceholders(len(repoIDs)) + `)
-	GROUP BY p.repo_id
-	ORDER BY p.repo_id`
-	args := []any{dueAt, dueAt, now}
-	args = append(args, archiveRepoIDArgs(repoIDs)...)
-	rows, err := d.ro.QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, fmt.Errorf("summarize due archive items: %w", err)
-	}
-	defer rows.Close()
-	summaries := make([]ArchiveItemDueSummary, 0)
-	for rows.Next() {
-		var summary ArchiveItemDueSummary
-		var nextRetry sql.NullString
-		if err := rows.Scan(&summary.RepoID, &summary.Due, &nextRetry); err != nil {
-			return nil, fmt.Errorf("scan due archive item summary: %w", err)
-		}
-		summary.NextRetryAt, err = parseDatasetProgressTimePtr(nextRetry)
-		if err != nil {
-			return nil, fmt.Errorf("parse due archive item retry time: %w", err)
-		}
-		summaries = append(summaries, summary)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("summarize due archive items: %w", err)
-	}
-	return summaries, nil
-}
 
 func claimArchiveItemForRepo(
 	ctx context.Context,
@@ -914,7 +850,7 @@ func claimArchiveItemForRepo(
 	excludedItemTypes []ArchiveItemType,
 ) (*ArchiveItemWork, error) {
 	query := dueArchiveItemsQuery
-	args := []any{now, repoID, formatDatasetProgressTime(now)}
+	args := []any{repoID, now, formatDatasetProgressTime(now)}
 	if len(excludedItemTypes) > 0 {
 		query += fmt.Sprintf(" AND ai.item_type NOT IN (%s)", sqlPlaceholders(len(excludedItemTypes)))
 		for _, itemType := range excludedItemTypes {

--- a/internal/db/queries_archive.go
+++ b/internal/db/queries_archive.go
@@ -826,21 +826,85 @@ func (d *DB) claimArchiveItem(
 	return &oldest, nil
 }
 
-const dueArchiveItemsQuery = `
-	SELECT ai.repo_id, ai.item_type, ai.item_number, ai.provider_created_at,
-		p.scan_generation, p.attempt_count
+// pendingArchiveItemsFrom selects every hydration lookup that is still open
+// for an active, unblocked full-archive repository, regardless of whether its
+// own retry time has arrived. Claiming and the due summary share it so the
+// worker's "is anything due" answer and the claim it then makes agree.
+const pendingArchiveItemsFrom = `
 	FROM forge_archive_dataset_progress p
 	JOIN forge_archive_items ai
 	  ON ai.repo_id = p.repo_id AND ai.item_type = p.item_type AND ai.item_number = p.item_number
 	JOIN forge_archive_repos ar ON ar.repo_id = p.repo_id
-	WHERE p.repo_id = ?
-	  AND ar.collection_mode = 'full'
+	WHERE ar.collection_mode = 'full'
 	  AND ar.operator_state = 'active'
 	  AND (ar.next_retry_at IS NULL OR ar.next_retry_at <= ?)
 	  AND ai.lifecycle_state = 'active'
 	  AND p.dataset = 'lookup'
-	  AND p.status IN ('pending', 'running', 'failed')
+	  AND p.status IN ('pending', 'running', 'failed')`
+
+const dueArchiveItemsQuery = `
+	SELECT ai.repo_id, ai.item_type, ai.item_number, ai.provider_created_at,
+		p.scan_generation, p.attempt_count` + pendingArchiveItemsFrom + `
+	  AND p.repo_id = ?
 	  AND (p.next_retry_at IS NULL OR p.next_retry_at <= ?)`
+
+// ArchiveItemDueSummary reports, for one repository, how many hydration
+// lookups are due now and the earliest retry time among those that are not.
+type ArchiveItemDueSummary struct {
+	RepoID      int64
+	Due         int
+	NextRetryAt *time.Time
+}
+
+// SummarizeArchiveItemsDue answers in one statement whether any hydration
+// lookup is claimable now for the given repositories and, when none is, the
+// earliest moment one becomes claimable. Repositories with no open lookups
+// are omitted. The worker uses it to skip per-repository claims on idle passes
+// and to sleep until the next retry instead of polling.
+func (d *DB) SummarizeArchiveItemsDue(
+	ctx context.Context,
+	repoIDs []int64,
+	now time.Time,
+) ([]ArchiveItemDueSummary, error) {
+	repoIDs = normalizedArchiveRepoIDs(repoIDs)
+	if len(repoIDs) == 0 {
+		return nil, nil
+	}
+	now = now.UTC()
+	dueAt := formatDatasetProgressTime(now)
+	query := `
+	SELECT p.repo_id,
+		SUM(CASE WHEN p.next_retry_at IS NULL OR p.next_retry_at <= ? THEN 1 ELSE 0 END),
+		MIN(CASE WHEN p.next_retry_at > ? THEN p.next_retry_at END)` +
+		pendingArchiveItemsFrom + `
+	  AND p.repo_id IN (` + sqlPlaceholders(len(repoIDs)) + `)
+	GROUP BY p.repo_id
+	ORDER BY p.repo_id`
+	args := []any{dueAt, dueAt, now}
+	args = append(args, archiveRepoIDArgs(repoIDs)...)
+	rows, err := d.ro.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("summarize due archive items: %w", err)
+	}
+	defer rows.Close()
+	summaries := make([]ArchiveItemDueSummary, 0)
+	for rows.Next() {
+		var summary ArchiveItemDueSummary
+		var nextRetry sql.NullString
+		if err := rows.Scan(&summary.RepoID, &summary.Due, &nextRetry); err != nil {
+			return nil, fmt.Errorf("scan due archive item summary: %w", err)
+		}
+		summary.NextRetryAt, err = parseDatasetProgressTimePtr(nextRetry)
+		if err != nil {
+			return nil, fmt.Errorf("parse due archive item retry time: %w", err)
+		}
+		summaries = append(summaries, summary)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("summarize due archive items: %w", err)
+	}
+	return summaries, nil
+}
 
 func claimArchiveItemForRepo(
 	ctx context.Context,
@@ -850,7 +914,7 @@ func claimArchiveItemForRepo(
 	excludedItemTypes []ArchiveItemType,
 ) (*ArchiveItemWork, error) {
 	query := dueArchiveItemsQuery
-	args := []any{repoID, now, formatDatasetProgressTime(now)}
+	args := []any{now, repoID, formatDatasetProgressTime(now)}
 	if len(excludedItemTypes) > 0 {
 		query += fmt.Sprintf(" AND ai.item_type NOT IN (%s)", sqlPlaceholders(len(excludedItemTypes)))
 		for _, itemType := range excludedItemTypes {

--- a/internal/github/archive_lifecycle_test.go
+++ b/internal/github/archive_lifecycle_test.go
@@ -751,9 +751,7 @@ func TestArchiveDisabledIssueHydrationRecoversAfterManualProbe(t *testing.T) {
 	assert.Equal(int32(2), fixture.hydrationCalls.Load())
 }
 
-func (*archiveLifecycleRecorder) RunPass(context.Context) (archive.NextWake, error) {
-	return archive.NextWake{}, nil
-}
+func (*archiveLifecycleRecorder) RunPass(context.Context) (bool, error) { return false, nil }
 
 func (r *archiveLifecycleRecorder) EnsureConfigured(_ context.Context, refs []platform.RepoRef) ([]platform.RepoRef, error) {
 	r.ensured = append(r.ensured, refs...)
@@ -772,7 +770,7 @@ func newBlockingArchiveRunner() *blockingArchiveRunner {
 	return &blockingArchiveRunner{started: make(chan struct{}), done: make(chan struct{})}
 }
 
-func (r *blockingArchiveRunner) RunPass(ctx context.Context) (archive.NextWake, error) {
+func (r *blockingArchiveRunner) RunPass(ctx context.Context) (bool, error) {
 	if r.calls.Add(1) == 1 {
 		close(r.started)
 	}
@@ -782,7 +780,7 @@ func (r *blockingArchiveRunner) RunPass(ctx context.Context) (archive.NextWake, 
 	default:
 		close(r.done)
 	}
-	return archive.NextWake{}, ctx.Err()
+	return false, ctx.Err()
 }
 
 func TestArchiveWorkerJoinsSyncerShutdown(t *testing.T) {

--- a/internal/github/archive_lifecycle_test.go
+++ b/internal/github/archive_lifecycle_test.go
@@ -751,7 +751,9 @@ func TestArchiveDisabledIssueHydrationRecoversAfterManualProbe(t *testing.T) {
 	assert.Equal(int32(2), fixture.hydrationCalls.Load())
 }
 
-func (*archiveLifecycleRecorder) RunEligible(context.Context) error { return nil }
+func (*archiveLifecycleRecorder) RunPass(context.Context) (archive.NextWake, error) {
+	return archive.NextWake{}, nil
+}
 
 func (r *archiveLifecycleRecorder) EnsureConfigured(_ context.Context, refs []platform.RepoRef) ([]platform.RepoRef, error) {
 	r.ensured = append(r.ensured, refs...)
@@ -770,7 +772,7 @@ func newBlockingArchiveRunner() *blockingArchiveRunner {
 	return &blockingArchiveRunner{started: make(chan struct{}), done: make(chan struct{})}
 }
 
-func (r *blockingArchiveRunner) RunEligible(ctx context.Context) error {
+func (r *blockingArchiveRunner) RunPass(ctx context.Context) (archive.NextWake, error) {
 	if r.calls.Add(1) == 1 {
 		close(r.started)
 	}
@@ -780,7 +782,7 @@ func (r *blockingArchiveRunner) RunEligible(ctx context.Context) error {
 	default:
 		close(r.done)
 	}
-	return ctx.Err()
+	return archive.NextWake{}, ctx.Err()
 }
 
 func TestArchiveWorkerJoinsSyncerShutdown(t *testing.T) {

--- a/internal/github/archive_wake_test.go
+++ b/internal/github/archive_wake_test.go
@@ -183,21 +183,40 @@ func TestArchiveLoopWakesWhenSyncRunCompletes(t *testing.T) {
 	})
 }
 
-func TestArchiveLoopWakesWhenHostProviderWorkFinishes(t *testing.T) {
+func TestArchiveLoopWakesOnlyHostsThatDeniedArchiveWork(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		require := require.New(t)
 		runner := &pacedArchiveRunner{}
 		syncer, stop := startPacedArchiveLoop(t, runner)
 		defer stop()
+		const key = "github\x00github.test"
 
 		time.Sleep(16 * time.Second)
 		synctest.Wait()
 		backedOff := runner.reset()
 
-		// Two overlapping live operations on one host: only the release that
-		// frees the host wakes the worker, and it wakes it immediately.
-		releaseFirst := syncer.beginProviderWork("github\x00github.test", archive.PriorityNormalIndex)
-		releaseSecond := syncer.beginProviderWork("github\x00github.test", archive.PriorityActiveDetail)
+		// A normal stream of live work on a host that never turned archive
+		// work away must not wake the worker, or every sync would trigger a
+		// denied pass and a deferral write per release.
+		release := syncer.beginProviderWork(key, archive.PriorityNormalIndex)
+		release()
+		synctest.Wait()
+		require.Empty(runner.offsetsFrom(backedOff), "releasing a host that denied nothing must stay quiet")
+
+		// Live work preempting an admitted archive request marks the host.
+		// Only the release that frees the host wakes the worker, immediately.
+		_, releaseArchive, ok := syncer.tryBeginArchiveProviderRequest(context.Background(), key)
+		require.True(ok)
+		started := make(chan struct{})
+		var releaseFirst func()
+		go func() {
+			releaseFirst = syncer.beginProviderWork(key, archive.PriorityActiveDetail)
+			close(started)
+		}()
+		synctest.Wait()
+		releaseArchive()
+		<-started
+		releaseSecond := syncer.beginProviderWork(key, archive.PriorityNotificationRefresh)
 		releaseFirst()
 		synctest.Wait()
 		require.Empty(runner.offsetsFrom(backedOff), "a host still busy must not wake the worker")
@@ -205,5 +224,12 @@ func TestArchiveLoopWakesWhenHostProviderWorkFinishes(t *testing.T) {
 		time.Sleep(time.Second)
 		synctest.Wait()
 		require.Equal([]time.Duration{0, time.Second}, runner.offsetsFrom(backedOff))
+
+		// The mark is consumed by the wake: the next quiet release stays quiet.
+		quiet := runner.reset()
+		release = syncer.beginProviderWork(key, archive.PriorityNormalIndex)
+		release()
+		synctest.Wait()
+		require.Empty(runner.offsetsFrom(quiet))
 	})
 }

--- a/internal/github/archive_wake_test.go
+++ b/internal/github/archive_wake_test.go
@@ -105,29 +105,43 @@ func TestArchiveWorkerIdleWakesRunNoRepositoryResolution(t *testing.T) {
 				return false
 			}
 		}
-		before := runner.passes.Load()
-		time.Sleep(50 * time.Millisecond)
-		return runner.passes.Load() == before
+		return true
 	}, 5*time.Second, 10*time.Millisecond)
+	idle := runner.awaitQuiescence(t)
 
 	// Hide the repository catalog so any resolution query fails loudly.
 	_, err = database.WriteDB().ExecContext(t.Context(),
 		`ALTER TABLE forge_repos RENAME TO forge_repos_hidden`)
 	require.NoError(err)
 
+	// Each wake runs exactly one pass. Waiting for quiescence after every
+	// wake keeps a wake from landing while the previous pass is still running,
+	// where the buffered channel would carry it into an extra pass.
 	for range 3 {
-		before := runner.passes.Load()
 		syncer.WakeArchive()
 		require.Eventually(func() bool {
-			return runner.passes.Load() > before
+			return runner.passes.Load() > idle
 		}, time.Second, time.Millisecond)
+		idle = runner.awaitQuiescence(t)
 	}
 	select {
 	case err := <-runner.errs:
 		require.NoError(err, "idle wakes must not resolve repositories")
 	default:
 	}
-	before := runner.passes.Load()
-	time.Sleep(50 * time.Millisecond)
-	require.Equal(before, runner.passes.Load(), "an idle worker must not poll between wakes")
+	require.Equal(idle, runner.passes.Load(), "an idle worker must not poll between wakes")
+}
+
+// awaitQuiescence waits until no pass has completed for a full quiet window
+// and returns the settled pass count.
+func (r *countingArchiveRunner) awaitQuiescence(t *testing.T) int32 {
+	t.Helper()
+	var settled int32
+	require.Eventually(t, func() bool {
+		before := r.passes.Load()
+		time.Sleep(200 * time.Millisecond)
+		settled = r.passes.Load()
+		return settled == before
+	}, 5*time.Second, 10*time.Millisecond)
+	return settled
 }

--- a/internal/github/archive_wake_test.go
+++ b/internal/github/archive_wake_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -15,6 +16,7 @@ import (
 // configurable "attempted work" result.
 type pacedArchiveRunner struct {
 	worked atomic.Bool
+	fail   atomic.Bool
 	mu     sync.Mutex
 	passes []time.Time
 }
@@ -23,6 +25,9 @@ func (r *pacedArchiveRunner) RunPass(context.Context) (bool, error) {
 	r.mu.Lock()
 	r.passes = append(r.passes, time.Now())
 	r.mu.Unlock()
+	if r.fail.Load() {
+		return false, errors.New("store unavailable")
+	}
 	return r.worked.Load(), nil
 }
 
@@ -134,5 +139,45 @@ func TestArchiveLoopIdleBackoffIsCapped(t *testing.T) {
 		last := passes[len(passes)-1]
 		previous := passes[len(passes)-2]
 		require.Equal(archiveIdleWait, last.Sub(previous))
+	})
+}
+
+func TestArchiveLoopKeepsPacingIntervalWhilePassesFail(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		require := require.New(t)
+		runner := &pacedArchiveRunner{}
+		runner.fail.Store(true)
+		start := time.Now()
+		_, stop := startPacedArchiveLoop(t, runner)
+		defer stop()
+
+		// A failing store must keep retrying at the pacing interval so
+		// recovery is prompt, not exponentially delayed.
+		time.Sleep(4 * time.Second)
+		synctest.Wait()
+		require.Equal([]time.Duration{
+			0, time.Second, 2 * time.Second, 3 * time.Second, 4 * time.Second,
+		}, runner.offsetsFrom(start))
+	})
+}
+
+func TestArchiveLoopWakesWhenSyncRunCompletes(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		require := require.New(t)
+		runner := &pacedArchiveRunner{}
+		syncer, stop := startPacedArchiveLoop(t, runner)
+		defer stop()
+
+		// Let the idle backoff grow well past the pacing interval.
+		time.Sleep(16 * time.Second)
+		synctest.Wait()
+		backedOff := runner.reset()
+
+		// A completed sync run (here with no repositories) must wake the
+		// worker immediately and restart the backoff from the pacing interval.
+		syncer.RunOnce(context.Background())
+		time.Sleep(time.Second)
+		synctest.Wait()
+		require.Equal([]time.Duration{0, time.Second}, runner.offsetsFrom(backedOff))
 	})
 }

--- a/internal/github/archive_wake_test.go
+++ b/internal/github/archive_wake_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/archive"
 )
 
 // pacedArchiveRunner records when each pass ran and answers with a
@@ -176,6 +177,31 @@ func TestArchiveLoopWakesWhenSyncRunCompletes(t *testing.T) {
 		// A completed sync run (here with no repositories) must wake the
 		// worker immediately and restart the backoff from the pacing interval.
 		syncer.RunOnce(context.Background())
+		time.Sleep(time.Second)
+		synctest.Wait()
+		require.Equal([]time.Duration{0, time.Second}, runner.offsetsFrom(backedOff))
+	})
+}
+
+func TestArchiveLoopWakesWhenHostProviderWorkFinishes(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		require := require.New(t)
+		runner := &pacedArchiveRunner{}
+		syncer, stop := startPacedArchiveLoop(t, runner)
+		defer stop()
+
+		time.Sleep(16 * time.Second)
+		synctest.Wait()
+		backedOff := runner.reset()
+
+		// Two overlapping live operations on one host: only the release that
+		// frees the host wakes the worker, and it wakes it immediately.
+		releaseFirst := syncer.beginProviderWork("github\x00github.test", archive.PriorityNormalIndex)
+		releaseSecond := syncer.beginProviderWork("github\x00github.test", archive.PriorityActiveDetail)
+		releaseFirst()
+		synctest.Wait()
+		require.Empty(runner.offsetsFrom(backedOff), "a host still busy must not wake the worker")
+		releaseSecond()
 		time.Sleep(time.Second)
 		synctest.Wait()
 		require.Equal([]time.Duration{0, time.Second}, runner.offsetsFrom(backedOff))

--- a/internal/github/archive_wake_test.go
+++ b/internal/github/archive_wake_test.go
@@ -1,0 +1,133 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/archive"
+	"go.kenn.io/forge/internal/platform"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+)
+
+func TestArchiveWaitPacesWorkAndSleepsUntilEligibility(t *testing.T) {
+	assert := assert.New(t)
+	now := time.Date(2026, 3, 1, 9, 0, 0, 0, time.UTC)
+	syncer := NewSyncerWithRegistry(nil, dbtest.Open(t), nil, nil, time.Hour, nil, nil)
+	syncer.SetClock(func() time.Time { return now })
+	syncer.SetArchivePollIntervalForTesting(2 * time.Second)
+
+	assert.Equal(2*time.Second, syncer.archiveWait(archive.NextWake{}, errors.New("store failed")),
+		"a failed pass retries at the work pacing interval")
+	assert.Equal(2*time.Second, syncer.archiveWait(archive.NextWake{Worked: true}, nil),
+		"a pass that attempted work re-runs at the work pacing interval")
+	assert.Equal(archiveIdleWait, syncer.archiveWait(archive.NextWake{}, nil),
+		"nothing scheduled sleeps for the idle bound")
+	assert.Equal(90*time.Second, syncer.archiveWait(archive.NextWake{At: now.Add(90 * time.Second)}, nil),
+		"an idle pass sleeps until the earliest eligibility time")
+	assert.Equal(2*time.Second, syncer.archiveWait(archive.NextWake{At: now.Add(-time.Minute)}, nil),
+		"an eligibility time already reached still paces by the work interval")
+	assert.Equal(archiveIdleWait, syncer.archiveWait(archive.NextWake{At: now.Add(time.Hour)}, nil),
+		"a distant eligibility time is bounded by the idle safety net")
+}
+
+// countingArchiveRunner records every worker pass made against the real
+// archive service and the errors those passes returned.
+type countingArchiveRunner struct {
+	service *archive.Service
+	passes  atomic.Int32
+	errs    chan error
+}
+
+func (r *countingArchiveRunner) RunPass(ctx context.Context) (archive.NextWake, error) {
+	wake, err := r.service.RunPass(ctx)
+	if err != nil {
+		select {
+		case r.errs <- err:
+		default:
+		}
+	}
+	r.passes.Add(1)
+	return wake, err
+}
+
+func TestArchiveWorkerIdleWakesRunNoRepositoryResolution(t *testing.T) {
+	require := require.New(t)
+	database := dbtest.Open(t)
+	ref := platform.RepoRef{
+		Platform: platform.KindGitHub, Host: "github.test",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		PlatformExternalID: "repo-1",
+	}
+	provider := &archiveWorkerProvider{ref: ref}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	syncer := NewSyncerWithRegistry(registry, database, nil, []RepoRef{{
+		Platform: ref.Platform, PlatformHost: ref.Host,
+		Owner: ref.Owner, Name: ref.Name, RepoPath: ref.RepoPath,
+		PlatformExternalID: ref.PlatformExternalID,
+	}}, time.Hour, nil, nil)
+	service, err := archive.NewService(database, registry, nil, syncer, nil, nil)
+	require.NoError(err)
+	service.SetWake(syncer.WakeArchive)
+	runner := &countingArchiveRunner{service: service, errs: make(chan error, 1)}
+	syncer.SetArchiveService(runner)
+	syncer.SetArchivePollIntervalForTesting(time.Millisecond)
+	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
+	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
+	require.NoError(err)
+	syncer.Start(t.Context())
+	t.Cleanup(syncer.Stop)
+
+	repo, err := database.GetRepoByIdentity(t.Context(), platform.DBRepoIdentity(ref))
+	require.NoError(err)
+	require.NotNil(repo)
+	require.Eventually(func() bool {
+		states, stateErr := database.ListArchiveRepoStates(t.Context(), []int64{repo.ID})
+		return stateErr == nil && len(states) == 1 && states[0].IssueInventory.Complete()
+	}, 2*time.Second, 5*time.Millisecond)
+
+	// The worker is idle once every inventoried item's hydration has either
+	// completed or is waiting on its retry time, and passes stop.
+	require.Eventually(func() bool {
+		summaries, summaryErr := database.SummarizeArchiveItemsDue(
+			t.Context(), []int64{repo.ID}, time.Now(),
+		)
+		if summaryErr != nil {
+			return false
+		}
+		for _, summary := range summaries {
+			if summary.Due > 0 {
+				return false
+			}
+		}
+		before := runner.passes.Load()
+		time.Sleep(50 * time.Millisecond)
+		return runner.passes.Load() == before
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Hide the repository catalog so any resolution query fails loudly.
+	_, err = database.WriteDB().ExecContext(t.Context(),
+		`ALTER TABLE forge_repos RENAME TO forge_repos_hidden`)
+	require.NoError(err)
+
+	for range 3 {
+		before := runner.passes.Load()
+		syncer.WakeArchive()
+		require.Eventually(func() bool {
+			return runner.passes.Load() > before
+		}, time.Second, time.Millisecond)
+	}
+	select {
+	case err := <-runner.errs:
+		require.NoError(err, "idle wakes must not resolve repositories")
+	default:
+	}
+	before := runner.passes.Load()
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(before, runner.passes.Load(), "an idle worker must not poll between wakes")
+}

--- a/internal/github/archive_wake_test.go
+++ b/internal/github/archive_wake_test.go
@@ -2,146 +2,137 @@ package github
 
 import (
 	"context"
-	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.kenn.io/forge/internal/archive"
-	"go.kenn.io/forge/internal/platform"
-	"go.kenn.io/forge/internal/testutil/dbtest"
 )
 
-func TestArchiveWaitPacesWorkAndSleepsUntilEligibility(t *testing.T) {
-	assert := assert.New(t)
-	now := time.Date(2026, 3, 1, 9, 0, 0, 0, time.UTC)
-	syncer := NewSyncerWithRegistry(nil, dbtest.Open(t), nil, nil, time.Hour, nil, nil)
-	syncer.SetClock(func() time.Time { return now })
-	syncer.SetArchivePollIntervalForTesting(2 * time.Second)
-
-	assert.Equal(2*time.Second, syncer.archiveWait(archive.NextWake{}, errors.New("store failed")),
-		"a failed pass retries at the work pacing interval")
-	assert.Equal(2*time.Second, syncer.archiveWait(archive.NextWake{Worked: true}, nil),
-		"a pass that attempted work re-runs at the work pacing interval")
-	assert.Equal(archiveIdleWait, syncer.archiveWait(archive.NextWake{}, nil),
-		"nothing scheduled sleeps for the idle bound")
-	assert.Equal(90*time.Second, syncer.archiveWait(archive.NextWake{At: now.Add(90 * time.Second)}, nil),
-		"an idle pass sleeps until the earliest eligibility time")
-	assert.Equal(2*time.Second, syncer.archiveWait(archive.NextWake{At: now.Add(-time.Minute)}, nil),
-		"an eligibility time already reached still paces by the work interval")
-	assert.Equal(archiveIdleWait, syncer.archiveWait(archive.NextWake{At: now.Add(time.Hour)}, nil),
-		"a distant eligibility time is bounded by the idle safety net")
+// pacedArchiveRunner records when each pass ran and answers with a
+// configurable "attempted work" result.
+type pacedArchiveRunner struct {
+	worked atomic.Bool
+	mu     sync.Mutex
+	passes []time.Time
 }
 
-// countingArchiveRunner records every worker pass made against the real
-// archive service and the errors those passes returned.
-type countingArchiveRunner struct {
-	service *archive.Service
-	passes  atomic.Int32
-	errs    chan error
+func (r *pacedArchiveRunner) RunPass(context.Context) (bool, error) {
+	r.mu.Lock()
+	r.passes = append(r.passes, time.Now())
+	r.mu.Unlock()
+	return r.worked.Load(), nil
 }
 
-func (r *countingArchiveRunner) RunPass(ctx context.Context) (archive.NextWake, error) {
-	wake, err := r.service.RunPass(ctx)
-	if err != nil {
-		select {
-		case r.errs <- err:
-		default:
-		}
-	}
-	r.passes.Add(1)
-	return wake, err
+// reset clears the recorded passes and returns the new origin for offsets.
+func (r *pacedArchiveRunner) reset() time.Time {
+	r.mu.Lock()
+	r.passes = nil
+	r.mu.Unlock()
+	return time.Now()
 }
 
-func TestArchiveWorkerIdleWakesRunNoRepositoryResolution(t *testing.T) {
-	require := require.New(t)
-	database := dbtest.Open(t)
-	ref := platform.RepoRef{
-		Platform: platform.KindGitHub, Host: "github.test",
-		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
-		PlatformExternalID: "repo-1",
+func (r *pacedArchiveRunner) offsetsFrom(origin time.Time) []time.Duration {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	offsets := make([]time.Duration, 0, len(r.passes))
+	for _, at := range r.passes {
+		offsets = append(offsets, at.Sub(origin))
 	}
-	provider := &archiveWorkerProvider{ref: ref}
-	registry, err := platform.NewRegistry(provider)
-	require.NoError(err)
-	syncer := NewSyncerWithRegistry(registry, database, nil, []RepoRef{{
-		Platform: ref.Platform, PlatformHost: ref.Host,
-		Owner: ref.Owner, Name: ref.Name, RepoPath: ref.RepoPath,
-		PlatformExternalID: ref.PlatformExternalID,
-	}}, time.Hour, nil, nil)
-	service, err := archive.NewService(database, registry, nil, syncer, nil, nil)
-	require.NoError(err)
-	service.SetWake(syncer.WakeArchive)
-	runner := &countingArchiveRunner{service: service, errs: make(chan error, 1)}
-	syncer.SetArchiveService(runner)
-	syncer.SetArchivePollIntervalForTesting(time.Millisecond)
-	requireEnsureConfigured(t, service, []platform.RepoRef{ref})
-	_, err = service.Start(t.Context(), []platform.RepoRef{ref})
-	require.NoError(err)
-	syncer.Start(t.Context())
-	t.Cleanup(syncer.Stop)
-
-	repo, err := database.GetRepoByIdentity(t.Context(), platform.DBRepoIdentity(ref))
-	require.NoError(err)
-	require.NotNil(repo)
-	require.Eventually(func() bool {
-		states, stateErr := database.ListArchiveRepoStates(t.Context(), []int64{repo.ID})
-		return stateErr == nil && len(states) == 1 && states[0].IssueInventory.Complete()
-	}, 2*time.Second, 5*time.Millisecond)
-
-	// The worker is idle once every inventoried item's hydration has either
-	// completed or is waiting on its retry time, and passes stop.
-	require.Eventually(func() bool {
-		summaries, summaryErr := database.SummarizeArchiveItemsDue(
-			t.Context(), []int64{repo.ID}, time.Now(),
-		)
-		if summaryErr != nil {
-			return false
-		}
-		for _, summary := range summaries {
-			if summary.Due > 0 {
-				return false
-			}
-		}
-		return true
-	}, 5*time.Second, 10*time.Millisecond)
-	idle := runner.awaitQuiescence(t)
-
-	// Hide the repository catalog so any resolution query fails loudly.
-	_, err = database.WriteDB().ExecContext(t.Context(),
-		`ALTER TABLE forge_repos RENAME TO forge_repos_hidden`)
-	require.NoError(err)
-
-	// Each wake runs exactly one pass. Waiting for quiescence after every
-	// wake keeps a wake from landing while the previous pass is still running,
-	// where the buffered channel would carry it into an extra pass.
-	for range 3 {
-		syncer.WakeArchive()
-		require.Eventually(func() bool {
-			return runner.passes.Load() > idle
-		}, time.Second, time.Millisecond)
-		idle = runner.awaitQuiescence(t)
-	}
-	select {
-	case err := <-runner.errs:
-		require.NoError(err, "idle wakes must not resolve repositories")
-	default:
-	}
-	require.Equal(idle, runner.passes.Load(), "an idle worker must not poll between wakes")
+	return offsets
 }
 
-// awaitQuiescence waits until no pass has completed for a full quiet window
-// and returns the settled pass count.
-func (r *countingArchiveRunner) awaitQuiescence(t *testing.T) int32 {
+func (r *pacedArchiveRunner) recorded() []time.Time {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]time.Time(nil), r.passes...)
+}
+
+// startPacedArchiveLoop runs the worker loop inside the current synctest
+// bubble so the syncer's channels and the loop's timers are all virtual.
+func startPacedArchiveLoop(t *testing.T, runner *pacedArchiveRunner) (*Syncer, func()) {
 	t.Helper()
-	var settled int32
-	require.Eventually(t, func() bool {
-		before := r.passes.Load()
-		time.Sleep(200 * time.Millisecond)
-		settled = r.passes.Load()
-		return settled == before
-	}, 5*time.Second, 10*time.Millisecond)
-	return settled
+	syncer := NewSyncerWithRegistry(nil, nil, nil, nil, time.Hour, nil, nil)
+	syncer.SetArchiveService(runner)
+	syncer.SetArchivePollIntervalForTesting(time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	ready := make(chan struct{})
+	close(ready)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		syncer.runArchiveLoop(ctx, ready)
+	}()
+	return syncer, func() {
+		cancel()
+		<-done
+	}
+}
+
+func TestArchiveLoopBacksOffWhileIdleAndResetsOnWake(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		require := require.New(t)
+		runner := &pacedArchiveRunner{}
+		start := time.Now()
+		syncer, stop := startPacedArchiveLoop(t, runner)
+		defer stop()
+
+		// Idle passes double their spacing: 1s, 2s, 4s, 8s, ...
+		time.Sleep(16 * time.Second)
+		synctest.Wait()
+		require.Equal([]time.Duration{
+			0, time.Second, 3 * time.Second, 7 * time.Second, 15 * time.Second,
+		}, runner.offsetsFrom(start))
+
+		// A wake runs a pass immediately and restarts the backoff from the
+		// pacing interval.
+		wakeAt := runner.reset()
+		syncer.WakeArchive()
+		time.Sleep(3 * time.Second)
+		synctest.Wait()
+		require.Equal([]time.Duration{0, time.Second, 3 * time.Second}, runner.offsetsFrom(wakeAt))
+	})
+}
+
+func TestArchiveLoopKeepsPacingIntervalWhileWorkFlows(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		require := require.New(t)
+		runner := &pacedArchiveRunner{}
+		runner.worked.Store(true)
+		start := time.Now()
+		_, stop := startPacedArchiveLoop(t, runner)
+		defer stop()
+
+		time.Sleep(5 * time.Second)
+		synctest.Wait()
+		require.Equal([]time.Duration{
+			0, time.Second, 2 * time.Second, 3 * time.Second, 4 * time.Second, 5 * time.Second,
+		}, runner.offsetsFrom(start))
+
+		// Once work dries up the loop backs off again: 1s, then 2s.
+		runner.worked.Store(false)
+		last := runner.reset()
+		time.Sleep(4 * time.Second)
+		synctest.Wait()
+		require.Equal([]time.Duration{time.Second, 3 * time.Second}, runner.offsetsFrom(last))
+	})
+}
+
+func TestArchiveLoopIdleBackoffIsCapped(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		require := require.New(t)
+		runner := &pacedArchiveRunner{}
+		_, stop := startPacedArchiveLoop(t, runner)
+		defer stop()
+
+		time.Sleep(time.Hour)
+		synctest.Wait()
+		passes := runner.recorded()
+		require.GreaterOrEqual(len(passes), 3)
+		last := passes[len(passes)-1]
+		previous := passes[len(passes)-2]
+		require.Equal(archiveIdleWait, last.Sub(previous))
+	})
 }

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -18,6 +18,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cenkalti/backoff/v7"
 	gh "github.com/google/go-github/v89/github"
 	"go.kenn.io/forge/internal/archive"
 	"go.kenn.io/forge/internal/config"
@@ -959,7 +960,9 @@ type archiveProviderRequest struct {
 }
 
 type archiveRunner interface {
-	RunPass(context.Context) (archive.NextWake, error)
+	// RunPass performs one worker pass and reports whether it attempted
+	// provider work.
+	RunPass(context.Context) (bool, error)
 }
 
 type archiveRepositoryLifecycle interface {
@@ -1265,8 +1268,8 @@ func (s *Syncer) WakeArchive() {
 }
 
 // SetArchivePollIntervalForTesting shortens the pacing between archive worker
-// passes that attempted work or failed. Idle passes still sleep until the
-// service reports work can become eligible.
+// passes. It is the wait after a pass that attempted work or failed and the
+// starting point of the idle backoff.
 func (s *Syncer) SetArchivePollIntervalForTesting(interval time.Duration) {
 	if interval > 0 {
 		s.archivePollInterval = interval
@@ -4689,16 +4692,34 @@ func (s *Syncer) runArchiveLoop(ctx context.Context, ready <-chan struct{}) {
 	case <-ctx.Done():
 		return
 	}
+	interval := s.archivePollInterval
+	if interval <= 0 {
+		interval = time.Second
+	}
+	// Idle passes back off exponentially from the pacing interval to
+	// archiveIdleWait. A pass that attempted work or failed, or a wake from
+	// config reload, sync completion, a budget reset, or an archive start,
+	// returns the loop to the pacing interval.
+	idle := backoff.NewExponentialBackOff()
+	idle.InitialInterval = interval
+	idle.MaxInterval = archiveIdleWait
+	idle.Multiplier = 2
+	idle.RandomizationFactor = 0
+	idle.Reset()
 	for {
-		wake, err := s.archiveRunner.RunPass(ctx)
+		worked, err := s.archiveRunner.RunPass(ctx)
 		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 			slog.Warn("archive worker iteration failed", "err", err)
 		}
-		timer := time.NewTimer(s.archiveWait(wake, err))
+		if worked || err != nil {
+			idle.Reset()
+		}
+		timer := time.NewTimer(idle.NextBackOff())
 		select {
 		case <-timer.C:
 		case <-s.archiveWake:
 			timer.Stop()
+			idle.Reset()
 		case <-s.stopCh:
 			timer.Stop()
 			return
@@ -4709,30 +4730,11 @@ func (s *Syncer) runArchiveLoop(ctx context.Context, ready <-chan struct{}) {
 	}
 }
 
-// archiveIdleWait bounds how long the archive worker sleeps when the service
-// reports nothing scheduled or a distant eligibility time. It is a safety net
-// against a missed wake, not the normal way work resumes: configuration
-// reloads, sync completion, budget resets, and explicit wakes all interrupt
-// the sleep through archiveWake.
+// archiveIdleWait caps the archive worker's idle backoff. Every source of
+// time-driven archive work waits at least a minute, so a bounded delay in
+// noticing it costs little, while an idle daemon stops paying for a pass
+// every second.
 const archiveIdleWait = 5 * time.Minute
-
-// archiveWait converts the service's wake computation into the sleep before
-// the next pass. A pass that attempted work or failed re-runs after the work
-// pacing interval; an idle pass sleeps until the earliest known eligibility
-// time, bounded below by the pacing interval and above by archiveIdleWait.
-func (s *Syncer) archiveWait(wake archive.NextWake, err error) time.Duration {
-	interval := s.archivePollInterval
-	if interval <= 0 {
-		interval = time.Second
-	}
-	if err != nil || wake.Worked {
-		return interval
-	}
-	if wake.At.IsZero() {
-		return archiveIdleWait
-	}
-	return min(max(wake.At.Sub(s.now()), interval), archiveIdleWait)
-}
 
 // backgroundReserveCost is the request allowance every background reserve check
 // asks for. One constant rather than a per-caller cost: against a 200-request
@@ -6037,6 +6039,10 @@ func (s *Syncer) runOnceWithSlot(
 				s.publishStatusLocked(terminalStatus)
 			}
 			s.statusMu.Unlock()
+			// A completed sync can change archive eligibility, for example by
+			// clearing a repository feature cooldown, so the idle archive
+			// worker must not wait out its backoff to notice.
+			s.WakeArchive()
 			return
 		}
 		s.statusMu.Unlock()

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -959,7 +959,7 @@ type archiveProviderRequest struct {
 }
 
 type archiveRunner interface {
-	RunEligible(context.Context) error
+	RunPass(context.Context) (archive.NextWake, error)
 }
 
 type archiveRepositoryLifecycle interface {
@@ -1264,6 +1264,9 @@ func (s *Syncer) WakeArchive() {
 	}
 }
 
+// SetArchivePollIntervalForTesting shortens the pacing between archive worker
+// passes that attempted work or failed. Idle passes still sleep until the
+// service reports work can become eligible.
 func (s *Syncer) SetArchivePollIntervalForTesting(interval time.Duration) {
 	if interval > 0 {
 		s.archivePollInterval = interval
@@ -4686,26 +4689,49 @@ func (s *Syncer) runArchiveLoop(ctx context.Context, ready <-chan struct{}) {
 	case <-ctx.Done():
 		return
 	}
+	for {
+		wake, err := s.archiveRunner.RunPass(ctx)
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			slog.Warn("archive worker iteration failed", "err", err)
+		}
+		timer := time.NewTimer(s.archiveWait(wake, err))
+		select {
+		case <-timer.C:
+		case <-s.archiveWake:
+			timer.Stop()
+		case <-s.stopCh:
+			timer.Stop()
+			return
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		}
+	}
+}
+
+// archiveIdleWait bounds how long the archive worker sleeps when the service
+// reports nothing scheduled or a distant eligibility time. It is a safety net
+// against a missed wake, not the normal way work resumes: configuration
+// reloads, sync completion, budget resets, and explicit wakes all interrupt
+// the sleep through archiveWake.
+const archiveIdleWait = 5 * time.Minute
+
+// archiveWait converts the service's wake computation into the sleep before
+// the next pass. A pass that attempted work or failed re-runs after the work
+// pacing interval; an idle pass sleeps until the earliest known eligibility
+// time, bounded below by the pacing interval and above by archiveIdleWait.
+func (s *Syncer) archiveWait(wake archive.NextWake, err error) time.Duration {
 	interval := s.archivePollInterval
 	if interval <= 0 {
 		interval = time.Second
 	}
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-	for {
-		if err := s.archiveRunner.RunEligible(ctx); err != nil &&
-			!errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-			slog.Warn("archive worker iteration failed", "err", err)
-		}
-		select {
-		case <-ticker.C:
-		case <-s.archiveWake:
-		case <-s.stopCh:
-			return
-		case <-ctx.Done():
-			return
-		}
+	if err != nil || wake.Worked {
+		return interval
 	}
+	if wake.At.IsZero() {
+		return archiveIdleWait
+	}
+	return min(max(wake.At.Sub(s.now()), interval), archiveIdleWait)
 }
 
 // backgroundReserveCost is the request allowance every background reserve check

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -845,13 +845,17 @@ type Syncer struct {
 	pendingRun               *pendingSyncRun // guarded by runMu
 	providerWorkMu           sync.Mutex
 	providerWork             map[string]map[archive.WorkPriority]int
-	archiveProviderRequests  map[string]archiveProviderRequest
-	status                   atomic.Value // stores *SyncStatus
-	stopCh                   chan struct{}
-	notificationSyncMu       sync.RWMutex
-	notificationSync         NotificationSyncStatus
-	stopOnce                 sync.Once
-	wg                       sync.WaitGroup
+	// archiveDeniedHosts records provider hosts whose live work denied or
+	// preempted an archive request; releasing such a host wakes the archive
+	// worker, while hosts that never turned archive work away stay quiet.
+	archiveDeniedHosts      map[string]struct{}
+	archiveProviderRequests map[string]archiveProviderRequest
+	status                  atomic.Value // stores *SyncStatus
+	stopCh                  chan struct{}
+	notificationSyncMu      sync.RWMutex
+	notificationSync        NotificationSyncStatus
+	stopOnce                sync.Once
+	wg                      sync.WaitGroup
 	// lifecycleMu serializes TriggerRun registration with Stop so
 	// no wg.Add can happen after Stop begins wg.Wait.
 	lifecycleMu        sync.Mutex
@@ -1346,6 +1350,7 @@ func (s *Syncer) Admit(
 	key := RateBucketKey(string(repoPlatform(keyRepo)), identity.Host, identity.Principal)
 	if s.higherPriorityProviderWorkActive(key, archive.PriorityFullArchive) {
 		probe.abandon()
+		s.noteArchiveDenied(key)
 		retryAt := now.Add(time.Second)
 		return archive.AdmissionResult{RetryAt: &retryAt, Detail: "higher-priority sync work is active"}, nil
 	}
@@ -1455,6 +1460,21 @@ func (s *Syncer) Admit(
 	}, nil
 }
 
+// noteArchiveDenied records that live work on key turned an archive request
+// away, so releasing the host later wakes the archive worker.
+func (s *Syncer) noteArchiveDenied(key string) {
+	s.providerWorkMu.Lock()
+	s.markArchiveDeniedLocked(key)
+	s.providerWorkMu.Unlock()
+}
+
+func (s *Syncer) markArchiveDeniedLocked(key string) {
+	if s.archiveDeniedHosts == nil {
+		s.archiveDeniedHosts = make(map[string]struct{})
+	}
+	s.archiveDeniedHosts[key] = struct{}{}
+}
+
 func (s *Syncer) tryBeginArchiveProviderRequest(
 	ctx context.Context,
 	key string,
@@ -1522,6 +1542,7 @@ func (s *Syncer) beginProviderWork(key string, priority archive.WorkPriority) fu
 	archiveRequest, waitForArchive := s.archiveProviderRequests[key]
 	if waitForArchive {
 		archiveRequest.cancel()
+		s.markArchiveDeniedLocked(key)
 	}
 	s.providerWorkMu.Unlock()
 	if waitForArchive {
@@ -1541,10 +1562,16 @@ func (s *Syncer) beginProviderWork(key string, priority archive.WorkPriority) fu
 			if hostFree {
 				delete(s.providerWork, key)
 			}
+			_, wake := s.archiveDeniedHosts[key]
+			if hostFree && wake {
+				delete(s.archiveDeniedHosts, key)
+			}
 			s.providerWorkMu.Unlock()
-			if hostFree {
-				// Archive admission was denied while this work held the host;
-				// the worker backed off, so tell it the host is free again.
+			if hostFree && wake {
+				// This host turned archive work away while live work held it
+				// and the worker backed off; tell it the host is free again.
+				// Hosts that never denied archive work stay quiet, so a normal
+				// sync's stream of releases does not trigger denied passes.
 				s.WakeArchive()
 			}
 		})

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -1532,14 +1532,20 @@ func (s *Syncer) beginProviderWork(key string, priority archive.WorkPriority) fu
 	return func() {
 		once.Do(func() {
 			s.providerWorkMu.Lock()
-			defer s.providerWorkMu.Unlock()
 			active := s.providerWork[key]
 			active[priority]--
 			if active[priority] == 0 {
 				delete(active, priority)
 			}
-			if len(active) == 0 {
+			hostFree := len(active) == 0
+			if hostFree {
 				delete(s.providerWork, key)
+			}
+			s.providerWorkMu.Unlock()
+			if hostFree {
+				// Archive admission was denied while this work held the host;
+				// the worker backed off, so tell it the host is free again.
+				s.WakeArchive()
 			}
 		})
 	}

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -20,7 +20,6 @@ import (
 	gh "github.com/google/go-github/v89/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.kenn.io/forge/internal/archive"
 	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/db"
 	ghclient "go.kenn.io/forge/internal/github"
@@ -37,9 +36,7 @@ type reloadArchiveLifecycleRecorder struct {
 	retried []platform.RepoRef
 }
 
-func (*reloadArchiveLifecycleRecorder) RunPass(context.Context) (archive.NextWake, error) {
-	return archive.NextWake{}, nil
-}
+func (*reloadArchiveLifecycleRecorder) RunPass(context.Context) (bool, error) { return false, nil }
 
 func (r *reloadArchiveLifecycleRecorder) EnsureConfigured(_ context.Context, refs []platform.RepoRef) ([]platform.RepoRef, error) {
 	r.ensured = append([]platform.RepoRef(nil), refs...)

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -20,6 +20,7 @@ import (
 	gh "github.com/google/go-github/v89/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/archive"
 	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/db"
 	ghclient "go.kenn.io/forge/internal/github"
@@ -36,7 +37,9 @@ type reloadArchiveLifecycleRecorder struct {
 	retried []platform.RepoRef
 }
 
-func (*reloadArchiveLifecycleRecorder) RunEligible(context.Context) error { return nil }
+func (*reloadArchiveLifecycleRecorder) RunPass(context.Context) (archive.NextWake, error) {
+	return archive.NextWake{}, nil
+}
 
 func (r *reloadArchiveLifecycleRecorder) EnsureConfigured(_ context.Context, refs []platform.RepoRef) ([]platform.RepoRef, error) {
 	r.ensured = append([]platform.RepoRef(nil), refs...)


### PR DESCRIPTION
The archive worker ticked every second and, on each tick, re-resolved every configured archive repository and ran a per-repository claim query. On a daemon with a few dozen archive repositories and nothing to do, that was on the order of 150 statement compilations per second.

- The worker now backs off while idle. After a pass that attempted no work, the wait doubles from the one-second pacing interval up to a five-minute cap, using the `cenkalti/backoff` schedule type already in the module. A pass that attempted work or failed, or any wake (config reload, sync completion, budget window reset, archive start), returns the loop to the one-second pacing, so throughput while work flows and the test-only interval setter behave as before.
- An admission denial before any provider request, such as a live sync holding the provider, counts as idle rather than work. Those denials carry a one-second retry, so counting them as work would have kept the loop polling every second through a whole sync. A unit that reached the provider still counts as work, including a provider-answered feature deferral or a request live work preempted, so sibling repositories on the host keep their turn.
- Every completed sync run wakes the worker. Releasing the last live provider operation on a host also wakes it, but only when that host denied or preempted an archive request, so work denied behind a notification refresh or active-detail fetch resumes when the host frees, while a normal sync's stream of releases does not trigger denied passes. Before, only the startup sync did, which the one-second poll hid. A sync can clear a repository feature cooldown, and archive work must not wait out the backoff to notice.
- The archive service caches its resolved repository list, keyed on the configured refs plus a new process-local repository reconciliation generation in `db` that advances on every catalog write. An unchanged pass runs no repository resolution queries.

Scheduling invariants inside the pass are unchanged: per-provider-host grouping, inventory-before-hydration ordering, admission and feature deferral handling.

Archive scheduling is eventually consistent by design. Time-driven work such as a deferral expiring, and any missed or late wake, is picked up within the current backoff window, five minutes at most. That delay is accepted behavior, not a defect.

Cross-cutting note for sibling work: the reconciliation generation counter in `internal/db/db.go` can be reused by any cache keyed on repository identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kitvdb4r5XdMd8eikGnESX
