### PR TITLE
perf: watch pushed workspace heads without spawning git every pass

### DIFF
--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -681,11 +681,11 @@ move restarts the cycle.
 The observer's steady state spawns no processes. It reads the worktree's
 current branch, upstream config, and remote-tracking SHA in process through
 go-git's reference store and config parser, layering `config.worktree` over
-the shared config when `extensions.worktreeConfig` is on, and only asks git,
-through the procutil capacity guard, for layouts it cannot answer faithfully:
-config includes, reftable ref storage, or unparsable files. Upstream repair
-remains a git write whose commands each take one guard slot; never wrap them
-in an outer acquisition
+the shared config when `extensions.worktreeConfig` is on. Layouts go-git
+cannot answer faithfully (config includes, reftable ref storage) are skipped
+like a detached HEAD, never re-read through git. Upstream repair is the one
+git write; its commands each take one procutil slot, so never wrap them in an
+outer acquisition
 (`internal/workspace/pushed_head_gitdir.go::gitdirRemoteHeadReader`).
 Build go-git storage from a locally resolved gitdir and common directory and
 use it as a reference store directly: `EnableDotGitCommonDir` leaks the linked

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -678,21 +678,10 @@ provider head still differs (`LastRefreshSucceededAt >= LastRefreshEnqueuedAt`)
 — otherwise the visible PR is re-synced and re-rendered forever. A tracking-ref
 move restarts the cycle.
 
-The observer's steady state spawns no processes. It reads the worktree's
-current branch, upstream config, and remote-tracking SHA in process through
-go-git's reference store and config parser, layering `config.worktree` over
-the shared config when `extensions.worktreeConfig` is on. Layouts go-git
-cannot answer faithfully (config includes, reftable ref storage) are skipped
-like a detached HEAD, never re-read through git. Upstream repair is the one
-git write; its commands each take one procutil slot, so never wrap them in an
-outer acquisition
+The observer's read path spawns no processes: it reads branch, upstream, and
+remote-tracking state in process through go-git, and only upstream repair runs
+git. Do not reintroduce per-pass git subprocesses there
 (`internal/workspace/pushed_head_gitdir.go::gitdirRemoteHeadReader`).
-Build go-git storage from a locally resolved gitdir and common directory and
-use it as a reference store directly: `EnableDotGitCommonDir` leaks the linked
-worktree's `commondir` file handle on every open (descriptor exhaustion under
-polling, undeletable worktrees on Windows), and `gogit.Open` rejects version-0
-repositories that declare `extensions.worktreeConfig`
-(`internal/workspace/pushed_head_gitdir.go::openWorktreeRepository`).
 
 ## Sidebar Ordering
 

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -679,12 +679,12 @@ provider head still differs (`LastRefreshSucceededAt >= LastRefreshEnqueuedAt`)
 move restarts the cycle.
 
 The observer's steady state spawns no processes. It reads the worktree's
-current branch, upstream config, and remote-tracking SHA straight from the git
-directory (`.git` or the linked-worktree gitdir file, `HEAD`, loose refs,
-`packed-refs`, and the common `config`), and only asks git, through the
-procutil capacity guard, for layouts the files cannot express: config
-includes, reftable ref storage, or unparsable content. Upstream repair remains
-a git write (`internal/workspace/pushed_head_gitdir.go::gitdirRemoteHeadReader`).
+current branch, upstream config, and remote-tracking SHA in process through
+go-git (linked-worktree common directories included) and only asks git,
+through the procutil capacity guard, for layouts go-git cannot answer
+faithfully: config includes, reftable ref storage, or unparsable files.
+Upstream repair remains a git write
+(`internal/workspace/pushed_head_gitdir.go::gitdirRemoteHeadReader`).
 
 ## Sidebar Ordering
 

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -678,6 +678,14 @@ provider head still differs (`LastRefreshSucceededAt >= LastRefreshEnqueuedAt`)
 — otherwise the visible PR is re-synced and re-rendered forever. A tracking-ref
 move restarts the cycle.
 
+The observer's steady state spawns no processes. It reads the worktree's
+current branch, upstream config, and remote-tracking SHA straight from the git
+directory (`.git` or the linked-worktree gitdir file, `HEAD`, loose refs,
+`packed-refs`, and the common `config`), and only asks git, through the
+procutil capacity guard, for layouts the files cannot express: config
+includes, reftable ref storage, or unparsable content. Upstream repair remains
+a git write (`internal/workspace/pushed_head_gitdir.go::gitdirRemoteHeadReader`).
+
 ## Sidebar Ordering
 
 The workspace sidebar has two separate activity concepts:

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -685,6 +685,11 @@ through the procutil capacity guard, for layouts go-git cannot answer
 faithfully: config includes, reftable ref storage, or unparsable files.
 Upstream repair remains a git write
 (`internal/workspace/pushed_head_gitdir.go::gitdirRemoteHeadReader`).
+Open go-git storage from a locally resolved gitdir and common directory, never
+with `EnableDotGitCommonDir`: that option leaks the linked worktree's
+`commondir` file handle on every open, which exhausts descriptors under
+periodic polling and blocks worktree deletion on Windows
+(`internal/workspace/pushed_head_gitdir.go::openWorktreeRepository`).
 
 ## Sidebar Ordering
 

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -680,15 +680,18 @@ move restarts the cycle.
 
 The observer's steady state spawns no processes. It reads the worktree's
 current branch, upstream config, and remote-tracking SHA in process through
-go-git (linked-worktree common directories included) and only asks git,
-through the procutil capacity guard, for layouts go-git cannot answer
-faithfully: config includes, reftable ref storage, or unparsable files.
-Upstream repair remains a git write
+go-git's reference store and config parser, layering `config.worktree` over
+the shared config when `extensions.worktreeConfig` is on, and only asks git,
+through the procutil capacity guard, for layouts it cannot answer faithfully:
+config includes, reftable ref storage, or unparsable files. Upstream repair
+remains a git write whose commands each take one guard slot; never wrap them
+in an outer acquisition
 (`internal/workspace/pushed_head_gitdir.go::gitdirRemoteHeadReader`).
-Open go-git storage from a locally resolved gitdir and common directory, never
-with `EnableDotGitCommonDir`: that option leaks the linked worktree's
-`commondir` file handle on every open, which exhausts descriptors under
-periodic polling and blocks worktree deletion on Windows
+Build go-git storage from a locally resolved gitdir and common directory and
+use it as a reference store directly: `EnableDotGitCommonDir` leaks the linked
+worktree's `commondir` file handle on every open (descriptor exhaustion under
+polling, undeletable worktrees on Windows), and `gogit.Open` rejects version-0
+repositories that declare `extensions.worktreeConfig`
 (`internal/workspace/pushed_head_gitdir.go::openWorktreeRepository`).
 
 ## Sidebar Ordering

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/gofrs/flock v0.13.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/go-github/v89 v89.0.0
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jellydator/ttlcache/v3 v3.4.1
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/klauspost/compress v1.19.2
@@ -146,7 +147,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/in-toto/attestation v1.2.0 // indirect
 	github.com/in-toto/in-toto-golang v0.11.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/danielgtaylor/shorthand/v2 v2.4.0
 	github.com/doordash-oss/oapi-codegen-dd/v3 v3.75.13
 	github.com/fsnotify/fsnotify v1.10.1
+	github.com/go-git/go-billy/v5 v5.9.0
 	github.com/go-git/go-git/v5 v5.19.2
 	github.com/gofrs/flock v0.13.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
@@ -109,7 +110,6 @@ require (
 	github.com/getkin/kin-openapi v0.142.0 // indirect
 	github.com/go-fed/httpsig v1.1.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
-	github.com/go-git/go-billy/v5 v5.9.0 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect

--- a/internal/workspace/pushed_head_gitdir.go
+++ b/internal/workspace/pushed_head_gitdir.go
@@ -1,0 +1,431 @@
+package workspace
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// gitdirRemoteHeadReader answers the pushed-head observer's read-only
+// questions from the worktree's git directory instead of spawning git. The
+// observer polls every ready workspace every few seconds, so its steady state
+// must cost a handful of small file reads rather than several forks of a
+// large daemon image per workspace.
+//
+// Only what the on-disk format can express is answered directly: symbolic or
+// detached HEAD, loose and packed refs under the common directory, and the
+// branch.*, remote.*, and extensions.* entries of the repository config
+// (plus config.worktree when extensions.worktreeConfig is on). Repositories
+// whose config uses include/includeIf, whose refs live in a reftable store,
+// or whose files cannot be parsed fall back to git for that question so the
+// observer never answers differently from git, only more cheaply.
+//
+// remoteURL is the configured remote.<name>.url; url.<base>.insteadOf
+// rewriting is not applied. The observer does not consume the URL.
+type gitdirRemoteHeadReader struct {
+	fallback remoteHeadGitReader
+}
+
+func (r *gitdirRemoteHeadReader) BranchName(ctx context.Context, dir string) (string, error) {
+	state, err := loadWorktreeGitState(dir)
+	if err != nil {
+		return r.fallbackBranchName(ctx, dir, err)
+	}
+	branch, ok := state.currentBranch()
+	if !ok {
+		return r.fallbackBranchName(ctx, dir, errors.New("unrecognized HEAD"))
+	}
+	return branch, nil
+}
+
+func (r *gitdirRemoteHeadReader) fallbackBranchName(ctx context.Context, dir string, reason error) (string, error) {
+	logGitdirFallback(dir, "branch", reason)
+	return r.fallback.BranchName(ctx, dir)
+}
+
+func (r *gitdirRemoteHeadReader) UpstreamState(ctx context.Context, dir, branch string) (upstreamState, error) {
+	state, err := loadWorktreeGitState(dir)
+	if err != nil {
+		logGitdirFallback(dir, "upstream", err)
+		return r.fallback.UpstreamState(ctx, dir, branch)
+	}
+	return state.upstream(branch), nil
+}
+
+func (r *gitdirRemoteHeadReader) RemoteTrackingSHA(ctx context.Context, dir, remote, branch string) (string, string, bool, error) {
+	trackingRef := "refs/remotes/" + remote + "/" + branch
+	state, err := loadWorktreeGitState(dir)
+	if err == nil {
+		var sha string
+		var ok bool
+		sha, ok, err = state.resolveRef(trackingRef)
+		if err == nil {
+			return sha, trackingRef, ok, nil
+		}
+	}
+	logGitdirFallback(dir, "tracking ref", err)
+	return r.fallback.RemoteTrackingSHA(ctx, dir, remote, branch)
+}
+
+func (r *gitdirRemoteHeadReader) SetBranchUpstream(ctx context.Context, dir, branch, remote, mergeRef string) error {
+	return r.fallback.SetBranchUpstream(ctx, dir, branch, remote, mergeRef)
+}
+
+func logGitdirFallback(dir, question string, reason error) {
+	slog.Debug("workspace pushed-head observer reading git state through git",
+		"dir", dir, "question", question, "reason", reason)
+}
+
+// errGitdirUnsupported marks repository layouts the direct reader cannot
+// interpret; callers answer through git instead.
+var errGitdirUnsupported = errors.New("git directory layout not readable directly")
+
+// worktreeGitState is one worktree's git directory, common directory, and
+// parsed repository config.
+type worktreeGitState struct {
+	gitDir    string
+	commonDir string
+	config    gitdirConfig
+}
+
+func loadWorktreeGitState(worktree string) (*worktreeGitState, error) {
+	gitDir, commonDir, err := resolveWorktreeGitDirs(worktree)
+	if err != nil {
+		return nil, err
+	}
+	config, err := parseGitConfigFile(filepath.Join(commonDir, "config"))
+	if err != nil {
+		return nil, err
+	}
+	if config.hasIncludes {
+		return nil, fmt.Errorf("%w: config uses includes", errGitdirUnsupported)
+	}
+	if storage := config.get("extensions", "", "refstorage"); storage != "" && !strings.EqualFold(storage, "files") {
+		return nil, fmt.Errorf("%w: ref storage %q", errGitdirUnsupported, storage)
+	}
+	if gitConfigBool(config.get("extensions", "", "worktreeconfig")) {
+		local, err := parseGitConfigFile(filepath.Join(gitDir, "config.worktree"))
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return nil, err
+		}
+		if local.hasIncludes {
+			return nil, fmt.Errorf("%w: worktree config uses includes", errGitdirUnsupported)
+		}
+		maps.Copy(config.values, local.values)
+	}
+	return &worktreeGitState{gitDir: gitDir, commonDir: commonDir, config: config}, nil
+}
+
+// resolveWorktreeGitDirs locates the worktree's private git directory (a
+// `.git` directory, or the target of a `.git` file written by
+// `git worktree add`) and the common directory that holds refs, packed-refs,
+// and config for every worktree of the repository.
+func resolveWorktreeGitDirs(worktree string) (gitDir, commonDir string, err error) {
+	dotGit := filepath.Join(worktree, ".git")
+	info, err := os.Stat(dotGit)
+	if err != nil {
+		return "", "", err
+	}
+	gitDir = dotGit
+	if !info.IsDir() {
+		data, err := os.ReadFile(dotGit)
+		if err != nil {
+			return "", "", err
+		}
+		line, _, _ := strings.Cut(string(data), "\n")
+		target, ok := strings.CutPrefix(line, "gitdir:")
+		if !ok {
+			return "", "", fmt.Errorf("%w: %s is neither a directory nor a gitdir file", errGitdirUnsupported, dotGit)
+		}
+		gitDir = strings.TrimSpace(target)
+		if !filepath.IsAbs(gitDir) {
+			gitDir = filepath.Join(worktree, gitDir)
+		}
+	}
+	commonDir = gitDir
+	data, err := os.ReadFile(filepath.Join(gitDir, "commondir"))
+	switch {
+	case err == nil:
+		commonDir = strings.TrimSpace(string(data))
+		if !filepath.IsAbs(commonDir) {
+			commonDir = filepath.Join(gitDir, commonDir)
+		}
+	case !errors.Is(err, fs.ErrNotExist):
+		return "", "", err
+	}
+	return filepath.Clean(gitDir), filepath.Clean(commonDir), nil
+}
+
+// currentBranch mirrors `git branch --show-current`: the branch name when
+// HEAD is a symbolic ref under refs/heads, an empty name when HEAD is
+// detached, and not ok for any other content.
+func (s *worktreeGitState) currentBranch() (string, bool) {
+	data, err := os.ReadFile(filepath.Join(s.gitDir, "HEAD"))
+	if err != nil {
+		return "", false
+	}
+	head := strings.TrimSpace(string(data))
+	if target, ok := strings.CutPrefix(head, "ref:"); ok {
+		target = strings.TrimSpace(target)
+		if branch, ok := strings.CutPrefix(target, "refs/heads/"); ok && branch != "" {
+			return branch, true
+		}
+		return "", strings.HasPrefix(target, "refs/")
+	}
+	if isGitObjectID(head) {
+		return "", true
+	}
+	return "", false
+}
+
+func (s *worktreeGitState) upstream(branch string) upstreamState {
+	remote := s.config.get("branch", branch, "remote")
+	merge := s.config.get("branch", branch, "merge")
+	if remote == "" || merge == "" {
+		return upstreamState{}
+	}
+	return upstreamState{
+		hasTracking: true,
+		remoteName:  remote,
+		branchName:  strings.TrimPrefix(merge, "refs/heads/"),
+		remoteURL:   s.config.get("remote", remote, "url"),
+	}
+}
+
+const maxSymbolicRefDepth = 5
+
+// resolveRef returns the object ID a full ref name points at, reading the
+// loose ref first and packed-refs second, exactly as git does. A missing ref
+// is not ok; unparsable content is an error.
+func (s *worktreeGitState) resolveRef(ref string) (string, bool, error) {
+	for range maxSymbolicRefDepth {
+		if !strings.HasPrefix(ref, "refs/") || strings.Contains(ref, "..") {
+			return "", false, fmt.Errorf("%w: ref %q", errGitdirUnsupported, ref)
+		}
+		data, err := os.ReadFile(filepath.Join(s.commonDir, filepath.FromSlash(ref)))
+		switch {
+		case err == nil:
+			content := strings.TrimSpace(string(data))
+			if target, ok := strings.CutPrefix(content, "ref:"); ok {
+				ref = strings.TrimSpace(target)
+				continue
+			}
+			if !isGitObjectID(content) {
+				return "", false, fmt.Errorf("%w: loose ref %q", errGitdirUnsupported, ref)
+			}
+			return content, true, nil
+		case errors.Is(err, fs.ErrNotExist):
+			sha, ok, err := s.packedRef(ref)
+			if err != nil || ok {
+				return sha, ok, err
+			}
+			return "", false, nil
+		default:
+			return "", false, err
+		}
+	}
+	return "", false, fmt.Errorf("%w: symbolic ref chain too deep at %q", errGitdirUnsupported, ref)
+}
+
+func (s *worktreeGitState) packedRef(ref string) (string, bool, error) {
+	file, err := os.Open(filepath.Join(s.commonDir, "packed-refs"))
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 || line[0] == '#' || line[0] == '^' {
+			continue
+		}
+		sha, name, ok := bytes.Cut(line, []byte{' '})
+		if !ok || string(bytes.TrimSpace(name)) != ref {
+			continue
+		}
+		id := string(sha)
+		if !isGitObjectID(id) {
+			return "", false, fmt.Errorf("%w: packed ref %q", errGitdirUnsupported, ref)
+		}
+		return id, true, nil
+	}
+	return "", false, scanner.Err()
+}
+
+func isGitObjectID(s string) bool {
+	if len(s) != 40 && len(s) != 64 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
+			return false
+		}
+	}
+	return true
+}
+
+// gitdirConfig is a flat view of one git config file. Keys are
+// "section.subsection.name" with section and name lower-cased and the
+// subsection kept verbatim; the last assignment wins, matching
+// `git config --get`.
+type gitdirConfig struct {
+	values      map[string]string
+	hasIncludes bool
+}
+
+func (c gitdirConfig) get(section, subsection, name string) string {
+	return c.values[gitConfigKey(section, subsection, name)]
+}
+
+func gitConfigKey(section, subsection, name string) string {
+	return strings.ToLower(section) + "\x00" + subsection + "\x00" + strings.ToLower(name)
+}
+
+func gitConfigBool(value string) bool {
+	switch strings.ToLower(value) {
+	case "true", "yes", "on", "1":
+		return true
+	}
+	return false
+}
+
+func parseGitConfigFile(path string) (gitdirConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return gitdirConfig{values: map[string]string{}}, err
+	}
+	return parseGitConfig(data)
+}
+
+// parseGitConfig understands the subset of git-config(1) syntax git itself
+// writes: section headers with optional quoted subsections, `name = value`
+// assignments with quoted values, backslash escapes, comments, and
+// backslash line continuations. Anything else is an error so the caller
+// falls back to git rather than guessing.
+func parseGitConfig(data []byte) (gitdirConfig, error) {
+	config := gitdirConfig{values: map[string]string{}}
+	section, subsection := "", ""
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := scanner.Text()
+		for strings.HasSuffix(line, "\\") && scanner.Scan() {
+			line = strings.TrimSuffix(line, "\\") + scanner.Text()
+		}
+		line = strings.TrimSpace(line)
+		if line == "" || line[0] == '#' || line[0] == ';' {
+			continue
+		}
+		if line[0] == '[' {
+			var err error
+			section, subsection, err = parseGitConfigSectionHeader(line)
+			if err != nil {
+				return config, err
+			}
+			if section == "include" || section == "includeif" {
+				config.hasIncludes = true
+			}
+			continue
+		}
+		if section == "" {
+			return config, fmt.Errorf("%w: config value before any section", errGitdirUnsupported)
+		}
+		name, rawValue, hasValue := strings.Cut(line, "=")
+		name = strings.ToLower(strings.TrimSpace(name))
+		if name == "" {
+			return config, fmt.Errorf("%w: config line %q", errGitdirUnsupported, line)
+		}
+		value := "true"
+		if hasValue {
+			var err error
+			value, err = parseGitConfigValue(rawValue)
+			if err != nil {
+				return config, err
+			}
+		}
+		config.values[gitConfigKey(section, subsection, name)] = value
+	}
+	return config, scanner.Err()
+}
+
+func parseGitConfigSectionHeader(line string) (section, subsection string, err error) {
+	end := strings.IndexByte(line, ']')
+	if end < 0 {
+		return "", "", fmt.Errorf("%w: config header %q", errGitdirUnsupported, line)
+	}
+	header := strings.TrimSpace(line[1:end])
+	name, rest, hasSub := strings.Cut(header, " ")
+	section = strings.ToLower(strings.TrimSpace(name))
+	if !hasSub {
+		if dot := strings.IndexByte(section, '.'); dot >= 0 {
+			// Deprecated `[section.subsection]` form.
+			return section[:dot], section[dot+1:], nil
+		}
+		return section, "", nil
+	}
+	rest = strings.TrimSpace(rest)
+	if len(rest) < 2 || rest[0] != '"' || rest[len(rest)-1] != '"' {
+		return "", "", fmt.Errorf("%w: config header %q", errGitdirUnsupported, line)
+	}
+	var sub strings.Builder
+	quoted := rest[1 : len(rest)-1]
+	for i := 0; i < len(quoted); i++ {
+		if quoted[i] == '\\' && i+1 < len(quoted) {
+			i++
+		}
+		sub.WriteByte(quoted[i])
+	}
+	return section, sub.String(), nil
+}
+
+// parseGitConfigValue unquotes one assignment value: whitespace around
+// unquoted text is trimmed, `#` and `;` start comments outside quotes, and
+// backslash escapes inside or outside quotes follow git-config(1).
+func parseGitConfigValue(raw string) (string, error) {
+	var out strings.Builder
+	inQuotes := false
+	raw = strings.TrimLeft(raw, " \t")
+	for i := 0; i < len(raw); i++ {
+		c := raw[i]
+		switch {
+		case c == '\\':
+			if i+1 >= len(raw) {
+				return "", fmt.Errorf("%w: dangling escape in config value", errGitdirUnsupported)
+			}
+			i++
+			switch raw[i] {
+			case 'n':
+				out.WriteByte('\n')
+			case 't':
+				out.WriteByte('\t')
+			case 'b':
+				out.WriteByte('\b')
+			case '\\', '"':
+				out.WriteByte(raw[i])
+			default:
+				return "", fmt.Errorf("%w: escape %q in config value", errGitdirUnsupported, raw[i])
+			}
+		case c == '"':
+			inQuotes = !inQuotes
+		case !inQuotes && (c == '#' || c == ';'):
+			return strings.TrimRight(out.String(), " \t"), nil
+		default:
+			out.WriteByte(c)
+		}
+	}
+	if inQuotes {
+		return "", fmt.Errorf("%w: unterminated quote in config value", errGitdirUnsupported)
+	}
+	return strings.TrimRight(out.String(), " \t"), nil
+}

--- a/internal/workspace/pushed_head_gitdir.go
+++ b/internal/workspace/pushed_head_gitdir.go
@@ -1,32 +1,29 @@
 package workspace
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"io/fs"
 	"log/slog"
-	"maps"
-	"os"
-	"path/filepath"
 	"strings"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
 )
 
 // gitdirRemoteHeadReader answers the pushed-head observer's read-only
-// questions from the worktree's git directory instead of spawning git. The
-// observer polls every ready workspace every few seconds, so its steady state
-// must cost a handful of small file reads rather than several forks of a
-// large daemon image per workspace.
+// questions in process through go-git instead of spawning git. The observer
+// polls every ready workspace every few seconds, so its steady state must
+// cost a few small file reads rather than several forks of a large daemon
+// image per workspace.
 //
-// Only what the on-disk format can express is answered directly: symbolic or
-// detached HEAD, loose and packed refs under the common directory, and the
-// branch.*, remote.*, and extensions.* entries of the repository config
-// (plus config.worktree when extensions.worktreeConfig is on). Repositories
-// whose config uses include/includeIf, whose refs live in a reftable store,
-// or whose files cannot be parsed fall back to git for that question so the
-// observer never answers differently from git, only more cheaply.
+// go-git reads the worktree's HEAD, loose and packed refs (through the
+// linked-worktree common directory), and the repository config. Layouts it
+// cannot interpret fall back to git for that question so the observer never
+// answers differently from git, only more cheaply: config include/includeIf
+// (go-git does not expand includes), reftable ref storage, or files it fails
+// to parse.
 //
 // remoteURL is the configured remote.<name>.url; url.<base>.insteadOf
 // rewriting is not applied. The observer does not consume the URL.
@@ -35,40 +32,58 @@ type gitdirRemoteHeadReader struct {
 }
 
 func (r *gitdirRemoteHeadReader) BranchName(ctx context.Context, dir string) (string, error) {
-	state, err := loadWorktreeGitState(dir)
-	if err != nil {
-		return r.fallbackBranchName(ctx, dir, err)
+	repo, _, err := openWorktreeRepository(dir)
+	if err == nil {
+		var head *plumbing.Reference
+		head, err = repo.Storer.Reference(plumbing.HEAD)
+		if err == nil {
+			// Mirrors `git branch --show-current`: the branch name for a
+			// symbolic HEAD under refs/heads, empty when detached.
+			if head.Type() == plumbing.HashReference {
+				return "", nil
+			}
+			if head.Target().IsBranch() {
+				return head.Target().Short(), nil
+			}
+			return "", nil
+		}
 	}
-	branch, ok := state.currentBranch()
-	if !ok {
-		return r.fallbackBranchName(ctx, dir, errors.New("unrecognized HEAD"))
-	}
-	return branch, nil
-}
-
-func (r *gitdirRemoteHeadReader) fallbackBranchName(ctx context.Context, dir string, reason error) (string, error) {
-	logGitdirFallback(dir, "branch", reason)
+	logGitdirFallback(dir, "branch", err)
 	return r.fallback.BranchName(ctx, dir)
 }
 
 func (r *gitdirRemoteHeadReader) UpstreamState(ctx context.Context, dir, branch string) (upstreamState, error) {
-	state, err := loadWorktreeGitState(dir)
+	_, cfg, err := openWorktreeRepository(dir)
 	if err != nil {
 		logGitdirFallback(dir, "upstream", err)
 		return r.fallback.UpstreamState(ctx, dir, branch)
 	}
-	return state.upstream(branch), nil
+	tracked := cfg.Branches[branch]
+	if tracked == nil || tracked.Remote == "" || tracked.Merge == "" {
+		return upstreamState{}, nil
+	}
+	state := upstreamState{
+		hasTracking: true,
+		remoteName:  tracked.Remote,
+		branchName:  strings.TrimPrefix(tracked.Merge.String(), "refs/heads/"),
+	}
+	if remote := cfg.Remotes[tracked.Remote]; remote != nil && len(remote.URLs) > 0 {
+		state.remoteURL = remote.URLs[0]
+	}
+	return state, nil
 }
 
 func (r *gitdirRemoteHeadReader) RemoteTrackingSHA(ctx context.Context, dir, remote, branch string) (string, string, bool, error) {
 	trackingRef := "refs/remotes/" + remote + "/" + branch
-	state, err := loadWorktreeGitState(dir)
+	repo, _, err := openWorktreeRepository(dir)
 	if err == nil {
-		var sha string
-		var ok bool
-		sha, ok, err = state.resolveRef(trackingRef)
-		if err == nil {
-			return sha, trackingRef, ok, nil
+		var ref *plumbing.Reference
+		ref, err = repo.Reference(plumbing.ReferenceName(trackingRef), true)
+		switch {
+		case err == nil:
+			return ref.Hash().String(), trackingRef, true, nil
+		case errors.Is(err, plumbing.ErrReferenceNotFound):
+			return "", trackingRef, false, nil
 		}
 	}
 	logGitdirFallback(dir, "tracking ref", err)
@@ -84,348 +99,27 @@ func logGitdirFallback(dir, question string, reason error) {
 		"dir", dir, "question", question, "reason", reason)
 }
 
-// errGitdirUnsupported marks repository layouts the direct reader cannot
-// interpret; callers answer through git instead.
-var errGitdirUnsupported = errors.New("git directory layout not readable directly")
+// errGitdirUnsupported marks repository layouts go-git cannot interpret
+// faithfully; callers answer through git instead.
+var errGitdirUnsupported = errors.New("repository layout not readable in process")
 
-// worktreeGitState is one worktree's git directory, common directory, and
-// parsed repository config.
-type worktreeGitState struct {
-	gitDir    string
-	commonDir string
-	config    gitdirConfig
-}
-
-func loadWorktreeGitState(worktree string) (*worktreeGitState, error) {
-	gitDir, commonDir, err := resolveWorktreeGitDirs(worktree)
+// openWorktreeRepository opens dir as a main or linked worktree and returns
+// its repository config, rejecting layouts whose answers go-git would get
+// wrong.
+func openWorktreeRepository(dir string) (*gogit.Repository, *config.Config, error) {
+	repo, err := gogit.PlainOpenWithOptions(dir, &gogit.PlainOpenOptions{EnableDotGitCommonDir: true})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	config, err := parseGitConfigFile(filepath.Join(commonDir, "config"))
+	cfg, err := repo.Config()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	if config.hasIncludes {
-		return nil, fmt.Errorf("%w: config uses includes", errGitdirUnsupported)
+	if cfg.Raw.HasSection("include") || cfg.Raw.HasSection("includeIf") {
+		return nil, nil, fmt.Errorf("%w: config uses includes", errGitdirUnsupported)
 	}
-	if storage := config.get("extensions", "", "refstorage"); storage != "" && !strings.EqualFold(storage, "files") {
-		return nil, fmt.Errorf("%w: ref storage %q", errGitdirUnsupported, storage)
+	if storage := cfg.Raw.Section("extensions").Option("refStorage"); storage != "" && !strings.EqualFold(storage, "files") {
+		return nil, nil, fmt.Errorf("%w: ref storage %q", errGitdirUnsupported, storage)
 	}
-	if gitConfigBool(config.get("extensions", "", "worktreeconfig")) {
-		local, err := parseGitConfigFile(filepath.Join(gitDir, "config.worktree"))
-		if err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return nil, err
-		}
-		if local.hasIncludes {
-			return nil, fmt.Errorf("%w: worktree config uses includes", errGitdirUnsupported)
-		}
-		maps.Copy(config.values, local.values)
-	}
-	return &worktreeGitState{gitDir: gitDir, commonDir: commonDir, config: config}, nil
-}
-
-// resolveWorktreeGitDirs locates the worktree's private git directory (a
-// `.git` directory, or the target of a `.git` file written by
-// `git worktree add`) and the common directory that holds refs, packed-refs,
-// and config for every worktree of the repository.
-func resolveWorktreeGitDirs(worktree string) (gitDir, commonDir string, err error) {
-	dotGit := filepath.Join(worktree, ".git")
-	info, err := os.Stat(dotGit)
-	if err != nil {
-		return "", "", err
-	}
-	gitDir = dotGit
-	if !info.IsDir() {
-		data, err := os.ReadFile(dotGit)
-		if err != nil {
-			return "", "", err
-		}
-		line, _, _ := strings.Cut(string(data), "\n")
-		target, ok := strings.CutPrefix(line, "gitdir:")
-		if !ok {
-			return "", "", fmt.Errorf("%w: %s is neither a directory nor a gitdir file", errGitdirUnsupported, dotGit)
-		}
-		gitDir = strings.TrimSpace(target)
-		if !filepath.IsAbs(gitDir) {
-			gitDir = filepath.Join(worktree, gitDir)
-		}
-	}
-	commonDir = gitDir
-	data, err := os.ReadFile(filepath.Join(gitDir, "commondir"))
-	switch {
-	case err == nil:
-		commonDir = strings.TrimSpace(string(data))
-		if !filepath.IsAbs(commonDir) {
-			commonDir = filepath.Join(gitDir, commonDir)
-		}
-	case !errors.Is(err, fs.ErrNotExist):
-		return "", "", err
-	}
-	return filepath.Clean(gitDir), filepath.Clean(commonDir), nil
-}
-
-// currentBranch mirrors `git branch --show-current`: the branch name when
-// HEAD is a symbolic ref under refs/heads, an empty name when HEAD is
-// detached, and not ok for any other content.
-func (s *worktreeGitState) currentBranch() (string, bool) {
-	data, err := os.ReadFile(filepath.Join(s.gitDir, "HEAD"))
-	if err != nil {
-		return "", false
-	}
-	head := strings.TrimSpace(string(data))
-	if target, ok := strings.CutPrefix(head, "ref:"); ok {
-		target = strings.TrimSpace(target)
-		if branch, ok := strings.CutPrefix(target, "refs/heads/"); ok && branch != "" {
-			return branch, true
-		}
-		return "", strings.HasPrefix(target, "refs/")
-	}
-	if isGitObjectID(head) {
-		return "", true
-	}
-	return "", false
-}
-
-func (s *worktreeGitState) upstream(branch string) upstreamState {
-	remote := s.config.get("branch", branch, "remote")
-	merge := s.config.get("branch", branch, "merge")
-	if remote == "" || merge == "" {
-		return upstreamState{}
-	}
-	return upstreamState{
-		hasTracking: true,
-		remoteName:  remote,
-		branchName:  strings.TrimPrefix(merge, "refs/heads/"),
-		remoteURL:   s.config.get("remote", remote, "url"),
-	}
-}
-
-const maxSymbolicRefDepth = 5
-
-// resolveRef returns the object ID a full ref name points at, reading the
-// loose ref first and packed-refs second, exactly as git does. A missing ref
-// is not ok; unparsable content is an error.
-func (s *worktreeGitState) resolveRef(ref string) (string, bool, error) {
-	for range maxSymbolicRefDepth {
-		if !strings.HasPrefix(ref, "refs/") || strings.Contains(ref, "..") {
-			return "", false, fmt.Errorf("%w: ref %q", errGitdirUnsupported, ref)
-		}
-		data, err := os.ReadFile(filepath.Join(s.commonDir, filepath.FromSlash(ref)))
-		switch {
-		case err == nil:
-			content := strings.TrimSpace(string(data))
-			if target, ok := strings.CutPrefix(content, "ref:"); ok {
-				ref = strings.TrimSpace(target)
-				continue
-			}
-			if !isGitObjectID(content) {
-				return "", false, fmt.Errorf("%w: loose ref %q", errGitdirUnsupported, ref)
-			}
-			return content, true, nil
-		case errors.Is(err, fs.ErrNotExist):
-			sha, ok, err := s.packedRef(ref)
-			if err != nil || ok {
-				return sha, ok, err
-			}
-			return "", false, nil
-		default:
-			return "", false, err
-		}
-	}
-	return "", false, fmt.Errorf("%w: symbolic ref chain too deep at %q", errGitdirUnsupported, ref)
-}
-
-func (s *worktreeGitState) packedRef(ref string) (string, bool, error) {
-	file, err := os.Open(filepath.Join(s.commonDir, "packed-refs"))
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return "", false, nil
-		}
-		return "", false, err
-	}
-	defer file.Close()
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if len(line) == 0 || line[0] == '#' || line[0] == '^' {
-			continue
-		}
-		sha, name, ok := bytes.Cut(line, []byte{' '})
-		if !ok || string(bytes.TrimSpace(name)) != ref {
-			continue
-		}
-		id := string(sha)
-		if !isGitObjectID(id) {
-			return "", false, fmt.Errorf("%w: packed ref %q", errGitdirUnsupported, ref)
-		}
-		return id, true, nil
-	}
-	return "", false, scanner.Err()
-}
-
-func isGitObjectID(s string) bool {
-	if len(s) != 40 && len(s) != 64 {
-		return false
-	}
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
-			return false
-		}
-	}
-	return true
-}
-
-// gitdirConfig is a flat view of one git config file. Keys are
-// "section.subsection.name" with section and name lower-cased and the
-// subsection kept verbatim; the last assignment wins, matching
-// `git config --get`.
-type gitdirConfig struct {
-	values      map[string]string
-	hasIncludes bool
-}
-
-func (c gitdirConfig) get(section, subsection, name string) string {
-	return c.values[gitConfigKey(section, subsection, name)]
-}
-
-func gitConfigKey(section, subsection, name string) string {
-	return strings.ToLower(section) + "\x00" + subsection + "\x00" + strings.ToLower(name)
-}
-
-func gitConfigBool(value string) bool {
-	switch strings.ToLower(value) {
-	case "true", "yes", "on", "1":
-		return true
-	}
-	return false
-}
-
-func parseGitConfigFile(path string) (gitdirConfig, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return gitdirConfig{values: map[string]string{}}, err
-	}
-	return parseGitConfig(data)
-}
-
-// parseGitConfig understands the subset of git-config(1) syntax git itself
-// writes: section headers with optional quoted subsections, `name = value`
-// assignments with quoted values, backslash escapes, comments, and
-// backslash line continuations. Anything else is an error so the caller
-// falls back to git rather than guessing.
-func parseGitConfig(data []byte) (gitdirConfig, error) {
-	config := gitdirConfig{values: map[string]string{}}
-	section, subsection := "", ""
-	scanner := bufio.NewScanner(bytes.NewReader(data))
-	for scanner.Scan() {
-		line := scanner.Text()
-		for strings.HasSuffix(line, "\\") && scanner.Scan() {
-			line = strings.TrimSuffix(line, "\\") + scanner.Text()
-		}
-		line = strings.TrimSpace(line)
-		if line == "" || line[0] == '#' || line[0] == ';' {
-			continue
-		}
-		if line[0] == '[' {
-			var err error
-			section, subsection, err = parseGitConfigSectionHeader(line)
-			if err != nil {
-				return config, err
-			}
-			if section == "include" || section == "includeif" {
-				config.hasIncludes = true
-			}
-			continue
-		}
-		if section == "" {
-			return config, fmt.Errorf("%w: config value before any section", errGitdirUnsupported)
-		}
-		name, rawValue, hasValue := strings.Cut(line, "=")
-		name = strings.ToLower(strings.TrimSpace(name))
-		if name == "" {
-			return config, fmt.Errorf("%w: config line %q", errGitdirUnsupported, line)
-		}
-		value := "true"
-		if hasValue {
-			var err error
-			value, err = parseGitConfigValue(rawValue)
-			if err != nil {
-				return config, err
-			}
-		}
-		config.values[gitConfigKey(section, subsection, name)] = value
-	}
-	return config, scanner.Err()
-}
-
-func parseGitConfigSectionHeader(line string) (section, subsection string, err error) {
-	end := strings.IndexByte(line, ']')
-	if end < 0 {
-		return "", "", fmt.Errorf("%w: config header %q", errGitdirUnsupported, line)
-	}
-	header := strings.TrimSpace(line[1:end])
-	name, rest, hasSub := strings.Cut(header, " ")
-	section = strings.ToLower(strings.TrimSpace(name))
-	if !hasSub {
-		if dot := strings.IndexByte(section, '.'); dot >= 0 {
-			// Deprecated `[section.subsection]` form.
-			return section[:dot], section[dot+1:], nil
-		}
-		return section, "", nil
-	}
-	rest = strings.TrimSpace(rest)
-	if len(rest) < 2 || rest[0] != '"' || rest[len(rest)-1] != '"' {
-		return "", "", fmt.Errorf("%w: config header %q", errGitdirUnsupported, line)
-	}
-	var sub strings.Builder
-	quoted := rest[1 : len(rest)-1]
-	for i := 0; i < len(quoted); i++ {
-		if quoted[i] == '\\' && i+1 < len(quoted) {
-			i++
-		}
-		sub.WriteByte(quoted[i])
-	}
-	return section, sub.String(), nil
-}
-
-// parseGitConfigValue unquotes one assignment value: whitespace around
-// unquoted text is trimmed, `#` and `;` start comments outside quotes, and
-// backslash escapes inside or outside quotes follow git-config(1).
-func parseGitConfigValue(raw string) (string, error) {
-	var out strings.Builder
-	inQuotes := false
-	raw = strings.TrimLeft(raw, " \t")
-	for i := 0; i < len(raw); i++ {
-		c := raw[i]
-		switch {
-		case c == '\\':
-			if i+1 >= len(raw) {
-				return "", fmt.Errorf("%w: dangling escape in config value", errGitdirUnsupported)
-			}
-			i++
-			switch raw[i] {
-			case 'n':
-				out.WriteByte('\n')
-			case 't':
-				out.WriteByte('\t')
-			case 'b':
-				out.WriteByte('\b')
-			case '\\', '"':
-				out.WriteByte(raw[i])
-			default:
-				return "", fmt.Errorf("%w: escape %q in config value", errGitdirUnsupported, raw[i])
-			}
-		case c == '"':
-			inQuotes = !inQuotes
-		case !inQuotes && (c == '#' || c == ';'):
-			return strings.TrimRight(out.String(), " \t"), nil
-		default:
-			out.WriteByte(c)
-		}
-	}
-	if inQuotes {
-		return "", fmt.Errorf("%w: unterminated quote in config value", errGitdirUnsupported)
-	}
-	return strings.TrimRight(out.String(), " \t"), nil
+	return repo, cfg, nil
 }

--- a/internal/workspace/pushed_head_gitdir.go
+++ b/internal/workspace/pushed_head_gitdir.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-git/v5/config"
@@ -20,6 +22,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/storer"
 	"github.com/go-git/go-git/v5/storage/filesystem"
 	"github.com/go-git/go-git/v5/storage/filesystem/dotgit"
+	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 // gitdirRemoteHeadReader answers the pushed-head observer's read-only
@@ -39,10 +42,24 @@ import (
 //
 // remoteURL is the configured remote.<name>.url; url.<base>.insteadOf
 // rewriting is not applied. The observer does not consume the URL.
-type gitdirRemoteHeadReader struct{}
+type gitdirRemoteHeadReader struct {
+	handles *lru.Cache[string, *worktreeGitHandle]
+}
 
-func (gitdirRemoteHeadReader) BranchName(_ context.Context, dir string) (string, error) {
-	refs, _, err := openWorktreeRepository(dir)
+// gitdirHandleCacheSize bounds cached worktrees; a daemon polls tens of
+// workspaces, and eviction only costs one re-open.
+const gitdirHandleCacheSize = 256
+
+func newGitdirRemoteHeadReader() gitdirRemoteHeadReader {
+	handles, err := lru.New[string, *worktreeGitHandle](gitdirHandleCacheSize)
+	if err != nil {
+		panic(err) // only for a non-positive size
+	}
+	return gitdirRemoteHeadReader{handles: handles}
+}
+
+func (r gitdirRemoteHeadReader) BranchName(_ context.Context, dir string) (string, error) {
+	refs, _, err := r.open(dir)
 	if err != nil {
 		return "", skipUnsupportedGitdir(dir, "branch", err)
 	}
@@ -58,8 +75,8 @@ func (gitdirRemoteHeadReader) BranchName(_ context.Context, dir string) (string,
 	return "", nil
 }
 
-func (gitdirRemoteHeadReader) UpstreamState(_ context.Context, dir, branch string) (upstreamState, error) {
-	_, cfg, err := openWorktreeRepository(dir)
+func (r gitdirRemoteHeadReader) UpstreamState(_ context.Context, dir, branch string) (upstreamState, error) {
+	_, cfg, err := r.open(dir)
 	if err != nil {
 		return upstreamState{}, skipUnsupportedGitdir(dir, "upstream", err)
 	}
@@ -78,9 +95,9 @@ func (gitdirRemoteHeadReader) UpstreamState(_ context.Context, dir, branch strin
 	return state, nil
 }
 
-func (gitdirRemoteHeadReader) RemoteTrackingSHA(_ context.Context, dir, remote, branch string) (string, string, bool, error) {
+func (r gitdirRemoteHeadReader) RemoteTrackingSHA(_ context.Context, dir, remote, branch string) (string, string, bool, error) {
 	trackingRef := "refs/remotes/" + remote + "/" + branch
-	refs, _, err := openWorktreeRepository(dir)
+	refs, _, err := r.open(dir)
 	if err != nil {
 		return "", trackingRef, false, skipUnsupportedGitdir(dir, "tracking ref", err)
 	}
@@ -119,9 +136,67 @@ func skipUnsupportedGitdir(dir, question string, err error) error {
 // faithfully; the observer skips them.
 var errGitdirUnsupported = errors.New("repository layout not readable in process")
 
-// openWorktreeRepository opens dir as a main or linked worktree and returns
-// a reference store over its git directory plus the effective repository
-// config, rejecting layouts whose answers go-git would get wrong.
+// worktreeGitHandle is one worktree's resolved layout, go-git reference
+// store, and parsed config. Layout and store are fixed for the life of the
+// entry; config is re-read only when its files change on disk. Refs are
+// never cached here: go-git reads them from disk on every lookup, which is
+// what lets the observer notice a push.
+type worktreeGitHandle struct {
+	gitDir    string
+	commonDir string
+	refs      storer.ReferenceStorer
+
+	mu          sync.Mutex
+	cfg         *config.Config
+	sharedStamp fileStamp
+	localStamp  fileStamp
+}
+
+type fileStamp struct {
+	modTime time.Time
+	size    int64
+	exists  bool
+}
+
+func stampFile(path string) (fileStamp, error) {
+	info, err := os.Stat(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return fileStamp{}, nil
+	}
+	if err != nil {
+		return fileStamp{}, err
+	}
+	return fileStamp{modTime: info.ModTime(), size: info.Size(), exists: true}, nil
+}
+
+// open returns the worktree's reference store and effective config,
+// rejecting layouts whose answers go-git would get wrong. A handle that
+// fails is dropped so a moved or deleted worktree is re-resolved next time.
+func (r gitdirRemoteHeadReader) open(dir string) (storer.ReferenceStorer, *config.Config, error) {
+	handle, ok := r.handles.Get(dir)
+	if !ok {
+		var err error
+		handle, err = newWorktreeGitHandle(dir)
+		if err != nil {
+			return nil, nil, err
+		}
+		r.handles.Add(dir, handle)
+	}
+	cfg, err := handle.effectiveConfig()
+	if err != nil {
+		r.handles.Remove(dir)
+		return nil, nil, err
+	}
+	if cfg.Raw.HasSection("include") || cfg.Raw.HasSection("includeIf") {
+		return nil, nil, fmt.Errorf("%w: config uses includes", errGitdirUnsupported)
+	}
+	if storage := cfg.Raw.Section("extensions").Option("refStorage"); storage != "" && !strings.EqualFold(storage, "files") {
+		return nil, nil, fmt.Errorf("%w: ref storage %q", errGitdirUnsupported, storage)
+	}
+	return handle.refs, cfg, nil
+}
+
+// newWorktreeGitHandle resolves the layout and builds the reference store.
 //
 // The git directory and common directory are resolved here rather than with
 // go-git's EnableDotGitCommonDir: that option reads the worktree's
@@ -131,35 +206,54 @@ var errGitdirUnsupported = errors.New("repository layout not readable in process
 // directly instead of through gogit.Open because Open rejects any
 // version-0 repository declaring extensions.worktreeConfig (its allow list
 // is case-mismatched), and ref lookups do not need that validation.
-func openWorktreeRepository(dir string) (storer.ReferenceStorer, *config.Config, error) {
+func newWorktreeGitHandle(dir string) (*worktreeGitHandle, error) {
 	gitDir, commonDir, err := resolveWorktreeGitDirs(dir)
 	if err != nil {
-		return nil, nil, err
-	}
-	cfg, err := effectiveRepositoryConfig(gitDir, commonDir)
-	if err != nil {
-		return nil, nil, err
-	}
-	if cfg.Raw.HasSection("include") || cfg.Raw.HasSection("includeIf") {
-		return nil, nil, fmt.Errorf("%w: config uses includes", errGitdirUnsupported)
-	}
-	if storage := cfg.Raw.Section("extensions").Option("refStorage"); storage != "" && !strings.EqualFold(storage, "files") {
-		return nil, nil, fmt.Errorf("%w: ref storage %q", errGitdirUnsupported, storage)
+		return nil, err
 	}
 	var repoFS = osfs.New(gitDir)
 	if commonDir != gitDir {
 		repoFS = dotgit.NewRepositoryFilesystem(repoFS, osfs.New(commonDir))
 	}
-	return filesystem.NewStorage(repoFS, cache.NewObjectLRUDefault()), cfg, nil
+	return &worktreeGitHandle{
+		gitDir:    gitDir,
+		commonDir: commonDir,
+		refs:      filesystem.NewStorage(repoFS, cache.NewObjectLRUDefault()),
+	}, nil
 }
 
-// effectiveRepositoryConfig reads the shared config and, when
-// extensions.worktreeConfig is on, layers the worktree's own config.worktree
+// effectiveConfig returns the shared config with, when
+// extensions.worktreeConfig is on, the worktree's own config.worktree layered
 // over it the way git does. Managed clones enable that extension to override
-// core.bare per linked worktree, so any branch setting stored there must win
-// over the shared value.
-func effectiveRepositoryConfig(gitDir, commonDir string) (*config.Config, error) {
-	shared, err := os.ReadFile(filepath.Join(commonDir, "config"))
+// core.bare per linked worktree, and kit's managed merge-request worktrees
+// store branch tracking there, so worktree values must win. The parse is
+// reused until either file's size or mtime changes.
+func (h *worktreeGitHandle) effectiveConfig() (*config.Config, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	sharedPath := filepath.Join(h.commonDir, "config")
+	localPath := filepath.Join(h.gitDir, "config.worktree")
+	shared, err := stampFile(sharedPath)
+	if err != nil {
+		return nil, err
+	}
+	local, err := stampFile(localPath)
+	if err != nil {
+		return nil, err
+	}
+	if h.cfg != nil && shared == h.sharedStamp && local == h.localStamp {
+		return h.cfg, nil
+	}
+	cfg, err := readEffectiveConfig(sharedPath, localPath)
+	if err != nil {
+		return nil, err
+	}
+	h.cfg, h.sharedStamp, h.localStamp = cfg, shared, local
+	return cfg, nil
+}
+
+func readEffectiveConfig(sharedPath, localPath string) (*config.Config, error) {
+	shared, err := os.ReadFile(sharedPath)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +265,7 @@ func effectiveRepositoryConfig(gitDir, commonDir string) (*config.Config, error)
 	if !extensions.HasOption("worktreeConfig") || !gitConfigTrue(extensions.Option("worktreeConfig")) {
 		return cfg, nil
 	}
-	local, err := os.ReadFile(filepath.Join(gitDir, "config.worktree"))
+	local, err := os.ReadFile(localPath)
 	if errors.Is(err, fs.ErrNotExist) {
 		return cfg, nil
 	}

--- a/internal/workspace/pushed_head_gitdir.go
+++ b/internal/workspace/pushed_head_gitdir.go
@@ -29,44 +29,39 @@ import (
 // image per workspace.
 //
 // go-git reads the worktree's HEAD, loose and packed refs (through the
-// linked-worktree common directory), and the repository config. Layouts it
-// cannot interpret fall back to git for that question so the observer never
-// answers differently from git, only more cheaply: config include/includeIf
-// (go-git does not expand includes), reftable ref storage, or files it fails
-// to parse.
+// linked-worktree common directory), and the repository config, with
+// config.worktree layered on top when extensions.worktreeConfig is on.
+// Layouts it cannot answer faithfully (config include/includeIf, which go-git
+// does not expand, or reftable ref storage) are skipped like a detached HEAD:
+// no kenn-forge workspace uses them, and spawning git for them would restore
+// the churn this reader exists to remove. Upstream repair is the one git
+// write, guarded per command by procutil.
 //
 // remoteURL is the configured remote.<name>.url; url.<base>.insteadOf
 // rewriting is not applied. The observer does not consume the URL.
-type gitdirRemoteHeadReader struct {
-	fallback remoteHeadGitReader
-}
+type gitdirRemoteHeadReader struct{}
 
-func (r *gitdirRemoteHeadReader) BranchName(ctx context.Context, dir string) (string, error) {
+func (gitdirRemoteHeadReader) BranchName(_ context.Context, dir string) (string, error) {
 	refs, _, err := openWorktreeRepository(dir)
-	if err == nil {
-		var head *plumbing.Reference
-		head, err = refs.Reference(plumbing.HEAD)
-		if err == nil {
-			// Mirrors `git branch --show-current`: the branch name for a
-			// symbolic HEAD under refs/heads, empty when detached.
-			if head.Type() == plumbing.HashReference {
-				return "", nil
-			}
-			if head.Target().IsBranch() {
-				return head.Target().Short(), nil
-			}
-			return "", nil
-		}
+	if err != nil {
+		return "", skipUnsupportedGitdir(dir, "branch", err)
 	}
-	logGitdirFallback(dir, "branch", err)
-	return r.fallback.BranchName(ctx, dir)
+	head, err := refs.Reference(plumbing.HEAD)
+	if err != nil {
+		return "", fmt.Errorf("read HEAD: %w", err)
+	}
+	// Mirrors `git branch --show-current`: the branch name for a symbolic
+	// HEAD under refs/heads, empty when detached.
+	if head.Type() == plumbing.SymbolicReference && head.Target().IsBranch() {
+		return head.Target().Short(), nil
+	}
+	return "", nil
 }
 
-func (r *gitdirRemoteHeadReader) UpstreamState(ctx context.Context, dir, branch string) (upstreamState, error) {
+func (gitdirRemoteHeadReader) UpstreamState(_ context.Context, dir, branch string) (upstreamState, error) {
 	_, cfg, err := openWorktreeRepository(dir)
 	if err != nil {
-		logGitdirFallback(dir, "upstream", err)
-		return r.fallback.UpstreamState(ctx, dir, branch)
+		return upstreamState{}, skipUnsupportedGitdir(dir, "upstream", err)
 	}
 	tracked := cfg.Branches[branch]
 	if tracked == nil || tracked.Remote == "" || tracked.Merge == "" {
@@ -83,34 +78,45 @@ func (r *gitdirRemoteHeadReader) UpstreamState(ctx context.Context, dir, branch 
 	return state, nil
 }
 
-func (r *gitdirRemoteHeadReader) RemoteTrackingSHA(ctx context.Context, dir, remote, branch string) (string, string, bool, error) {
+func (gitdirRemoteHeadReader) RemoteTrackingSHA(_ context.Context, dir, remote, branch string) (string, string, bool, error) {
 	trackingRef := "refs/remotes/" + remote + "/" + branch
 	refs, _, err := openWorktreeRepository(dir)
-	if err == nil {
-		var ref *plumbing.Reference
-		ref, err = storer.ResolveReference(refs, plumbing.ReferenceName(trackingRef))
-		switch {
-		case err == nil:
-			return ref.Hash().String(), trackingRef, true, nil
-		case errors.Is(err, plumbing.ErrReferenceNotFound):
-			return "", trackingRef, false, nil
-		}
+	if err != nil {
+		return "", trackingRef, false, skipUnsupportedGitdir(dir, "tracking ref", err)
 	}
-	logGitdirFallback(dir, "tracking ref", err)
-	return r.fallback.RemoteTrackingSHA(ctx, dir, remote, branch)
+	ref, err := storer.ResolveReference(refs, plumbing.ReferenceName(trackingRef))
+	switch {
+	case err == nil:
+		return ref.Hash().String(), trackingRef, true, nil
+	case errors.Is(err, plumbing.ErrReferenceNotFound):
+		return "", trackingRef, false, nil
+	default:
+		return "", trackingRef, false, fmt.Errorf("resolve %s: %w", trackingRef, err)
+	}
 }
 
-func (r *gitdirRemoteHeadReader) SetBranchUpstream(ctx context.Context, dir, branch, remote, mergeRef string) error {
-	return r.fallback.SetBranchUpstream(ctx, dir, branch, remote, mergeRef)
+// SetBranchUpstream is the observer's only git write. setBranchUpstream's
+// commands each take one procutil slot; wrapping them in an outer acquisition
+// would nest and stall until the git timeout whenever the limiter is full.
+func (gitdirRemoteHeadReader) SetBranchUpstream(ctx context.Context, dir, branch, remote, mergeRef string) error {
+	gitCtx, cancel := context.WithTimeout(ctx, pushedHeadGitTimeout)
+	defer cancel()
+	return setBranchUpstream(gitCtx, dir, branch, remote, mergeRef)
 }
 
-func logGitdirFallback(dir, question string, reason error) {
-	slog.Debug("workspace pushed-head observer reading git state through git",
-		"dir", dir, "question", question, "reason", reason)
+// skipUnsupportedGitdir turns an unsupported-layout error into a silent skip
+// (nil error, zero answer) and passes every other error through.
+func skipUnsupportedGitdir(dir, question string, err error) error {
+	if errors.Is(err, errGitdirUnsupported) {
+		slog.Debug("workspace pushed-head observer skipping unsupported repository layout",
+			"dir", dir, "question", question, "reason", err)
+		return nil
+	}
+	return err
 }
 
 // errGitdirUnsupported marks repository layouts go-git cannot interpret
-// faithfully; callers answer through git instead.
+// faithfully; the observer skips them.
 var errGitdirUnsupported = errors.New("repository layout not readable in process")
 
 // openWorktreeRepository opens dir as a main or linked worktree and returns

--- a/internal/workspace/pushed_head_gitdir.go
+++ b/internal/workspace/pushed_head_gitdir.go
@@ -4,12 +4,19 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 
+	"github.com/go-git/go-billy/v5/osfs"
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/cache"
+	"github.com/go-git/go-git/v5/storage/filesystem"
+	"github.com/go-git/go-git/v5/storage/filesystem/dotgit"
 )
 
 // gitdirRemoteHeadReader answers the pushed-head observer's read-only
@@ -106,8 +113,22 @@ var errGitdirUnsupported = errors.New("repository layout not readable in process
 // openWorktreeRepository opens dir as a main or linked worktree and returns
 // its repository config, rejecting layouts whose answers go-git would get
 // wrong.
+//
+// The git directory and common directory are resolved here rather than with
+// go-git's EnableDotGitCommonDir: that option reads the worktree's
+// `commondir` file without closing it, and the observer opens every
+// workspace several times a minute, so the daemon would leak a descriptor per
+// open and keep linked worktrees undeletable on Windows.
 func openWorktreeRepository(dir string) (*gogit.Repository, *config.Config, error) {
-	repo, err := gogit.PlainOpenWithOptions(dir, &gogit.PlainOpenOptions{EnableDotGitCommonDir: true})
+	gitDir, commonDir, err := resolveWorktreeGitDirs(dir)
+	if err != nil {
+		return nil, nil, err
+	}
+	var repoFS = osfs.New(gitDir)
+	if commonDir != gitDir {
+		repoFS = dotgit.NewRepositoryFilesystem(repoFS, osfs.New(commonDir))
+	}
+	repo, err := gogit.Open(filesystem.NewStorage(repoFS, cache.NewObjectLRUDefault()), osfs.New(dir))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -122,4 +143,44 @@ func openWorktreeRepository(dir string) (*gogit.Repository, *config.Config, erro
 		return nil, nil, fmt.Errorf("%w: ref storage %q", errGitdirUnsupported, storage)
 	}
 	return repo, cfg, nil
+}
+
+// resolveWorktreeGitDirs locates the worktree's private git directory (a
+// `.git` directory, or the target of the `.git` file written by
+// `git worktree add`) and the common directory holding refs, packed-refs,
+// and config for every worktree of the repository.
+func resolveWorktreeGitDirs(worktree string) (gitDir, commonDir string, err error) {
+	dotGit := filepath.Join(worktree, ".git")
+	info, err := os.Stat(dotGit)
+	if err != nil {
+		return "", "", err
+	}
+	gitDir = dotGit
+	if !info.IsDir() {
+		data, err := os.ReadFile(dotGit)
+		if err != nil {
+			return "", "", err
+		}
+		line, _, _ := strings.Cut(string(data), "\n")
+		target, ok := strings.CutPrefix(line, "gitdir:")
+		if !ok {
+			return "", "", fmt.Errorf("%w: %s is neither a directory nor a gitdir file", errGitdirUnsupported, dotGit)
+		}
+		gitDir = strings.TrimSpace(target)
+		if !filepath.IsAbs(gitDir) {
+			gitDir = filepath.Join(worktree, gitDir)
+		}
+	}
+	commonDir = gitDir
+	data, err := os.ReadFile(filepath.Join(gitDir, "commondir"))
+	switch {
+	case err == nil:
+		commonDir = strings.TrimSpace(string(data))
+		if !filepath.IsAbs(commonDir) {
+			commonDir = filepath.Join(gitDir, commonDir)
+		}
+	case !errors.Is(err, fs.ErrNotExist):
+		return "", "", err
+	}
+	return filepath.Clean(gitDir), filepath.Clean(commonDir), nil
 }

--- a/internal/workspace/pushed_head_gitdir.go
+++ b/internal/workspace/pushed_head_gitdir.go
@@ -1,20 +1,23 @@
 package workspace
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/go-git/go-billy/v5/osfs"
-	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/cache"
+	"github.com/go-git/go-git/v5/plumbing/storer"
 	"github.com/go-git/go-git/v5/storage/filesystem"
 	"github.com/go-git/go-git/v5/storage/filesystem/dotgit"
 )
@@ -39,10 +42,10 @@ type gitdirRemoteHeadReader struct {
 }
 
 func (r *gitdirRemoteHeadReader) BranchName(ctx context.Context, dir string) (string, error) {
-	repo, _, err := openWorktreeRepository(dir)
+	refs, _, err := openWorktreeRepository(dir)
 	if err == nil {
 		var head *plumbing.Reference
-		head, err = repo.Storer.Reference(plumbing.HEAD)
+		head, err = refs.Reference(plumbing.HEAD)
 		if err == nil {
 			// Mirrors `git branch --show-current`: the branch name for a
 			// symbolic HEAD under refs/heads, empty when detached.
@@ -82,10 +85,10 @@ func (r *gitdirRemoteHeadReader) UpstreamState(ctx context.Context, dir, branch 
 
 func (r *gitdirRemoteHeadReader) RemoteTrackingSHA(ctx context.Context, dir, remote, branch string) (string, string, bool, error) {
 	trackingRef := "refs/remotes/" + remote + "/" + branch
-	repo, _, err := openWorktreeRepository(dir)
+	refs, _, err := openWorktreeRepository(dir)
 	if err == nil {
 		var ref *plumbing.Reference
-		ref, err = repo.Reference(plumbing.ReferenceName(trackingRef), true)
+		ref, err = storer.ResolveReference(refs, plumbing.ReferenceName(trackingRef))
 		switch {
 		case err == nil:
 			return ref.Hash().String(), trackingRef, true, nil
@@ -111,28 +114,23 @@ func logGitdirFallback(dir, question string, reason error) {
 var errGitdirUnsupported = errors.New("repository layout not readable in process")
 
 // openWorktreeRepository opens dir as a main or linked worktree and returns
-// its repository config, rejecting layouts whose answers go-git would get
-// wrong.
+// a reference store over its git directory plus the effective repository
+// config, rejecting layouts whose answers go-git would get wrong.
 //
 // The git directory and common directory are resolved here rather than with
 // go-git's EnableDotGitCommonDir: that option reads the worktree's
 // `commondir` file without closing it, and the observer opens every
 // workspace several times a minute, so the daemon would leak a descriptor per
-// open and keep linked worktrees undeletable on Windows.
-func openWorktreeRepository(dir string) (*gogit.Repository, *config.Config, error) {
+// open and keep linked worktrees undeletable on Windows. The store is used
+// directly instead of through gogit.Open because Open rejects any
+// version-0 repository declaring extensions.worktreeConfig (its allow list
+// is case-mismatched), and ref lookups do not need that validation.
+func openWorktreeRepository(dir string) (storer.ReferenceStorer, *config.Config, error) {
 	gitDir, commonDir, err := resolveWorktreeGitDirs(dir)
 	if err != nil {
 		return nil, nil, err
 	}
-	var repoFS = osfs.New(gitDir)
-	if commonDir != gitDir {
-		repoFS = dotgit.NewRepositoryFilesystem(repoFS, osfs.New(commonDir))
-	}
-	repo, err := gogit.Open(filesystem.NewStorage(repoFS, cache.NewObjectLRUDefault()), osfs.New(dir))
-	if err != nil {
-		return nil, nil, err
-	}
-	cfg, err := repo.Config()
+	cfg, err := effectiveRepositoryConfig(gitDir, commonDir)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -142,7 +140,53 @@ func openWorktreeRepository(dir string) (*gogit.Repository, *config.Config, erro
 	if storage := cfg.Raw.Section("extensions").Option("refStorage"); storage != "" && !strings.EqualFold(storage, "files") {
 		return nil, nil, fmt.Errorf("%w: ref storage %q", errGitdirUnsupported, storage)
 	}
-	return repo, cfg, nil
+	var repoFS = osfs.New(gitDir)
+	if commonDir != gitDir {
+		repoFS = dotgit.NewRepositoryFilesystem(repoFS, osfs.New(commonDir))
+	}
+	return filesystem.NewStorage(repoFS, cache.NewObjectLRUDefault()), cfg, nil
+}
+
+// effectiveRepositoryConfig reads the shared config and, when
+// extensions.worktreeConfig is on, layers the worktree's own config.worktree
+// over it the way git does. Managed clones enable that extension to override
+// core.bare per linked worktree, so any branch setting stored there must win
+// over the shared value.
+func effectiveRepositoryConfig(gitDir, commonDir string) (*config.Config, error) {
+	shared, err := os.ReadFile(filepath.Join(commonDir, "config"))
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := config.ReadConfig(bytes.NewReader(shared))
+	if err != nil {
+		return nil, err
+	}
+	extensions := cfg.Raw.Section("extensions")
+	if !extensions.HasOption("worktreeConfig") || !gitConfigTrue(extensions.Option("worktreeConfig")) {
+		return cfg, nil
+	}
+	local, err := os.ReadFile(filepath.Join(gitDir, "config.worktree"))
+	if errors.Is(err, fs.ErrNotExist) {
+		return cfg, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	// Later assignments win in go-git's config, matching git's precedence.
+	return config.ReadConfig(io.MultiReader(bytes.NewReader(shared), strings.NewReader("\n"), bytes.NewReader(local)))
+}
+
+// gitConfigTrue applies git-config(1) boolean parsing: yes/on/true, any
+// nonzero integer, or a key with no value are true.
+func gitConfigTrue(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "true", "yes", "on":
+		return true
+	case "false", "no", "off":
+		return false
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(value))
+	return err == nil && n != 0
 }
 
 // resolveWorktreeGitDirs locates the worktree's private git directory (a

--- a/internal/workspace/pushed_head_gitdir_test.go
+++ b/internal/workspace/pushed_head_gitdir_test.go
@@ -66,7 +66,7 @@ func TestGitdirReaderSymbolicHeadWithUpstream(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	fixture := newPushedHeadFixture(t)
-	reader := gitdirRemoteHeadReader{}
+	reader := newGitdirRemoteHeadReader()
 	ctx := t.Context()
 
 	branch, err := reader.BranchName(ctx, fixture.clone)
@@ -92,7 +92,7 @@ func TestGitdirReaderSymbolicHeadWithUpstream(t *testing.T) {
 func TestGitdirReaderDetachedHead(t *testing.T) {
 	fixture := newPushedHeadFixture(t)
 	runWorkspaceTestGit(t, fixture.clone, "checkout", "--detach")
-	reader := gitdirRemoteHeadReader{}
+	reader := newGitdirRemoteHeadReader()
 
 	branch, err := reader.BranchName(t.Context(), fixture.clone)
 	require.NoError(t, err)
@@ -104,7 +104,7 @@ func TestGitdirReaderBranchWithoutUpstream(t *testing.T) {
 	require := require.New(t)
 	fixture := newPushedHeadFixture(t)
 	runWorkspaceTestGit(t, fixture.clone, "checkout", "-b", "scratch")
-	reader := gitdirRemoteHeadReader{}
+	reader := newGitdirRemoteHeadReader()
 	ctx := t.Context()
 
 	upstream, err := reader.UpstreamState(ctx, fixture.clone, "scratch")
@@ -122,7 +122,7 @@ func TestGitdirReaderPackedAndLooseRefs(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	fixture := newPushedHeadFixture(t)
-	reader := gitdirRemoteHeadReader{}
+	reader := newGitdirRemoteHeadReader()
 	ctx := t.Context()
 	gitDir := filepath.Join(fixture.clone, ".git")
 	looseRef := filepath.Join(gitDir, "refs", "remotes", "origin", "feature")
@@ -155,7 +155,7 @@ func TestGitdirReaderLinkedWorktree(t *testing.T) {
 	worktree := filepath.Join(filepath.Dir(fixture.clone), "linked")
 	runWorkspaceTestGit(t, fixture.clone, "worktree", "add", "-b", "topic", worktree, "main")
 	runWorkspaceTestGit(t, worktree, "push", "-u", "origin", "topic")
-	reader := gitdirRemoteHeadReader{}
+	reader := newGitdirRemoteHeadReader()
 	ctx := t.Context()
 
 	branch, err := reader.BranchName(ctx, worktree)
@@ -185,7 +185,7 @@ func TestGitdirReaderSkipsConfigIncludes(t *testing.T) {
 	included := filepath.Join(filepath.Dir(fixture.clone), "included.gitconfig")
 	require.NoError(os.WriteFile(included, []byte("[branch \"feature\"]\n\tremote = origin\n\tmerge = refs/heads/feature\n"), 0o600))
 	runWorkspaceTestGit(t, fixture.clone, "config", "include.path", included)
-	reader := gitdirRemoteHeadReader{}
+	reader := newGitdirRemoteHeadReader()
 	ctx := t.Context()
 
 	// go-git does not expand includes, so the effective config is unknowable
@@ -288,7 +288,7 @@ func TestGitdirReaderDoesNotLeakDescriptorsOnLinkedWorktree(t *testing.T) {
 	worktree := filepath.Join(filepath.Dir(fixture.clone), "linked")
 	runWorkspaceTestGit(t, fixture.clone, "worktree", "add", "-b", "topic", worktree, "main")
 	runWorkspaceTestGit(t, worktree, "push", "-u", "origin", "topic")
-	reader := gitdirRemoteHeadReader{}
+	reader := newGitdirRemoteHeadReader()
 	ctx := t.Context()
 
 	openDescriptors := func() int {
@@ -326,7 +326,7 @@ func TestGitdirReaderOverlaysWorktreeConfig(t *testing.T) {
 	runWorkspaceTestGit(t, fixture.clone, "config", "branch.topic.merge", "refs/heads/topic")
 	runWorkspaceTestGit(t, fixture.clone, "config", "extensions.worktreeConfig", "2")
 	runWorkspaceTestGit(t, worktree, "config", "--worktree", "branch.topic.merge", "refs/heads/feature")
-	reader := gitdirRemoteHeadReader{}
+	reader := newGitdirRemoteHeadReader()
 	ctx := t.Context()
 
 	upstream, err := reader.UpstreamState(ctx, worktree, "topic")
@@ -356,11 +356,35 @@ func TestGitdirReaderRepairsUpstreamWithOneLimiterSlot(t *testing.T) {
 	)
 	defer restore()
 
-	err := gitdirRemoteHeadReader{}.SetBranchUpstream(
+	err := newGitdirRemoteHeadReader().SetBranchUpstream(
 		t.Context(), fixture.clone, "scratch", "origin", "refs/heads/feature",
 	)
 	require.NoError(err)
 	restore()
 	merge := strings.TrimSpace(string(runWorkspaceTestGit(t, fixture.clone, "config", "--get", "branch.scratch.merge")))
 	assert.Equal(t, "refs/heads/feature", merge)
+}
+
+func TestGitdirReaderSeesConfigChangesAfterCaching(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := newPushedHeadFixture(t)
+	reader := newGitdirRemoteHeadReader()
+	ctx := t.Context()
+
+	first, err := reader.UpstreamState(ctx, fixture.clone, "feature")
+	require.NoError(err)
+	assert.Equal("feature", first.branchName)
+
+	// Rewrite the upstream through git; the cached parse must be replaced
+	// because the config file's stamp changed.
+	runWorkspaceTestGit(t, fixture.clone, "config", "branch.feature.merge", "refs/heads/main")
+	second, err := reader.UpstreamState(ctx, fixture.clone, "feature")
+	require.NoError(err)
+	assert.Equal("main", second.branchName)
+
+	// A deleted worktree must not be answered from the cached handle.
+	require.NoError(os.RemoveAll(fixture.clone))
+	_, err = reader.BranchName(ctx, fixture.clone)
+	assert.Error(err)
 }

--- a/internal/workspace/pushed_head_gitdir_test.go
+++ b/internal/workspace/pushed_head_gitdir_test.go
@@ -134,21 +134,23 @@ func TestGitdirReaderDetachedHead(t *testing.T) {
 }
 
 func TestGitdirReaderBranchWithoutUpstream(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	fixture := newPushedHeadFixture(t)
 	runWorkspaceTestGit(t, fixture.clone, "checkout", "-b", "scratch")
 	reader, fallback := newGitdirReaderForTest()
 	ctx := t.Context()
 
 	upstream, err := reader.UpstreamState(ctx, fixture.clone, "scratch")
-	require.NoError(t, err)
-	assert.Equal(t, upstreamState{}, upstream)
+	require.NoError(err)
+	assert.Equal(upstreamState{}, upstream)
 
 	sha, ref, ok, err := reader.RemoteTrackingSHA(ctx, fixture.clone, "origin", "scratch")
-	require.NoError(t, err)
-	assert.False(t, ok)
-	assert.Empty(t, sha)
-	assert.Equal(t, "refs/remotes/origin/scratch", ref)
-	assert.Equal(t, 0, fallback.calls)
+	require.NoError(err)
+	assert.False(ok)
+	assert.Empty(sha)
+	assert.Equal("refs/remotes/origin/scratch", ref)
+	assert.Equal(0, fallback.calls)
 }
 
 func TestGitdirReaderPackedAndLooseRefs(t *testing.T) {
@@ -214,23 +216,25 @@ func TestGitdirReaderLinkedWorktree(t *testing.T) {
 }
 
 func TestGitdirReaderFallsBackForConfigIncludes(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	fixture := newPushedHeadFixture(t)
 	included := filepath.Join(filepath.Dir(fixture.clone), "included.gitconfig")
-	require.NoError(t, os.WriteFile(included, []byte("[branch \"feature\"]\n\tremote = origin\n\tmerge = refs/heads/feature\n"), 0o600))
+	require.NoError(os.WriteFile(included, []byte("[branch \"feature\"]\n\tremote = origin\n\tmerge = refs/heads/feature\n"), 0o600))
 	runWorkspaceTestGit(t, fixture.clone, "config", "--unset", "branch.feature.remote")
 	runWorkspaceTestGit(t, fixture.clone, "config", "--unset", "branch.feature.merge")
 	runWorkspaceTestGit(t, fixture.clone, "config", "include.path", included)
 	reader, fallback := newGitdirReaderForTest()
 
 	upstream, err := reader.UpstreamState(t.Context(), fixture.clone, "feature")
-	require.NoError(t, err)
-	assert.Equal(t, upstreamState{
+	require.NoError(err)
+	assert.Equal(upstreamState{
 		branchName:  "feature",
 		remoteName:  "origin",
 		remoteURL:   fixture.remote,
 		hasTracking: true,
 	}, upstream, "included config is only visible through git")
-	assert.Equal(t, 1, fallback.calls)
+	assert.Equal(1, fallback.calls)
 }
 
 // TestPushedHeadObserverPassSpawnsNoGitWhenUnchanged runs the real observer

--- a/internal/workspace/pushed_head_gitdir_test.go
+++ b/internal/workspace/pushed_head_gitdir_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/procutil"
 )
 
 // pushedHeadFixture is a bare remote with one clone whose "feature" branch
@@ -349,4 +350,58 @@ func TestGitdirReaderDoesNotLeakDescriptorsOnLinkedWorktree(t *testing.T) {
 	}
 	assert.Equal(before, openDescriptors(), "reading a linked worktree must not leave descriptors open")
 	assert.Equal(0, fallback.calls)
+}
+
+func TestGitdirReaderOverlaysWorktreeConfig(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := newPushedHeadFixture(t)
+	worktree := filepath.Join(filepath.Dir(fixture.clone), "linked")
+	runWorkspaceTestGit(t, fixture.clone, "worktree", "add", "-b", "topic", worktree, "main")
+	// Shared config says topic tracks origin/topic; the worktree's own
+	// config.worktree overrides that to origin/feature, which is what git
+	// reports once extensions.worktreeConfig is on. Git accepts any nonzero
+	// integer as true for that extension.
+	runWorkspaceTestGit(t, fixture.clone, "config", "branch.topic.remote", "origin")
+	runWorkspaceTestGit(t, fixture.clone, "config", "branch.topic.merge", "refs/heads/topic")
+	runWorkspaceTestGit(t, fixture.clone, "config", "extensions.worktreeConfig", "2")
+	runWorkspaceTestGit(t, worktree, "config", "--worktree", "branch.topic.merge", "refs/heads/feature")
+	reader, fallback := newGitdirReaderForTest()
+	ctx := t.Context()
+
+	upstream, err := reader.UpstreamState(ctx, worktree, "topic")
+	require.NoError(err)
+	assert.Equal(upstreamState{
+		branchName:  "feature",
+		remoteName:  "origin",
+		remoteURL:   fixture.remote,
+		hasTracking: true,
+	}, upstream, "config.worktree must override the shared config")
+
+	shared, err := reader.UpstreamState(ctx, fixture.clone, "topic")
+	require.NoError(err)
+	assert.Equal("topic", shared.branchName, "the main worktree keeps the shared value")
+	assert.Equal(0, fallback.calls)
+}
+
+// TestSubprocessReaderRepairsUpstreamWithOneLimiterSlot proves upstream
+// repair holds one subprocess slot per git command rather than nesting an
+// outer acquisition around guarded commands, which stalls until the git
+// timeout whenever the limiter is at capacity.
+func TestSubprocessReaderRepairsUpstreamWithOneLimiterSlot(t *testing.T) {
+	require := require.New(t)
+	fixture := newPushedHeadFixture(t)
+	runWorkspaceTestGit(t, fixture.clone, "checkout", "-b", "scratch")
+	restore := procutil.SetDefaultLimiterForTest(
+		procutil.NewLimiterWithAcquireTimeout(1, 200*time.Millisecond),
+	)
+	defer restore()
+
+	err := gitRemoteHeadReader{}.SetBranchUpstream(
+		t.Context(), fixture.clone, "scratch", "origin", "refs/heads/feature",
+	)
+	require.NoError(err)
+	restore()
+	merge := strings.TrimSpace(string(runWorkspaceTestGit(t, fixture.clone, "config", "--get", "branch.scratch.merge")))
+	assert.Equal(t, "refs/heads/feature", merge)
 }

--- a/internal/workspace/pushed_head_gitdir_test.go
+++ b/internal/workspace/pushed_head_gitdir_test.go
@@ -1,7 +1,6 @@
 package workspace
 
 import (
-	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -63,43 +62,11 @@ func (f pushedHeadFixture) revParse(t *testing.T, ref string) string {
 	return strings.TrimSpace(string(runWorkspaceTestGit(t, f.clone, "rev-parse", "--verify", ref)))
 }
 
-// countingRemoteHeadReader records fallback use so tests can prove the direct
-// reader answered from the git directory alone.
-type countingRemoteHeadReader struct {
-	inner remoteHeadGitReader
-	calls int
-}
-
-func (c *countingRemoteHeadReader) BranchName(ctx context.Context, dir string) (string, error) {
-	c.calls++
-	return c.inner.BranchName(ctx, dir)
-}
-
-func (c *countingRemoteHeadReader) UpstreamState(ctx context.Context, dir, branch string) (upstreamState, error) {
-	c.calls++
-	return c.inner.UpstreamState(ctx, dir, branch)
-}
-
-func (c *countingRemoteHeadReader) RemoteTrackingSHA(ctx context.Context, dir, remote, branch string) (string, string, bool, error) {
-	c.calls++
-	return c.inner.RemoteTrackingSHA(ctx, dir, remote, branch)
-}
-
-func (c *countingRemoteHeadReader) SetBranchUpstream(ctx context.Context, dir, branch, remote, mergeRef string) error {
-	c.calls++
-	return c.inner.SetBranchUpstream(ctx, dir, branch, remote, mergeRef)
-}
-
-func newGitdirReaderForTest() (*gitdirRemoteHeadReader, *countingRemoteHeadReader) {
-	fallback := &countingRemoteHeadReader{inner: gitRemoteHeadReader{}}
-	return &gitdirRemoteHeadReader{fallback: fallback}, fallback
-}
-
 func TestGitdirReaderSymbolicHeadWithUpstream(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	fixture := newPushedHeadFixture(t)
-	reader, fallback := newGitdirReaderForTest()
+	reader := gitdirRemoteHeadReader{}
 	ctx := t.Context()
 
 	branch, err := reader.BranchName(ctx, fixture.clone)
@@ -120,18 +87,16 @@ func TestGitdirReaderSymbolicHeadWithUpstream(t *testing.T) {
 	assert.True(ok)
 	assert.Equal("refs/remotes/origin/feature", ref)
 	assert.Equal(fixture.revParse(t, "refs/remotes/origin/feature"), sha)
-	assert.Equal(0, fallback.calls, "a plain clone must be answered without git")
 }
 
 func TestGitdirReaderDetachedHead(t *testing.T) {
 	fixture := newPushedHeadFixture(t)
 	runWorkspaceTestGit(t, fixture.clone, "checkout", "--detach")
-	reader, fallback := newGitdirReaderForTest()
+	reader := gitdirRemoteHeadReader{}
 
 	branch, err := reader.BranchName(t.Context(), fixture.clone)
 	require.NoError(t, err)
 	assert.Empty(t, branch, "detached HEAD has no current branch")
-	assert.Equal(t, 0, fallback.calls)
 }
 
 func TestGitdirReaderBranchWithoutUpstream(t *testing.T) {
@@ -139,7 +104,7 @@ func TestGitdirReaderBranchWithoutUpstream(t *testing.T) {
 	require := require.New(t)
 	fixture := newPushedHeadFixture(t)
 	runWorkspaceTestGit(t, fixture.clone, "checkout", "-b", "scratch")
-	reader, fallback := newGitdirReaderForTest()
+	reader := gitdirRemoteHeadReader{}
 	ctx := t.Context()
 
 	upstream, err := reader.UpstreamState(ctx, fixture.clone, "scratch")
@@ -151,14 +116,13 @@ func TestGitdirReaderBranchWithoutUpstream(t *testing.T) {
 	assert.False(ok)
 	assert.Empty(sha)
 	assert.Equal("refs/remotes/origin/scratch", ref)
-	assert.Equal(0, fallback.calls)
 }
 
 func TestGitdirReaderPackedAndLooseRefs(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	fixture := newPushedHeadFixture(t)
-	reader, fallback := newGitdirReaderForTest()
+	reader := gitdirRemoteHeadReader{}
 	ctx := t.Context()
 	gitDir := filepath.Join(fixture.clone, ".git")
 	looseRef := filepath.Join(gitDir, "refs", "remotes", "origin", "feature")
@@ -182,7 +146,6 @@ func TestGitdirReaderPackedAndLooseRefs(t *testing.T) {
 	require.NoError(err)
 	assert.True(ok)
 	assert.Equal(pushed, sha)
-	assert.Equal(0, fallback.calls)
 }
 
 func TestGitdirReaderLinkedWorktree(t *testing.T) {
@@ -192,7 +155,7 @@ func TestGitdirReaderLinkedWorktree(t *testing.T) {
 	worktree := filepath.Join(filepath.Dir(fixture.clone), "linked")
 	runWorkspaceTestGit(t, fixture.clone, "worktree", "add", "-b", "topic", worktree, "main")
 	runWorkspaceTestGit(t, worktree, "push", "-u", "origin", "topic")
-	reader, fallback := newGitdirReaderForTest()
+	reader := gitdirRemoteHeadReader{}
 	ctx := t.Context()
 
 	branch, err := reader.BranchName(ctx, worktree)
@@ -213,29 +176,27 @@ func TestGitdirReaderLinkedWorktree(t *testing.T) {
 	assert.True(ok)
 	assert.Equal("refs/remotes/origin/topic", ref)
 	assert.Equal(fixture.revParse(t, "refs/remotes/origin/topic"), sha)
-	assert.Equal(0, fallback.calls)
 }
 
-func TestGitdirReaderFallsBackForConfigIncludes(t *testing.T) {
+func TestGitdirReaderSkipsConfigIncludes(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	fixture := newPushedHeadFixture(t)
 	included := filepath.Join(filepath.Dir(fixture.clone), "included.gitconfig")
 	require.NoError(os.WriteFile(included, []byte("[branch \"feature\"]\n\tremote = origin\n\tmerge = refs/heads/feature\n"), 0o600))
-	runWorkspaceTestGit(t, fixture.clone, "config", "--unset", "branch.feature.remote")
-	runWorkspaceTestGit(t, fixture.clone, "config", "--unset", "branch.feature.merge")
 	runWorkspaceTestGit(t, fixture.clone, "config", "include.path", included)
-	reader, fallback := newGitdirReaderForTest()
+	reader := gitdirRemoteHeadReader{}
+	ctx := t.Context()
 
-	upstream, err := reader.UpstreamState(t.Context(), fixture.clone, "feature")
+	// go-git does not expand includes, so the effective config is unknowable
+	// in process; the observer treats the workspace as unobservable rather
+	// than guessing from the partial file or spawning git.
+	branch, err := reader.BranchName(ctx, fixture.clone)
 	require.NoError(err)
-	assert.Equal(upstreamState{
-		branchName:  "feature",
-		remoteName:  "origin",
-		remoteURL:   fixture.remote,
-		hasTracking: true,
-	}, upstream, "included config is only visible through git")
-	assert.Equal(1, fallback.calls)
+	assert.Empty(branch)
+	upstream, err := reader.UpstreamState(ctx, fixture.clone, "feature")
+	require.NoError(err)
+	assert.Equal(upstreamState{}, upstream)
 }
 
 // TestPushedHeadObserverPassSpawnsNoGitWhenUnchanged runs the real observer
@@ -327,7 +288,7 @@ func TestGitdirReaderDoesNotLeakDescriptorsOnLinkedWorktree(t *testing.T) {
 	worktree := filepath.Join(filepath.Dir(fixture.clone), "linked")
 	runWorkspaceTestGit(t, fixture.clone, "worktree", "add", "-b", "topic", worktree, "main")
 	runWorkspaceTestGit(t, worktree, "push", "-u", "origin", "topic")
-	reader, fallback := newGitdirReaderForTest()
+	reader := gitdirRemoteHeadReader{}
 	ctx := t.Context()
 
 	openDescriptors := func() int {
@@ -349,7 +310,6 @@ func TestGitdirReaderDoesNotLeakDescriptorsOnLinkedWorktree(t *testing.T) {
 		read()
 	}
 	assert.Equal(before, openDescriptors(), "reading a linked worktree must not leave descriptors open")
-	assert.Equal(0, fallback.calls)
 }
 
 func TestGitdirReaderOverlaysWorktreeConfig(t *testing.T) {
@@ -366,7 +326,7 @@ func TestGitdirReaderOverlaysWorktreeConfig(t *testing.T) {
 	runWorkspaceTestGit(t, fixture.clone, "config", "branch.topic.merge", "refs/heads/topic")
 	runWorkspaceTestGit(t, fixture.clone, "config", "extensions.worktreeConfig", "2")
 	runWorkspaceTestGit(t, worktree, "config", "--worktree", "branch.topic.merge", "refs/heads/feature")
-	reader, fallback := newGitdirReaderForTest()
+	reader := gitdirRemoteHeadReader{}
 	ctx := t.Context()
 
 	upstream, err := reader.UpstreamState(ctx, worktree, "topic")
@@ -381,14 +341,13 @@ func TestGitdirReaderOverlaysWorktreeConfig(t *testing.T) {
 	shared, err := reader.UpstreamState(ctx, fixture.clone, "topic")
 	require.NoError(err)
 	assert.Equal("topic", shared.branchName, "the main worktree keeps the shared value")
-	assert.Equal(0, fallback.calls)
 }
 
-// TestSubprocessReaderRepairsUpstreamWithOneLimiterSlot proves upstream
+// TestGitdirReaderRepairsUpstreamWithOneLimiterSlot proves upstream
 // repair holds one subprocess slot per git command rather than nesting an
 // outer acquisition around guarded commands, which stalls until the git
 // timeout whenever the limiter is at capacity.
-func TestSubprocessReaderRepairsUpstreamWithOneLimiterSlot(t *testing.T) {
+func TestGitdirReaderRepairsUpstreamWithOneLimiterSlot(t *testing.T) {
 	require := require.New(t)
 	fixture := newPushedHeadFixture(t)
 	runWorkspaceTestGit(t, fixture.clone, "checkout", "-b", "scratch")
@@ -397,7 +356,7 @@ func TestSubprocessReaderRepairsUpstreamWithOneLimiterSlot(t *testing.T) {
 	)
 	defer restore()
 
-	err := gitRemoteHeadReader{}.SetBranchUpstream(
+	err := gitdirRemoteHeadReader{}.SetBranchUpstream(
 		t.Context(), fixture.clone, "scratch", "origin", "refs/heads/feature",
 	)
 	require.NoError(err)

--- a/internal/workspace/pushed_head_gitdir_test.go
+++ b/internal/workspace/pushed_head_gitdir_test.go
@@ -309,3 +309,44 @@ func TestPushedHeadObserverPassSpawnsNoGitWhenUnchanged(t *testing.T) {
 	assert.Equal("refs/remotes/origin/feature", result.HeadChanges[0].TrackingRef)
 	assert.Empty(gitInvocations(), "detecting a pushed head must not spawn git")
 }
+
+// TestGitdirReaderDoesNotLeakDescriptorsOnLinkedWorktree guards the storage
+// construction in openWorktreeRepository: go-git's EnableDotGitCommonDir
+// option opens the linked worktree's commondir file without closing it, and
+// the observer opens every workspace several times a minute, so a leak there
+// exhausts the daemon's descriptors and keeps worktrees undeletable on
+// Windows.
+func TestGitdirReaderDoesNotLeakDescriptorsOnLinkedWorktree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("descriptor table is read through /dev/fd")
+	}
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := newPushedHeadFixture(t)
+	worktree := filepath.Join(filepath.Dir(fixture.clone), "linked")
+	runWorkspaceTestGit(t, fixture.clone, "worktree", "add", "-b", "topic", worktree, "main")
+	runWorkspaceTestGit(t, worktree, "push", "-u", "origin", "topic")
+	reader, fallback := newGitdirReaderForTest()
+	ctx := t.Context()
+
+	openDescriptors := func() int {
+		entries, err := os.ReadDir("/dev/fd")
+		require.NoError(err)
+		return len(entries)
+	}
+	read := func() {
+		_, err := reader.BranchName(ctx, worktree)
+		require.NoError(err)
+		_, err = reader.UpstreamState(ctx, worktree, "topic")
+		require.NoError(err)
+		_, _, _, err = reader.RemoteTrackingSHA(ctx, worktree, "origin", "topic")
+		require.NoError(err)
+	}
+	read()
+	before := openDescriptors()
+	for range 20 {
+		read()
+	}
+	assert.Equal(before, openDescriptors(), "reading a linked worktree must not leave descriptors open")
+	assert.Equal(0, fallback.calls)
+}

--- a/internal/workspace/pushed_head_gitdir_test.go
+++ b/internal/workspace/pushed_head_gitdir_test.go
@@ -1,0 +1,307 @@
+package workspace
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/forge/internal/db"
+)
+
+// pushedHeadFixture is a bare remote with one clone whose "feature" branch
+// tracks origin/feature. Fixture commands run through the kit git runner,
+// which strips inherited GIT_* variables and nulls global/system config, and
+// every path lives under t.TempDir outside any real repository.
+type pushedHeadFixture struct {
+	remote string
+	clone  string
+}
+
+func newPushedHeadFixture(t *testing.T) pushedHeadFixture {
+	t.Helper()
+	dir := t.TempDir()
+	remote := filepath.Join(dir, "remote.git")
+	clone := filepath.Join(dir, "clone")
+	runWorkspaceTestGit(t, dir, "init", "--bare", "--initial-branch=main", remote)
+	runWorkspaceTestGit(t, dir, "clone", remote, clone)
+	runWorkspaceTestGit(t, clone, "config", "user.email", "test@example.com")
+	runWorkspaceTestGit(t, clone, "config", "user.name", "Test")
+	require.NoError(t, os.WriteFile(filepath.Join(clone, "base.txt"), []byte("base\n"), 0o644))
+	runWorkspaceTestGit(t, clone, "add", ".")
+	runWorkspaceTestGit(t, clone, "commit", "-m", "base commit")
+	runWorkspaceTestGit(t, clone, "push", "origin", "main")
+	runWorkspaceTestGit(t, clone, "checkout", "-b", "feature")
+	require.NoError(t, os.WriteFile(filepath.Join(clone, "feature.txt"), []byte("feature\n"), 0o644))
+	runWorkspaceTestGit(t, clone, "add", ".")
+	runWorkspaceTestGit(t, clone, "commit", "-m", "feature commit")
+	runWorkspaceTestGit(t, clone, "push", "-u", "origin", "feature")
+	return pushedHeadFixture{remote: remote, clone: clone}
+}
+
+// pushFeatureCommit adds a commit to the feature branch and pushes it so
+// origin/feature moves; it returns the new remote-tracking SHA.
+func (f pushedHeadFixture) pushFeatureCommit(t *testing.T, name string) string {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(f.clone, name), []byte(name+"\n"), 0o644))
+	runWorkspaceTestGit(t, f.clone, "add", ".")
+	runWorkspaceTestGit(t, f.clone, "commit", "-m", name)
+	runWorkspaceTestGit(t, f.clone, "push", "origin", "feature")
+	return f.revParse(t, "refs/remotes/origin/feature")
+}
+
+func (f pushedHeadFixture) revParse(t *testing.T, ref string) string {
+	t.Helper()
+	return strings.TrimSpace(string(runWorkspaceTestGit(t, f.clone, "rev-parse", "--verify", ref)))
+}
+
+// countingRemoteHeadReader records fallback use so tests can prove the direct
+// reader answered from the git directory alone.
+type countingRemoteHeadReader struct {
+	inner remoteHeadGitReader
+	calls int
+}
+
+func (c *countingRemoteHeadReader) BranchName(ctx context.Context, dir string) (string, error) {
+	c.calls++
+	return c.inner.BranchName(ctx, dir)
+}
+
+func (c *countingRemoteHeadReader) UpstreamState(ctx context.Context, dir, branch string) (upstreamState, error) {
+	c.calls++
+	return c.inner.UpstreamState(ctx, dir, branch)
+}
+
+func (c *countingRemoteHeadReader) RemoteTrackingSHA(ctx context.Context, dir, remote, branch string) (string, string, bool, error) {
+	c.calls++
+	return c.inner.RemoteTrackingSHA(ctx, dir, remote, branch)
+}
+
+func (c *countingRemoteHeadReader) SetBranchUpstream(ctx context.Context, dir, branch, remote, mergeRef string) error {
+	c.calls++
+	return c.inner.SetBranchUpstream(ctx, dir, branch, remote, mergeRef)
+}
+
+func newGitdirReaderForTest() (*gitdirRemoteHeadReader, *countingRemoteHeadReader) {
+	fallback := &countingRemoteHeadReader{inner: gitRemoteHeadReader{}}
+	return &gitdirRemoteHeadReader{fallback: fallback}, fallback
+}
+
+func TestGitdirReaderSymbolicHeadWithUpstream(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := newPushedHeadFixture(t)
+	reader, fallback := newGitdirReaderForTest()
+	ctx := t.Context()
+
+	branch, err := reader.BranchName(ctx, fixture.clone)
+	require.NoError(err)
+	assert.Equal("feature", branch)
+
+	upstream, err := reader.UpstreamState(ctx, fixture.clone, "feature")
+	require.NoError(err)
+	assert.Equal(upstreamState{
+		branchName:  "feature",
+		remoteName:  "origin",
+		remoteURL:   fixture.remote,
+		hasTracking: true,
+	}, upstream)
+
+	sha, ref, ok, err := reader.RemoteTrackingSHA(ctx, fixture.clone, "origin", "feature")
+	require.NoError(err)
+	assert.True(ok)
+	assert.Equal("refs/remotes/origin/feature", ref)
+	assert.Equal(fixture.revParse(t, "refs/remotes/origin/feature"), sha)
+	assert.Equal(0, fallback.calls, "a plain clone must be answered without git")
+}
+
+func TestGitdirReaderDetachedHead(t *testing.T) {
+	fixture := newPushedHeadFixture(t)
+	runWorkspaceTestGit(t, fixture.clone, "checkout", "--detach")
+	reader, fallback := newGitdirReaderForTest()
+
+	branch, err := reader.BranchName(t.Context(), fixture.clone)
+	require.NoError(t, err)
+	assert.Empty(t, branch, "detached HEAD has no current branch")
+	assert.Equal(t, 0, fallback.calls)
+}
+
+func TestGitdirReaderBranchWithoutUpstream(t *testing.T) {
+	fixture := newPushedHeadFixture(t)
+	runWorkspaceTestGit(t, fixture.clone, "checkout", "-b", "scratch")
+	reader, fallback := newGitdirReaderForTest()
+	ctx := t.Context()
+
+	upstream, err := reader.UpstreamState(ctx, fixture.clone, "scratch")
+	require.NoError(t, err)
+	assert.Equal(t, upstreamState{}, upstream)
+
+	sha, ref, ok, err := reader.RemoteTrackingSHA(ctx, fixture.clone, "origin", "scratch")
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Empty(t, sha)
+	assert.Equal(t, "refs/remotes/origin/scratch", ref)
+	assert.Equal(t, 0, fallback.calls)
+}
+
+func TestGitdirReaderPackedAndLooseRefs(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := newPushedHeadFixture(t)
+	reader, fallback := newGitdirReaderForTest()
+	ctx := t.Context()
+	gitDir := filepath.Join(fixture.clone, ".git")
+	looseRef := filepath.Join(gitDir, "refs", "remotes", "origin", "feature")
+
+	// Force the tracking ref into packed-refs only.
+	runWorkspaceTestGit(t, fixture.clone, "pack-refs", "--all")
+	_, statErr := os.Stat(looseRef)
+	require.ErrorIs(statErr, os.ErrNotExist, "pack-refs must leave no loose ref")
+	packed := fixture.revParse(t, "refs/remotes/origin/feature")
+	sha, _, ok, err := reader.RemoteTrackingSHA(ctx, fixture.clone, "origin", "feature")
+	require.NoError(err)
+	assert.True(ok)
+	assert.Equal(packed, sha)
+
+	// A push updates the loose ref, which must win over the stale packed entry.
+	pushed := fixture.pushFeatureCommit(t, "second.txt")
+	_, statErr = os.Stat(looseRef)
+	require.NoError(statErr, "push must write a loose tracking ref")
+	assert.NotEqual(packed, pushed)
+	sha, _, ok, err = reader.RemoteTrackingSHA(ctx, fixture.clone, "origin", "feature")
+	require.NoError(err)
+	assert.True(ok)
+	assert.Equal(pushed, sha)
+	assert.Equal(0, fallback.calls)
+}
+
+func TestGitdirReaderLinkedWorktree(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := newPushedHeadFixture(t)
+	worktree := filepath.Join(filepath.Dir(fixture.clone), "linked")
+	runWorkspaceTestGit(t, fixture.clone, "worktree", "add", "-b", "topic", worktree, "main")
+	runWorkspaceTestGit(t, worktree, "push", "-u", "origin", "topic")
+	reader, fallback := newGitdirReaderForTest()
+	ctx := t.Context()
+
+	branch, err := reader.BranchName(ctx, worktree)
+	require.NoError(err)
+	assert.Equal("topic", branch)
+
+	upstream, err := reader.UpstreamState(ctx, worktree, "topic")
+	require.NoError(err)
+	assert.Equal(upstreamState{
+		branchName:  "topic",
+		remoteName:  "origin",
+		remoteURL:   fixture.remote,
+		hasTracking: true,
+	}, upstream)
+
+	sha, ref, ok, err := reader.RemoteTrackingSHA(ctx, worktree, "origin", "topic")
+	require.NoError(err)
+	assert.True(ok)
+	assert.Equal("refs/remotes/origin/topic", ref)
+	assert.Equal(fixture.revParse(t, "refs/remotes/origin/topic"), sha)
+	assert.Equal(0, fallback.calls)
+}
+
+func TestGitdirReaderFallsBackForConfigIncludes(t *testing.T) {
+	fixture := newPushedHeadFixture(t)
+	included := filepath.Join(filepath.Dir(fixture.clone), "included.gitconfig")
+	require.NoError(t, os.WriteFile(included, []byte("[branch \"feature\"]\n\tremote = origin\n\tmerge = refs/heads/feature\n"), 0o600))
+	runWorkspaceTestGit(t, fixture.clone, "config", "--unset", "branch.feature.remote")
+	runWorkspaceTestGit(t, fixture.clone, "config", "--unset", "branch.feature.merge")
+	runWorkspaceTestGit(t, fixture.clone, "config", "include.path", included)
+	reader, fallback := newGitdirReaderForTest()
+
+	upstream, err := reader.UpstreamState(t.Context(), fixture.clone, "feature")
+	require.NoError(t, err)
+	assert.Equal(t, upstreamState{
+		branchName:  "feature",
+		remoteName:  "origin",
+		remoteURL:   fixture.remote,
+		hasTracking: true,
+	}, upstream, "included config is only visible through git")
+	assert.Equal(t, 1, fallback.calls)
+}
+
+// TestPushedHeadObserverPassSpawnsNoGitWhenUnchanged runs the real observer
+// against a fixture worktree with a git shim first on PATH that logs every
+// invocation, proving idle passes and pushed-head detection need no
+// subprocess at all.
+func TestPushedHeadObserverPassSpawnsNoGitWhenUnchanged(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH shim requires a POSIX shell")
+	}
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := newPushedHeadFixture(t)
+	oldHead := fixture.revParse(t, "refs/remotes/origin/feature")
+
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMRWithPlatformHead(t, d, repoID, 42, "feature", oldHead, "https://github.com/acme/widget.git")
+	require.NoError(d.InsertWorkspace(t.Context(), &db.Workspace{
+		ID:              "ws-pr",
+		Platform:        "github",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        db.WorkspaceItemTypePullRequest,
+		ItemNumber:      42,
+		GitHeadRef:      "feature",
+		WorkspaceBranch: "feature",
+		WorktreePath:    fixture.clone,
+		TmuxSession:     "kenn-forge-ws-pr",
+		Status:          "ready",
+	}))
+	observer := NewPushedHeadObserver(d)
+	observer.setNowForTest(func() time.Time {
+		return time.Date(2026, 5, 20, 14, 15, 0, 0, time.UTC)
+	})
+
+	realGit, err := exec.LookPath("git")
+	require.NoError(err)
+	shimDir := t.TempDir()
+	logPath := filepath.Join(shimDir, "invocations.log")
+	shim := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '" + logPath + "'\nexec '" + realGit + "' \"$@\"\n"
+	require.NoError(os.WriteFile(filepath.Join(shimDir, "git"), []byte(shim), 0o700))
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	gitInvocations := func() string {
+		data, readErr := os.ReadFile(logPath)
+		if os.IsNotExist(readErr) {
+			return ""
+		}
+		require.NoError(readErr)
+		return string(data)
+	}
+
+	result, err := observer.RunOnce(t.Context())
+	require.NoError(err)
+	assert.Empty(result.HeadChanges, "first observation matches the provider head")
+	assert.Empty(gitInvocations(), "first pass must not spawn git")
+
+	result, err = observer.RunOnce(t.Context())
+	require.NoError(err)
+	assert.Empty(result.HeadChanges)
+	assert.Empty(gitInvocations(), "unchanged pass must not spawn git")
+
+	newHead := fixture.pushFeatureCommit(t, "second.txt")
+	require.NoError(os.Remove(logPath))
+
+	result, err = observer.RunOnce(t.Context())
+	require.NoError(err)
+	require.Len(result.HeadChanges, 1)
+	assert.Equal(oldHead, result.HeadChanges[0].OldSHA)
+	assert.Equal(newHead, result.HeadChanges[0].NewSHA)
+	assert.Equal("refs/remotes/origin/feature", result.HeadChanges[0].TrackingRef)
+	assert.Empty(gitInvocations(), "detecting a pushed head must not spawn git")
+}

--- a/internal/workspace/pushed_head_observer.go
+++ b/internal/workspace/pushed_head_observer.go
@@ -11,7 +11,6 @@ import (
 
 	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/platform"
-	"go.kenn.io/forge/internal/procutil"
 )
 
 type remoteHeadKey struct {
@@ -80,62 +79,6 @@ const (
 	pushedHeadRefreshRetryInterval = 30 * time.Second
 )
 
-// gitRemoteHeadReader answers through git subprocesses. It is the fallback
-// behind gitdirRemoteHeadReader for repository layouts the direct reader
-// cannot interpret, and the only writer (SetBranchUpstream). Every spawn
-// takes the shared procutil capacity guard because the observer fans out
-// across all ready workspaces on one pass.
-type gitRemoteHeadReader struct{}
-
-const pushedHeadSubprocessReason = "git pushed-head observer subprocess capacity"
-
-func (gitRemoteHeadReader) BranchName(ctx context.Context, dir string) (string, error) {
-	gitCtx, cancel := context.WithTimeout(ctx, pushedHeadGitTimeout)
-	defer cancel()
-	release, err := procutil.TryAcquire(gitCtx, pushedHeadSubprocessReason)
-	if err != nil {
-		return "", err
-	}
-	defer release()
-	return gitBranchName(gitCtx, dir)
-}
-
-func (gitRemoteHeadReader) UpstreamState(ctx context.Context, dir, branch string) (upstreamState, error) {
-	gitCtx, cancel := context.WithTimeout(ctx, pushedHeadGitTimeout)
-	defer cancel()
-	release, err := procutil.TryAcquire(gitCtx, pushedHeadSubprocessReason)
-	if err != nil {
-		return upstreamState{}, err
-	}
-	defer release()
-	return gitUpstreamState(gitCtx, dir, branch)
-}
-
-// SetBranchUpstream takes no limiter slot of its own: setBranchUpstream's
-// git commands each acquire the guard, and an outer acquisition around them
-// would nest and stall until the git timeout whenever the limiter is full.
-func (gitRemoteHeadReader) SetBranchUpstream(ctx context.Context, dir, branch, remote, mergeRef string) error {
-	gitCtx, cancel := context.WithTimeout(ctx, pushedHeadGitTimeout)
-	defer cancel()
-	return setBranchUpstream(gitCtx, dir, branch, remote, mergeRef)
-}
-
-func (gitRemoteHeadReader) RemoteTrackingSHA(ctx context.Context, dir, remote, branch string) (string, string, bool, error) {
-	trackingRef := "refs/remotes/" + remote + "/" + branch
-	gitCtx, cancel := context.WithTimeout(ctx, pushedHeadGitTimeout)
-	defer cancel()
-	release, err := procutil.TryAcquire(gitCtx, pushedHeadSubprocessReason)
-	if err != nil {
-		return "", trackingRef, false, err
-	}
-	defer release()
-	out, err := gitOutput(gitCtx, dir, "rev-parse", "--verify", "--quiet", trackingRef+"^{commit}")
-	if err != nil {
-		return "", trackingRef, false, nil
-	}
-	return strings.TrimSpace(out), trackingRef, true, nil
-}
-
 type PushedHeadObserver struct {
 	db       *db.DB
 	monitor  *PRMonitor
@@ -152,7 +95,7 @@ func NewPushedHeadObserver(
 	return &PushedHeadObserver{
 		db:       database,
 		monitor:  NewPRMonitor(database, monitorOptions...),
-		git:      &gitdirRemoteHeadReader{fallback: gitRemoteHeadReader{}},
+		git:      gitdirRemoteHeadReader{},
 		now:      time.Now,
 		observed: make(map[remoteHeadKey]remoteHeadObservation),
 		failures: make(map[string]int),

--- a/internal/workspace/pushed_head_observer.go
+++ b/internal/workspace/pushed_head_observer.go
@@ -11,6 +11,7 @@ import (
 
 	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/platform"
+	"go.kenn.io/forge/internal/procutil"
 )
 
 type remoteHeadKey struct {
@@ -79,23 +80,45 @@ const (
 	pushedHeadRefreshRetryInterval = 30 * time.Second
 )
 
+// gitRemoteHeadReader answers through git subprocesses. It is the fallback
+// behind gitdirRemoteHeadReader for repository layouts the direct reader
+// cannot interpret, and the only writer (SetBranchUpstream). Every spawn
+// takes the shared procutil capacity guard because the observer fans out
+// across all ready workspaces on one pass.
 type gitRemoteHeadReader struct{}
+
+const pushedHeadSubprocessReason = "git pushed-head observer subprocess capacity"
 
 func (gitRemoteHeadReader) BranchName(ctx context.Context, dir string) (string, error) {
 	gitCtx, cancel := context.WithTimeout(ctx, pushedHeadGitTimeout)
 	defer cancel()
+	release, err := procutil.TryAcquire(gitCtx, pushedHeadSubprocessReason)
+	if err != nil {
+		return "", err
+	}
+	defer release()
 	return gitBranchName(gitCtx, dir)
 }
 
 func (gitRemoteHeadReader) UpstreamState(ctx context.Context, dir, branch string) (upstreamState, error) {
 	gitCtx, cancel := context.WithTimeout(ctx, pushedHeadGitTimeout)
 	defer cancel()
+	release, err := procutil.TryAcquire(gitCtx, pushedHeadSubprocessReason)
+	if err != nil {
+		return upstreamState{}, err
+	}
+	defer release()
 	return gitUpstreamState(gitCtx, dir, branch)
 }
 
 func (gitRemoteHeadReader) SetBranchUpstream(ctx context.Context, dir, branch, remote, mergeRef string) error {
 	gitCtx, cancel := context.WithTimeout(ctx, pushedHeadGitTimeout)
 	defer cancel()
+	release, err := procutil.TryAcquire(gitCtx, pushedHeadSubprocessReason)
+	if err != nil {
+		return err
+	}
+	defer release()
 	return setBranchUpstream(gitCtx, dir, branch, remote, mergeRef)
 }
 
@@ -103,6 +126,11 @@ func (gitRemoteHeadReader) RemoteTrackingSHA(ctx context.Context, dir, remote, b
 	trackingRef := "refs/remotes/" + remote + "/" + branch
 	gitCtx, cancel := context.WithTimeout(ctx, pushedHeadGitTimeout)
 	defer cancel()
+	release, err := procutil.TryAcquire(gitCtx, pushedHeadSubprocessReason)
+	if err != nil {
+		return "", trackingRef, false, err
+	}
+	defer release()
 	out, err := gitOutput(gitCtx, dir, "rev-parse", "--verify", "--quiet", trackingRef+"^{commit}")
 	if err != nil {
 		return "", trackingRef, false, nil
@@ -126,7 +154,7 @@ func NewPushedHeadObserver(
 	return &PushedHeadObserver{
 		db:       database,
 		monitor:  NewPRMonitor(database, monitorOptions...),
-		git:      gitRemoteHeadReader{},
+		git:      &gitdirRemoteHeadReader{fallback: gitRemoteHeadReader{}},
 		now:      time.Now,
 		observed: make(map[remoteHeadKey]remoteHeadObservation),
 		failures: make(map[string]int),

--- a/internal/workspace/pushed_head_observer.go
+++ b/internal/workspace/pushed_head_observer.go
@@ -111,14 +111,12 @@ func (gitRemoteHeadReader) UpstreamState(ctx context.Context, dir, branch string
 	return gitUpstreamState(gitCtx, dir, branch)
 }
 
+// SetBranchUpstream takes no limiter slot of its own: setBranchUpstream's
+// git commands each acquire the guard, and an outer acquisition around them
+// would nest and stall until the git timeout whenever the limiter is full.
 func (gitRemoteHeadReader) SetBranchUpstream(ctx context.Context, dir, branch, remote, mergeRef string) error {
 	gitCtx, cancel := context.WithTimeout(ctx, pushedHeadGitTimeout)
 	defer cancel()
-	release, err := procutil.TryAcquire(gitCtx, pushedHeadSubprocessReason)
-	if err != nil {
-		return err
-	}
-	defer release()
 	return setBranchUpstream(gitCtx, dir, branch, remote, mergeRef)
 }
 

--- a/internal/workspace/pushed_head_observer.go
+++ b/internal/workspace/pushed_head_observer.go
@@ -95,7 +95,7 @@ func NewPushedHeadObserver(
 	return &PushedHeadObserver{
 		db:       database,
 		monitor:  NewPRMonitor(database, monitorOptions...),
-		git:      gitdirRemoteHeadReader{},
+		git:      newGitdirRemoteHeadReader(),
 		now:      time.Now,
 		observed: make(map[remoteHeadKey]remoteHeadObservation),
 		failures: make(map[string]int),


### PR DESCRIPTION
The workspace pushed-head observer no longer spawns git on its routine five-second pass. Before, every ready workspace cost five git processes per pass (current branch, two config reads, remote URL, remote-tracking SHA) even when nothing had changed, none of them under the shared subprocess limiter. On a daemon with a dozen ready workspaces that was most of the roughly ten forks per second seen while idle, and each fork copied a large resident image.

The observer now reads the same facts in process through go-git, which is already a dependency: HEAD, loose and packed refs (through the linked-worktree common directory), and the repository config, with `config.worktree` layered on top when `extensions.worktreeConfig` is on (kit's managed merge-request worktrees store branch tracking there). A pass where nothing changed, and a pass that notices a newly pushed head, spawn no process at all.

- The old subprocess reader is deleted rather than kept as a fallback. Layouts go-git cannot answer faithfully (repository-level config `include`/`includeIf`, which go-git does not expand, and reftable ref storage) are skipped like a detached HEAD; no kenn-forge workspace uses them. The upstream repair write stays a git command, guarded per command by procutil.
- Eligibility, upstream healing, the per-pass tracking-SHA cache, refresh enqueueing, and broadcasts are unchanged; the go-git reader sits behind the existing reader interface.
- One known difference: the reader returns the configured `remote.<name>.url` without `insteadOf` rewriting. The observer does not consume that URL.
- The reader builds go-git storage from a locally resolved gitdir and common directory and uses it as a reference store directly. go-git's `EnableDotGitCommonDir` opens a linked worktree's `commondir` file without closing it (that leaked three descriptors per linked worktree every five seconds and made worktrees undeletable on Windows; the Windows PTY job caught it), and `gogit.Open` rejects version-0 repositories that declare `extensions.worktreeConfig`. A regression test asserts the descriptor count stays flat across repeated opens.
- Each worktree's resolved layout, go-git reference store, and parsed config live in a bounded LRU across passes; the config parse is reused until `config` or `config.worktree` changes size or mtime. Refs are always read from disk. One read pass per workspace is about 55 microseconds and 13 KB.
- Upstream repair no longer takes a limiter slot around git commands that each take their own; with a full limiter the nested wait used to outlive the git timeout. A capacity-one test covers it.

Tests build real fixture repositories (symbolic and detached HEAD, loose and packed refs, a `git worktree add` checkout, a worktree-scoped upstream override, a branch with no upstream, a config include that is skipped) and run the observer with a logging `git` shim first on PATH to assert that idle and change-detecting passes spawn nothing.

Related spawn sources left for sibling work:

- The kit git runner probes `git config --global --includes --get-all safe.directory` before every command it builds, so each remaining git call anywhere in the daemon is really two processes.
- Issue and ad-hoc workspaces with no associated PR yet still run the PR monitor's association probe (`detectAssociatedPR`, three git spawns) on every observer pass; that helper is shared with the PR monitor loop and was out of scope here.

<sup>generated by a clanker</sup>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011cJNvuKvzwpXDScZpYpfia
