### PR TITLE
perf: make fleet background monitors change-driven and idle without clients

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ only routes to them.
 - Tests, docs, fixtures, commit messages, and PR text should use generic synthetic examples unless the user explicitly asks to preserve exact private project names, paths, prose, or domain details.
 - **Use Bun only for dependency installation** — run `bun install`, and launch Vite+, Vitest, Svelte tooling, and Playwright with Node via `./node_modules/.bin/vp ...` (or `../node_modules/.bin/vp ...` from `frontend/`). Never use npm; it creates `package-lock.json`, which conflicts with the Bun lockfile
 - No emojis in code or output
+- Sub-second race windows that self-heal on the next event or pass are accepted eventual consistency. Do not fix them, add guards for them, or raise them as review findings; the maintainer has decided this.
 - Datetimes are UTC across storage and API boundaries. Store timestamps in UTC, emit API timestamps as UTC RFC3339, and only convert to local time in the Svelte UI presentation layer.
 
 ## Roborev

--- a/context/fleet-architecture.md
+++ b/context/fleet-architecture.md
@@ -89,6 +89,41 @@ or remote workspace and session operations.
   redirects, authentication challenges, or connection-nominated headers
   (`internal/server/fleetapi/fleet_proxy.go::Handler.serveRemoteFleetRESTProxy`).
 
+## Background Monitors
+
+The local snapshot never does git or tmux I/O on the read path; three
+Fleet-owned monitors keep the store and caches it reads fresh. They are
+change-driven and idle-cheap:
+
+- Every monitor pass is gated on live event-stream subscribers. With no
+  subscriber a wake-up records a skip and re-checks on a short idle probe, so
+  the first client after an idle stretch is served within seconds rather than
+  a full interval; a nil subscriber source means always run
+  (`internal/server/fleetapi/fleet_monitor_gate.go::runFleetMonitorLoop`,
+  `internal/server/fleetapi/handler.go::Deps.SubscriberCount`).
+- Worktree discovery and worktree stats fingerprint the git directory (sizes
+  and mtimes of `HEAD`, `index`, `packed-refs`, the `refs/` tree, and for
+  discovery `config` and `worktrees/`) without spawning git, and re-run their
+  git commands and database writes only when the fingerprint moved. A checkout
+  whose fingerprint cannot be computed always takes the full path so it is
+  marked stale; a failed pass drops the fingerprint so recovery is re-inspected
+  (`internal/server/fleetapi/fleet_git_fingerprint.go::worktreeStatsFingerprint`,
+  `internal/server/fleetapi/fleet_worktree_discovery.go::fleetWorktreeDiscoverer.refreshProjectIfChanged`,
+  `internal/server/fleetapi/fleet_worktree_stats.go::fleetWorktreeStatsSampler.sampleTargets`).
+- Unstaged edits and untracked files do not touch the git directory, so the
+  background stats pass does not see them. The on-demand refresh paths
+  (`RefreshWorktreeStats`, `RefreshProjectInventory`) ignore the fingerprint
+  and always measure; lifecycle mutations that change the working tree must
+  keep calling them.
+- Every discovery git spawn goes through `internal/procutil`; the stats probes
+  already did.
+- The tmux monitor runs one pass per interval: `list-sessions` always, then
+  `list-windows` only when the session listing is not byte-identical to the
+  previous pass or the window refresh bound elapsed, then `list-panes` plus
+  process metrics only when managed sessions exist. Process metrics query the
+  pane PIDs and their descendants (`ps -p`, `pgrep -P` per generation) rather
+  than the whole host (`internal/server/fleetapi/fleet_tmux_monitor.go::probeFleetProcessTrees`).
+
 ## Transport Trust Boundary
 
 - Supported fleets expose every Forge peer only through operator-controlled

--- a/context/fleet-architecture.md
+++ b/context/fleet-architecture.md
@@ -95,26 +95,33 @@ The local snapshot never does git or tmux I/O on the read path; three
 Fleet-owned monitors keep the store and caches it reads fresh. They are
 change-driven and idle-cheap:
 
-- Every monitor pass is gated on live event-stream subscribers. With no
-  subscriber a wake-up records a skip and re-checks on a short idle probe, so
-  the first client after an idle stretch is served within seconds rather than
-  a full interval; a nil subscriber source means always run
-  (`internal/server/fleetapi/fleet_monitor_gate.go::runFleetMonitorLoop`,
-  `internal/server/fleetapi/handler.go::Deps.SubscriberCount`).
+- Every monitor pass is gated on demand: a live event-stream subscriber, or a
+  snapshot read within the demand window. Hubs consume spokes through raw
+  snapshot fetches without a spoke-local event stream, so the read itself is
+  the demand signal. With none, a wake-up records a skip and re-checks on a
+  short idle probe, so the first client after an idle stretch is served
+  within seconds rather than a full interval; a nil subscriber source means
+  always run (`internal/server/fleetapi/fleet_monitor_gate.go::runFleetMonitorLoop`,
+  `internal/server/fleetapi/handler.go::Handler.noteSnapshotDemand`).
 - Worktree discovery and worktree stats fingerprint the git directory (sizes
-  and mtimes of `HEAD`, `index`, `packed-refs`, the `refs/` tree, and for
-  discovery `config` and `worktrees/`) without spawning git, and re-run their
-  git commands and database writes only when the fingerprint moved. A checkout
-  whose fingerprint cannot be computed always takes the full path so it is
-  marked stale; a failed pass drops the fingerprint so recovery is re-inspected
+  and mtimes of `HEAD`, `index`, `config`, `packed-refs`, the `refs/` tree,
+  and for discovery `worktrees/`) without spawning git, and re-run their git
+  commands and database writes only when the fingerprint moved. The stats key
+  also carries the default branch, so a discovery pass that moves it
+  invalidates the sample. The fingerprint is a change hint, not proof: a
+  matching fingerprint older than the max age is re-measured anyway, which
+  bounds the staleness of anything it cannot see. A checkout whose fingerprint
+  cannot be computed always takes the full path so it is marked stale; a
+  failed pass drops the fingerprint so recovery is re-inspected
   (`internal/server/fleetapi/fleet_git_fingerprint.go::worktreeStatsFingerprint`,
   `internal/server/fleetapi/fleet_worktree_discovery.go::fleetWorktreeDiscoverer.refreshProjectIfChanged`,
   `internal/server/fleetapi/fleet_worktree_stats.go::fleetWorktreeStatsSampler.sampleTargets`).
 - Unstaged edits and untracked files do not touch the git directory, so the
-  background stats pass does not see them. The on-demand refresh paths
-  (`RefreshWorktreeStats`, `RefreshProjectInventory`) ignore the fingerprint
-  and always measure; lifecycle mutations that change the working tree must
-  keep calling them.
+  background stats pass only sees them at the max-age resample. The on-demand
+  refresh paths (`RefreshWorktreeStats`, `RefreshProjectInventory`, and the
+  fleet-wide refresh route through `runOnceForced`) ignore the fingerprint and
+  always measure; lifecycle mutations that change the working tree must keep
+  calling them.
 - Every discovery git spawn goes through `internal/procutil`; the stats probes
   already did.
 - The tmux monitor runs one pass per interval: `list-sessions` always, then
@@ -122,7 +129,10 @@ change-driven and idle-cheap:
   previous pass or the window refresh bound elapsed, then `list-panes` plus
   process metrics only when managed sessions exist. Process metrics query the
   pane PIDs and their descendants (`ps -p`, `pgrep -P` per generation) rather
-  than the whole host (`internal/server/fleetapi/fleet_tmux_monitor.go::probeFleetProcessTrees`).
+  than the whole host, descending until no children remain or the process
+  table cap is hit. Exit status 1 from `ps` or `pgrep` is the no-match
+  outcome; any other failure is a probe error, never an empty tree
+  (`internal/server/fleetapi/fleet_tmux_monitor.go::probeFleetProcessTrees`).
 
 ## Transport Trust Boundary
 

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -497,7 +497,7 @@ Workspace create endpoints may return 202 with a pre-existing workspace
   profile with `--agent`; kit preserves unrelated handlers and never enables
   agent consent or auto-approval (`cmd/kenn-forge/agent_hook.go::installAgentHooks`).
 - Matching live runtime/worktree reports prioritize approval, input, working, done, then idle.
-  Stop/Interrupt stays `done` for the 30-minute report window; row activation acknowledges a versioned completion for the browser-tab session, while a new timestamp resurfaces (`internal/agentactivity/store.go::statePriority`, `frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte::openWorkspace`).
+  Stop/Interrupt stays `done` until the session ends or its runtime is removed; row activation acknowledges a versioned completion for the browser-tab session, while a new timestamp resurfaces (`internal/agentactivity/store.go::statePriority`, `frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte::openWorkspace`).
 - Hook installs require absolute data roots; kit preserves config symlinks, while
   report/worktree matching uses canonical paths (`cmd/kenn-forge/agent_hook.go::installAgentHooks`,
   `internal/agentactivity/store.go::canonicalWorkspacePath`).

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -44,9 +44,15 @@ Rules:
   same session preserves `UpdatedAt`, so the sidebar's acknowledged Done badge
   does not reappear when Claude Code's `idle_prompt` follows Stop
   (`internal/agentactivity/store.go::Store.HandleEvent`).
-- Claude Code's `idle_prompt` notification follows Stop on a finished turn and
-  maps to `done`, not `input`; only `elicitation_dialog` and user-input tools
-  mean the agent is waiting on a person (`internal/agentactivity/store.go::stateForHook`).
+- Claude Code's `idle_prompt` notification fires after a minute of waiting
+  whatever the agent waits for. It leaves a pending `input` or `approval`
+  state untouched and otherwise maps to `done`; only `elicitation_dialog` and
+  user-input tools put a session into `input`
+  (`internal/agentactivity/store.go::Store.HandleEvent`).
+- Reports are reconciled against persisted and live runtime session keys
+  after startup restoration and after every missing-tmux prune, so a report
+  whose runtime row was pruned does not outlive it
+  (`internal/server/workspaceapi/lifecycle.go::Handler.reconcileAgentActivityReports`).
 
 ## Provider-Backed Lifecycle Facts
 

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -34,9 +34,16 @@ Rules:
   supported reports joined by canonical worktree and runtime key to a live `agent`
   runtime (`internal/server/workspaceapi/agent_sessions.go::Handler.listWorkspaceAgentSessions`).
 - Hook reports own workspace activity where they exist: a workspace with a
-  fresh hook report for a live agent runtime is never probed through tmux pane
-  capture, and regains the tmux probe only when that coverage lapses
-  (`internal/server/workspaceapi/routes_handlers.go::Handler.applyWorkspaceTmuxEnrichment`).
+  hook report for a live agent runtime is never probed through tmux pane
+  capture, its last-activity time is the report's timestamp, and the tmux
+  probe returns only when the session ends or its runtime is removed. Reports
+  have no time-based expiry; a launched agent keeps reporting until teardown
+  (`internal/server/workspaceapi/routes_handlers.go::Handler.applyWorkspaceTmuxEnrichment`,
+  `internal/agentactivity/store.go::Store.LiveReportsForWorkspace`).
+- A completion keeps its first timestamp: `done` written over `done` for the
+  same session preserves `UpdatedAt`, so the sidebar's acknowledged Done badge
+  does not reappear when Claude Code's `idle_prompt` follows Stop
+  (`internal/agentactivity/store.go::Store.HandleEvent`).
 - Claude Code's `idle_prompt` notification follows Stop on a finished turn and
   maps to `done`, not `input`; only `elicitation_dialog` and user-input tools
   mean the agent is waiting on a person (`internal/agentactivity/store.go::stateForHook`).

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -33,6 +33,13 @@ Rules:
 - Coding-agent session IDs are hook-authoritative and live-only: expose only fresh,
   supported reports joined by canonical worktree and runtime key to a live `agent`
   runtime (`internal/server/workspaceapi/agent_sessions.go::Handler.listWorkspaceAgentSessions`).
+- Hook reports own workspace activity where they exist: a workspace with a
+  fresh hook report for a live agent runtime is never probed through tmux pane
+  capture, and regains the tmux probe only when that coverage lapses
+  (`internal/server/workspaceapi/routes_handlers.go::Handler.applyWorkspaceTmuxEnrichment`).
+- Claude Code's `idle_prompt` notification follows Stop on a finished turn and
+  maps to `done`, not `input`; only `elicitation_dialog` and user-input tools
+  mean the agent is waiting on a person (`internal/agentactivity/store.go::stateForHook`).
 
 ## Provider-Backed Lifecycle Facts
 

--- a/internal/agentactivity/store.go
+++ b/internal/agentactivity/store.go
@@ -347,8 +347,13 @@ func stateForHook(input HookEvent) (State, bool, bool) {
 		switch input.NotificationType {
 		case "permission_prompt":
 			return StateApproval, false, true
-		case "idle_prompt", "elicitation_dialog":
+		case "elicitation_dialog":
 			return StateInput, false, true
+		case "idle_prompt":
+			// Claude Code raises idle_prompt about a minute after a turn
+			// ends with nothing pending. It follows Stop and would otherwise
+			// flip a finished session from done to input.
+			return StateDone, false, true
 		default:
 			return "", false, false
 		}

--- a/internal/agentactivity/store.go
+++ b/internal/agentactivity/store.go
@@ -247,6 +247,33 @@ func (s *Store) RemoveRuntimeSession(runtimeSessionKey string) error {
 	return errors.Join(errs...)
 }
 
+// RetainRuntimeSessions removes every report whose runtime session key is not
+// in keep. Startup pruning and the periodic missing-tmux prune delete runtime
+// rows without an exit hook, so this is how their reports follow them.
+func (s *Store) RetainRuntimeSessions(keep map[string]struct{}) error {
+	if s == nil || strings.TrimSpace(s.root) == "" {
+		return nil
+	}
+	var errs []error
+	removed := false
+	for _, report := range s.reports() {
+		if _, ok := keep[report.RuntimeSessionKey]; ok {
+			continue
+		}
+		err := os.Remove(s.reportPath(report.Agent, report.SessionID))
+		switch {
+		case err == nil:
+			removed = true
+		case !errors.Is(err, os.ErrNotExist):
+			errs = append(errs, err)
+		}
+	}
+	if removed {
+		s.invalidateCache()
+	}
+	return errors.Join(errs...)
+}
+
 func (s *Store) reports() []Report {
 	s.cacheMu.Lock()
 	defer s.cacheMu.Unlock()

--- a/internal/agentactivity/store.go
+++ b/internal/agentactivity/store.go
@@ -27,10 +27,6 @@ const (
 
 const RuntimeSessionKeyEnv = "KENN_FORGE_RUNTIME_SESSION_KEY"
 
-// ReportFreshness bounds how long a hook state can override tmux activity
-// without another lifecycle event confirming it.
-const ReportFreshness = 30 * time.Minute
-
 type Report struct {
 	Agent             string    `json:"agent"`
 	SessionID         string    `json:"session_id"`
@@ -61,10 +57,9 @@ type Store struct {
 	root string
 	now  func() time.Time
 
-	cacheMu         sync.Mutex
-	cacheFiles      map[string]os.FileInfo
-	cacheValidUntil time.Time
-	cacheReports    []Report
+	cacheMu      sync.Mutex
+	cacheFiles   map[string]os.FileInfo
+	cacheReports []Report
 }
 
 func NewStore(root string) *Store {
@@ -125,6 +120,15 @@ func (s *Store) HandleEvent(agent string, hook HookEvent, runtimeSessionKey stri
 		State:             state,
 		UpdatedAt:         s.now().UTC(),
 	}
+	// A completion that is already recorded keeps its original timestamp:
+	// Claude Code follows Stop with an idle_prompt notification, and a fresh
+	// timestamp would make an acknowledged "done" reappear as new.
+	if state == StateDone {
+		if previous, ok := s.readReport(s.reportPath(agent, hook.SessionID)); ok &&
+			previous.State == StateDone && previous.RuntimeSessionKey == runtimeSessionKey {
+			report.UpdatedAt = previous.UpdatedAt
+		}
+	}
 	return s.writeReport(report)
 }
 
@@ -142,8 +146,11 @@ func (s *Store) SnapshotForWorkspace(cwd string, liveSessionKeys []string) (Snap
 	return Snapshot{State: reports[0].State, UpdatedAt: reports[0].UpdatedAt}, true
 }
 
-// LiveReportsForWorkspace returns fresh reports whose canonical worktree and
-// runtime-session key match the supplied live inventory.
+// LiveReportsForWorkspace returns reports whose canonical worktree and
+// runtime-session key match the supplied live inventory. A report lives until
+// its session ends or its runtime session is removed; there is no time-based
+// expiry, because a launched agent keeps reporting until it is torn down and
+// its hook state must not lapse back to weaker signals in between.
 func (s *Store) LiveReportsForWorkspace(cwd string, liveSessionKeys []string) []Report {
 	if s == nil || strings.TrimSpace(s.root) == "" || len(liveSessionKeys) == 0 {
 		return nil
@@ -236,7 +243,6 @@ func (s *Store) reports() []Report {
 		s.clearCacheLocked()
 		return nil
 	}
-	now := s.now().UTC()
 	files := make(map[string]os.FileInfo)
 	metadataComplete := true
 	for _, entry := range entries {
@@ -250,13 +256,11 @@ func (s *Store) reports() []Report {
 		}
 		files[entry.Name()] = info
 	}
-	if metadataComplete && sameReportFiles(files, s.cacheFiles) &&
-		(s.cacheValidUntil.IsZero() || now.Before(s.cacheValidUntil)) {
+	if metadataComplete && sameReportFiles(files, s.cacheFiles) {
 		return slices.Clone(s.cacheReports)
 	}
 
 	reports := make([]Report, 0, len(entries))
-	validUntil := time.Time{}
 	cleanupPending := false
 	for _, entry := range entries {
 		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
@@ -277,26 +281,12 @@ func (s *Store) reports() []Report {
 			}
 			continue
 		}
-		expiresAt := report.UpdatedAt.Add(ReportFreshness)
-		if !now.Before(expiresAt) {
-			if removeErr := os.Remove(path); removeErr == nil ||
-				errors.Is(removeErr, os.ErrNotExist) {
-				delete(files, entry.Name())
-			} else {
-				cleanupPending = true
-			}
-			continue
-		}
-		if validUntil.IsZero() || expiresAt.Before(validUntil) {
-			validUntil = expiresAt
-		}
 		reports = append(reports, report)
 	}
 	s.cacheFiles = files
 	if cleanupPending || !metadataComplete {
 		s.cacheFiles = nil
 	}
-	s.cacheValidUntil = validUntil
 	s.cacheReports = slices.Clone(reports)
 	return reports
 }
@@ -309,7 +299,6 @@ func (s *Store) invalidateCache() {
 
 func (s *Store) clearCacheLocked() {
 	s.cacheFiles = nil
-	s.cacheValidUntil = time.Time{}
 	s.cacheReports = nil
 }
 

--- a/internal/agentactivity/store.go
+++ b/internal/agentactivity/store.go
@@ -120,16 +120,29 @@ func (s *Store) HandleEvent(agent string, hook HookEvent, runtimeSessionKey stri
 		State:             state,
 		UpdatedAt:         s.now().UTC(),
 	}
-	// A completion that is already recorded keeps its original timestamp:
-	// Claude Code follows Stop with an idle_prompt notification, and a fresh
-	// timestamp would make an acknowledged "done" reappear as new.
 	if state == StateDone {
-		if previous, ok := s.readReport(s.reportPath(agent, hook.SessionID)); ok &&
-			previous.State == StateDone && previous.RuntimeSessionKey == runtimeSessionKey {
-			report.UpdatedAt = previous.UpdatedAt
+		previous, ok := s.readReport(s.reportPath(agent, hook.SessionID))
+		if ok && previous.RuntimeSessionKey == runtimeSessionKey {
+			switch {
+			case isIdlePrompt(hook) && (previous.State == StateInput ||
+				previous.State == StateApproval):
+				// Claude Code raises idle_prompt after a minute of waiting for
+				// input whatever it is waiting for; an unanswered question or
+				// permission prompt is still pending, not finished.
+				return nil
+			case previous.State == StateDone:
+				// A completion that is already recorded keeps its original
+				// timestamp: idle_prompt follows Stop, and a fresh timestamp
+				// would make an acknowledged "done" reappear as new.
+				report.UpdatedAt = previous.UpdatedAt
+			}
 		}
 	}
 	return s.writeReport(report)
+}
+
+func isIdlePrompt(hook HookEvent) bool {
+	return hook.HookEventName == "Notification" && hook.NotificationType == "idle_prompt"
 }
 
 func (s *Store) SnapshotForWorkspace(cwd string, liveSessionKeys []string) (Snapshot, bool) {
@@ -147,7 +160,7 @@ func (s *Store) SnapshotForWorkspace(cwd string, liveSessionKeys []string) (Snap
 }
 
 // LiveReportsForWorkspace returns reports whose canonical worktree and
-// runtime-session key match the supplied live inventory. A report lives until
+// runtime-session key match the supplied live inventory, newest first. A report lives until
 // its session ends or its runtime session is removed; there is no time-based
 // expiry, because a launched agent keeps reporting until it is torn down and
 // its hook state must not lapse back to weaker signals in between.

--- a/internal/agentactivity/store_test.go
+++ b/internal/agentactivity/store_test.go
@@ -3,6 +3,7 @@ package agentactivity
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -340,4 +341,33 @@ func TestStoreKeepsDoneTimestampAcrossIdlePrompt(t *testing.T) {
 	require.True(ok)
 	assert.Equal(StateDone, snapshot.State)
 	assert.Equal(now, snapshot.UpdatedAt)
+}
+
+func TestStoreIdlePromptKeepsPendingInputAndApproval(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	store := NewStore(t.TempDir())
+	workspace := t.TempDir()
+
+	for _, tc := range []struct {
+		name  string
+		event map[string]any
+		want  State
+	}{
+		{"question", map[string]any{"hook_event_name": "PreToolUse", "tool_name": "AskUserQuestion"}, StateInput},
+		{"permission", map[string]any{"hook_event_name": "PermissionRequest"}, StateApproval},
+	} {
+		event := map[string]any{"session_id": "agent-" + tc.name, "cwd": workspace}
+		maps.Copy(event, tc.event)
+		reportHook(t, store, "runtime-"+tc.name, event)
+		// Claude Code raises idle_prompt after a minute of waiting for an
+		// answer; the question is still pending.
+		reportHook(t, store, "runtime-"+tc.name, map[string]any{
+			"session_id": "agent-" + tc.name, "cwd": workspace,
+			"hook_event_name": "Notification", "notification_type": "idle_prompt",
+		})
+		snapshot, ok := store.SnapshotForWorkspace(workspace, []string{"runtime-" + tc.name})
+		require.True(ok, tc.name)
+		assert.Equal(tc.want, snapshot.State, tc.name)
+	}
 }

--- a/internal/agentactivity/store_test.go
+++ b/internal/agentactivity/store_test.go
@@ -93,7 +93,7 @@ func TestStoreMatchesWorkspaceReachedThroughSymlink(t *testing.T) {
 	assert.Equal(t, StateWorking, snapshot.State)
 }
 
-func TestStoreExpiresAndRemovesStaleReports(t *testing.T) {
+func TestStoreKeepsReportsUntilTheSessionIsTornDown(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	root := t.TempDir()
@@ -102,13 +102,20 @@ func TestStoreExpiresAndRemovesStaleReports(t *testing.T) {
 	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
 	store.now = func() time.Time { return now }
 
-	reportHook(t, store, "runtime-stale", map[string]any{
-		"session_id": "agent-stale", "cwd": workspace,
-		"hook_event_name": "PermissionRequest",
+	reportHook(t, store, "runtime-quiet", map[string]any{
+		"session_id": "agent-quiet", "cwd": workspace,
+		"hook_event_name": "UserPromptSubmit",
 	})
-	now = now.Add(31 * time.Minute)
+	// A launched agent may go hours without a lifecycle event while it works;
+	// its hook state must not lapse to weaker signals on a timer.
+	now = now.Add(6 * time.Hour)
 
-	_, ok := store.SnapshotForWorkspace(workspace, []string{"runtime-stale"})
+	snapshot, ok := store.SnapshotForWorkspace(workspace, []string{"runtime-quiet"})
+	require.True(ok)
+	assert.Equal(StateWorking, snapshot.State)
+
+	require.NoError(store.RemoveRuntimeSession("runtime-quiet"))
+	_, ok = store.SnapshotForWorkspace(workspace, []string{"runtime-quiet"})
 	assert.False(ok)
 	entries, err := os.ReadDir(root)
 	require.NoError(err)
@@ -290,4 +297,47 @@ func TestStoreTreatsIdlePromptAsDone(t *testing.T) {
 	snapshot, ok = store.SnapshotForWorkspace(workspace, []string{"runtime-a"})
 	require.True(ok)
 	assert.Equal(StateInput, snapshot.State)
+}
+
+func TestStoreKeepsDoneTimestampAcrossIdlePrompt(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	store := NewStore(t.TempDir())
+	workspace := t.TempDir()
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return now }
+
+	reportHook(t, store, "runtime-a", map[string]any{
+		"session_id": "agent-a", "cwd": workspace,
+		"hook_event_name": "Stop",
+	})
+	stoppedAt := now
+	now = now.Add(time.Minute)
+	reportHook(t, store, "runtime-a", map[string]any{
+		"session_id": "agent-a", "cwd": workspace,
+		"hook_event_name": "Notification", "notification_type": "idle_prompt",
+	})
+
+	// The sidebar acknowledges a completion by its timestamp; a later
+	// idle_prompt must not mint a new one.
+	snapshot, ok := store.SnapshotForWorkspace(workspace, []string{"runtime-a"})
+	require.True(ok)
+	assert.Equal(StateDone, snapshot.State)
+	assert.Equal(stoppedAt, snapshot.UpdatedAt)
+
+	// A new turn resets the clock as before.
+	now = now.Add(time.Minute)
+	reportHook(t, store, "runtime-a", map[string]any{
+		"session_id": "agent-a", "cwd": workspace,
+		"hook_event_name": "UserPromptSubmit",
+	})
+	now = now.Add(time.Minute)
+	reportHook(t, store, "runtime-a", map[string]any{
+		"session_id": "agent-a", "cwd": workspace,
+		"hook_event_name": "Stop",
+	})
+	snapshot, ok = store.SnapshotForWorkspace(workspace, []string{"runtime-a"})
+	require.True(ok)
+	assert.Equal(StateDone, snapshot.State)
+	assert.Equal(now, snapshot.UpdatedAt)
 }

--- a/internal/agentactivity/store_test.go
+++ b/internal/agentactivity/store_test.go
@@ -371,3 +371,27 @@ func TestStoreIdlePromptKeepsPendingInputAndApproval(t *testing.T) {
 		assert.Equal(tc.want, snapshot.State, tc.name)
 	}
 }
+
+func TestStoreRetainRuntimeSessionsRemovesOthers(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	root := t.TempDir()
+	store := NewStore(root)
+	workspace := t.TempDir()
+	for _, key := range []string{"runtime-a", "runtime-b"} {
+		reportHook(t, store, key, map[string]any{
+			"session_id": "agent-" + key, "cwd": workspace,
+			"hook_event_name": "UserPromptSubmit",
+		})
+	}
+
+	require.NoError(store.RetainRuntimeSessions(map[string]struct{}{"runtime-a": {}}))
+
+	entries, err := os.ReadDir(root)
+	require.NoError(err)
+	assert.Len(entries, 1)
+	_, ok := store.SnapshotForWorkspace(workspace, []string{"runtime-a"})
+	assert.True(ok)
+	_, ok = store.SnapshotForWorkspace(workspace, []string{"runtime-b"})
+	assert.False(ok, "the report of a runtime not in the keep set is removed")
+}

--- a/internal/agentactivity/store_test.go
+++ b/internal/agentactivity/store_test.go
@@ -261,3 +261,33 @@ func reportAgentHook(
 	require.NoError(t, err)
 	require.NoError(t, store.HandleHook(agent, strings.NewReader(string(data)), runtimeKey))
 }
+
+func TestStoreTreatsIdlePromptAsDone(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	store := NewStore(t.TempDir())
+	workspace := t.TempDir()
+
+	reportHook(t, store, "runtime-a", map[string]any{
+		"session_id": "agent-a", "cwd": workspace,
+		"hook_event_name": "Stop",
+	})
+	// Claude Code raises idle_prompt roughly a minute after Stop when the
+	// turn ended with nothing pending; it must not turn done into input.
+	reportHook(t, store, "runtime-a", map[string]any{
+		"session_id": "agent-a", "cwd": workspace,
+		"hook_event_name": "Notification", "notification_type": "idle_prompt",
+	})
+	snapshot, ok := store.SnapshotForWorkspace(workspace, []string{"runtime-a"})
+	require.True(ok)
+	assert.Equal(StateDone, snapshot.State)
+
+	// A real question for the user still surfaces as input.
+	reportHook(t, store, "runtime-a", map[string]any{
+		"session_id": "agent-a", "cwd": workspace,
+		"hook_event_name": "Notification", "notification_type": "elicitation_dialog",
+	})
+	snapshot, ok = store.SnapshotForWorkspace(workspace, []string{"runtime-a"})
+	require.True(ok)
+	assert.Equal(StateInput, snapshot.State)
+}

--- a/internal/server/fleetapi/fleet_adapter_test.go
+++ b/internal/server/fleetapi/fleet_adapter_test.go
@@ -372,7 +372,7 @@ func TestBuildLocalRawReconcilesLiveTmuxInventory(t *testing.T) {
 		CreatedAt:   createdAt,
 	}))
 
-	mon := newFleetTmuxMonitor([]string{"tmux"}, false, nil)
+	mon := newFleetTmuxMonitor([]string{"tmux"}, false, nil, nil)
 	mon.recordInventorySample(fleetTmuxInventorySample{
 		PolledAt:  polledAt,
 		Succeeded: true,
@@ -451,7 +451,7 @@ func TestBuildLocalRawIncludesProjectWorktreeRuntimeTmuxSession(t *testing.T) {
 		CreatedAt:   createdAt,
 	}))
 
-	mon := newFleetTmuxMonitor([]string{"tmux"}, false, nil)
+	mon := newFleetTmuxMonitor([]string{"tmux"}, false, nil, nil)
 	mon.recordInventorySample(fleetTmuxInventorySample{
 		PolledAt:  polledAt,
 		Succeeded: true,

--- a/internal/server/fleetapi/fleet_git_fingerprint.go
+++ b/internal/server/fleetapi/fleet_git_fingerprint.go
@@ -1,0 +1,207 @@
+package fleetapi
+
+import (
+	"bufio"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"hash/fnv"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// gitDirs is the on-disk layout of one checkout: gitDir holds the
+// per-worktree files (HEAD, index) and commonDir holds what every worktree of
+// the repository shares (refs, packed-refs, config, worktrees/). They are the
+// same directory for a main checkout or a bare repository.
+type gitDirs struct {
+	gitDir    string
+	commonDir string
+}
+
+// resolveGitDirs locates a checkout's git directories from the filesystem
+// alone, so the fleet monitors can decide whether anything changed without
+// spawning git. It understands a main checkout (.git directory), a linked
+// worktree (.git file pointing at <common>/worktrees/<name>), and a bare
+// repository (HEAD and objects directly under the path).
+func resolveGitDirs(path string) (gitDirs, error) {
+	dotGit := filepath.Join(path, ".git")
+	info, err := os.Stat(dotGit)
+	switch {
+	case err == nil && info.IsDir():
+		return withCommonDir(dotGit)
+	case err == nil:
+		gitDir, err := readGitDirPointer(dotGit, path)
+		if err != nil {
+			return gitDirs{}, err
+		}
+		return withCommonDir(gitDir)
+	case !errors.Is(err, fs.ErrNotExist):
+		return gitDirs{}, fmt.Errorf("stat %s: %w", dotGit, err)
+	}
+	if _, err := os.Stat(filepath.Join(path, "HEAD")); err != nil {
+		return gitDirs{}, fmt.Errorf("%s is not a git checkout", path)
+	}
+	if info, err := os.Stat(filepath.Join(path, "objects")); err != nil || !info.IsDir() {
+		return gitDirs{}, fmt.Errorf("%s is not a git checkout", path)
+	}
+	return withCommonDir(path)
+}
+
+// readGitDirPointer parses a .git file ("gitdir: <path>") and resolves a
+// relative target against the checkout directory.
+func readGitDirPointer(dotGit, base string) (string, error) {
+	f, err := os.Open(dotGit)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	line, err := bufio.NewReader(io.LimitReader(f, 4096)).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", fmt.Errorf("read %s: %w", dotGit, err)
+	}
+	target, ok := strings.CutPrefix(strings.TrimSpace(line), "gitdir:")
+	if !ok {
+		return "", fmt.Errorf("%s is not a gitdir pointer", dotGit)
+	}
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return "", fmt.Errorf("%s has an empty gitdir pointer", dotGit)
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(base, target)
+	}
+	return filepath.Clean(target), nil
+}
+
+// withCommonDir pairs a git directory with its common directory, following
+// the optional "commondir" file a linked worktree's git directory carries.
+func withCommonDir(gitDir string) (gitDirs, error) {
+	dirs := gitDirs{gitDir: gitDir, commonDir: gitDir}
+	raw, err := os.ReadFile(filepath.Join(gitDir, "commondir"))
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return dirs, nil
+		}
+		return gitDirs{}, fmt.Errorf("read commondir for %s: %w", gitDir, err)
+	}
+	common := strings.TrimSpace(string(raw))
+	if common == "" {
+		return dirs, nil
+	}
+	if !filepath.IsAbs(common) {
+		common = filepath.Join(gitDir, common)
+	}
+	dirs.commonDir = filepath.Clean(common)
+	return dirs, nil
+}
+
+// worktreeStatsFingerprint summarizes every git-directory input the stats
+// sampler's diff and divergence probes depend on: the checked-out commit
+// (HEAD), staged content (index), and every ref the merge base or upstream can
+// resolve through (loose refs and packed-refs). Two equal fingerprints mean
+// the sampled numbers cannot have changed through git, so the probes and the
+// database write can be skipped. Unstaged edits to tracked files and new
+// untracked files do not touch the git directory and are deliberately outside
+// this fingerprint; the on-demand refresh path measures them unconditionally.
+func worktreeStatsFingerprint(path string) (string, error) {
+	dirs, err := resolveGitDirs(path)
+	if err != nil {
+		return "", err
+	}
+	h := newGitFingerprintHasher()
+	h.file("HEAD", filepath.Join(dirs.gitDir, "HEAD"))
+	h.file("index", filepath.Join(dirs.gitDir, "index"))
+	h.file("packed-refs", filepath.Join(dirs.commonDir, "packed-refs"))
+	h.tree("refs", filepath.Join(dirs.commonDir, "refs"))
+	if dirs.gitDir != dirs.commonDir {
+		h.tree("worktree-refs", filepath.Join(dirs.gitDir, "refs"))
+	}
+	return h.sum(), nil
+}
+
+// projectDiscoveryFingerprint summarizes what discovery reads for a registered
+// project: the linked-worktree registry (worktrees/), the refs the default
+// branch resolves through, HEAD, and config (init.defaultBranch, remotes).
+func projectDiscoveryFingerprint(root string) (string, error) {
+	dirs, err := resolveGitDirs(root)
+	if err != nil {
+		return "", err
+	}
+	h := newGitFingerprintHasher()
+	h.file("HEAD", filepath.Join(dirs.gitDir, "HEAD"))
+	h.file("config", filepath.Join(dirs.commonDir, "config"))
+	h.file("packed-refs", filepath.Join(dirs.commonDir, "packed-refs"))
+	h.tree("refs", filepath.Join(dirs.commonDir, "refs"))
+	h.tree("worktrees", filepath.Join(dirs.commonDir, "worktrees"))
+	return h.sum(), nil
+}
+
+// gitFingerprintHasher folds file metadata into one digest. Only sizes and
+// modification times are read, never content, so a fingerprint costs a handful
+// of stat calls plus one directory walk per refs tree.
+type gitFingerprintHasher struct {
+	h hash.Hash
+}
+
+func newGitFingerprintHasher() *gitFingerprintHasher {
+	return &gitFingerprintHasher{h: fnv.New128a()}
+}
+
+func (g *gitFingerprintHasher) file(label, path string) {
+	info, err := os.Stat(path)
+	if err != nil {
+		g.write(label, "missing")
+		return
+	}
+	g.stamp(label, info)
+}
+
+func (g *gitFingerprintHasher) tree(label, root string) {
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if path == root && errors.Is(err, fs.ErrNotExist) {
+				g.write(label, "missing")
+				return filepath.SkipAll
+			}
+			g.write(label+"/"+path, "error")
+			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			g.write(label+"/"+path, "error")
+			return nil
+		}
+		g.stamp(label+"/"+path, info)
+		return nil
+	})
+	if err != nil {
+		g.write(label, "walk-error")
+	}
+}
+
+func (g *gitFingerprintHasher) stamp(label string, info fs.FileInfo) {
+	g.write(label,
+		strconv.FormatInt(info.Size(), 10)+":"+
+			strconv.FormatInt(info.ModTime().UnixNano(), 10)+":"+
+			strconv.FormatBool(info.IsDir()),
+	)
+}
+
+// write folds one label/value pair into the digest; hash.Hash writers never
+// return an error.
+func (g *gitFingerprintHasher) write(label, value string) {
+	_, _ = io.WriteString(g.h, label)
+	_, _ = g.h.Write([]byte{0})
+	_, _ = io.WriteString(g.h, value)
+	_, _ = g.h.Write([]byte{0})
+}
+
+func (g *gitFingerprintHasher) sum() string {
+	return hex.EncodeToString(g.h.Sum(nil))
+}

--- a/internal/server/fleetapi/fleet_git_fingerprint.go
+++ b/internal/server/fleetapi/fleet_git_fingerprint.go
@@ -101,14 +101,15 @@ func withCommonDir(gitDir string) (gitDirs, error) {
 	return dirs, nil
 }
 
-// worktreeStatsFingerprint summarizes every git-directory input the stats
+// worktreeStatsFingerprint summarizes the git-directory inputs the stats
 // sampler's diff and divergence probes depend on: the checked-out commit
-// (HEAD), staged content (index), and every ref the merge base or upstream can
-// resolve through (loose refs and packed-refs). Two equal fingerprints mean
-// the sampled numbers cannot have changed through git, so the probes and the
-// database write can be skipped. Unstaged edits to tracked files and new
-// untracked files do not touch the git directory and are deliberately outside
-// this fingerprint; the on-demand refresh path measures them unconditionally.
+// (HEAD), staged content (index), the upstream and remote configuration
+// (config), and every ref the merge base or upstream can resolve through
+// (loose refs and packed-refs). It is a change hint, not proof: unstaged edits
+// to tracked files and new untracked files do not touch the git directory,
+// and a same-size rewrite inside the filesystem's timestamp resolution is
+// invisible. The sampler bounds that blind spot with a maximum fingerprint
+// age, and the on-demand refresh paths measure unconditionally.
 func worktreeStatsFingerprint(path string) (string, error) {
 	dirs, err := resolveGitDirs(path)
 	if err != nil {
@@ -117,6 +118,7 @@ func worktreeStatsFingerprint(path string) (string, error) {
 	h := newGitFingerprintHasher()
 	h.file("HEAD", filepath.Join(dirs.gitDir, "HEAD"))
 	h.file("index", filepath.Join(dirs.gitDir, "index"))
+	h.file("config", filepath.Join(dirs.commonDir, "config"))
 	h.file("packed-refs", filepath.Join(dirs.commonDir, "packed-refs"))
 	h.tree("refs", filepath.Join(dirs.commonDir, "refs"))
 	if dirs.gitDir != dirs.commonDir {

--- a/internal/server/fleetapi/fleet_git_fingerprint_test.go
+++ b/internal/server/fleetapi/fleet_git_fingerprint_test.go
@@ -1,0 +1,143 @@
+package fleetapi
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedFingerprintRepo creates a repository with one commit and a linked
+// worktree, returning the root checkout and the linked worktree path.
+func seedFingerprintRepo(t *testing.T) (string, string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init", "-q")
+	runGit(t, repoDir, "config", "user.email", "t@e.st")
+	runGit(t, repoDir, "config", "user.name", "Tester")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoDir, "base.txt"), []byte("base\n"), 0o644,
+	))
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-q", "-m", "base")
+	wtDir := filepath.Join(t.TempDir(), "feature")
+	runGit(t, repoDir, "worktree", "add", "-q", "-b", "feature", wtDir)
+	return repoDir, wtDir
+}
+
+func TestResolveGitDirsLayouts(t *testing.T) {
+	repoDir, wtDir := seedFingerprintRepo(t)
+	require := require.New(t)
+	assert := assert.New(t)
+
+	root, err := resolveGitDirs(repoDir)
+	require.NoError(err)
+	assert.Equal(filepath.Join(repoDir, ".git"), root.gitDir)
+	assert.Equal(root.gitDir, root.commonDir, "a main checkout shares one directory")
+
+	// git records symlink-resolved absolute paths in the worktree pointer
+	// files, so compare in resolved space.
+	linked, err := resolveGitDirs(wtDir)
+	require.NoError(err)
+	assert.Equal(
+		resolvedPathKey(filepath.Join(repoDir, ".git", "worktrees", "feature")),
+		resolvedPathKey(linked.gitDir),
+	)
+	assert.Equal(
+		resolvedPathKey(filepath.Join(repoDir, ".git")),
+		resolvedPathKey(linked.commonDir),
+		"a linked worktree's refs live in the main repository",
+	)
+
+	bareDir := t.TempDir()
+	runGit(t, bareDir, "init", "-q", "--bare")
+	bare, err := resolveGitDirs(bareDir)
+	require.NoError(err)
+	assert.Equal(bareDir, bare.gitDir)
+	assert.Equal(bareDir, bare.commonDir)
+
+	_, err = resolveGitDirs(t.TempDir())
+	assert.Error(err, "a plain directory is not a checkout")
+}
+
+func TestWorktreeStatsFingerprintTracksGitDirectoryChanges(t *testing.T) {
+	repoDir, wtDir := seedFingerprintRepo(t)
+	require := require.New(t)
+	assert := assert.New(t)
+
+	first, err := worktreeStatsFingerprint(wtDir)
+	require.NoError(err)
+	again, err := worktreeStatsFingerprint(wtDir)
+	require.NoError(err)
+	assert.Equal(first, again, "an untouched checkout is stable")
+
+	// Staging changes the index in the linked worktree's own git directory.
+	require.NoError(os.WriteFile(
+		filepath.Join(wtDir, "new.txt"), []byte("x\n"), 0o644,
+	))
+	afterWrite, err := worktreeStatsFingerprint(wtDir)
+	require.NoError(err)
+	assert.Equal(first, afterWrite, "an unstaged working-tree file is outside the fingerprint")
+	runGit(t, wtDir, "add", "new.txt")
+	afterAdd, err := worktreeStatsFingerprint(wtDir)
+	require.NoError(err)
+	assert.NotEqual(afterWrite, afterAdd, "staging moves the index")
+
+	// Committing moves the branch ref under the shared refs tree.
+	runGit(t, wtDir, "commit", "-q", "-m", "feature")
+	afterCommit, err := worktreeStatsFingerprint(wtDir)
+	require.NoError(err)
+	assert.NotEqual(afterAdd, afterCommit, "a commit moves the branch ref")
+
+	// A commit on the default branch in the root checkout changes the merge
+	// base of the linked worktree, which shares the refs tree.
+	beforeMain, err := worktreeStatsFingerprint(wtDir)
+	require.NoError(err)
+	runGit(t, repoDir, "commit", "-q", "--allow-empty", "-m", "main moves")
+	afterMain, err := worktreeStatsFingerprint(wtDir)
+	require.NoError(err)
+	assert.NotEqual(beforeMain, afterMain, "the default branch ref is part of the fingerprint")
+
+	// Packing refs rewrites packed-refs and removes loose refs.
+	runGit(t, repoDir, "pack-refs", "--all")
+	afterPack, err := worktreeStatsFingerprint(wtDir)
+	require.NoError(err)
+	assert.NotEqual(afterMain, afterPack)
+}
+
+func TestProjectDiscoveryFingerprintTracksWorktreeRegistry(t *testing.T) {
+	repoDir, wtDir := seedFingerprintRepo(t)
+	require := require.New(t)
+	assert := assert.New(t)
+
+	first, err := projectDiscoveryFingerprint(repoDir)
+	require.NoError(err)
+	again, err := projectDiscoveryFingerprint(repoDir)
+	require.NoError(err)
+	assert.Equal(first, again)
+
+	runGit(t, repoDir, "worktree", "remove", wtDir)
+	afterRemove, err := projectDiscoveryFingerprint(repoDir)
+	require.NoError(err)
+	assert.NotEqual(first, afterRemove, "removing a worktree changes worktrees/")
+
+	other := filepath.Join(t.TempDir(), "other")
+	runGit(t, repoDir, "worktree", "add", "-q", "-b", "other", other)
+	afterAdd, err := projectDiscoveryFingerprint(repoDir)
+	require.NoError(err)
+	assert.NotEqual(afterRemove, afterAdd, "adding a worktree changes worktrees/")
+
+	runGit(t, repoDir, "remote", "add", "origin", repoDir)
+	afterRemote, err := projectDiscoveryFingerprint(repoDir)
+	require.NoError(err)
+	assert.NotEqual(afterAdd, afterRemote, "config is part of the discovery inputs")
+
+	_, err = projectDiscoveryFingerprint(filepath.Join(t.TempDir(), "gone"))
+	assert.Error(err)
+}

--- a/internal/server/fleetapi/fleet_monitor_gate.go
+++ b/internal/server/fleetapi/fleet_monitor_gate.go
@@ -13,6 +13,11 @@ import (
 // itself is a mutex-guarded map length, not a subprocess.
 const fleetMonitorIdleProbeInterval = 2 * time.Second
 
+// fleetMonitorDemandWindow is how long a snapshot read keeps the monitors
+// active after it. Hubs consume spokes through raw snapshot fetches without
+// opening a spoke-local event stream, so a read is demand in its own right.
+const fleetMonitorDemandWindow = 90 * time.Second
+
 // fleetMonitorGate decides whether a background monitor may run an expensive
 // pass. The fleet monitors exist to keep the live snapshot fresh for connected
 // clients, so while nobody is subscribed to the event stream they only record

--- a/internal/server/fleetapi/fleet_monitor_gate.go
+++ b/internal/server/fleetapi/fleet_monitor_gate.go
@@ -1,0 +1,77 @@
+package fleetapi
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"time"
+)
+
+// fleetMonitorIdleProbeInterval is how often an idle monitor re-checks for
+// subscribers. It is short so a client that connects between two regular ticks
+// gets a fresh pass promptly instead of waiting out a full interval; the check
+// itself is a mutex-guarded map length, not a subprocess.
+const fleetMonitorIdleProbeInterval = 2 * time.Second
+
+// fleetMonitorGate decides whether a background monitor may run an expensive
+// pass. The fleet monitors exist to keep the live snapshot fresh for connected
+// clients, so while nobody is subscribed to the event stream they only record
+// that they skipped. A nil hasSubscribers means the monitor is always active,
+// which is what unit tests and callers without an event hub want.
+type fleetMonitorGate struct {
+	name           string
+	hasSubscribers func() bool
+	idleSkips      atomic.Int64
+}
+
+func newFleetMonitorGate(name string, hasSubscribers func() bool) *fleetMonitorGate {
+	return &fleetMonitorGate{name: name, hasSubscribers: hasSubscribers}
+}
+
+// active reports whether a pass should run now. When it returns false the
+// skip has already been recorded.
+func (g *fleetMonitorGate) active() bool {
+	if g == nil || g.hasSubscribers == nil || g.hasSubscribers() {
+		return true
+	}
+	g.idleSkips.Add(1)
+	slog.Debug("fleet monitor: no subscribers, skipping pass", "monitor", g.name)
+	return false
+}
+
+// skipped returns how many passes the gate has suppressed so far.
+func (g *fleetMonitorGate) skipped() int64 {
+	if g == nil {
+		return 0
+	}
+	return g.idleSkips.Load()
+}
+
+// runFleetMonitorLoop drives pass on a fixed interval until ctx ends. Every
+// wake-up, including the initial one, consults the gate: a suppressed pass is
+// followed by a short idle probe rather than a full interval, so the first
+// subscriber after an idle stretch is served within the probe interval.
+func runFleetMonitorLoop(
+	ctx context.Context,
+	interval time.Duration,
+	gate *fleetMonitorGate,
+	pass func(context.Context),
+) {
+	wait := time.Duration(0)
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+		if gate.active() {
+			pass(ctx)
+			wait = interval
+		} else {
+			wait = min(fleetMonitorIdleProbeInterval, interval)
+		}
+		timer.Reset(wait)
+	}
+}

--- a/internal/server/fleetapi/fleet_monitor_gate_test.go
+++ b/internal/server/fleetapi/fleet_monitor_gate_test.go
@@ -1,0 +1,60 @@
+package fleetapi
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFleetMonitorLoopSkipsWhileNoSubscribers(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+		var subscribers atomic.Int32
+		gate := newFleetMonitorGate("test", func() bool { return subscribers.Load() > 0 })
+		var passes atomic.Int32
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		go runFleetMonitorLoop(ctx, time.Minute, gate, func(context.Context) {
+			passes.Add(1)
+		})
+
+		// Idle for several intervals: every wake-up is recorded as a skip and
+		// nothing runs, not even the initial pass.
+		time.Sleep(5 * time.Minute)
+		synctest.Wait()
+		assert.Equal(int32(0), passes.Load(), "no pass runs without subscribers")
+		assert.Greater(gate.skipped(), int64(1), "idle wake-ups are recorded")
+
+		// A subscriber is served within the idle probe interval, not a full
+		// interval later.
+		subscribers.Store(1)
+		time.Sleep(fleetMonitorIdleProbeInterval)
+		synctest.Wait()
+		require.Equal(int32(1), passes.Load(), "first subscriber triggers a prompt pass")
+
+		// With a subscriber the loop paces on the regular interval.
+		time.Sleep(time.Minute)
+		synctest.Wait()
+		assert.Equal(int32(2), passes.Load())
+
+		// Losing the subscriber returns the loop to skipping.
+		skippedBefore := gate.skipped()
+		subscribers.Store(0)
+		time.Sleep(3 * time.Minute)
+		synctest.Wait()
+		assert.Equal(int32(2), passes.Load(), "passes stop once subscribers leave")
+		assert.Greater(gate.skipped(), skippedBefore)
+	})
+}
+
+func TestFleetMonitorGateWithoutSubscriberSourceAlwaysRuns(t *testing.T) {
+	gate := newFleetMonitorGate("test", nil)
+	assert.True(t, gate.active())
+	assert.Equal(t, int64(0), gate.skipped())
+}

--- a/internal/server/fleetapi/fleet_monitor_review_test.go
+++ b/internal/server/fleetapi/fleet_monitor_review_test.go
@@ -1,0 +1,219 @@
+package fleetapi
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/forge/internal/config"
+	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/procutil"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+)
+
+// seedStatsProject registers a repository with one feature worktree that is two
+// lines ahead of main and returns the database, project, and worktree path.
+func seedStatsProject(t *testing.T) (*db.DB, *db.Project, string) {
+	t.Helper()
+	repoDir, featDir := seedFingerprintRepo(t)
+	database := dbtest.Open(t)
+	ctx := context.Background()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(featDir, "feature.txt"), []byte("x\ny\n"), 0o644,
+	))
+	runGit(t, featDir, "add", ".")
+	runGit(t, featDir, "commit", "-q", "-m", "feature work")
+	proj, err := database.CreateProject(ctx, db.CreateProjectInput{
+		DisplayName: "app", LocalPath: repoDir, DefaultBranch: "main",
+	})
+	require.NoError(t, err)
+	_, err = database.CreateProjectWorktree(ctx, db.CreateProjectWorktreeInput{
+		ProjectID: proj.ID, Branch: "feature", Path: featDir,
+	})
+	require.NoError(t, err)
+	return database, proj, featDir
+}
+
+func TestFleetWorktreeStatsForcedPassMeasuresUnstagedEdits(t *testing.T) {
+	require := require.New(t)
+	database, _, featDir := seedStatsProject(t)
+	ctx := context.Background()
+	sampler := &fleetWorktreeStatsSampler{db: database}
+
+	sampler.runOnce(ctx)
+	stats, err := database.ListWorktreeStats(ctx)
+	require.NoError(err)
+	require.Equal(2, stats[normPath(featDir)].DiffAdded)
+
+	// An unstaged edit leaves the git directory untouched.
+	require.NoError(os.WriteFile(
+		filepath.Join(featDir, "feature.txt"), []byte("x\ny\nz\n"), 0o644,
+	))
+	sampler.runOnce(ctx)
+	stats, err = database.ListWorktreeStats(ctx)
+	require.NoError(err)
+	require.Equal(2, stats[normPath(featDir)].DiffAdded,
+		"the background pass cannot see an unstaged edit")
+
+	sampler.runOnceForced(ctx)
+	stats, err = database.ListWorktreeStats(ctx)
+	require.NoError(err)
+	require.Equal(3, stats[normPath(featDir)].DiffAdded,
+		"the forced pass behind the refresh route measures it")
+}
+
+func TestFleetWorktreeStatsResamplesWhenDefaultBranchChanges(t *testing.T) {
+	require := require.New(t)
+	database, proj, featDir := seedStatsProject(t)
+	ctx := context.Background()
+	sampler := &fleetWorktreeStatsSampler{db: database}
+	sampler.runOnce(ctx)
+	stats, err := database.ListWorktreeStats(ctx)
+	require.NoError(err)
+	require.Equal(2, stats[normPath(featDir)].DiffAdded)
+
+	// Discovery moving the project's default branch changes the diff base
+	// without touching any git file: measured against itself the worktree
+	// has no diff.
+	require.NoError(database.ReconcileProjectInventory(ctx, proj.ID, db.ProjectInventory{
+		RepositoryKind: "standard", DefaultBranch: "feature",
+		Worktrees: []db.DiscoveredWorktree{{Path: featDir, Branch: "feature"}},
+	}, time.Now()))
+	sampler.runOnce(ctx)
+	stats, err = database.ListWorktreeStats(ctx)
+	require.NoError(err)
+	require.Equal(0, stats[normPath(featDir)].DiffAdded,
+		"a changed default branch invalidates the sample")
+}
+
+func TestFleetWorktreeStatsFingerprintAgeBoundsStaleness(t *testing.T) {
+	require := require.New(t)
+	database, _, featDir := seedStatsProject(t)
+	ctx := context.Background()
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	sampler := &fleetWorktreeStatsSampler{db: database, now: func() time.Time { return now }}
+	sampler.runOnce(ctx)
+
+	require.NoError(os.WriteFile(
+		filepath.Join(featDir, "feature.txt"), []byte("x\ny\nz\n"), 0o644,
+	))
+	now = now.Add(fleetWorktreeStatsFingerprintMaxAge - time.Second)
+	sampler.runOnce(ctx)
+	stats, err := database.ListWorktreeStats(ctx)
+	require.NoError(err)
+	require.Equal(2, stats[normPath(featDir)].DiffAdded, "inside the age bound the sample is reused")
+
+	now = now.Add(2 * time.Second)
+	sampler.runOnce(ctx)
+	stats, err = database.ListWorktreeStats(ctx)
+	require.NoError(err)
+	require.Equal(3, stats[normPath(featDir)].DiffAdded, "past the age bound the worktree is re-measured")
+}
+
+func TestFleetWorktreeDiscoveryFingerprintAgeBoundsStaleness(t *testing.T) {
+	require := require.New(t)
+	repoDir, _ := seedFingerprintRepo(t)
+	database := dbtest.Open(t)
+	ctx := context.Background()
+	project, err := database.CreateProject(ctx, db.CreateProjectInput{
+		DisplayName: "app", LocalPath: repoDir,
+	})
+	require.NoError(err)
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	discoverer := newFleetWorktreeDiscoverer(database, nil)
+	discoverer.now = func() time.Time { return now }
+	discoverer.runOnce(ctx)
+
+	require.NoError(database.MarkProjectStale(ctx, project.ID, now))
+	now = now.Add(fleetWorktreeDiscoveryFingerprintMaxAge - time.Second)
+	discoverer.runOnce(ctx)
+	stale, err := database.GetProjectByID(ctx, project.ID)
+	require.NoError(err)
+	require.True(stale.IsStale, "inside the age bound the project is skipped")
+
+	now = now.Add(2 * time.Second)
+	discoverer.runOnce(ctx)
+	fresh, err := database.GetProjectByID(ctx, project.ID)
+	require.NoError(err)
+	require.False(fresh.IsStale, "past the age bound the project is reconciled")
+}
+
+func TestFleetMonitorsStayActiveAfterSnapshotReadWithoutSubscribers(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	handler := New(Deps{
+		DB:              dbtest.Open(t),
+		Config:          ConfigSnapshot{Fleet: config.Fleet{}},
+		Now:             func() time.Time { return now },
+		SubscriberCount: func() int { return 0 },
+	})
+
+	assert.False(handler.fleetWorktreeStatsSampler.gate.active(),
+		"no subscribers and no reads means idle")
+
+	// A hub consuming this daemon as a spoke reads the raw snapshot without
+	// opening a local event stream; that read is demand.
+	_, err := handler.getSnapshotRaw(context.Background(), nil)
+	require.NoError(err)
+	assert.True(handler.fleetWorktreeStatsSampler.gate.active())
+	assert.True(handler.fleetWorktreeDiscoverer.gate.active())
+	assert.True(handler.fleetTmuxMonitor.gate.active())
+
+	now = now.Add(fleetMonitorDemandWindow + time.Second)
+	assert.False(handler.fleetWorktreeStatsSampler.gate.active(),
+		"demand lapses once the window passes without another read")
+}
+
+func TestFleetProcessProbeOutputExitStatusSemantics(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	assert := assert.New(t)
+	require := require.New(t)
+	dir := t.TempDir()
+	write := func(name, body string) string {
+		path := filepath.Join(dir, name)
+		require.NoError(os.WriteFile(path, []byte("#!/bin/sh\n"+body), 0o755))
+		return path
+	}
+	noMatch := write("nomatch", "exit 1\n")
+	usage := write("usage", "echo 'usage: bad flags' >&2\nexit 2\n")
+
+	out, err := fleetProcessProbeOutput(context.Background(), "test", noMatch)
+	require.NoError(err, "exit status 1 is the documented no-match outcome")
+	assert.Empty(out)
+
+	_, err = fleetProcessProbeOutput(context.Background(), "test", usage)
+	assert.Error(err, "a usage failure must not be published as an empty tree")
+}
+
+func TestProbeFleetProcessTreesFollowsDescendants(t *testing.T) {
+	for _, tool := range []string{"ps", "pgrep", "sh"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("%s not available", tool)
+		}
+	}
+	require := require.New(t)
+	// A shell whose child is another sleeping shell: two generations below
+	// the test process.
+	cmd := procutil.Command("sh", "-c", "sh -c 'sleep 30; true' & wait")
+	require.NoError(cmd.Start())
+	t.Cleanup(func() { _ = cmd.Process.Kill(); _ = cmd.Wait() })
+
+	var processes map[int]fleetProcessInfo
+	require.Eventually(func() bool {
+		var err error
+		processes, err = probeFleetProcessTrees(context.Background(), []int{cmd.Process.Pid})
+		return err == nil && len(processes) >= 3
+	}, 5*time.Second, 100*time.Millisecond,
+		"the root, its shell child, and the sleep grandchild are all collected")
+	_, hasRoot := processes[cmd.Process.Pid]
+	require.True(hasRoot)
+}

--- a/internal/server/fleetapi/fleet_routes.go
+++ b/internal/server/fleetapi/fleet_routes.go
@@ -60,6 +60,7 @@ func (s *Handler) getSnapshotAggregate(
 	ctx context.Context,
 	input *aggregateSnapshotInput,
 ) (*aggregateSnapshotOutput, error) {
+	s.noteSnapshotDemand()
 	fleetConfig := s.configSnapshot().Fleet
 	if !fleetConfig.Enabled ||
 		fleetConfig.RoleOrDefault() != config.FleetRoleHub {
@@ -107,7 +108,7 @@ type refreshFleetStatsOutput struct {
 func (s *Handler) refreshFleetStats(
 	ctx context.Context, _ *struct{},
 ) (*refreshFleetStatsOutput, error) {
-	s.fleetWorktreeStatsSampler.runOnce(ctx)
+	s.fleetWorktreeStatsSampler.runOnceForced(ctx)
 	out := &refreshFleetStatsOutput{}
 	out.Body.Refreshed = true
 	return out, nil
@@ -116,6 +117,7 @@ func (s *Handler) refreshFleetStats(
 // getSnapshot returns the observer-relative snapshot. With include_peers=true,
 // a hub aggregates member raw state and a spoke consumes that aggregate.
 func (s *Handler) getSnapshot(ctx context.Context, in *snapshotInput) (*snapshotOutput, error) {
+	s.noteSnapshotDemand()
 	snap, err := s.buildFleetSnapshot(ctx, in.IncludePeers)
 	if err != nil {
 		return nil, httpapi.Internal("build snapshot: " + err.Error())
@@ -126,6 +128,7 @@ func (s *Handler) getSnapshot(ctx context.Context, in *snapshotInput) (*snapshot
 // getSnapshotRaw returns this daemon's local raw inventory. It never fans out
 // or re-exports a fetched aggregate, so federation cannot loop.
 func (s *Handler) getSnapshotRaw(ctx context.Context, _ *struct{}) (*rawSnapshotOutput, error) {
+	s.noteSnapshotDemand()
 	raw, err := s.buildLocalRaw(ctx)
 	if err != nil {
 		return nil, httpapi.Internal("build raw snapshot: " + err.Error())

--- a/internal/server/fleetapi/fleet_tmux_monitor.go
+++ b/internal/server/fleetapi/fleet_tmux_monitor.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"maps"
 	"os"
 	"os/exec"
@@ -32,9 +33,10 @@ const (
 	// listing may reuse the previous window inventory, so window renames and
 	// activity stamps still converge without a per-pass list-windows spawn.
 	fleetTmuxWindowRefreshInterval = 60 * time.Second
-	// fleetTmuxProcessTreeDepth bounds how many generations below a pane's
-	// process the metrics probe follows.
-	fleetTmuxProcessTreeDepth = 6
+	// fleetTmuxProcessTableLimit caps how many processes the metrics probe
+	// will collect across every pane tree before it stops descending, so a
+	// runaway fork tree cannot turn the probe into an unbounded walk.
+	fleetTmuxProcessTableLimit = 4096
 	// tmux 3.5a renders literal tabs in -F output as underscores, so use a
 	// printable separator the real command preserves.
 	fleetTmuxFieldSeparator = "|"
@@ -392,14 +394,20 @@ func panePIDs(panes []fleetTmuxPaneInfo) []int {
 // probeFleetProcessTrees builds a process table covering only the given pane
 // processes and their descendants, instead of enumerating the whole host. Each
 // generation costs one ps for the known pids and one pgrep for their children;
-// the walk stops when a generation has no children or the depth bound is hit.
-// An empty pid set spawns nothing.
+// the walk descends until a generation has no children, or stops early once
+// the table reaches its size cap and logs that the metrics are partial. An
+// empty pid set spawns nothing.
 func probeFleetProcessTrees(
 	ctx context.Context, roots []int,
 ) (map[int]fleetProcessInfo, error) {
 	processes := map[int]fleetProcessInfo{}
 	pending := slices.Clone(roots)
-	for depth := 0; len(pending) > 0 && depth <= fleetTmuxProcessTreeDepth; depth++ {
+	for len(pending) > 0 {
+		if len(processes) >= fleetTmuxProcessTableLimit {
+			slog.Warn("fleet tmux metrics: process tree truncated",
+				"limit", fleetTmuxProcessTableLimit, "pending", len(pending))
+			break
+		}
 		list := joinPIDs(pending)
 		psOut, err := fleetProcessProbeOutput(ctx, "fleet process probe",
 			"ps", "-o", "pid=,ppid=,%cpu=,rss=,comm=", "-p", list)
@@ -428,9 +436,11 @@ func probeFleetProcessTrees(
 }
 
 // fleetProcessProbeOutput runs one ps or pgrep query through the process
-// limiter. Both tools exit non-zero when no listed pid exists, which is a
-// normal outcome for a pane whose process just exited, so a clean exit
-// status failure yields whatever they printed rather than an error.
+// limiter. Both BSD and procps implementations exit 1 when nothing matched,
+// which is a normal outcome for a pane whose process just exited, so exit
+// status 1 yields whatever was printed. Any other failure, including the
+// usage errors both tools report with status 2, surfaces as an error so a
+// broken probe is not published as an empty process tree.
 func fleetProcessProbeOutput(
 	ctx context.Context, reason, name string, args ...string,
 ) ([]byte, error) {
@@ -438,7 +448,7 @@ func fleetProcessProbeOutput(
 	out, err := procutil.Output(ctx, cmd, reason)
 	if err != nil {
 		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && ctx.Err() == nil {
+		if errors.As(err, &exitErr) && ctx.Err() == nil && exitErr.ExitCode() == 1 {
 			return out, nil
 		}
 		return nil, err

--- a/internal/server/fleetapi/fleet_tmux_monitor.go
+++ b/internal/server/fleetapi/fleet_tmux_monitor.go
@@ -1,6 +1,7 @@
 package fleetapi
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"maps"
@@ -23,6 +24,17 @@ const (
 	fleetTmuxProbeTimeout      = 750 * time.Millisecond
 	fleetTmuxStaleThreshold    = 30 * time.Second
 	fleetTmuxActivityCPUThresh = 0.1
+	// fleetTmuxPollInterval paces one monitor pass: a session listing, a
+	// window listing when the session listing moved, and process metrics for
+	// the panes of managed sessions.
+	fleetTmuxPollInterval = 15 * time.Second
+	// fleetTmuxWindowRefreshInterval bounds how long a byte-identical session
+	// listing may reuse the previous window inventory, so window renames and
+	// activity stamps still converge without a per-pass list-windows spawn.
+	fleetTmuxWindowRefreshInterval = 60 * time.Second
+	// fleetTmuxProcessTreeDepth bounds how many generations below a pane's
+	// process the metrics probe follows.
+	fleetTmuxProcessTreeDepth = 6
 	// tmux 3.5a renders literal tabs in -F output as underscores, so use a
 	// printable separator the real command preserves.
 	fleetTmuxFieldSeparator = "|"
@@ -34,6 +46,13 @@ type fleetTmuxMonitor struct {
 	includeUnmanagedDetails bool
 	clock                   func() time.Time
 	probeTimeout            time.Duration
+	gate                    *fleetMonitorGate
+
+	// lastSessionsOutput is the raw list-sessions output of the last
+	// successful inventory pass and lastWindowsAt when list-windows last ran;
+	// together they decide whether a pass may reuse the previous windows.
+	lastSessionsOutput []byte
+	lastWindowsAt      time.Time
 
 	currentInventory     fleetTmuxInventorySample
 	previousInventory    fleetTmuxInventorySample
@@ -100,6 +119,7 @@ func newFleetTmuxMonitor(
 	tmuxCmd []string,
 	includeUnmanagedDetails bool,
 	clock func() time.Time,
+	hasSubscribers func() bool,
 ) *fleetTmuxMonitor {
 	if clock == nil {
 		clock = time.Now
@@ -112,6 +132,7 @@ func newFleetTmuxMonitor(
 		includeUnmanagedDetails: includeUnmanagedDetails,
 		clock:                   clock,
 		probeTimeout:            fleetTmuxProbeTimeout,
+		gate:                    newFleetMonitorGate("tmux", hasSubscribers),
 	}
 }
 
@@ -199,6 +220,7 @@ func (m *fleetTmuxMonitor) refreshInventory(ctx context.Context) {
 			"#{session_name}",
 	)
 	if err != nil {
+		m.forgetSessionsOutput()
 		if tmuxEmptyServerError(err) {
 			m.recordInventorySample(fleetTmuxInventorySample{
 				PolledAt:  m.clock().UTC(),
@@ -211,6 +233,22 @@ func (m *fleetTmuxMonitor) refreshInventory(ctx context.Context) {
 			PolledAt:  m.clock().UTC(),
 			Error:     err.Error(),
 			Succeeded: false,
+		})
+		return
+	}
+	if previousWindows, ok := m.reusableWindows(sessionsOut); ok {
+		sessions := parseFleetTmuxInventory(string(sessionsOut), "")
+		for name, session := range sessions {
+			if prior, ok := previousWindows[name]; ok {
+				session.Windows = slices.Clone(prior.Windows)
+				session.WindowCount = max(session.WindowCount, len(session.Windows))
+				sessions[name] = session
+			}
+		}
+		m.recordInventorySample(fleetTmuxInventorySample{
+			PolledAt:  m.clock().UTC(),
+			Sessions:  sessions,
+			Succeeded: true,
 		})
 		return
 	}
@@ -223,6 +261,7 @@ func (m *fleetTmuxMonitor) refreshInventory(ctx context.Context) {
 			"#{window_activity}",
 	)
 	if err != nil {
+		m.forgetSessionsOutput()
 		if tmuxEmptyServerError(err) {
 			m.recordInventorySample(fleetTmuxInventorySample{
 				PolledAt:  m.clock().UTC(),
@@ -238,6 +277,7 @@ func (m *fleetTmuxMonitor) refreshInventory(ctx context.Context) {
 		})
 		return
 	}
+	m.rememberSessionsOutput(sessionsOut)
 	m.recordInventorySample(fleetTmuxInventorySample{
 		PolledAt:  m.clock().UTC(),
 		Sessions:  parseFleetTmuxInventory(string(sessionsOut), string(windowsOut)),
@@ -245,8 +285,42 @@ func (m *fleetTmuxMonitor) refreshInventory(ctx context.Context) {
 	})
 }
 
+// reusableWindows reports whether the session listing is byte-identical to the
+// one that produced the current inventory and the window listing is recent
+// enough to reuse; when so it returns the current inventory's sessions so the
+// caller can carry their windows forward without a list-windows spawn.
+func (m *fleetTmuxMonitor) reusableWindows(
+	sessionsOut []byte,
+) (map[string]fleetTmuxLiveSession, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if !m.hasCurrentInventory || m.lastSessionsOutput == nil ||
+		!bytes.Equal(m.lastSessionsOutput, sessionsOut) ||
+		m.clock().Sub(m.lastWindowsAt) >= fleetTmuxWindowRefreshInterval {
+		return nil, false
+	}
+	return cloneFleetTmuxInventorySample(m.currentInventory).Sessions, true
+}
+
+func (m *fleetTmuxMonitor) rememberSessionsOutput(sessionsOut []byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.lastSessionsOutput = bytes.Clone(sessionsOut)
+	m.lastWindowsAt = m.clock()
+}
+
+func (m *fleetTmuxMonitor) forgetSessionsOutput() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.lastSessionsOutput = nil
+	m.lastWindowsAt = time.Time{}
+}
+
 func (m *fleetTmuxMonitor) refreshMetrics(ctx context.Context) {
-	cctx, cancel := context.WithTimeout(ctx, m.probeTimeout)
+	// The pane listing plus a ps and pgrep per process generation can add up
+	// to a dozen short spawns, so the metrics pass gets a wider budget than a
+	// single tmux probe.
+	cctx, cancel := context.WithTimeout(ctx, m.probeTimeout*4)
 	defer cancel()
 
 	snap := m.snapshot()
@@ -278,11 +352,8 @@ func (m *fleetTmuxMonitor) refreshMetrics(ctx context.Context) {
 		})
 		return
 	}
-	psCmd := procutil.CommandContext(
-		cctx, "ps", "-ax", "-o", "pid=", "-o", "ppid=", "-o",
-		"%cpu=", "-o", "rss=", "-o", "comm=",
-	)
-	processOut, err := procutil.Output(cctx, psCmd, "fleet process probe")
+	panes := parseFleetTmuxPanes(string(panesOut), managed)
+	processes, err := probeFleetProcessTrees(cctx, panePIDs(panes))
 	if err != nil {
 		m.recordMetricsSample(fleetTmuxMetricsSample{
 			SampledAt: m.clock().UTC(),
@@ -293,30 +364,94 @@ func (m *fleetTmuxMonitor) refreshMetrics(ctx context.Context) {
 	sampledAt := m.clock().UTC()
 	m.recordMetricsSample(fleetTmuxMetricsSample{
 		SampledAt: sampledAt,
-		Sessions: parseFleetTmuxMetrics(
-			string(panesOut), string(processOut), managed, sampledAt,
-		),
+		Sessions:  aggregateFleetTmuxMetrics(panes, processes, sampledAt),
 	})
 }
 
-func (m *fleetTmuxMonitor) run(ctx context.Context) {
+// refresh runs one monitor pass: the session inventory, then process metrics
+// for managed panes.
+func (m *fleetTmuxMonitor) refresh(ctx context.Context) {
 	m.refreshInventory(ctx)
 	m.refreshMetrics(ctx)
+}
 
-	inventoryTicker := time.NewTicker(4 * time.Second)
-	defer inventoryTicker.Stop()
-	metricsTicker := time.NewTicker(15 * time.Second)
-	defer metricsTicker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-inventoryTicker.C:
-			m.refreshInventory(ctx)
-		case <-metricsTicker.C:
-			m.refreshMetrics(ctx)
+func (m *fleetTmuxMonitor) run(ctx context.Context) {
+	runFleetMonitorLoop(ctx, fleetTmuxPollInterval, m.gate, m.refresh)
+}
+
+func panePIDs(panes []fleetTmuxPaneInfo) []int {
+	pids := make([]int, 0, len(panes))
+	for _, pane := range panes {
+		if pane.PID > 0 && !slices.Contains(pids, pane.PID) {
+			pids = append(pids, pane.PID)
 		}
 	}
+	return pids
+}
+
+// probeFleetProcessTrees builds a process table covering only the given pane
+// processes and their descendants, instead of enumerating the whole host. Each
+// generation costs one ps for the known pids and one pgrep for their children;
+// the walk stops when a generation has no children or the depth bound is hit.
+// An empty pid set spawns nothing.
+func probeFleetProcessTrees(
+	ctx context.Context, roots []int,
+) (map[int]fleetProcessInfo, error) {
+	processes := map[int]fleetProcessInfo{}
+	pending := slices.Clone(roots)
+	for depth := 0; len(pending) > 0 && depth <= fleetTmuxProcessTreeDepth; depth++ {
+		list := joinPIDs(pending)
+		psOut, err := fleetProcessProbeOutput(ctx, "fleet process probe",
+			"ps", "-o", "pid=,ppid=,%cpu=,rss=,comm=", "-p", list)
+		if err != nil {
+			return nil, err
+		}
+		maps.Copy(processes, parseFleetProcessTable(string(psOut)))
+		childrenOut, err := fleetProcessProbeOutput(ctx, "fleet process children probe",
+			"pgrep", "-P", list)
+		if err != nil {
+			return nil, err
+		}
+		pending = pending[:0]
+		for field := range strings.FieldsSeq(string(childrenOut)) {
+			pid, err := strconv.Atoi(field)
+			if err != nil || pid <= 0 {
+				continue
+			}
+			if _, known := processes[pid]; known || slices.Contains(pending, pid) {
+				continue
+			}
+			pending = append(pending, pid)
+		}
+	}
+	return processes, nil
+}
+
+// fleetProcessProbeOutput runs one ps or pgrep query through the process
+// limiter. Both tools exit non-zero when no listed pid exists, which is a
+// normal outcome for a pane whose process just exited, so a clean exit
+// status failure yields whatever they printed rather than an error.
+func fleetProcessProbeOutput(
+	ctx context.Context, reason, name string, args ...string,
+) ([]byte, error) {
+	cmd := procutil.CommandContext(ctx, name, args...)
+	out, err := procutil.Output(ctx, cmd, reason)
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && ctx.Err() == nil {
+			return out, nil
+		}
+		return nil, err
+	}
+	return out, nil
+}
+
+func joinPIDs(pids []int) string {
+	parts := make([]string, 0, len(pids))
+	for _, pid := range pids {
+		parts = append(parts, strconv.Itoa(pid))
+	}
+	return strings.Join(parts, ",")
 }
 
 func (m *fleetTmuxMonitor) tmuxOutput(ctx context.Context, args ...string) ([]byte, error) {
@@ -439,14 +574,14 @@ func parseFleetTmuxWindowLine(
 	return "", fleet.TmuxWindowInfo{}, false
 }
 
-func parseFleetTmuxMetrics(
-	paneOutput string,
-	processOutput string,
-	managedSessions map[string]struct{},
+// aggregateFleetTmuxMetrics folds a process table into per-session metrics,
+// attributing each pane's process and every descendant present in the table
+// to the pane's session.
+func aggregateFleetTmuxMetrics(
+	panes []fleetTmuxPaneInfo,
+	processes map[int]fleetProcessInfo,
 	sampledAt time.Time,
 ) map[string]fleetTmuxSessionMetrics {
-	panes := parseFleetTmuxPanes(paneOutput, managedSessions)
-	processes := parseFleetProcessTable(processOutput)
 	children := map[int][]int{}
 	for pid, proc := range processes {
 		children[proc.PPID] = append(children[proc.PPID], pid)

--- a/internal/server/fleetapi/fleet_tmux_monitor_polling_test.go
+++ b/internal/server/fleetapi/fleet_tmux_monitor_polling_test.go
@@ -1,0 +1,141 @@
+package fleetapi
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeCountingTmuxScript returns a fake tmux that appends each subcommand to
+// a log file and answers list-sessions from a sessions file, so a test can
+// change the session listing between passes and count what was spawned.
+func writeCountingTmuxScript(t *testing.T, panePID int) (tmux, logPath, sessionsPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	logPath = filepath.Join(dir, "calls.log")
+	sessionsPath = filepath.Join(dir, "sessions.txt")
+	script := `#!/bin/sh
+echo "$1" >> "` + logPath + `"
+case "$1" in
+  list-sessions)
+    cat "` + sessionsPath + `"
+    ;;
+  list-windows)
+    printf 'forge-a|@1|0|shell|1717150000\n'
+    ;;
+  list-panes)
+    printf 'forge-a|1717150000|` + strconv.Itoa(panePID) + `|sh\n'
+    ;;
+esac
+exit 0
+`
+	tmux = writeFleetTmuxMonitorScript(t, script)
+	return tmux, logPath, sessionsPath
+}
+
+func countCalls(t *testing.T, logPath, sub string) int {
+	t.Helper()
+	raw, err := os.ReadFile(logPath)
+	if err != nil {
+		return 0
+	}
+	return strings.Count(string(raw), sub+"\n")
+}
+
+func TestFleetTmuxMonitorReusesWindowsWhileSessionsUnchanged(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	tmux, logPath, sessionsPath := writeCountingTmuxScript(t, os.Getpid())
+	require.NoError(os.WriteFile(sessionsPath, []byte("1717150000|1|forge-a\n"), 0o644))
+
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	mon := newFleetTmuxMonitor([]string{tmux}, false, func() time.Time { return now }, nil)
+	mon.probeTimeout = 5 * time.Second
+
+	mon.refreshInventory(context.Background())
+	require.Equal(1, countCalls(t, logPath, "list-windows"), "the first pass lists windows")
+	snap := mon.snapshot()
+	require.NotNil(snap.CurrentInventory)
+	require.Len(snap.CurrentInventory.Sessions["forge-a"].Windows, 1)
+
+	now = now.Add(fleetTmuxPollInterval)
+	mon.refreshInventory(context.Background())
+	assert.Equal(2, countCalls(t, logPath, "list-sessions"))
+	assert.Equal(1, countCalls(t, logPath, "list-windows"),
+		"a byte-identical session listing reuses the previous windows")
+	snap = mon.snapshot()
+	require.NotNil(snap.CurrentInventory)
+	assert.Len(snap.CurrentInventory.Sessions["forge-a"].Windows, 1,
+		"reused windows stay in the inventory")
+	assert.Equal(now, snap.CurrentInventory.PolledAt, "the sample is still refreshed")
+
+	// A changed listing re-lists windows.
+	require.NoError(os.WriteFile(sessionsPath, []byte("1717150000|2|forge-a\n"), 0o644))
+	now = now.Add(fleetTmuxPollInterval)
+	mon.refreshInventory(context.Background())
+	assert.Equal(2, countCalls(t, logPath, "list-windows"))
+
+	// An unchanged listing still re-lists windows once the refresh bound
+	// elapses.
+	now = now.Add(fleetTmuxWindowRefreshInterval)
+	mon.refreshInventory(context.Background())
+	assert.Equal(3, countCalls(t, logPath, "list-windows"))
+}
+
+func TestFleetTmuxMonitorMetricsQueryOnlyPaneProcesses(t *testing.T) {
+	for _, tool := range []string{"ps", "pgrep"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("%s not available", tool)
+		}
+	}
+	require := require.New(t)
+	assert := assert.New(t)
+	tmux, logPath, sessionsPath := writeCountingTmuxScript(t, os.Getpid())
+	require.NoError(os.WriteFile(sessionsPath, []byte("1717150000|1|forge-a\n"), 0o644))
+	mon := newFleetTmuxMonitor([]string{tmux}, false, nil, nil)
+	mon.probeTimeout = 5 * time.Second
+
+	mon.refresh(context.Background())
+
+	snap := mon.snapshot()
+	require.NotNil(snap.Metrics)
+	require.Empty(snap.Metrics.Error)
+	metric, ok := snap.Metrics.Sessions["forge-a"]
+	require.True(ok, "the pane's session gets metrics")
+	assert.GreaterOrEqual(metric.ProcessCount, 1, "the test process itself is counted")
+	assert.NotEmpty(metric.ExecutableName)
+	assert.Equal(1, countCalls(t, logPath, "list-panes"))
+}
+
+func TestFleetTmuxMonitorMetricsSpawnNothingWithoutSessions(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	tmux, logPath, sessionsPath := writeCountingTmuxScript(t, os.Getpid())
+	require.NoError(os.WriteFile(sessionsPath, []byte(""), 0o644))
+	mon := newFleetTmuxMonitor([]string{tmux}, false, nil, nil)
+	mon.probeTimeout = 5 * time.Second
+
+	mon.refresh(context.Background())
+
+	snap := mon.snapshot()
+	require.NotNil(snap.CurrentInventory)
+	assert.Empty(snap.CurrentInventory.Sessions)
+	assert.Equal(0, countCalls(t, logPath, "list-panes"),
+		"no managed session means no pane or process probe")
+	require.NotNil(snap.Metrics)
+	assert.Empty(snap.Metrics.Sessions)
+}
+
+func TestProbeFleetProcessTreesWithNoRootsSpawnsNothing(t *testing.T) {
+	processes, err := probeFleetProcessTrees(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Empty(t, processes)
+}

--- a/internal/server/fleetapi/fleet_tmux_monitor_test.go
+++ b/internal/server/fleetapi/fleet_tmux_monitor_test.go
@@ -96,7 +96,7 @@ func TestFleetTmuxMonitorKeepsPreviousInventorySample(t *testing.T) {
 	secondAt := firstAt.Add(4 * time.Second)
 	mon := newFleetTmuxMonitor([]string{"tmux"}, false, func() time.Time {
 		return secondAt
-	})
+	}, nil)
 	mon.recordInventorySample(fleetTmuxInventorySample{
 		PolledAt: firstAt,
 		Sessions: map[string]fleetTmuxLiveSession{
@@ -156,7 +156,7 @@ exit 0
 			require := require.New(t)
 			assert := assert.New(t)
 			mon := newFleetTmuxMonitor(
-				[]string{writeFleetTmuxMonitorScript(t, tc.script)}, false, nil,
+				[]string{writeFleetTmuxMonitorScript(t, tc.script)}, false, nil, nil,
 			)
 			mon.probeTimeout = 5 * time.Second
 
@@ -172,7 +172,7 @@ exit 0
 }
 
 func TestFleetTmuxMonitorReportsFirstInventoryError(t *testing.T) {
-	mon := newFleetTmuxMonitor([]string{"tmux"}, false, nil)
+	mon := newFleetTmuxMonitor([]string{"tmux"}, false, nil, nil)
 
 	mon.recordInventorySample(fleetTmuxInventorySample{
 		Error:     "tmux exploded",
@@ -200,9 +200,11 @@ func TestParseFleetTmuxMetricsAggregatesPaneDescendants(t *testing.T) {
 		"301 300 2.0 2048 sh\n" +
 		"200 1 99.0 99999 vim\n"
 
-	got := parseFleetTmuxMetrics(panes, processes, map[string]struct{}{
-		"managed-1": {},
-	}, sampledAt)
+	got := aggregateFleetTmuxMetrics(
+		parseFleetTmuxPanes(panes, map[string]struct{}{"managed-1": {}}),
+		parseFleetProcessTable(processes),
+		sampledAt,
+	)
 
 	require.Len(got, 1)
 	metric := got["managed-1"]
@@ -227,9 +229,11 @@ func TestParseFleetTmuxMetricsUsesAggregateCPUForActivity(t *testing.T) {
 		"100 1 0.06 1024 codex\n" +
 		"200 1 0.06 1024 helper\n"
 
-	got := parseFleetTmuxMetrics(panes, processes, map[string]struct{}{
-		"managed-aggregate": {},
-	}, sampledAt)
+	got := aggregateFleetTmuxMetrics(
+		parseFleetTmuxPanes(panes, map[string]struct{}{"managed-aggregate": {}}),
+		parseFleetProcessTable(processes),
+		sampledAt,
+	)
 
 	require.Len(got, 1)
 	metric := got["managed-aggregate"]

--- a/internal/server/fleetapi/fleet_worktree_discovery.go
+++ b/internal/server/fleetapi/fleet_worktree_discovery.go
@@ -22,6 +22,11 @@ import (
 // only spawns git when that fingerprint moved.
 const fleetWorktreeDiscoveryInterval = 15 * time.Second
 
+// fleetWorktreeDiscoveryFingerprintMaxAge bounds how long a matching
+// fingerprint may keep a project from being re-inspected, so a change the
+// stat-based fingerprint missed is corrected within bounded time.
+const fleetWorktreeDiscoveryFingerprintMaxAge = 10 * time.Minute
+
 // fleetWorktreeDiscoverer keeps the project registry's on-disk facts fresh.
 // On a fixed interval it inspects each registered project's git checkout — its
 // repository kind, default branch, and linked worktrees — and reconciles the
@@ -33,14 +38,30 @@ type fleetWorktreeDiscoverer struct {
 	db       *db.DB
 	interval time.Duration
 	gate     *fleetMonitorGate
+	// now is the discoverer's clock; nil means time.Now.
+	now func() time.Time
 
 	// fingerprints remembers, per project ID, the git-directory fingerprint
-	// observed by the last successful reconcile. A background pass whose
-	// fingerprint still matches skips both the git spawns and the database
-	// write; a failed or stale-marking pass drops the entry so recovery is
-	// re-inspected in full.
+	// observed by the last successful reconcile and when. A background pass
+	// whose fingerprint still matches and is younger than the max age skips
+	// both the git spawns and the database write; a failed or stale-marking
+	// pass drops the entry so recovery is re-inspected in full.
 	fingerprintsMu sync.Mutex
-	fingerprints   map[string]string
+	fingerprints   map[string]projectDiscoveryFingerprintEntry
+}
+
+// projectDiscoveryFingerprintEntry is one remembered fingerprint and when it
+// was recorded.
+type projectDiscoveryFingerprintEntry struct {
+	value string
+	at    time.Time
+}
+
+func (d *fleetWorktreeDiscoverer) clock() time.Time {
+	if d.now != nil {
+		return d.now()
+	}
+	return time.Now()
 }
 
 func newFleetWorktreeDiscoverer(
@@ -50,7 +71,7 @@ func newFleetWorktreeDiscoverer(
 		db:           database,
 		interval:     fleetWorktreeDiscoveryInterval,
 		gate:         newFleetMonitorGate("worktree discovery", hasSubscribers),
-		fingerprints: map[string]string{},
+		fingerprints: map[string]projectDiscoveryFingerprintEntry{},
 	}
 }
 
@@ -100,7 +121,8 @@ func (d *fleetWorktreeDiscoverer) refreshProjectIfChanged(
 		d.fingerprintsMu.Lock()
 		previous, seen := d.fingerprints[projectID]
 		d.fingerprintsMu.Unlock()
-		if seen && previous == fingerprint {
+		if seen && previous.value == fingerprint &&
+			d.clock().Sub(previous.at) < fleetWorktreeDiscoveryFingerprintMaxAge {
 			return
 		}
 	}
@@ -151,7 +173,12 @@ func (d *fleetWorktreeDiscoverer) reconcileProject(
 	}
 	if haveFingerprint {
 		d.fingerprintsMu.Lock()
-		d.fingerprints[projectID] = fingerprint
+		if d.fingerprints == nil {
+			d.fingerprints = map[string]projectDiscoveryFingerprintEntry{}
+		}
+		d.fingerprints[projectID] = projectDiscoveryFingerprintEntry{
+			value: fingerprint, at: d.clock(),
+		}
 		d.fingerprintsMu.Unlock()
 	}
 }

--- a/internal/server/fleetapi/fleet_worktree_discovery.go
+++ b/internal/server/fleetapi/fleet_worktree_discovery.go
@@ -6,9 +6,11 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/procutil"
 	gitcmd "go.kenn.io/kit/git/cmd"
 	gitworktree "go.kenn.io/kit/git/worktree"
 )
@@ -16,6 +18,8 @@ import (
 // fleetWorktreeDiscoveryInterval is how often the discoverer re-inspects every
 // registered project's checkout. It is short because the result feeds the live
 // fleet snapshot; a missing or newly added worktree should surface quickly.
+// Each pass is cheap for an unchanged project: it stats the git directory and
+// only spawns git when that fingerprint moved.
 const fleetWorktreeDiscoveryInterval = 15 * time.Second
 
 // fleetWorktreeDiscoverer keeps the project registry's on-disk facts fresh.
@@ -28,56 +32,108 @@ const fleetWorktreeDiscoveryInterval = 15 * time.Second
 type fleetWorktreeDiscoverer struct {
 	db       *db.DB
 	interval time.Duration
+	gate     *fleetMonitorGate
+
+	// fingerprints remembers, per project ID, the git-directory fingerprint
+	// observed by the last successful reconcile. A background pass whose
+	// fingerprint still matches skips both the git spawns and the database
+	// write; a failed or stale-marking pass drops the entry so recovery is
+	// re-inspected in full.
+	fingerprintsMu sync.Mutex
+	fingerprints   map[string]string
 }
 
-func newFleetWorktreeDiscoverer(database *db.DB) *fleetWorktreeDiscoverer {
+func newFleetWorktreeDiscoverer(
+	database *db.DB, hasSubscribers func() bool,
+) *fleetWorktreeDiscoverer {
 	return &fleetWorktreeDiscoverer{
-		db:       database,
-		interval: fleetWorktreeDiscoveryInterval,
+		db:           database,
+		interval:     fleetWorktreeDiscoveryInterval,
+		gate:         newFleetMonitorGate("worktree discovery", hasSubscribers),
+		fingerprints: map[string]string{},
 	}
 }
 
-// run drives discovery passes until ctx is cancelled, starting with an
-// immediate pass so a freshly started daemon does not wait a full interval
-// before its worktrees appear.
+// run drives discovery passes until ctx is cancelled. The first pass runs as
+// soon as a client is subscribed so a freshly started daemon does not wait a
+// full interval before its worktrees appear.
 func (d *fleetWorktreeDiscoverer) run(ctx context.Context) {
 	if d == nil || d.db == nil {
 		return
 	}
-	d.runOnce(ctx)
-	ticker := time.NewTicker(d.interval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			d.runOnce(ctx)
-		}
-	}
+	runFleetMonitorLoop(ctx, d.interval, d.gate, d.runOnce)
 }
 
-// runOnce reconciles every registered project once.
+// runOnce reconciles every registered project whose git directory changed
+// since its last successful reconcile, and prunes fingerprints of projects
+// that left the registry.
 func (d *fleetWorktreeDiscoverer) runOnce(ctx context.Context) {
 	projects, err := d.db.ListProjects(ctx)
 	if err != nil {
 		slog.Warn("fleet worktree discovery: list projects failed", "err", err)
 		return
 	}
+	keep := make(map[string]struct{}, len(projects))
 	for i := range projects {
-		d.refreshProject(ctx, projects[i].ID, projects[i].LocalPath)
+		keep[projects[i].ID] = struct{}{}
+		d.refreshProjectIfChanged(ctx, projects[i].ID, projects[i].LocalPath)
 	}
+	d.fingerprintsMu.Lock()
+	for id := range d.fingerprints {
+		if _, ok := keep[id]; !ok {
+			delete(d.fingerprints, id)
+		}
+	}
+	d.fingerprintsMu.Unlock()
 }
 
-// refreshProject inspects one project and reconciles the result. A checkout
-// that cannot be inspected (moved or deleted) is marked stale rather than
-// dropped, so a temporarily missing repository recovers on a later pass.
+// refreshProjectIfChanged is the background variant of refreshProject: it
+// inspects the project only when its git-directory fingerprint differs from
+// the one recorded by the last successful reconcile. A checkout whose
+// fingerprint cannot be computed (moved or deleted) always goes through the
+// full path so it is marked stale.
+func (d *fleetWorktreeDiscoverer) refreshProjectIfChanged(
+	ctx context.Context, projectID, localPath string,
+) {
+	fingerprint, err := projectDiscoveryFingerprint(normPath(localPath))
+	if err == nil {
+		d.fingerprintsMu.Lock()
+		previous, seen := d.fingerprints[projectID]
+		d.fingerprintsMu.Unlock()
+		if seen && previous == fingerprint {
+			return
+		}
+	}
+	d.reconcileProject(ctx, projectID, localPath, fingerprint, err == nil)
+}
+
+// refreshProject inspects one project and reconciles the result
+// unconditionally. It is the on-demand path used after registration and
+// lifecycle mutations, so it never consults the change fingerprint; it does
+// record the fingerprint it observed so the next background pass can skip.
 func (d *fleetWorktreeDiscoverer) refreshProject(
 	ctx context.Context, projectID, localPath string,
 ) {
 	if d == nil || d.db == nil {
 		return
 	}
+	fingerprint, err := projectDiscoveryFingerprint(normPath(localPath))
+	d.reconcileProject(ctx, projectID, localPath, fingerprint, err == nil)
+}
+
+// reconcileProject runs the git inspection and writes the result. A checkout
+// that cannot be inspected (moved or deleted) is marked stale rather than
+// dropped, so a temporarily missing repository recovers on a later pass. The
+// fingerprint is remembered only after a successful reconcile; the
+// fingerprint is taken before inspection so a change that lands mid-pass
+// shows up as a mismatch next time instead of being lost.
+func (d *fleetWorktreeDiscoverer) reconcileProject(
+	ctx context.Context, projectID, localPath, fingerprint string, haveFingerprint bool,
+) {
+	if d == nil || d.db == nil {
+		return
+	}
+	d.forgetFingerprint(projectID)
 	inv, err := discoverProjectInventory(ctx, localPath)
 	if err != nil {
 		slog.Warn("fleet worktree discovery: inspect failed, marking stale",
@@ -91,7 +147,19 @@ func (d *fleetWorktreeDiscoverer) refreshProject(
 	if err := d.db.ReconcileProjectInventory(ctx, projectID, inv, time.Now()); err != nil {
 		slog.Warn("fleet worktree discovery: reconcile failed",
 			"project_id", projectID, "err", err)
+		return
 	}
+	if haveFingerprint {
+		d.fingerprintsMu.Lock()
+		d.fingerprints[projectID] = fingerprint
+		d.fingerprintsMu.Unlock()
+	}
+}
+
+func (d *fleetWorktreeDiscoverer) forgetFingerprint(projectID string) {
+	d.fingerprintsMu.Lock()
+	delete(d.fingerprints, projectID)
+	d.fingerprintsMu.Unlock()
 }
 
 // discoverProjectInventory inspects a project's git checkout and returns its
@@ -228,8 +296,12 @@ func gitSymbolicRef(ctx context.Context, dir, ref string) string {
 	return strings.TrimSpace(out)
 }
 
+// gitDiscoveryOutput runs one git command for discovery through the shared
+// subprocess limiter, so a registry of many projects cannot fan out past the
+// host process budget the rest of the daemon respects.
 func gitDiscoveryOutput(ctx context.Context, dir string, args ...string) (string, error) {
-	out, err := gitcmd.New().Output(ctx, dir, args...)
+	cmd := gitcmd.New().Command(ctx, dir, args...)
+	out, err := procutil.Output(ctx, cmd, "fleet worktree discovery")
 	if err != nil {
 		return "", err
 	}

--- a/internal/server/fleetapi/fleet_worktree_discovery_fingerprint_test.go
+++ b/internal/server/fleetapi/fleet_worktree_discovery_fingerprint_test.go
@@ -1,0 +1,76 @@
+package fleetapi
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+)
+
+// TestFleetWorktreeDiscovererSkipsUnchangedProjects proves a background pass
+// leaves a project alone while its git directory fingerprint is unchanged and
+// reconciles it again as soon as the worktree registry moves.
+func TestFleetWorktreeDiscovererSkipsUnchangedProjects(t *testing.T) {
+	repoDir, _ := seedFingerprintRepo(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	ctx := context.Background()
+
+	project, err := database.CreateProject(ctx, db.CreateProjectInput{
+		DisplayName: "app", LocalPath: repoDir,
+	})
+	require.NoError(err)
+	discoverer := newFleetWorktreeDiscoverer(database, nil)
+
+	discoverer.runOnce(ctx)
+	rows, err := database.ListProjectWorktrees(ctx, project.ID)
+	require.NoError(err)
+	require.Len(rows, 2)
+
+	// Mark the project stale behind the discoverer's back. An unchanged pass
+	// skips the project, so the flag is left as is; the flag itself is not a
+	// git-directory input.
+	require.NoError(database.MarkProjectStale(ctx, project.ID, time.Now()))
+	discoverer.runOnce(ctx)
+	stale, err := database.GetProjectByID(ctx, project.ID)
+	require.NoError(err)
+	require.True(stale.IsStale, "an unchanged project is not reconciled")
+
+	// The on-demand path always reconciles.
+	discoverer.refreshProject(ctx, project.ID, repoDir)
+	fresh, err := database.GetProjectByID(ctx, project.ID)
+	require.NoError(err)
+	require.False(fresh.IsStale)
+
+	// A registry change is picked up by the next background pass.
+	require.NoError(database.MarkProjectStale(ctx, project.ID, time.Now()))
+	other := filepath.Join(t.TempDir(), "other")
+	runGit(t, repoDir, "worktree", "add", "-q", "-b", "other", other)
+	discoverer.runOnce(ctx)
+	after, err := database.GetProjectByID(ctx, project.ID)
+	require.NoError(err)
+	require.False(after.IsStale, "a changed fingerprint reconciles the project")
+	rows, err = database.ListProjectWorktrees(ctx, project.ID)
+	require.NoError(err)
+	require.Len(rows, 3)
+
+	// A vanished checkout is always inspected so it is marked stale, and it
+	// recovers on the pass after it returns.
+	moved := repoDir + ".moved"
+	require.NoError(os.Rename(repoDir, moved))
+	discoverer.runOnce(ctx)
+	gone, err := database.GetProjectByID(ctx, project.ID)
+	require.NoError(err)
+	require.True(gone.IsStale, "a missing checkout is marked stale")
+	require.NoError(os.Rename(moved, repoDir))
+	discoverer.runOnce(ctx)
+	back, err := database.GetProjectByID(ctx, project.ID)
+	require.NoError(err)
+	require.False(back.IsStale, "a returned checkout is reconciled without a forced refresh")
+}

--- a/internal/server/fleetapi/fleet_worktree_stats.go
+++ b/internal/server/fleetapi/fleet_worktree_stats.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"sync"
 	"time"
 
 	"go.kenn.io/forge/internal/db"
@@ -15,7 +16,9 @@ import (
 // fleetWorktreeStatsInterval is how often the sampler re-measures every
 // worktree's git stats. It is longer than the discovery interval because the
 // work is heavier (a diff plus an ahead/behind probe per worktree) and the
-// numbers drift more slowly than the structural worktree set.
+// numbers drift more slowly than the structural worktree set. A worktree whose
+// git-directory fingerprint has not moved since its last sample costs only the
+// stat calls behind that fingerprint.
 const fleetWorktreeStatsInterval = 30 * time.Second
 
 // fleetWorktreeStatsSampler keeps live git stats fresh for every worktree the
@@ -31,39 +34,40 @@ type fleetWorktreeStatsSampler struct {
 	// payload-free signal — a refetch hint — not a stats carrier. May be nil.
 	onChanged         func()
 	workspaceSnapshot func(context.Context) (workspaceapi.FleetSnapshot, error)
+	gate              *fleetMonitorGate
+
+	// fingerprints remembers, per normalized worktree path, the git-directory
+	// fingerprint observed by the last sample that reached the store. A
+	// background pass whose fingerprint still matches skips the git probes and
+	// the upsert; the entry is dropped when the path leaves the target set.
+	fingerprintsMu sync.Mutex
+	fingerprints   map[string]string
 }
 
 func newFleetWorktreeStatsSampler(
 	database *db.DB,
 	workspaceSnapshot func(context.Context) (workspaceapi.FleetSnapshot, error),
 	onChanged func(),
+	hasSubscribers func() bool,
 ) *fleetWorktreeStatsSampler {
 	return &fleetWorktreeStatsSampler{
 		db:                database,
 		interval:          fleetWorktreeStatsInterval,
 		onChanged:         onChanged,
 		workspaceSnapshot: workspaceSnapshot,
+		gate:              newFleetMonitorGate("worktree stats", hasSubscribers),
+		fingerprints:      map[string]string{},
 	}
 }
 
-// run drives sampling passes until ctx is cancelled, starting with an immediate
-// pass so a freshly started daemon reports stats without waiting a full
-// interval.
+// run drives sampling passes until ctx is cancelled. The first pass runs as
+// soon as a client is subscribed so a freshly started daemon reports stats
+// without waiting a full interval.
 func (s *fleetWorktreeStatsSampler) run(ctx context.Context) {
 	if s == nil || s.db == nil {
 		return
 	}
-	s.runOnce(ctx)
-	ticker := time.NewTicker(s.interval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			s.runOnce(ctx)
-		}
-	}
+	runFleetMonitorLoop(ctx, s.interval, s.gate, s.runOnce)
 }
 
 // worktreeStatsTarget is one worktree to sample: its normalized path and the
@@ -88,6 +92,7 @@ func (s *fleetWorktreeStatsSampler) runOnce(ctx context.Context) {
 	if err := s.db.PruneWorktreeStats(ctx, keep); err != nil {
 		slog.Warn("fleet worktree stats: prune failed", "err", err)
 	}
+	s.pruneFingerprints(keep)
 	if anyChanged {
 		s.fireChanged()
 	}
@@ -95,8 +100,9 @@ func (s *fleetWorktreeStatsSampler) runOnce(ctx context.Context) {
 
 // sampleTargets measures and upserts each target's git stats, reporting whether
 // any sample's counts changed and the set of paths to keep (for pruning). A
-// target whose path is gone or whose probe fails leaves its prior sample in
-// place and does not count as a change.
+// target whose git-directory fingerprint matches its last stored sample is
+// skipped outright. A target whose path is gone or whose probe fails leaves its
+// prior sample in place and does not count as a change.
 func (s *fleetWorktreeStatsSampler) sampleTargets(
 	ctx context.Context, targets []worktreeStatsTarget,
 ) (anyChanged bool, keep []string) {
@@ -104,19 +110,75 @@ func (s *fleetWorktreeStatsSampler) sampleTargets(
 	keep = make([]string, 0, len(targets))
 	for _, target := range targets {
 		keep = append(keep, target.path)
-		stats, ok := sampleWorktreeGitStats(ctx, target.path, target.defaultBranch)
+		fingerprint, fingerprintErr := worktreeStatsFingerprint(target.path)
+		if fingerprintErr == nil && s.fingerprintMatches(target.path, fingerprint) {
+			continue
+		}
+		changed, ok := s.sampleAndStore(ctx, target.path, target.defaultBranch, now)
 		if !ok {
 			continue
 		}
-		changed, err := s.db.UpsertWorktreeStats(ctx, target.path, stats, now)
-		if err != nil {
-			slog.Warn("fleet worktree stats: upsert failed",
-				"path", target.path, "err", err)
-			continue
+		if fingerprintErr == nil {
+			s.rememberFingerprint(target.path, fingerprint)
 		}
 		anyChanged = anyChanged || changed
 	}
 	return anyChanged, keep
+}
+
+// sampleAndStore measures one worktree and upserts the result. ok is false
+// when the sample could not be taken or stored, in which case any prior row
+// stays untouched.
+func (s *fleetWorktreeStatsSampler) sampleAndStore(
+	ctx context.Context, path, defaultBranch string, now time.Time,
+) (changed, ok bool) {
+	s.forgetFingerprint(path)
+	stats, ok := sampleWorktreeGitStats(ctx, path, defaultBranch)
+	if !ok {
+		return false, false
+	}
+	changed, err := s.db.UpsertWorktreeStats(ctx, path, stats, now)
+	if err != nil {
+		slog.Warn("fleet worktree stats: upsert failed", "path", path, "err", err)
+		return false, false
+	}
+	return changed, true
+}
+
+func (s *fleetWorktreeStatsSampler) fingerprintMatches(path, fingerprint string) bool {
+	s.fingerprintsMu.Lock()
+	defer s.fingerprintsMu.Unlock()
+	previous, seen := s.fingerprints[path]
+	return seen && previous == fingerprint
+}
+
+func (s *fleetWorktreeStatsSampler) rememberFingerprint(path, fingerprint string) {
+	s.fingerprintsMu.Lock()
+	defer s.fingerprintsMu.Unlock()
+	if s.fingerprints == nil {
+		s.fingerprints = map[string]string{}
+	}
+	s.fingerprints[path] = fingerprint
+}
+
+func (s *fleetWorktreeStatsSampler) forgetFingerprint(path string) {
+	s.fingerprintsMu.Lock()
+	defer s.fingerprintsMu.Unlock()
+	delete(s.fingerprints, path)
+}
+
+func (s *fleetWorktreeStatsSampler) pruneFingerprints(keep []string) {
+	s.fingerprintsMu.Lock()
+	defer s.fingerprintsMu.Unlock()
+	live := make(map[string]struct{}, len(keep))
+	for _, path := range keep {
+		live[path] = struct{}{}
+	}
+	for path := range s.fingerprints {
+		if _, ok := live[path]; !ok {
+			delete(s.fingerprints, path)
+		}
+	}
 }
 
 // fireChanged invokes the onChanged refetch hint if one is registered. It is the
@@ -245,13 +307,14 @@ func sampleWorktreeGitStats(
 }
 
 // refreshWorktreeStats re-measures a single worktree's git stats and upserts
-// them immediately, bypassing the interval wait. It lets a lifecycle mutation
-// (or an on-demand refresh) make the fleet snapshot's diff/sync fields coherent
-// for the affected worktree without a full sampler pass; the background sampler
-// remains the eventual-consistency fallback. It mirrors runOnce's per-target
-// work — a path that is gone or whose diff probe fails leaves any prior sample
-// in place — and normalizes the path so the upserted row matches the snapshot
-// overlay's lookup key.
+// them immediately, bypassing the interval wait and the change fingerprint. It
+// lets a lifecycle mutation (or an on-demand refresh) make the fleet snapshot's
+// diff/sync fields coherent for the affected worktree without a full sampler
+// pass, including working-tree edits the fingerprint cannot see; the
+// background sampler remains the eventual-consistency fallback. It mirrors
+// runOnce's per-target work — a path that is gone or whose diff probe fails
+// leaves any prior sample in place — and normalizes the path so the upserted
+// row matches the snapshot overlay's lookup key.
 func (s *fleetWorktreeStatsSampler) refreshWorktreeStats(
 	ctx context.Context, path, defaultBranch string,
 ) error {
@@ -262,6 +325,8 @@ func (s *fleetWorktreeStatsSampler) refreshWorktreeStats(
 	if path == "" {
 		return nil
 	}
+	fingerprint, fingerprintErr := worktreeStatsFingerprint(path)
+	s.forgetFingerprint(path)
 	stats, ok := sampleWorktreeGitStats(ctx, path, defaultBranch)
 	if !ok {
 		return nil
@@ -269,6 +334,9 @@ func (s *fleetWorktreeStatsSampler) refreshWorktreeStats(
 	changed, err := s.db.UpsertWorktreeStats(ctx, path, stats, time.Now())
 	if err != nil {
 		return err
+	}
+	if fingerprintErr == nil {
+		s.rememberFingerprint(path, fingerprint)
 	}
 	if changed {
 		s.fireChanged()

--- a/internal/server/fleetapi/fleet_worktree_stats.go
+++ b/internal/server/fleetapi/fleet_worktree_stats.go
@@ -21,6 +21,13 @@ import (
 // stat calls behind that fingerprint.
 const fleetWorktreeStatsInterval = 30 * time.Second
 
+// fleetWorktreeStatsFingerprintMaxAge bounds how long a matching fingerprint
+// may keep a worktree from being re-measured. The fingerprint only sees the
+// git directory, so unstaged edits, untracked files, and a rewrite that lands
+// within the filesystem's timestamp resolution are invisible to it; this cap
+// turns that blind spot into bounded staleness.
+const fleetWorktreeStatsFingerprintMaxAge = 10 * time.Minute
+
 // fleetWorktreeStatsSampler keeps live git stats fresh for every worktree the
 // fleet snapshot reports. On a fixed interval it measures each worktree's
 // whole-branch diff size and upstream ahead/behind, writing them to the store
@@ -36,12 +43,31 @@ type fleetWorktreeStatsSampler struct {
 	workspaceSnapshot func(context.Context) (workspaceapi.FleetSnapshot, error)
 	gate              *fleetMonitorGate
 
-	// fingerprints remembers, per normalized worktree path, the git-directory
-	// fingerprint observed by the last sample that reached the store. A
-	// background pass whose fingerprint still matches skips the git probes and
-	// the upsert; the entry is dropped when the path leaves the target set.
+	// now is the sampler's clock; nil means time.Now.
+	now func() time.Time
+
+	// fingerprints remembers, per normalized worktree path, the sampling key
+	// observed by the last sample that reached the store: the git-directory
+	// fingerprint plus the default branch the diff was measured against. A
+	// background pass whose key still matches and is younger than the max age
+	// skips the git probes and the upsert; the entry is dropped when the path
+	// leaves the target set.
 	fingerprintsMu sync.Mutex
-	fingerprints   map[string]string
+	fingerprints   map[string]worktreeStatsSampleKey
+}
+
+// worktreeStatsSampleKey is one remembered sampling key and when it was
+// recorded.
+type worktreeStatsSampleKey struct {
+	key string
+	at  time.Time
+}
+
+func (s *fleetWorktreeStatsSampler) clock() time.Time {
+	if s.now != nil {
+		return s.now()
+	}
+	return time.Now()
 }
 
 func newFleetWorktreeStatsSampler(
@@ -56,7 +82,7 @@ func newFleetWorktreeStatsSampler(
 		onChanged:         onChanged,
 		workspaceSnapshot: workspaceSnapshot,
 		gate:              newFleetMonitorGate("worktree stats", hasSubscribers),
-		fingerprints:      map[string]string{},
+		fingerprints:      map[string]worktreeStatsSampleKey{},
 	}
 }
 
@@ -77,9 +103,20 @@ type worktreeStatsTarget struct {
 	defaultBranch string
 }
 
-// runOnce samples every worktree once and prunes stats for paths that have left
-// the snapshot's worktree set.
+// runOnce samples every worktree whose sampling key changed and prunes stats
+// for paths that have left the snapshot's worktree set.
 func (s *fleetWorktreeStatsSampler) runOnce(ctx context.Context) {
+	s.runPass(ctx, false)
+}
+
+// runOnceForced samples every worktree unconditionally. It backs the
+// fleet-wide refresh route, whose callers expect working-tree edits the
+// fingerprint cannot see to be measured.
+func (s *fleetWorktreeStatsSampler) runOnceForced(ctx context.Context) {
+	s.runPass(ctx, true)
+}
+
+func (s *fleetWorktreeStatsSampler) runPass(ctx context.Context, force bool) {
 	if s == nil || s.db == nil {
 		return
 	}
@@ -88,7 +125,7 @@ func (s *fleetWorktreeStatsSampler) runOnce(ctx context.Context) {
 		slog.Warn("fleet worktree stats: collect targets failed", "err", err)
 		return
 	}
-	anyChanged, keep := s.sampleTargets(ctx, targets)
+	anyChanged, keep := s.sampleTargets(ctx, targets, force)
 	if err := s.db.PruneWorktreeStats(ctx, keep); err != nil {
 		slog.Warn("fleet worktree stats: prune failed", "err", err)
 	}
@@ -99,31 +136,44 @@ func (s *fleetWorktreeStatsSampler) runOnce(ctx context.Context) {
 }
 
 // sampleTargets measures and upserts each target's git stats, reporting whether
-// any sample's counts changed and the set of paths to keep (for pruning). A
-// target whose git-directory fingerprint matches its last stored sample is
-// skipped outright. A target whose path is gone or whose probe fails leaves its
-// prior sample in place and does not count as a change.
+// any sample's counts changed and the set of paths to keep (for pruning).
+// Unless force is set, a target whose sampling key matches its last stored
+// sample and is younger than the max age is skipped outright. A target whose
+// path is gone or whose probe fails leaves its prior sample in place and does
+// not count as a change.
 func (s *fleetWorktreeStatsSampler) sampleTargets(
-	ctx context.Context, targets []worktreeStatsTarget,
+	ctx context.Context, targets []worktreeStatsTarget, force bool,
 ) (anyChanged bool, keep []string) {
-	now := time.Now()
+	now := s.clock()
 	keep = make([]string, 0, len(targets))
 	for _, target := range targets {
 		keep = append(keep, target.path)
-		fingerprint, fingerprintErr := worktreeStatsFingerprint(target.path)
-		if fingerprintErr == nil && s.fingerprintMatches(target.path, fingerprint) {
+		key, keyErr := worktreeStatsSamplingKey(target)
+		if !force && keyErr == nil && s.fingerprintMatches(target.path, key, now) {
 			continue
 		}
 		changed, ok := s.sampleAndStore(ctx, target.path, target.defaultBranch, now)
 		if !ok {
 			continue
 		}
-		if fingerprintErr == nil {
-			s.rememberFingerprint(target.path, fingerprint)
+		if keyErr == nil {
+			s.rememberFingerprint(target.path, key, now)
 		}
 		anyChanged = anyChanged || changed
 	}
 	return anyChanged, keep
+}
+
+// worktreeStatsSamplingKey is the change key for one target: its
+// git-directory fingerprint joined with the default branch its diff is
+// measured against, so a discovery pass that changes the project's default
+// branch invalidates the sample even though no git file moved.
+func worktreeStatsSamplingKey(target worktreeStatsTarget) (string, error) {
+	fingerprint, err := worktreeStatsFingerprint(target.path)
+	if err != nil {
+		return "", err
+	}
+	return fingerprint + "\x00" + target.defaultBranch, nil
 }
 
 // sampleAndStore measures one worktree and upserts the result. ok is false
@@ -145,20 +195,21 @@ func (s *fleetWorktreeStatsSampler) sampleAndStore(
 	return changed, true
 }
 
-func (s *fleetWorktreeStatsSampler) fingerprintMatches(path, fingerprint string) bool {
+func (s *fleetWorktreeStatsSampler) fingerprintMatches(path, key string, now time.Time) bool {
 	s.fingerprintsMu.Lock()
 	defer s.fingerprintsMu.Unlock()
 	previous, seen := s.fingerprints[path]
-	return seen && previous == fingerprint
+	return seen && previous.key == key &&
+		now.Sub(previous.at) < fleetWorktreeStatsFingerprintMaxAge
 }
 
-func (s *fleetWorktreeStatsSampler) rememberFingerprint(path, fingerprint string) {
+func (s *fleetWorktreeStatsSampler) rememberFingerprint(path, key string, now time.Time) {
 	s.fingerprintsMu.Lock()
 	defer s.fingerprintsMu.Unlock()
 	if s.fingerprints == nil {
-		s.fingerprints = map[string]string{}
+		s.fingerprints = map[string]worktreeStatsSampleKey{}
 	}
-	s.fingerprints[path] = fingerprint
+	s.fingerprints[path] = worktreeStatsSampleKey{key: key, at: now}
 }
 
 func (s *fleetWorktreeStatsSampler) forgetFingerprint(path string) {
@@ -325,18 +376,21 @@ func (s *fleetWorktreeStatsSampler) refreshWorktreeStats(
 	if path == "" {
 		return nil
 	}
-	fingerprint, fingerprintErr := worktreeStatsFingerprint(path)
+	now := s.clock()
+	key, keyErr := worktreeStatsSamplingKey(worktreeStatsTarget{
+		path: path, defaultBranch: defaultBranch,
+	})
 	s.forgetFingerprint(path)
 	stats, ok := sampleWorktreeGitStats(ctx, path, defaultBranch)
 	if !ok {
 		return nil
 	}
-	changed, err := s.db.UpsertWorktreeStats(ctx, path, stats, time.Now())
+	changed, err := s.db.UpsertWorktreeStats(ctx, path, stats, now)
 	if err != nil {
 		return err
 	}
-	if fingerprintErr == nil {
-		s.rememberFingerprint(path, fingerprint)
+	if keyErr == nil {
+		s.rememberFingerprint(path, key, now)
 	}
 	if changed {
 		s.fireChanged()

--- a/internal/server/fleetapi/fleet_worktree_stats_fingerprint_test.go
+++ b/internal/server/fleetapi/fleet_worktree_stats_fingerprint_test.go
@@ -1,0 +1,85 @@
+package fleetapi
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+)
+
+// TestFleetWorktreeStatsSamplerSkipsUnchangedWorktrees proves the background
+// pass neither re-measures nor rewrites a worktree whose git directory has not
+// moved: a row altered behind the sampler's back survives an unchanged pass
+// and is corrected only once the fingerprint changes.
+func TestFleetWorktreeStatsSamplerSkipsUnchangedWorktrees(t *testing.T) {
+	repoDir, featDir := seedFingerprintRepo(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	ctx := context.Background()
+
+	require.NoError(os.WriteFile(
+		filepath.Join(featDir, "feature.txt"), []byte("x\ny\n"), 0o644,
+	))
+	runGit(t, featDir, "add", ".")
+	runGit(t, featDir, "commit", "-q", "-m", "feature work")
+
+	proj, err := database.CreateProject(ctx, db.CreateProjectInput{
+		DisplayName: "app", LocalPath: repoDir, DefaultBranch: "main",
+	})
+	require.NoError(err)
+	_, err = database.CreateProjectWorktree(ctx, db.CreateProjectWorktreeInput{
+		ProjectID: proj.ID, Branch: "feature", Path: featDir,
+	})
+	require.NoError(err)
+
+	fires := 0
+	sampler := &fleetWorktreeStatsSampler{
+		db:        database,
+		onChanged: func() { fires++ },
+	}
+	sampler.runOnce(ctx)
+	require.Equal(1, fires)
+	stats, err := database.ListWorktreeStats(ctx)
+	require.NoError(err)
+	require.Equal(2, stats[normPath(featDir)].DiffAdded)
+
+	// Tamper with the stored row. An unchanged pass must not touch it.
+	tampered := db.WorktreeGitStats{DiffAdded: 99, DiffRemoved: 99}
+	_, err = database.UpsertWorktreeStats(ctx, normPath(featDir), tampered, time.Now())
+	require.NoError(err)
+	sampler.runOnce(ctx)
+	stats, err = database.ListWorktreeStats(ctx)
+	require.NoError(err)
+	require.Equal(99, stats[normPath(featDir)].DiffAdded,
+		"an unchanged worktree is skipped, so the tampered row survives")
+	require.Equal(1, fires)
+
+	// A commit in the worktree moves its branch ref, so the next pass
+	// re-measures and repairs the row.
+	require.NoError(os.WriteFile(
+		filepath.Join(featDir, "more.txt"), []byte("z\n"), 0o644,
+	))
+	runGit(t, featDir, "add", ".")
+	runGit(t, featDir, "commit", "-q", "-m", "more")
+	sampler.runOnce(ctx)
+	stats, err = database.ListWorktreeStats(ctx)
+	require.NoError(err)
+	require.Equal(3, stats[normPath(featDir)].DiffAdded,
+		"a changed fingerprint re-samples the worktree")
+	require.Equal(2, fires)
+
+	// The on-demand refresh ignores the fingerprint entirely.
+	_, err = database.UpsertWorktreeStats(ctx, normPath(featDir), tampered, time.Now())
+	require.NoError(err)
+	require.NoError(sampler.refreshWorktreeStats(ctx, featDir, "main"))
+	stats, err = database.ListWorktreeStats(ctx)
+	require.NoError(err)
+	require.Equal(3, stats[normPath(featDir)].DiffAdded,
+		"the on-demand refresh always re-measures")
+}

--- a/internal/server/fleetapi/handler.go
+++ b/internal/server/fleetapi/handler.go
@@ -57,6 +57,10 @@ type Deps struct {
 	PersistHubBinding           func(context.Context, config.FleetHub) error
 	RemoveMember                func(context.Context, string) error
 	CancelEventStreams          func(string)
+	// SubscriberCount reports how many event-stream clients are connected.
+	// The fleet background monitors skip their expensive passes while it is
+	// zero; nil means always run.
+	SubscriberCount func() int
 }
 
 // Handler implements Fleet routes, caches, transports, and workers.
@@ -142,14 +146,20 @@ func New(deps Deps) *Handler {
 		h.federationHTTPClient = newFederationHTTPClient()
 	}
 	h.memberClients = make(map[string]federationMemberClients)
+	var hasSubscribers func() bool
+	if deps.SubscriberCount != nil {
+		hasSubscribers = func() bool { return deps.SubscriberCount() > 0 }
+	}
 	h.fleetTmuxMonitor = newFleetTmuxMonitor(
 		deps.Config.TmuxCommand,
 		deps.Config.Fleet.Sessions.IncludeUnmanagedDetails,
 		nil,
+		hasSubscribers,
 	)
-	h.fleetWorktreeDiscoverer = newFleetWorktreeDiscoverer(deps.DB)
+	h.fleetWorktreeDiscoverer = newFleetWorktreeDiscoverer(deps.DB, hasSubscribers)
 	h.fleetWorktreeStatsSampler = newFleetWorktreeStatsSampler(
 		deps.DB, deps.WorkspaceStatsSnapshot, h.notifyWorktreeStatsChanged,
+		hasSubscribers,
 	)
 	h.fleetPlatformAuthMonitor = newFleetPlatformAuthMonitor(
 		h.snapshotPlatformAuthConfig,

--- a/internal/server/fleetapi/handler.go
+++ b/internal/server/fleetapi/handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.kenn.io/forge/internal/config"
@@ -59,7 +60,7 @@ type Deps struct {
 	CancelEventStreams          func(string)
 	// SubscriberCount reports how many event-stream clients are connected.
 	// The fleet background monitors skip their expensive passes while it is
-	// zero; nil means always run.
+	// zero and no snapshot was read recently; nil means always run.
 	SubscriberCount func() int
 }
 
@@ -105,6 +106,10 @@ type Handler struct {
 	lifecycleStopping         bool
 	lifecycleDone             chan struct{}
 	lifecycleStarted          bool
+	// snapshotDemandAt is the UnixNano time of the last snapshot read served
+	// by this handler; it keeps the monitors active for hub-driven spokes
+	// that never open a local event stream.
+	snapshotDemandAt atomic.Int64
 }
 
 // New constructs a Fleet handler without starting its workers.
@@ -148,7 +153,9 @@ func New(deps Deps) *Handler {
 	h.memberClients = make(map[string]federationMemberClients)
 	var hasSubscribers func() bool
 	if deps.SubscriberCount != nil {
-		hasSubscribers = func() bool { return deps.SubscriberCount() > 0 }
+		hasSubscribers = func() bool {
+			return deps.SubscriberCount() > 0 || h.recentSnapshotDemand()
+		}
 	}
 	h.fleetTmuxMonitor = newFleetTmuxMonitor(
 		deps.Config.TmuxCommand,
@@ -283,6 +290,28 @@ func (h *Handler) Start(parent context.Context, tmuxAvailable, disableMonitors b
 	h.runBackground(h.fleetWorktreeDiscoverer.run)
 	h.runBackground(h.fleetWorktreeStatsSampler.run)
 	h.runBackground(h.fleetPlatformAuthMonitor.run)
+}
+
+// noteSnapshotDemand records that a client read a snapshot, which counts as
+// demand for fresh monitor data even without an event-stream subscription.
+func (h *Handler) noteSnapshotDemand() {
+	if h == nil {
+		return
+	}
+	h.snapshotDemandAt.Store(h.now().UnixNano())
+}
+
+// recentSnapshotDemand reports whether a snapshot was read within the demand
+// window.
+func (h *Handler) recentSnapshotDemand() bool {
+	if h == nil {
+		return false
+	}
+	at := h.snapshotDemandAt.Load()
+	if at == 0 {
+		return false
+	}
+	return h.now().Sub(time.Unix(0, at)) < fleetMonitorDemandWindow
 }
 
 // RefreshWorktreeStats refreshes the cached git statistics for one worktree.

--- a/internal/server/fleetapi/main_test.go
+++ b/internal/server/fleetapi/main_test.go
@@ -1,0 +1,12 @@
+package fleetapi
+
+import (
+	"os"
+	"testing"
+
+	"go.kenn.io/forge/internal/testutil/gitsafe"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(gitsafe.RunIsolatedMain(m))
+}

--- a/internal/server/fleetapi/test_helpers_test.go
+++ b/internal/server/fleetapi/test_helpers_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/danielgtaylor/huma/v2/adapters/humago"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
+	"go.kenn.io/forge/internal/testutil/gitsafe"
 	gitcmd "go.kenn.io/kit/git/cmd"
 
 	"go.kenn.io/forge/internal/config"
@@ -352,7 +353,7 @@ func httpDo(
 
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	runner := gitcmd.New().WithConfig("init.defaultBranch", "main")
+	runner := gitsafe.Runner().WithConfig("init.defaultBranch", "main")
 	out, stderr, err := runner.Run(t.Context(), dir, nil, args...)
 	require.NoError(t, err, "git %v failed: %s%s", args, out, stderr)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1007,7 +1007,8 @@ func newServer(
 		Broadcast: func(event fleetapi.Event) uint64 {
 			return s.hub.Broadcast(Event{Type: event.Type, Data: event.Data})
 		},
-		Generation: s.hub.Generation,
+		Generation:      s.hub.Generation,
+		SubscriberCount: s.hub.SubscriberCount,
 		WorkspaceSnapshot: func(ctx context.Context) (workspaceapi.FleetSnapshot, error) {
 			if s.workspaceAPI == nil {
 				return workspaceapi.FleetSnapshot{}, nil

--- a/internal/server/workspaceapi/agent_activity_reconcile_test.go
+++ b/internal/server/workspaceapi/agent_activity_reconcile_test.go
@@ -1,0 +1,67 @@
+package workspaceapi
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/agentactivity"
+	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/workspace"
+	"go.kenn.io/forge/internal/workspace/localruntime"
+)
+
+// TestRestoreRuntimeSessionsDropsReportsOfPrunedRuntimes proves that a report
+// whose runtime row is gone, as happens when the startup prune removes a
+// missing tmux session before restoration runs, is removed by restoration,
+// while a report backed by a persisted row survives.
+func TestRestoreRuntimeSessionsDropsReportsOfPrunedRuntimes(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	database := dbtest.Open(t)
+	worktree := t.TempDir()
+	workspaceID := "ws-reconcile"
+	require.NoError(database.InsertWorkspace(ctx, &db.Workspace{
+		ID: workspaceID, Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widgets",
+		ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 9,
+		GitHeadRef: "feature/reconcile", WorkspaceBranch: "feature/reconcile",
+		WorktreePath: worktree, Status: "ready",
+	}))
+	// A persisted runtime whose pty-owner state is gone restores as
+	// unavailable, which keeps its row; its report must survive.
+	require.NoError(database.UpsertWorkspaceRuntimeSession(ctx, &db.WorkspaceRuntimeSession{
+		WorkspaceID: workspaceID, SessionKey: "runtime-kept",
+		TargetKey: "claude", Label: "Claude", Kind: "agent", Scope: "session",
+	}))
+
+	activityRoot := t.TempDir()
+	activity := agentactivity.NewStore(activityRoot)
+	require.NoError(activity.HandleEvent("claude", agentactivity.HookEvent{
+		SessionID: "kept", CWD: worktree, HookEventName: "UserPromptSubmit",
+	}, "runtime-kept"))
+	require.NoError(activity.HandleEvent("claude", agentactivity.HookEvent{
+		SessionID: "pruned", CWD: worktree, HookEventName: "UserPromptSubmit",
+	}, "runtime-pruned"))
+	entries, err := os.ReadDir(activityRoot)
+	require.NoError(err)
+	require.Len(entries, 2)
+
+	runtime := localruntime.NewManager(localruntime.Options{})
+	t.Cleanup(runtime.Shutdown)
+	handler := New(Deps{
+		DB: database, Workspaces: workspace.NewManager(database, t.TempDir()),
+		Runtime: runtime, AgentActivity: activity,
+	})
+	require.NoError(handler.RestoreRuntimeSessions(ctx))
+
+	entries, err = os.ReadDir(activityRoot)
+	require.NoError(err)
+	require.Len(entries, 1, "the report of the pruned runtime is gone")
+	reports := activity.LiveReportsForWorkspace(worktree, []string{"runtime-kept", "runtime-pruned"})
+	require.Len(reports, 1)
+	assert.Equal("runtime-kept", reports[0].RuntimeSessionKey)
+}

--- a/internal/server/workspaceapi/lifecycle.go
+++ b/internal/server/workspaceapi/lifecycle.go
@@ -167,7 +167,43 @@ func (h *Handler) RestoreRuntimeSessions(ctx context.Context) error {
 		}
 		return err
 	}
+	h.reconcileAgentActivityReports(ctx)
 	return nil
+}
+
+// reconcileAgentActivityReports drops agent activity reports whose runtime
+// session is neither persisted nor live. Startup pruning and the periodic
+// missing-tmux prune delete runtime rows without an exit hook, and reports do
+// not expire on their own, so this is what keeps the report directory from
+// collecting sessions that died while the daemon was down.
+func (h *Handler) reconcileAgentActivityReports(ctx context.Context) {
+	if h == nil || h.agentActivity == nil || h.db == nil {
+		return
+	}
+	keep := map[string]struct{}{}
+	stored, err := h.db.ListAllWorkspaceRuntimeSessions(ctx)
+	if err != nil {
+		slog.Warn("reconcile agent activity reports: list runtime sessions", "err", err)
+		return
+	}
+	for _, session := range stored {
+		keep[session.SessionKey] = struct{}{}
+	}
+	if h.runtime != nil {
+		summaries, err := h.db.ListWorkspaceSummaries(ctx)
+		if err != nil {
+			slog.Warn("reconcile agent activity reports: list workspaces", "err", err)
+			return
+		}
+		for _, summary := range summaries {
+			for _, session := range h.runtime.ListSessions(summary.ID) {
+				keep[session.Key] = struct{}{}
+			}
+		}
+	}
+	if err := h.agentActivity.RetainRuntimeSessions(keep); err != nil {
+		slog.Warn("reconcile agent activity reports", "err", err)
+	}
 }
 
 // HandleRuntimeSessionExit reconciles a workspace runtime exit with persisted

--- a/internal/server/workspaceapi/lifecycle.go
+++ b/internal/server/workspaceapi/lifecycle.go
@@ -150,6 +150,10 @@ func (h *Handler) RestoreRuntimeSessions(ctx context.Context) error {
 			); forgetErr != nil {
 				return forgetErr
 			}
+			// The agent exited while the daemon was down, so no exit hook
+			// removed its activity report; reports do not expire on their
+			// own, so the forgotten runtime takes its report with it.
+			h.removeAgentActivityRuntimeSession(session.SessionKey)
 			continue
 		}
 		if errors.Is(err, localruntime.ErrSessionUnavailable) {

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
+	"go.kenn.io/forge/internal/agentactivity"
 	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/gitclone"
 	ghclient "go.kenn.io/forge/internal/github"
@@ -2087,14 +2088,17 @@ func (s *Handler) workspaceResponseWithTmuxEnrichment(
 // pane probe. A workspace whose live agent session has reported through the
 // hook integration is not probed at all: the lifecycle events are the
 // authoritative activity signal there, and the pane capture would only spend
-// tmux spawns to second-guess them. Such a workspace counts as a complete,
-// activity-free tmux sample.
+// tmux spawns to second-guess them. Such a workspace counts as a complete
+// tmux sample whose last-activity time is the hook report's own timestamp, so
+// subject activity feeds still see hook-driven work move.
 func (s *Handler) applyWorkspaceTmuxEnrichment(
 	ctx context.Context,
 	summary *db.WorkspaceSummary,
 	resp *workspaceResponse,
 ) error {
-	if s.hookActivityCoversWorkspace(summary) {
+	if hook, ok := s.hookActivityCoveringWorkspace(summary); ok {
+		activityAt := hook.UpdatedAt.UTC().Format(time.RFC3339)
+		resp.TmuxLastOutputAt = &activityAt
 		return nil
 	}
 	sessions, sessionsErr := s.workspaceTmuxActivitySessions(ctx, summary)
@@ -2105,16 +2109,17 @@ func (s *Handler) applyWorkspaceTmuxEnrichment(
 	return errors.Join(sessionsErr, activityErr)
 }
 
-// hookActivityCoversWorkspace reports whether a fresh hook report exists for
-// one of the workspace's live agent sessions.
-func (s *Handler) hookActivityCoversWorkspace(summary *db.WorkspaceSummary) bool {
+// hookActivityCoveringWorkspace returns the hook activity snapshot for one of
+// the workspace's live agent sessions, when one exists.
+func (s *Handler) hookActivityCoveringWorkspace(
+	summary *db.WorkspaceSummary,
+) (agentactivity.Snapshot, bool) {
 	if s.agentActivity == nil || s.runtime == nil || summary == nil {
-		return false
+		return agentactivity.Snapshot{}, false
 	}
-	_, ok := s.agentActivity.SnapshotForWorkspace(
+	return s.agentActivity.SnapshotForWorkspace(
 		summary.WorktreePath, s.liveAgentSessionKeys(summary.ID),
 	)
-	return ok
 }
 
 // liveAgentSessionKeys lists the runtime session keys of the workspace's

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -2096,8 +2096,8 @@ func (s *Handler) applyWorkspaceTmuxEnrichment(
 	summary *db.WorkspaceSummary,
 	resp *workspaceResponse,
 ) error {
-	if hook, ok := s.hookActivityCoveringWorkspace(summary); ok {
-		activityAt := hook.UpdatedAt.UTC().Format(time.RFC3339)
+	if latest, ok := s.latestHookReportForWorkspace(summary); ok {
+		activityAt := latest.UpdatedAt.UTC().Format(time.RFC3339)
 		resp.TmuxLastOutputAt = &activityAt
 		return nil
 	}
@@ -2109,17 +2109,24 @@ func (s *Handler) applyWorkspaceTmuxEnrichment(
 	return errors.Join(sessionsErr, activityErr)
 }
 
-// hookActivityCoveringWorkspace returns the hook activity snapshot for one of
-// the workspace's live agent sessions, when one exists.
-func (s *Handler) hookActivityCoveringWorkspace(
+// latestHookReportForWorkspace returns the most recent hook report among the
+// workspace's live agent sessions, when one exists. It is deliberately the
+// newest report rather than the state-priority pick behind AgentState: with
+// two live agents an older approval must not hide a newer event when the
+// workspace's last activity is derived.
+func (s *Handler) latestHookReportForWorkspace(
 	summary *db.WorkspaceSummary,
-) (agentactivity.Snapshot, bool) {
+) (agentactivity.Report, bool) {
 	if s.agentActivity == nil || s.runtime == nil || summary == nil {
-		return agentactivity.Snapshot{}, false
+		return agentactivity.Report{}, false
 	}
-	return s.agentActivity.SnapshotForWorkspace(
+	reports := s.agentActivity.LiveReportsForWorkspace(
 		summary.WorktreePath, s.liveAgentSessionKeys(summary.ID),
 	)
+	if len(reports) == 0 {
+		return agentactivity.Report{}, false
+	}
+	return reports[0], true
 }
 
 // liveAgentSessionKeys lists the runtime session keys of the workspace's

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -1922,16 +1922,8 @@ func (s *Handler) applyAgentActivity(
 	if s.agentActivity == nil || s.runtime == nil || resp == nil || summary == nil {
 		return
 	}
-	liveSessionKeys := make([]string, 0)
-	for _, session := range s.runtime.ListSessions(summary.ID) {
-		if session.Kind == localruntime.LaunchTargetAgent &&
-			(session.Status == localruntime.SessionStatusRunning ||
-				session.Status == localruntime.SessionStatusStarting) {
-			liveSessionKeys = append(liveSessionKeys, session.Key)
-		}
-	}
 	snapshot, ok := s.agentActivity.SnapshotForWorkspace(
-		summary.WorktreePath, liveSessionKeys,
+		summary.WorktreePath, s.liveAgentSessionKeys(summary.ID),
 	)
 	if !ok {
 		return
@@ -2053,14 +2045,7 @@ func (s *Handler) probeWorkspaceEnrichment(
 	}
 	var tmuxErr error
 	if plan.tmux {
-		sessions, sessionsErr := s.workspaceTmuxActivitySessions(ctx, summary)
-		activity, hasActivity, activityErr := s.probeWorkspaceTmuxActivity(
-			ctx, summary, sessions,
-		)
-		if hasActivity {
-			applyTmuxActivity(&resp, activity)
-		}
-		tmuxErr = errors.Join(sessionsErr, activityErr)
+		tmuxErr = s.applyWorkspaceTmuxEnrichment(ctx, summary, &resp)
 		result.tmuxComplete = tmuxErr == nil
 		result.tmuxErr = tmuxErr
 	}
@@ -2091,16 +2076,60 @@ func (s *Handler) workspaceResponseWithTmuxEnrichment(
 	if s.workspaces == nil || summary.Status != "ready" {
 		return workspaceEnrichmentProbeResult{response: resp, kind: workspaceEnrichmentTmux}
 	}
-	sessions, sessionsErr := s.workspaceTmuxActivitySessions(ctx, summary)
-	activity, hasActivity, activityErr := s.probeWorkspaceTmuxActivity(ctx, summary, sessions)
-	if hasActivity {
-		applyTmuxActivity(&resp, activity)
-	}
-	err := errors.Join(sessionsErr, activityErr)
+	err := s.applyWorkspaceTmuxEnrichment(ctx, summary, &resp)
 	return workspaceEnrichmentProbeResult{
 		response: resp, tmuxComplete: err == nil, tmuxErr: err, err: err,
 		kind: workspaceEnrichmentTmux,
 	}
+}
+
+// applyWorkspaceTmuxEnrichment fills the tmux activity fields of resp from a
+// pane probe. A workspace whose live agent session has reported through the
+// hook integration is not probed at all: the lifecycle events are the
+// authoritative activity signal there, and the pane capture would only spend
+// tmux spawns to second-guess them. Such a workspace counts as a complete,
+// activity-free tmux sample.
+func (s *Handler) applyWorkspaceTmuxEnrichment(
+	ctx context.Context,
+	summary *db.WorkspaceSummary,
+	resp *workspaceResponse,
+) error {
+	if s.hookActivityCoversWorkspace(summary) {
+		return nil
+	}
+	sessions, sessionsErr := s.workspaceTmuxActivitySessions(ctx, summary)
+	activity, hasActivity, activityErr := s.probeWorkspaceTmuxActivity(ctx, summary, sessions)
+	if hasActivity {
+		applyTmuxActivity(resp, activity)
+	}
+	return errors.Join(sessionsErr, activityErr)
+}
+
+// hookActivityCoversWorkspace reports whether a fresh hook report exists for
+// one of the workspace's live agent sessions.
+func (s *Handler) hookActivityCoversWorkspace(summary *db.WorkspaceSummary) bool {
+	if s.agentActivity == nil || s.runtime == nil || summary == nil {
+		return false
+	}
+	_, ok := s.agentActivity.SnapshotForWorkspace(
+		summary.WorktreePath, s.liveAgentSessionKeys(summary.ID),
+	)
+	return ok
+}
+
+// liveAgentSessionKeys lists the runtime session keys of the workspace's
+// running or starting agent sessions, the only sessions whose hook reports
+// count.
+func (s *Handler) liveAgentSessionKeys(workspaceID string) []string {
+	liveSessionKeys := make([]string, 0)
+	for _, session := range s.runtime.ListSessions(workspaceID) {
+		if session.Kind == localruntime.LaunchTargetAgent &&
+			(session.Status == localruntime.SessionStatusRunning ||
+				session.Status == localruntime.SessionStatusStarting) {
+			liveSessionKeys = append(liveSessionKeys, session.Key)
+		}
+	}
+	return liveSessionKeys
 }
 
 func (s *Handler) workspaceTmuxActivitySessions(

--- a/internal/server/workspaceapi/workspace_enrichment.go
+++ b/internal/server/workspaceapi/workspace_enrichment.go
@@ -696,6 +696,7 @@ func (s *Handler) runWorkspaceTmuxPrune(ctx context.Context) {
 	// broadcast made every open view refetch its workspace every prune
 	// interval even though nothing happened.
 	if pruned {
+		s.reconcileAgentActivityReports(pruneCtx)
 		s.hub.Broadcast(Event{Type: "workspace_status", Data: map[string]string{}})
 	}
 }

--- a/internal/server/workspaceapi/workspace_enrichment.go
+++ b/internal/server/workspaceapi/workspace_enrichment.go
@@ -690,13 +690,20 @@ func (s *Handler) runWorkspaceTmuxPrune(ctx context.Context) {
 	pruned, err := s.workspaces.PruneMissingTmuxSessions(pruneCtx)
 	if err != nil {
 		slog.Debug("prune missing tmux sessions", "err", err)
+	}
+	if !pruned {
 		return
 	}
+	// Rows may have been deleted even when the prune also failed part way,
+	// so their reports are reconciled whenever anything was pruned, on a
+	// budget of their own rather than the prune's remaining one.
+	reconcileCtx, cancelReconcile := context.WithTimeout(
+		ctx, workspaceEnrichmentRefreshTimeout,
+	)
+	defer cancelReconcile()
+	s.reconcileAgentActivityReports(reconcileCtx)
 	// Broadcast only when the pass changed state. The unconditional
 	// broadcast made every open view refetch its workspace every prune
 	// interval even though nothing happened.
-	if pruned {
-		s.reconcileAgentActivityReports(pruneCtx)
-		s.hub.Broadcast(Event{Type: "workspace_status", Data: map[string]string{}})
-	}
+	s.hub.Broadcast(Event{Type: "workspace_status", Data: map[string]string{}})
 }

--- a/internal/server/workspaceapi/workspace_tmux_hook_gate_test.go
+++ b/internal/server/workspaceapi/workspace_tmux_hook_gate_test.go
@@ -1,0 +1,113 @@
+package workspaceapi
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/agentactivity"
+	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/ptyowner"
+	ptyownerruntime "go.kenn.io/forge/internal/ptyowner/runtime"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/workspace"
+	"go.kenn.io/forge/internal/workspace/localruntime"
+)
+
+// TestTmuxEnrichmentSkipsWorkspacesCoveredByHookReports proves that a
+// workspace whose live agent session has reported through the hook
+// integration is not probed through tmux at all, and that the probe resumes
+// once the hook coverage is gone.
+func TestTmuxEnrichmentSkipsWorkspacesCoveredByHookReports(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	t.Setenv("KENN_FORGE_AGENT_SESSION_HELPER", "1")
+	ctx := t.Context()
+	database := dbtest.Open(t)
+	worktree := t.TempDir()
+	workspaceID := "ws-hook-gate"
+	require.NoError(database.InsertWorkspace(ctx, &db.Workspace{
+		ID:              workspaceID,
+		Platform:        "github",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widgets",
+		ItemType:        db.WorkspaceItemTypePullRequest,
+		ItemNumber:      7,
+		GitHeadRef:      "feature/hook-gate",
+		WorkspaceBranch: "feature/hook-gate",
+		WorktreePath:    worktree,
+		TmuxSession:     "forge-hook-gate",
+		Status:          "ready",
+	}))
+
+	// Every tmux invocation the workspace manager makes lands in this log.
+	logPath := filepath.Join(t.TempDir(), "tmux-calls.log")
+	tmuxScript := filepath.Join(t.TempDir(), "tmux")
+	require.NoError(os.WriteFile(tmuxScript, []byte(
+		"#!/bin/sh\necho \"$@\" >> \""+logPath+"\"\nexit 1\n",
+	), 0o755))
+	manager := workspace.NewManager(database, t.TempDir())
+	manager.SetTmuxCommand([]string{tmuxScript})
+
+	helperCommand := []string{
+		os.Args[0], "-test.run=^TestWorkspaceAgentSessionHelper$", "--", "sleep",
+	}
+	runtime := localruntime.NewManager(localruntime.Options{
+		Targets: []localruntime.LaunchTarget{{
+			Key: "claude", Label: "Claude", Kind: localruntime.LaunchTargetAgent,
+			Source: "test", Command: helperCommand, Available: true,
+		}},
+		PtyOwnerRuntime: ptyownerruntime.New(&ptyowner.Client{
+			Root: filepath.Join(t.TempDir(), "pty-owner"), InProcess: true,
+		}, nil),
+	})
+	t.Cleanup(func() {
+		runtime.StopWorkspace(context.Background(), workspaceID)
+		runtime.Shutdown()
+	})
+	agentRuntime, err := runtime.Launch(ctx, workspaceID, worktree, "claude")
+	require.NoError(err)
+
+	activity := agentactivity.NewStore(t.TempDir())
+	handler := New(Deps{
+		DB: database, Workspaces: manager, Runtime: runtime, AgentActivity: activity,
+	})
+	summary, err := database.GetWorkspaceSummary(ctx, workspaceID)
+	require.NoError(err)
+
+	tmuxCalls := func() string {
+		raw, _ := os.ReadFile(logPath)
+		return string(raw)
+	}
+
+	// Without any hook report the classic pane probe runs.
+	result := handler.workspaceResponseWithTmuxEnrichment(ctx, summary)
+	assert.NotEmpty(tmuxCalls(), "an uncovered workspace is probed through tmux")
+	assert.False(result.tmuxComplete, "the fake tmux fails, so the probe is incomplete")
+
+	// A live agent session reporting through hooks makes the probe redundant.
+	require.NoError(activity.HandleEvent("claude", agentactivity.HookEvent{
+		SessionID: "claude-session", CWD: worktree, HookEventName: "UserPromptSubmit",
+	}, agentRuntime.Key))
+	require.NoError(os.Remove(logPath))
+	result = handler.workspaceResponseWithTmuxEnrichment(ctx, summary)
+	assert.Empty(tmuxCalls(), "a hook-covered workspace spawns no tmux probe")
+	assert.True(result.tmuxComplete, "hook coverage counts as a complete sample")
+	assert.False(result.response.TmuxWorking)
+	assert.Nil(result.response.TmuxLastOutputAt)
+
+	full := handler.workspaceResponseWithEnrichment(ctx, summary)
+	assert.Empty(tmuxCalls(), "the full enrichment pass honours the same gate")
+	assert.True(full.tmuxComplete)
+
+	// Once the session ends its hook report is gone and tmux is probed again.
+	require.NoError(activity.HandleEvent("claude", agentactivity.HookEvent{
+		SessionID: "claude-session", CWD: worktree, HookEventName: "SessionEnd",
+	}, agentRuntime.Key))
+	_ = handler.workspaceResponseWithTmuxEnrichment(ctx, summary)
+	assert.NotEmpty(tmuxCalls(), "losing hook coverage resumes the tmux probe")
+}

--- a/internal/server/workspaceapi/workspace_tmux_hook_gate_test.go
+++ b/internal/server/workspaceapi/workspace_tmux_hook_gate_test.go
@@ -105,6 +105,32 @@ func TestTmuxEnrichmentSkipsWorkspacesCoveredByHookReports(t *testing.T) {
 	assert.Equal(hook.UpdatedAt.UTC().Format(time.RFC3339), *result.response.TmuxLastOutputAt,
 		"the hook report's timestamp stands in for last activity")
 
+	// A second agent whose older report outranks the first by state priority
+	// must not hide the newer event: last activity follows the newest report.
+	secondRuntime, err := runtime.Launch(ctx, workspaceID, worktree, "claude")
+	require.NoError(err)
+	require.NoError(activity.HandleEvent("claude", agentactivity.HookEvent{
+		SessionID: "second-session", CWD: worktree, HookEventName: "PermissionRequest",
+	}, secondRuntime.Key))
+	time.Sleep(1100 * time.Millisecond)
+	require.NoError(activity.HandleEvent("claude", agentactivity.HookEvent{
+		SessionID: "claude-session", CWD: worktree, HookEventName: "PostToolUse",
+	}, agentRuntime.Key))
+	reports := activity.LiveReportsForWorkspace(worktree, []string{agentRuntime.Key, secondRuntime.Key})
+	require.Len(reports, 2)
+	newest := reports[0]
+	assert.Equal("claude-session", newest.SessionID)
+	badge, ok := activity.SnapshotForWorkspace(worktree, []string{agentRuntime.Key, secondRuntime.Key})
+	require.True(ok)
+	assert.Equal(agentactivity.StateApproval, badge.State, "the badge still shows the pending approval")
+	result = handler.workspaceResponseWithTmuxEnrichment(ctx, summary)
+	require.NotNil(result.response.TmuxLastOutputAt)
+	assert.Equal(newest.UpdatedAt.UTC().Format(time.RFC3339), *result.response.TmuxLastOutputAt,
+		"last activity comes from the newest report, not the priority pick")
+	require.NoError(activity.HandleEvent("claude", agentactivity.HookEvent{
+		SessionID: "second-session", CWD: worktree, HookEventName: "SessionEnd",
+	}, secondRuntime.Key))
+
 	full := handler.workspaceResponseWithEnrichment(ctx, summary)
 	assert.Empty(tmuxCalls(), "the full enrichment pass honours the same gate")
 	assert.True(full.tmuxComplete)

--- a/internal/server/workspaceapi/workspace_tmux_hook_gate_test.go
+++ b/internal/server/workspaceapi/workspace_tmux_hook_gate_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -98,7 +99,11 @@ func TestTmuxEnrichmentSkipsWorkspacesCoveredByHookReports(t *testing.T) {
 	assert.Empty(tmuxCalls(), "a hook-covered workspace spawns no tmux probe")
 	assert.True(result.tmuxComplete, "hook coverage counts as a complete sample")
 	assert.False(result.response.TmuxWorking)
-	assert.Nil(result.response.TmuxLastOutputAt)
+	hook, ok := activity.SnapshotForWorkspace(worktree, []string{agentRuntime.Key})
+	require.True(ok)
+	require.NotNil(result.response.TmuxLastOutputAt)
+	assert.Equal(hook.UpdatedAt.UTC().Format(time.RFC3339), *result.response.TmuxLastOutputAt,
+		"the hook report's timestamp stands in for last activity")
 
 	full := handler.workspaceResponseWithEnrichment(ctx, summary)
 	assert.Empty(tmuxCalls(), "the full enrichment pass honours the same gate")


### PR DESCRIPTION
An idle daemon spent up to half a CPU core on its own fleet monitors: tmux listings every 4 seconds, a host-wide `ps` every 15, and git probes for every project and worktree whether or not anything had changed or anyone was looking. This PR makes those monitors change-driven and idle when nobody needs them, and makes agent hook events the single activity signal for the workspaces that have them.

**Fleet monitors**

- Monitors only run while there is demand: an SSE subscriber or a snapshot read in the last 90 seconds. Idle monitors record a skip and re-check every 2 seconds, so the first client after an idle stretch is served within seconds.
- Discovery and worktree stats fingerprint the git directory (`HEAD`, `index`, `config`, `packed-refs`, `refs/`, and `worktrees/`) and only spawn git and write the database when it moved. The stats key includes the default branch, and any fingerprint older than 10 minutes is re-measured, which bounds what the fingerprint cannot see. The on-demand refresh paths still measure unconditionally.
- The tmux monitor polls every 15 seconds, lists windows only when the session list changed or a minute passed, and measures pane processes and their descendants with `ps -p` and `pgrep -P` instead of scanning the host.

**Agent activity**

- A workspace whose launched agent has sent a hook event is no longer probed through tmux pane capture. Hook state stays authoritative until the session ends or its runtime is removed; there is no timer. The newest report's timestamp is the workspace's last activity.
- `idle_prompt` no longer turns a finished session into Input, and no longer turns a pending question or permission prompt into Done. A repeated done keeps its first timestamp so an acknowledged badge does not reappear.
- Reports of runtimes that were pruned or could not be restored are removed at startup and after each missing-tmux prune, so agents that exited while the daemon was down leave nothing behind.

Accepted trade-offs: the first snapshot read after an idle stretch is served from the cache, and unstaged working-tree edits reach the background stats only at the 10-minute resample or through an explicit refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FC7FJJ4zL4SGNnx9nuCmvi

<sup>generated by a clanker</sup>

