### PR TITLE
perf: keep hot SQLite reads in memory and stop recompiling statements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ only routes to them.
 | Provider identity, sync, import, routes, or settings | `context/platform-sync-invariants.md` |
 | GitHub-specific sync or notifications | `context/github-sync-invariants.md`, `context/notifications-in-activity.md` |
 | Config fields that persist to TOML | `context/config-persistence.md` |
-| Database schema migrations | `context/db-migrations.md` |
+| Database schema migrations or the SQLite connection layer | `context/db-migrations.md` |
 | Deferred merge behavior | `context/deferred-merge.md` |
 | Embed routes or host bridges | `context/embeds.md` |
 | Daemon startup, discovery, host/origin validation, or SSE replay | `context/server-runtime.md` |

--- a/context/db-migrations.md
+++ b/context/db-migrations.md
@@ -43,6 +43,19 @@ schema migrations.
   tests.
 - When changing persisted data, test with real SQLite tables and representative child rows. Include dependent records that can be lost through foreign keys, uniqueness conflicts, or `INSERT OR IGNORE`.
 
+## Connection Layer
+
+- Package queries go through the `*DB` helpers or the pool-specific
+  `stmtCache`, never `d.ro`/`d.rw` directly outside `BeginTx`; direct pool
+  calls skip the prepared-statement cache and recompile on every call
+  (`internal/db/stmt_cache.go::stmtCache`).
+- `rwExecContext` and its query siblings intentionally bypass the repository
+  route fence that `execContext` enforces; keep that split when moving a write
+  between them (`internal/db/db.go::rwExecContext`).
+- Per-connection pragmas live only in `connectionDSN`; idle limits equal open
+  limits so pooled connections and their compiled statements persist
+  (`internal/db/db.go::openPool`).
+
 ## Federation Spoke Preparation
 
 Migration `000054_federated_spoke_preparation` is the atomic standalone-to-spoke

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -83,7 +83,15 @@ const (
 //     well over 100 MB, and the 2 MB default kept hot reads on pread.
 //   - mmap_size lets reads share the OS page cache instead of copying through
 //     SQLite's own cache; 256 MiB covers the whole file for typical installs.
+//     SQLite clamps the value to its compile-time maximum and ignores it on
+//     hosts without memory mapping, so no fallback path is needed.
 //   - temp_store keeps sort and materialization scratch space in memory.
+//
+// Memory envelope: the five pooled connections can retain at most 320 MiB of
+// private page cache, but with mmap active reads come straight from the shared
+// file mapping and only written pages land in the private cache, so the
+// writer's cache is the one that fills. The mapping itself is pageable, not
+// resident.
 //
 // synchronous stays at the WAL default (FULL) so every committed transaction
 // is durable across power loss, not just process crashes. The values are

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -15,6 +15,8 @@ import (
 type DB struct {
 	rw                *sql.DB
 	ro                *sql.DB
+	rwStmts           *stmtCache
+	roStmts           *stmtCache
 	mrReconcileMu     sync.RWMutex
 	mrReconcileGate   sync.Mutex
 	mrSnapshotLocksMu sync.Mutex
@@ -63,21 +65,54 @@ func OpenPreparedForTest(path string) (*DB, error) {
 	return open(path, false)
 }
 
+// Connection pool sizing. The writer is a single connection because SQLite
+// serializes writers anyway; readers run concurrently under WAL.
+const (
+	writePoolSize = 1
+	readPoolSize  = 4
+)
+
+// connectionDSN carries the per-connection pragmas. modernc.org/sqlite runs
+// each _pragma entry when it opens a connection, so every pooled connection
+// gets the same settings without a connect hook.
+//
+//   - busy_timeout keeps writers from failing immediately on a locked file.
+//   - foreign_keys enforces the schema's referential integrity.
+//   - cache_size is negative KiB: 64 MiB per connection. A maintainer
+//     database with tens of thousands of merge requests and their events is
+//     well over 100 MB, and the 2 MB default kept hot reads on pread.
+//   - mmap_size lets reads share the OS page cache instead of copying through
+//     SQLite's own cache; 256 MiB covers the whole file for typical installs.
+//   - temp_store keeps sort and materialization scratch space in memory.
+//
+// synchronous stays at the WAL default (FULL) so every committed transaction
+// is durable across power loss, not just process crashes. The values are
+// constants rather than config: they are tuning for the daemon's own store,
+// not a user-facing preference, and config persistence has no I/O section.
+const connectionDSN = "?_pragma=busy_timeout(5000)" +
+	"&_pragma=foreign_keys(1)" +
+	"&_pragma=cache_size(-65536)" +
+	"&_pragma=mmap_size(268435456)" +
+	"&_pragma=temp_store(MEMORY)"
+
 func open(path string, initialize bool) (*DB, error) {
-	rw, err := sql.Open("sqlite", path+"?_pragma=busy_timeout(5000)&_pragma=foreign_keys(1)")
+	rw, err := openPool(path, writePoolSize)
 	if err != nil {
 		return nil, fmt.Errorf("open db: %w", err)
 	}
-	rw.SetMaxOpenConns(1)
 
-	ro, err := sql.Open("sqlite", path+"?_pragma=busy_timeout(5000)&_pragma=foreign_keys(1)")
+	ro, err := openPool(path, readPoolSize)
 	if err != nil {
 		rw.Close()
 		return nil, fmt.Errorf("open db read-only: %w", err)
 	}
-	ro.SetMaxOpenConns(4)
 
-	d := &DB{rw: rw, ro: ro}
+	d := &DB{
+		rw:      rw,
+		ro:      ro,
+		rwStmts: newStmtCache(rw, stmtCacheLimit),
+		roStmts: newStmtCache(ro, stmtCacheLimit),
+	}
 	if initialize {
 		err = d.init()
 	}
@@ -86,6 +121,19 @@ func open(path string, initialize bool) (*DB, error) {
 		return nil, err
 	}
 	return d, nil
+}
+
+// openPool opens one connection pool whose idle limit matches its open limit,
+// so connections (and the statements compiled on them) survive idle periods
+// instead of being closed and re-opened with the DSN pragmas on every burst.
+func openPool(path string, size int) (*sql.DB, error) {
+	pool, err := sql.Open("sqlite", path+connectionDSN)
+	if err != nil {
+		return nil, err
+	}
+	pool.SetMaxOpenConns(size)
+	pool.SetMaxIdleConns(size)
+	return pool, nil
 }
 
 func (d *DB) init() error {
@@ -107,10 +155,14 @@ func (d *DB) init() error {
 	return nil
 }
 
-// Close closes both database connections.
+// Close finalizes cached statements and closes both connection pools.
 func (d *DB) Close() error {
-	d.ro.Close()
-	return d.rw.Close()
+	return errors.Join(
+		d.roStmts.Close(),
+		d.rwStmts.Close(),
+		d.ro.Close(),
+		d.rw.Close(),
+	)
 }
 
 // ReadDB returns the read-only connection pool.
@@ -224,7 +276,36 @@ func (d *DB) execContext(
 		return nil, err
 	}
 	defer release()
-	return d.rw.ExecContext(lockedCtx, query, args...)
+	return d.rwStmts.ExecContext(lockedCtx, query, args...)
+}
+
+// rwExecContext writes through the write pool without the repository route
+// fence. Callers that hold reconciliation locks themselves, or that write
+// tables outside repository identity, use it exactly as they previously used
+// the raw pool.
+func (d *DB) rwExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	return d.rwStmts.ExecContext(ctx, query, args...)
+}
+
+// rwQueryContext runs a RETURNING or read-your-writes query on the write pool.
+func (d *DB) rwQueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	return d.rwStmts.QueryContext(ctx, query, args...)
+}
+
+// rwQueryRowContext runs a single-row RETURNING query on the write pool.
+func (d *DB) rwQueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	return d.rwStmts.QueryRowContext(ctx, query, args...)
+}
+
+// roQueryContext runs a read on the read pool through the statement cache.
+func (d *DB) roQueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	return d.roStmts.QueryContext(ctx, query, args...)
+}
+
+// roQueryRowContext runs a single-row read on the read pool through the
+// statement cache.
+func (d *DB) roQueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	return d.roStmts.QueryRowContext(ctx, query, args...)
 }
 
 func (d *DB) lockRepositoryReconciliationWrite() func() {

--- a/internal/db/hot_reads_bench_test.go
+++ b/internal/db/hot_reads_bench_test.go
@@ -1,0 +1,158 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// legacyConnectionDSN is the DSN the daemon used before per-connection cache,
+// mmap, and temp_store pragmas were added. The hot-read benchmark opens
+// pools with it to isolate what each layer of the change buys.
+const legacyConnectionDSN = "?_pragma=busy_timeout(5000)&_pragma=foreign_keys(1)"
+
+type hotReadVariant struct {
+	name       string
+	dsn        string
+	cacheLimit int
+}
+
+func hotReadVariants() []hotReadVariant {
+	return []hotReadVariant{
+		{name: "baseline", dsn: legacyConnectionDSN, cacheLimit: 0},
+		{name: "pragmas-only", dsn: connectionDSN, cacheLimit: 0},
+		{name: "stmt-cache-only", dsn: legacyConnectionDSN, cacheLimit: stmtCacheLimit},
+		{name: "pragmas+stmt-cache", dsn: connectionDSN, cacheLimit: stmtCacheLimit},
+	}
+}
+
+// openHotReadDB builds a DB over an already-seeded file with the requested
+// DSN and cache capacity, mirroring open() without running migrations.
+func openHotReadDB(b *testing.B, path string, variant hotReadVariant) *DB {
+	b.Helper()
+	openPoolWith := func(size int) *sql.DB {
+		pool, err := sql.Open("sqlite", path+variant.dsn)
+		require.NoError(b, err)
+		pool.SetMaxOpenConns(size)
+		pool.SetMaxIdleConns(size)
+		return pool
+	}
+	rw := openPoolWith(writePoolSize)
+	ro := openPoolWith(readPoolSize)
+	d := &DB{
+		rw:      rw,
+		ro:      ro,
+		rwStmts: newStmtCache(rw, variant.cacheLimit),
+		roStmts: newStmtCache(ro, variant.cacheLimit),
+	}
+	b.Cleanup(func() { require.NoError(b, d.Close()) })
+	return d
+}
+
+// seedHotReadDatabase writes a store shaped like a busy maintainer install:
+// many repositories, thousands of merge requests, and tens of thousands of
+// timeline events with comment-sized bodies. It returns the file path.
+func seedHotReadDatabase(b *testing.B, repos, mrsPerRepo, eventsPerMR int) string {
+	b.Helper()
+	path := filepath.Join(b.TempDir(), "hot-reads.db")
+	d, err := Open(path)
+	require.NoError(b, err)
+	ctx := context.Background()
+	body := make([]byte, 600)
+	for i := range body {
+		body[i] = 'a' + byte(i%26)
+	}
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for r := range repos {
+		identity := verifiedTestRepoIdentity("github", "github.com", "acme", fmt.Sprintf("service-%03d", r))
+		repoID, err := d.UpsertRepo(ctx, identity)
+		require.NoError(b, err)
+		events := make([]MREvent, 0, mrsPerRepo*eventsPerMR)
+		for n := 1; n <= mrsPerRepo; n++ {
+			mr := testMR(repoID, n)
+			mr.LastActivityAt = base.Add(time.Duration(r*mrsPerRepo+n) * time.Minute)
+			mr.UpdatedAt = mr.LastActivityAt
+			if n%3 == 0 {
+				mr.State = "merged"
+			}
+			mrID, err := d.UpsertMergeRequest(ctx, mr)
+			require.NoError(b, err)
+			for e := range eventsPerMR {
+				events = append(events, MREvent{
+					MergeRequestID:     mrID,
+					PlatformExternalID: fmt.Sprintf("evt-%d-%d", mrID, e),
+					EventType:          "comment",
+					Author:             fmt.Sprintf("user-%d", e%7),
+					Summary:            "commented",
+					Body:               string(body),
+					CreatedAt:          mr.LastActivityAt.Add(time.Duration(e) * time.Second),
+					DedupeKey:          fmt.Sprintf("comment:%d:%d", mrID, e),
+				})
+			}
+		}
+		require.NoError(b, d.UpsertMREvents(ctx, events))
+	}
+	require.NoError(b, d.Close())
+	return path
+}
+
+// BenchmarkHotReads measures the read paths a running daemon repeats most:
+// the repository summary list, the open merge request list, one merge
+// request detail with its timeline, and the activity feed. Each variant
+// toggles the connection pragmas and the statement cache independently so
+// the contribution of each is visible.
+func BenchmarkHotReads(b *testing.B) {
+	const repos, mrsPerRepo, eventsPerMR = 50, 100, 10
+	path := seedHotReadDatabase(b, repos, mrsPerRepo, eventsPerMR)
+	info, err := os.Stat(path)
+	require.NoError(b, err)
+	b.Logf("seeded %d repos, %d merge requests, %d events: %.1f MB",
+		repos, repos*mrsPerRepo, repos*mrsPerRepo*eventsPerMR, float64(info.Size())/1e6)
+	ctx := context.Background()
+
+	reads := []struct {
+		name string
+		run  func(d *DB) error
+	}{
+		{name: "ListRepoSummaries", run: func(d *DB) error {
+			_, err := d.ListRepoSummaries(ctx)
+			return err
+		}},
+		{name: "ListMergeRequests", run: func(d *DB) error {
+			_, err := d.ListMergeRequests(ctx, ListMergeRequestsOpts{State: "open", Limit: 50})
+			return err
+		}},
+		{name: "MergeRequestDetail", run: func(d *DB) error {
+			mr, err := d.GetMergeRequest(ctx, "github", "github.com", "acme", "service-025", 42)
+			if err != nil {
+				return err
+			}
+			_, err = d.ListMREvents(ctx, mr.ID)
+			return err
+		}},
+		{name: "ListActivity", run: func(d *DB) error {
+			_, err := d.ListActivity(ctx, ListActivityOpts{Limit: 50})
+			return err
+		}},
+	}
+	for _, read := range reads {
+		b.Run(read.name, func(b *testing.B) {
+			for _, variant := range hotReadVariants() {
+				b.Run(variant.name, func(b *testing.B) {
+					d := openHotReadDB(b, path, variant)
+					require.NoError(b, read.run(d), "warm-up")
+					b.ResetTimer()
+					for b.Loop() {
+						require.NoError(b, read.run(d))
+					}
+				})
+			}
+		})
+	}
+}

--- a/internal/db/hot_reads_bench_test.go
+++ b/internal/db/hot_reads_bench_test.go
@@ -102,19 +102,48 @@ func seedHotReadDatabase(b *testing.B, repos, mrsPerRepo, eventsPerMR int) strin
 	return path
 }
 
+// hotReadDatabase returns the file to benchmark. Set KENN_FORGE_BENCH_DB to a
+// private snapshot of a real store to measure against production-shaped
+// data; the snapshot is migrated in place, so never point it at a live file.
+// Without it the benchmark seeds a synthetic store.
+func hotReadDatabase(b *testing.B) string {
+	b.Helper()
+	if snapshot := os.Getenv("KENN_FORGE_BENCH_DB"); snapshot != "" {
+		d, err := Open(snapshot)
+		require.NoError(b, err)
+		require.NoError(b, d.Close())
+		return snapshot
+	}
+	const repos, mrsPerRepo, eventsPerMR = 50, 100, 10
+	return seedHotReadDatabase(b, repos, mrsPerRepo, eventsPerMR)
+}
+
 // BenchmarkHotReads measures the read paths a running daemon repeats most:
 // the repository summary list, the open merge request list, one merge
 // request detail with its timeline, and the activity feed. Each variant
 // toggles the connection pragmas and the statement cache independently so
 // the contribution of each is visible.
 func BenchmarkHotReads(b *testing.B) {
-	const repos, mrsPerRepo, eventsPerMR = 50, 100, 10
-	path := seedHotReadDatabase(b, repos, mrsPerRepo, eventsPerMR)
+	path := hotReadDatabase(b)
 	info, err := os.Stat(path)
 	require.NoError(b, err)
-	b.Logf("seeded %d repos, %d merge requests, %d events: %.1f MB",
-		repos, repos*mrsPerRepo, repos*mrsPerRepo*eventsPerMR, float64(info.Size())/1e6)
 	ctx := context.Background()
+
+	probe, err := Open(path)
+	require.NoError(b, err)
+	var repos, mrs, events int
+	require.NoError(b, probe.ReadDB().QueryRowContext(ctx, "SELECT COUNT(*) FROM forge_repos").Scan(&repos))
+	require.NoError(b, probe.ReadDB().QueryRowContext(ctx, "SELECT COUNT(*) FROM forge_merge_requests").Scan(&mrs))
+	require.NoError(b, probe.ReadDB().QueryRowContext(ctx, "SELECT COUNT(*) FROM forge_mr_events").Scan(&events))
+	openMRs, err := probe.ListMergeRequests(ctx, ListMergeRequestsOpts{State: "open", Limit: 1})
+	require.NoError(b, err)
+	require.NotEmpty(b, openMRs, "benchmark store needs at least one open merge request")
+	detail := openMRs[0]
+	detailRepo, err := probe.GetRepoByID(ctx, detail.RepoID)
+	require.NoError(b, err)
+	require.NotNil(b, detailRepo)
+	require.NoError(b, probe.Close())
+	b.Logf("store: %d repos, %d merge requests, %d events, %.1f MB", repos, mrs, events, float64(info.Size())/1e6)
 
 	reads := []struct {
 		name string
@@ -129,7 +158,7 @@ func BenchmarkHotReads(b *testing.B) {
 			return err
 		}},
 		{name: "MergeRequestDetail", run: func(d *DB) error {
-			mr, err := d.GetMergeRequest(ctx, "github", "github.com", "acme", "service-025", 42)
+			mr, err := d.GetMergeRequest(ctx, detailRepo.Platform, detailRepo.PlatformHost, detailRepo.Owner, detailRepo.Name, detail.Number)
 			if err != nil {
 				return err
 			}

--- a/internal/db/hot_reads_bench_test.go
+++ b/internal/db/hot_reads_bench_test.go
@@ -25,7 +25,7 @@ type hotReadVariant struct {
 
 func hotReadVariants() []hotReadVariant {
 	return []hotReadVariant{
-		{name: "baseline", dsn: legacyConnectionDSN, cacheLimit: 0},
+		{name: "baseline", dsn: legacyConnectionDSN, cacheLimit: 0}, // raw pools, per-call compile
 		{name: "pragmas-only", dsn: connectionDSN, cacheLimit: 0},
 		{name: "stmt-cache-only", dsn: legacyConnectionDSN, cacheLimit: stmtCacheLimit},
 		{name: "pragmas+stmt-cache", dsn: connectionDSN, cacheLimit: stmtCacheLimit},
@@ -87,7 +87,7 @@ func seedHotReadDatabase(b *testing.B, repos, mrsPerRepo, eventsPerMR int) strin
 				events = append(events, MREvent{
 					MergeRequestID:     mrID,
 					PlatformExternalID: fmt.Sprintf("evt-%d-%d", mrID, e),
-					EventType:          "comment",
+					EventType:          "issue_comment",
 					Author:             fmt.Sprintf("user-%d", e%7),
 					Summary:            "commented",
 					Body:               string(body),
@@ -103,16 +103,21 @@ func seedHotReadDatabase(b *testing.B, repos, mrsPerRepo, eventsPerMR int) strin
 }
 
 // hotReadDatabase returns the file to benchmark. Set KENN_FORGE_BENCH_DB to a
-// private snapshot of a real store to measure against production-shaped
-// data; the snapshot is migrated in place, so never point it at a live file.
+// SQLite backup of a real store to measure against production-shaped data.
+// The file is copied into the benchmark's private temp dir first, and only
+// the copy is migrated and opened; the supplied file is never written.
 // Without it the benchmark seeds a synthetic store.
 func hotReadDatabase(b *testing.B) string {
 	b.Helper()
 	if snapshot := os.Getenv("KENN_FORGE_BENCH_DB"); snapshot != "" {
-		d, err := Open(snapshot)
+		path := filepath.Join(b.TempDir(), "snapshot.db")
+		content, err := os.ReadFile(snapshot)
+		require.NoError(b, err)
+		require.NoError(b, os.WriteFile(path, content, 0o600))
+		d, err := Open(path)
 		require.NoError(b, err)
 		require.NoError(b, d.Close())
-		return snapshot
+		return path
 	}
 	const repos, mrsPerRepo, eventsPerMR = 50, 100, 10
 	return seedHotReadDatabase(b, repos, mrsPerRepo, eventsPerMR)
@@ -142,8 +147,12 @@ func BenchmarkHotReads(b *testing.B) {
 	detailRepo, err := probe.GetRepoByID(ctx, detail.RepoID)
 	require.NoError(b, err)
 	require.NotNil(b, detailRepo)
+	activity, err := probe.ListActivity(ctx, ListActivityOpts{Limit: 50})
+	require.NoError(b, err)
+	require.NotEmpty(b, activity, "benchmark store needs activity rows")
 	require.NoError(b, probe.Close())
-	b.Logf("store: %d repos, %d merge requests, %d events, %.1f MB", repos, mrs, events, float64(info.Size())/1e6)
+	b.Logf("store: %d repos, %d merge requests, %d events, %.1f MB; newest activity is %q",
+		repos, mrs, events, float64(info.Size())/1e6, activity[0].ActivityType)
 
 	reads := []struct {
 		name string

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -797,7 +797,7 @@ func (d *DB) ReplaceRepoLabelCatalog(ctx context.Context, repoID int64, labels [
 }
 
 func (d *DB) ListRepoLabelCatalog(ctx context.Context, repoID int64) ([]Label, LabelCatalogFreshness, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT id, repo_id, COALESCE(platform_id, 0), platform_external_id,
 		       name, description, color, is_default, updated_at,
 		       catalog_present, catalog_seen_at
@@ -841,7 +841,7 @@ func (d *DB) ListRepoLabelCatalog(ctx context.Context, repoID int64) ([]Label, L
 
 func (d *DB) GetRepoLabelCatalogFreshness(ctx context.Context, repoID int64) (LabelCatalogFreshness, error) {
 	var freshness LabelCatalogFreshness
-	err := d.ro.QueryRowContext(ctx, `
+	err := d.roQueryRowContext(ctx, `
 		SELECT label_catalog_synced_at, label_catalog_checked_at, label_catalog_sync_error
 		FROM forge_repos
 		WHERE id = ?`, repoID,
@@ -927,7 +927,7 @@ func (d *DB) loadLabelsForMergeRequests(ctx context.Context, ids []int64) (map[i
 		JOIN forge_labels l ON l.id = ml.label_id
 		WHERE ml.merge_request_id IN (%s)
 		ORDER BY l.name, l.id`, sqlPlaceholders(len(ids)))
-	rows, err := d.ro.QueryContext(ctx, query, args...)
+	rows, err := d.roQueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("query merge request labels: %w", err)
 	}
@@ -963,7 +963,7 @@ func (d *DB) loadLabelsForIssues(ctx context.Context, ids []int64) (map[int64][]
 		JOIN forge_labels l ON l.id = il.label_id
 		WHERE il.issue_id IN (%s)
 		ORDER BY l.name, l.id`, sqlPlaceholders(len(ids)))
-	rows, err := d.ro.QueryContext(ctx, query, args...)
+	rows, err := d.roQueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("query issue labels: %w", err)
 	}
@@ -1190,7 +1190,7 @@ func lookupRepoIdentityByIDTx(
 }
 
 func (d *DB) ListRepos(ctx context.Context) ([]Repo, error) {
-	rows, err := d.ro.QueryContext(ctx,
+	rows, err := d.roQueryContext(ctx,
 		`SELECT id, platform, platform_host, platform_repo_id,
 		        owner, name, repo_path,
 		        owner_key, name_key, repo_path_key,
@@ -1424,7 +1424,7 @@ func (d *DB) getRepoByID(ctx context.Context, id int64, activeOnly bool) (*Repo,
 	if activeOnly {
 		query += ` AND lifecycle_state = 'active'`
 	}
-	err := d.ro.QueryRowContext(ctx, query, id).Scan(
+	err := d.roQueryRowContext(ctx, query, id).Scan(
 		&r.ID, &r.Platform, &r.PlatformHost, &r.PlatformRepoID,
 		&r.Owner, &r.Name, &r.RepoPath,
 		&r.OwnerKey, &r.NameKey, &r.RepoPathKey,
@@ -1851,7 +1851,7 @@ func (d *DB) GetMergeRequest(
 	platform = canonicalRepoPlatform(platform)
 	platformHost, owner, name = canonicalRepoLookupIdentifier(platformHost, owner, name)
 	var mr MergeRequest
-	err := d.ro.QueryRowContext(ctx, `
+	err := d.roQueryRowContext(ctx, `
 		SELECT p.id, p.snapshot_revision, p.repo_id, p.platform_id, p.platform_external_id, p.number, p.url, p.title,
 		       p.author, p.author_display_name, p.state, p.is_draft, p.is_locked,
 		       p.body, p.head_branch, p.base_branch,
@@ -1948,7 +1948,7 @@ func (d *DB) getMergeRequestByRepoIDAndNumber(
 			  AND ai.lifecycle_state = 'removed_upstream'
 		)`
 	}
-	err := d.ro.QueryRowContext(ctx, `
+	err := d.roQueryRowContext(ctx, `
 		SELECT p.id, p.snapshot_revision, p.repo_id, p.platform_id, p.platform_external_id, p.number, p.url, p.title,
 		       p.author, p.author_display_name, p.state, p.is_draft, p.is_locked,
 		       p.body, p.head_branch, p.base_branch,
@@ -2125,7 +2125,7 @@ func (d *DB) ListMergeRequests(ctx context.Context, opts ListMergeRequestsOpts) 
 		ORDER BY %s DESC, p.id DESC`, activityCTE, activityJoin, where, activityOrder)
 	query = appendLimitOffset(query, &args, opts.Limit, opts.Offset)
 
-	rows, err := d.ro.QueryContext(ctx, query, args...)
+	rows, err := d.roQueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list merge requests: %w", err)
 	}
@@ -2423,7 +2423,7 @@ func (d *DB) MRCommentEventExists(
 	platformID int64,
 ) (bool, error) {
 	var exists bool
-	err := d.ro.QueryRowContext(ctx, `
+	err := d.roQueryRowContext(ctx, `
 		SELECT EXISTS (
 			SELECT 1
 			FROM forge_mr_events
@@ -2487,7 +2487,7 @@ func replaceMRCommentEventsTx(
 
 // ListMREvents returns all events for a merge request ordered by created_at DESC.
 func (d *DB) ListMREvents(ctx context.Context, mrID int64) ([]MREvent, error) {
-	return listMREvents(ctx, d.ro, mrID)
+	return listMREvents(ctx, d.roStmts, mrID)
 }
 
 type mrEventQueryer interface {
@@ -2552,7 +2552,7 @@ func (d *DB) UpdateThreadResolved(ctx context.Context, mrID int64, threadID stri
 func (d *DB) mergeRequestWorkflowRef(ctx context.Context, mrID int64) (int64, int, error) {
 	var repoID int64
 	var number int
-	err := d.ro.QueryRowContext(ctx,
+	err := d.roQueryRowContext(ctx,
 		`SELECT repo_id, number FROM forge_merge_requests WHERE id = ?`,
 		mrID,
 	).Scan(&repoID, &number)
@@ -2590,7 +2590,7 @@ func (d *DB) SetKanbanState(ctx context.Context, mrID int64, status string) erro
 // GetKanbanState returns the PR workflow state for a merge request, or nil if not found.
 func (d *DB) GetKanbanState(ctx context.Context, mrID int64) (*KanbanState, error) {
 	var k KanbanState
-	err := d.ro.QueryRowContext(ctx,
+	err := d.roQueryRowContext(ctx,
 		`SELECT p.id, w.status, w.updated_at
 		   FROM forge_merge_requests p
 		   JOIN forge_item_workflow_state w
@@ -2614,7 +2614,7 @@ func (d *DB) GetPreviouslyOpenMRNumbers(
 	repoID int64,
 	stillOpen map[int]bool,
 ) ([]int, error) {
-	rows, err := d.ro.QueryContext(ctx,
+	rows, err := d.roQueryContext(ctx,
 		`SELECT mr.number FROM forge_merge_requests mr
 		 WHERE mr.repo_id = ? AND mr.state = 'open'
 		   AND NOT EXISTS (
@@ -2677,7 +2677,7 @@ func (d *DB) GetMergedMRNumbersMissingMergedActor(
 	before MergedMRMissingActorCursor,
 	limit int,
 ) ([]MergedMRMissingActor, error) {
-	rows, err := d.ro.QueryContext(ctx,
+	rows, err := d.roQueryContext(ctx,
 		`SELECT mr.id, mr.number, mr.merged_at FROM forge_merge_requests mr
 		 WHERE mr.repo_id = ? AND mr.state = 'merged'
 		   AND mr.merged_at >= ?
@@ -2717,7 +2717,7 @@ func (d *DB) GetMergedMRNumbersMissingMergedActor(
 
 func (d *DB) CountOpenMergeRequestsForRepo(ctx context.Context, repoID int64) (int, error) {
 	var count int
-	err := d.ro.QueryRowContext(ctx,
+	err := d.roQueryRowContext(ctx,
 		`SELECT COUNT(*) FROM forge_merge_requests
 		WHERE repo_id = ? AND state = 'open'`,
 		repoID,
@@ -3015,7 +3015,7 @@ func (d *DB) GetDiffSHAsByRepoID(ctx context.Context, repoID int64, number int) 
 
 func (d *DB) getDiffSHAs(ctx context.Context, where string, args ...any) (*DiffSHAs, error) {
 	var s DiffSHAs
-	err := d.ro.QueryRowContext(ctx, `
+	err := d.roQueryRowContext(ctx, `
 		SELECT p.platform_head_sha, p.platform_base_sha,
 		       p.diff_head_sha, p.diff_base_sha, p.merge_base_sha,
 		       p.state
@@ -3206,7 +3206,7 @@ func (d *DB) GetIssue(
 	platform = canonicalRepoPlatform(platform)
 	platformHost, owner, name = canonicalRepoLookupIdentifier(platformHost, owner, name)
 	var issue Issue
-	err := d.ro.QueryRowContext(ctx, `
+	err := d.roQueryRowContext(ctx, `
 		SELECT i.id, i.snapshot_revision, i.repo_id, i.platform_id, i.platform_external_id, i.number, i.url, i.title,
 		       i.author, i.state, i.body, i.comment_count, i.labels_json, i.assignees_json,
 		       i.detail_fetched_at,
@@ -3286,7 +3286,7 @@ func (d *DB) getIssueByRepoIDAndNumber(
 			  AND ai.lifecycle_state = 'removed_upstream'
 		)`
 	}
-	err := d.ro.QueryRowContext(ctx, `
+	err := d.roQueryRowContext(ctx, `
 		SELECT i.id, i.snapshot_revision, i.repo_id, i.platform_id, i.platform_external_id, i.number, i.url, i.title,
 		       i.author, i.state, i.body, i.comment_count, i.labels_json, i.assignees_json,
 		       i.detail_fetched_at,
@@ -3432,7 +3432,7 @@ func (d *DB) ListIssues(
 		ORDER BY %s DESC, i.id DESC`, activityCTE, activityJoin, where, activityOrder)
 	query = appendLimitOffset(query, &args, opts.Limit, opts.Offset)
 
-	rows, err := d.ro.QueryContext(ctx, query, args...)
+	rows, err := d.roQueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list issues: %w", err)
 	}
@@ -3481,7 +3481,7 @@ func (d *DB) ResolveItemNumber(
 	ctx context.Context, repoID int64, number int,
 ) (itemType string, found bool, err error) {
 	var exists int
-	err = d.ro.QueryRowContext(ctx,
+	err = d.roQueryRowContext(ctx,
 		`SELECT 1 FROM forge_merge_requests
 		 WHERE repo_id = ? AND number = ?
 		   AND NOT EXISTS (
@@ -3500,7 +3500,7 @@ func (d *DB) ResolveItemNumber(
 		return "", false, fmt.Errorf("check merge_requests: %w", err)
 	}
 
-	err = d.ro.QueryRowContext(ctx,
+	err = d.roQueryRowContext(ctx,
 		`SELECT 1 FROM forge_issues
 		 WHERE repo_id = ? AND number = ?
 		   AND NOT EXISTS (
@@ -3553,7 +3553,7 @@ func (d *DB) ResolveItemNumberOfType(
 	}
 
 	var exists int
-	err := d.ro.QueryRowContext(ctx, query, repoID, number).Scan(&exists)
+	err := d.roQueryRowContext(ctx, query, repoID, number).Scan(&exists)
 	if err == nil {
 		return itemType, true, nil
 	}
@@ -3591,7 +3591,7 @@ func (d *DB) GetPreviouslyOpenIssueNumbers(
 	repoID int64,
 	stillOpen map[int]bool,
 ) ([]int, error) {
-	rows, err := d.ro.QueryContext(ctx,
+	rows, err := d.roQueryContext(ctx,
 		`SELECT i.number FROM forge_issues i
 		 WHERE i.repo_id = ? AND i.state = 'open'
 		   AND NOT EXISTS (
@@ -3623,7 +3623,7 @@ func (d *DB) GetPreviouslyOpenIssueNumbers(
 
 func (d *DB) CountOpenIssuesForRepo(ctx context.Context, repoID int64) (int, error) {
 	var count int
-	err := d.ro.QueryRowContext(ctx,
+	err := d.roQueryRowContext(ctx,
 		`SELECT COUNT(*) FROM forge_issues
 		WHERE repo_id = ? AND state = 'open'`,
 		repoID,
@@ -3641,7 +3641,7 @@ func (d *DB) GetHTTPEtag(
 ) (string, error) {
 	platformHost, owner, name = canonicalRepoLookupIdentifier(platformHost, owner, name)
 	var etag string
-	err := d.ro.QueryRowContext(ctx,
+	err := d.roQueryRowContext(ctx,
 		`SELECT etag FROM forge_http_etags
 		WHERE platform = ?
 		  AND platform_host = ?
@@ -3955,7 +3955,7 @@ func (d *DB) IssueCommentEventExists(
 	platformID int64,
 ) (bool, error) {
 	var exists bool
-	err := d.ro.QueryRowContext(ctx, `
+	err := d.roQueryRowContext(ctx, `
 		SELECT EXISTS (
 			SELECT 1
 			FROM forge_issue_events
@@ -4021,7 +4021,7 @@ func replaceIssueCommentEventsTx(
 
 // ListIssueEvents returns all events for an issue ordered by created_at DESC.
 func (d *DB) ListIssueEvents(ctx context.Context, issueID int64) ([]IssueEvent, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT id, issue_id, platform_id, platform_external_id, event_type, author, summary, body,
 		       metadata_json, created_at, dedupe_key, direct_url, thread_id
 		FROM forge_issue_events
@@ -4070,7 +4070,7 @@ func (d *DB) ListCommentAutocompleteUsers(
 	containsQuery := "%" + strings.ToLower(query) + "%"
 	prefixQuery := strings.ToLower(query) + "%"
 
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		WITH repo AS (
 			SELECT id
 			FROM forge_repos
@@ -4176,7 +4176,7 @@ func (d *DB) ListCommentAutocompleteReferences(
 	titleQuery := "%" + strings.ToLower(query) + "%"
 	numberPrefix := query + "%"
 
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		WITH repo AS (
 			SELECT id
 			FROM forge_repos
@@ -4283,7 +4283,7 @@ func (d *DB) IsStarred(
 	ctx context.Context, itemType string, repoID int64, number int,
 ) (bool, error) {
 	var count int
-	err := d.ro.QueryRowContext(ctx, `
+	err := d.roQueryRowContext(ctx, `
 		SELECT COUNT(*) FROM forge_starred_items
 		WHERE item_type = ? AND repo_id = ? AND number = ?`,
 		itemType, repoID, number,
@@ -4325,7 +4325,7 @@ func (d *DB) UpsertPlatformRateLimit(
 	rateLimit int,
 	rateResetAt *time.Time,
 ) error {
-	_, err := d.rw.Exec(`
+	_, err := d.rwExecContext(context.Background(), `
 		INSERT INTO forge_rate_limits
 		    (platform, platform_host, rate_principal, api_type, requests_hour,
 		     hour_start, rate_remaining, rate_limit, rate_reset_at, updated_at)
@@ -4363,7 +4363,7 @@ func (d *DB) GetPlatformRateLimit(
 	apiType string,
 ) (*RateLimit, error) {
 	var r RateLimit
-	err := d.ro.QueryRow(`
+	err := d.roQueryRowContext(context.Background(), `
 		SELECT id, platform, platform_host, rate_principal, api_type,
 		       requests_hour, hour_start, rate_remaining, rate_limit,
 		       rate_reset_at, updated_at
@@ -4432,7 +4432,7 @@ func (d *DB) SetWorktreeLinks(
 func (d *DB) GetWorktreeLinksForMR(
 	ctx context.Context, mergeRequestID int64,
 ) ([]WorktreeLink, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT id, merge_request_id, worktree_key,
 		       worktree_path, worktree_branch, linked_at
 		FROM forge_mr_worktree_links
@@ -4476,7 +4476,7 @@ func (d *DB) GetWorktreeLinksForMRs(
 			WHERE merge_request_id IN (` +
 			strings.Join(placeholders, ",") + `)
 			ORDER BY linked_at DESC`
-		rows, err := d.ro.QueryContext(ctx, query, args...)
+		rows, err := d.roQueryContext(ctx, query, args...)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"get worktree links for MRs: %w", err,
@@ -4497,7 +4497,7 @@ func (d *DB) GetWorktreeLinksForMRs(
 func (d *DB) GetAllWorktreeLinks(
 	ctx context.Context,
 ) ([]WorktreeLink, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT id, merge_request_id, worktree_key,
 		       worktree_path, worktree_branch, linked_at
 		FROM forge_mr_worktree_links
@@ -4534,7 +4534,7 @@ func (d *DB) workspaceRouteHasHistoricalOccupants(
 	// cataloged). Legacy route-only repositories (no provider ID) record
 	// their route as non-current without being vacated, so a record with
 	// no occupant counts only when its repository is cataloged.
-	err := d.ro.QueryRowContext(ctx, `
+	err := d.roQueryRowContext(ctx, `
 		SELECT EXISTS (
 			SELECT 1
 			FROM forge_repo_routes historical
@@ -4601,7 +4601,7 @@ func (d *DB) canonicalizeWorkspaceRepo(
 
 	var matchedProvider, displayOwner, displayName, repoOwnerKey, repoNameKey, repoPathKey string
 	var repoID int64
-	err := d.ro.QueryRowContext(ctx, `
+	err := d.roQueryRowContext(ctx, `
 		SELECT platform, owner, name, owner_key, name_key, repo_path_key, id
 		FROM forge_repos
 		WHERE platform_host = ? AND repo_path_key = ?
@@ -4779,7 +4779,7 @@ func (d *DB) InsertWorkspace(
 	if err != nil {
 		return err
 	}
-	if err := insertPreparedWorkspace(ctx, d.rw, ws, prepared); err != nil {
+	if err := insertPreparedWorkspace(ctx, d.rwStmts, ws, prepared); err != nil {
 		return err
 	}
 	ws.ItemKey = prepared.itemKey
@@ -4886,7 +4886,7 @@ func insertPreparedWorkspace(
 func (d *DB) GetWorkspace(
 	ctx context.Context, id string,
 ) (*Workspace, error) {
-	ws, err := d.scanWorkspace(ctx, d.ro.QueryRowContext(ctx, `
+	ws, err := d.scanWorkspace(ctx, d.roQueryRowContext(ctx, `
 		SELECT id, platform, platform_host, repo_owner, repo_name, repo_id,
 		       item_type, item_number, item_key, associated_pr_number,
 		       git_head_ref, mr_head_repo, workspace_branch,
@@ -4975,7 +4975,7 @@ func (d *DB) GetWorkspaceLinkedToMRForProvider(
 		mrNumber,
 		WorkspaceItemTypePullRequest, mrNumber,
 	)
-	ws, err := d.scanWorkspace(ctx, d.ro.QueryRowContext(ctx, query, args...))
+	ws, err := d.scanWorkspace(ctx, d.roQueryRowContext(ctx, query, args...))
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -5012,7 +5012,7 @@ func (d *DB) getWorkspaceByMR(
 			WHERE item_type = ? AND item_number = ?
 			  AND (` + predicate + `)`
 	args := append([]any{WorkspaceItemTypePullRequest, mrNumber}, lookupArgs...)
-	ws, err := d.scanWorkspace(ctx, d.ro.QueryRowContext(ctx, query, args...))
+	ws, err := d.scanWorkspace(ctx, d.roQueryRowContext(ctx, query, args...))
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -5071,7 +5071,7 @@ func (d *DB) getWorkspaceByIssue(
 		WHERE item_type = ? AND item_number = ?
 		  AND (` + predicate + `)`
 	args := append([]any{WorkspaceItemTypeIssue, issueNumber}, lookupArgs...)
-	ws, err := d.scanWorkspace(ctx, d.ro.QueryRowContext(ctx, query, args...))
+	ws, err := d.scanWorkspace(ctx, d.roQueryRowContext(ctx, query, args...))
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -5112,7 +5112,7 @@ func (d *DB) GetWorkspaceByItemKeyForProvider(
 		WHERE item_type = ? AND item_key = ?
 		  AND (` + predicate + `)`
 	args := append([]any{itemType, itemKey}, lookupArgs...)
-	ws, err := d.scanWorkspace(ctx, d.ro.QueryRowContext(ctx, query, args...))
+	ws, err := d.scanWorkspace(ctx, d.roQueryRowContext(ctx, query, args...))
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -5134,7 +5134,7 @@ func (d *DB) GetKataWorkspaceByIssue(
 	if daemonID == "" || issueUID == "" {
 		return nil, nil
 	}
-	ws, err := d.scanWorkspace(ctx, d.ro.QueryRowContext(ctx, `
+	ws, err := d.scanWorkspace(ctx, d.roQueryRowContext(ctx, `
 		SELECT id, platform, platform_host, repo_owner, repo_name, repo_id,
 		       item_type, item_number, item_key, associated_pr_number,
 		       git_head_ref, mr_head_repo, workspace_branch,
@@ -5161,7 +5161,7 @@ func (d *DB) GetKataWorkspaceByIssue(
 func (d *DB) ListWorkspaces(
 	ctx context.Context,
 ) ([]Workspace, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT w.id,
 		       COALESCE(r.platform, w.platform),
 		       COALESCE(r.platform_host, w.platform_host),
@@ -5272,7 +5272,7 @@ func (d *DB) beginWorkspaceDeletion(
 		return true, nil
 	}
 	var status string
-	err = d.ro.QueryRowContext(ctx, `SELECT status FROM forge_workspaces WHERE id = ?`, id).Scan(&status)
+	err = d.roQueryRowContext(ctx, `SELECT status FROM forge_workspaces WHERE id = ?`, id).Scan(&status)
 	if errors.Is(err, sql.ErrNoRows) || status == "deleting" ||
 		(!retryFailure && status == "deletion_failed") {
 		return false, nil
@@ -5456,7 +5456,7 @@ func (d *DB) UpdateWorkspaceMRHeadRepoForSnapshot(
 		return true, nil
 	}
 	var workspaceExists bool
-	if err := d.ro.QueryRowContext(
+	if err := d.roQueryRowContext(
 		ctx,
 		`SELECT EXISTS(
 		    SELECT 1 FROM forge_workspaces WHERE id = ?
@@ -5547,7 +5547,7 @@ func (d *DB) InsertWorkspaceSetupEvent(
 func (d *DB) ListWorkspaceSetupEvents(
 	ctx context.Context, workspaceID string,
 ) ([]WorkspaceSetupEvent, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT id, workspace_id, stage, outcome, message,
 		       created_at
 		FROM forge_workspace_setup_events
@@ -5595,7 +5595,7 @@ func (d *DB) ListWorkspaceRuntimeSessions(
 	ctx context.Context,
 	workspaceID string,
 ) ([]WorkspaceRuntimeSession, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT workspace_id, session_key, target_key, label, kind, display_region, scope,
 		       tmux_session, created_at
 		FROM forge_workspace_runtime_sessions
@@ -5615,7 +5615,7 @@ func (d *DB) ListWorkspaceRuntimeSessions(
 func (d *DB) ListAllWorkspaceRuntimeSessions(
 	ctx context.Context,
 ) ([]WorkspaceRuntimeSession, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT workspace_id, session_key, target_key, label, kind, display_region, scope,
 		       tmux_session, created_at
 		FROM forge_workspace_runtime_sessions
@@ -5635,7 +5635,7 @@ func (d *DB) ListWorkspaceRuntimeTmuxSessions(
 	ctx context.Context,
 	workspaceID string,
 ) ([]WorkspaceRuntimeSession, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT workspace_id, session_key, target_key, label, kind, display_region, scope,
 		       tmux_session, created_at
 		FROM forge_workspace_runtime_sessions
@@ -5655,7 +5655,7 @@ func (d *DB) ListWorkspaceRuntimeTmuxSessions(
 func (d *DB) ListAllWorkspaceRuntimeTmuxSessions(
 	ctx context.Context,
 ) ([]WorkspaceRuntimeSession, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT workspace_id, session_key, target_key, label, kind, display_region, scope,
 		       tmux_session, created_at
 		FROM forge_workspace_runtime_sessions
@@ -5967,7 +5967,7 @@ func (d *DB) ListWorkspaceSummaries(
 	query := "SELECT " + workspaceSummaryColumns +
 		workspaceSummaryJoins +
 		"\nORDER BY w.created_at DESC"
-	rows, err := d.ro.QueryContext(ctx, query)
+	rows, err := d.roQueryContext(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"list workspace summaries: %w", err,
@@ -5997,7 +5997,7 @@ func (d *DB) GetWorkspaceSummary(
 		workspaceSummaryJoins +
 		"\nWHERE w.id = ?"
 	s, err := scanWorkspaceSummary(
-		d.ro.QueryRowContext(ctx, query, id),
+		d.roQueryRowContext(ctx, query, id),
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil

--- a/internal/db/queries_activity.go
+++ b/internal/db/queries_activity.go
@@ -91,7 +91,7 @@ func issueEventLedgerRevisionExpr(issue string) string {
 func (d *DB) ListActivity(
 	ctx context.Context, opts ListActivityOpts,
 ) ([]ActivityItem, error) {
-	return listActivityWithQueryer(ctx, d.ro, opts)
+	return listActivityWithQueryer(ctx, d.roStmts, opts)
 }
 
 type activityQueryer interface {
@@ -580,7 +580,7 @@ func listActivityWithQueryer(
 func (d *DB) ListActivitySubjects(
 	ctx context.Context, opts ListActivitySubjectsOpts,
 ) ([]ActivitySubject, error) {
-	return listActivitySubjectsWithQueryer(ctx, d.ro, opts)
+	return listActivitySubjectsWithQueryer(ctx, d.roStmts, opts)
 }
 
 func listActivitySubjectsWithQueryer(
@@ -945,7 +945,7 @@ func (d *DB) ListActivityAuthors(
 	queryArgs := make([]any, 0, len(notificationArgs)+len(args))
 	queryArgs = append(queryArgs, notificationArgs...)
 	queryArgs = append(queryArgs, args...)
-	rows, err := d.ro.QueryContext(ctx, query, queryArgs...)
+	rows, err := d.roQueryContext(ctx, query, queryArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("list activity authors: %w", err)
 	}

--- a/internal/db/queries_app_metadata.go
+++ b/internal/db/queries_app_metadata.go
@@ -15,7 +15,7 @@ func (d *DB) AppMetadataValue(ctx context.Context, key string) (string, bool, er
 	}
 
 	var value string
-	err := d.ro.QueryRowContext(ctx,
+	err := d.roQueryRowContext(ctx,
 		`SELECT value FROM forge_app_metadata WHERE key = ?`,
 		key,
 	).Scan(&value)

--- a/internal/db/queries_archive.go
+++ b/internal/db/queries_archive.go
@@ -669,7 +669,7 @@ func (d *DB) QueueArchivePromptByIdentity(
 	identity RepoIdentity,
 	now time.Time,
 ) error {
-	return queueArchivePromptByIdentity(ctx, d.rw, identity, now)
+	return queueArchivePromptByIdentity(ctx, d.rwStmts, identity, now)
 }
 
 type archiveExecer interface {
@@ -706,7 +706,7 @@ func queueArchivePromptByIdentity(
 // ListArchiveRepoStates returns stored archive state in repository ID order.
 func (d *DB) ListArchiveRepoStates(ctx context.Context, repoIDs []int64) ([]ArchiveRepoState, error) {
 	repoIDs = normalizedArchiveRepoIDs(repoIDs)
-	return listArchiveRepoStates(ctx, d.ro, repoIDs)
+	return listArchiveRepoStates(ctx, d.roStmts, repoIDs)
 }
 
 func listArchiveRepoStates(
@@ -926,7 +926,7 @@ func (d *DB) IsArchiveItemRemovedUpstream(
 	itemNumber int,
 ) (bool, error) {
 	var exists int
-	err := d.ro.QueryRowContext(ctx, `
+	err := d.roQueryRowContext(ctx, `
 		SELECT 1
 		FROM forge_archive_items
 		WHERE repo_id = ? AND item_type = ? AND item_number = ?

--- a/internal/db/queries_branch_activity.go
+++ b/internal/db/queries_branch_activity.go
@@ -87,7 +87,7 @@ func (d *DB) GetBranchTip(
 	var observedAt string
 	var createdAt string
 	var updatedAt string
-	err := d.ro.QueryRowContext(ctx, `
+	err := d.roQueryRowContext(ctx, `
 		SELECT repo_id, branch_name, tip_sha, observed_at, created_at, updated_at
 		FROM forge_branch_tips
 		WHERE repo_id = ? AND branch_name = ?`,

--- a/internal/db/queries_branch_match.go
+++ b/internal/db/queries_branch_match.go
@@ -31,7 +31,7 @@ type WorktreeRepoRef struct {
 // so the recompute can both scope the merge-request lookup and build watched-MR
 // entries from one read.
 func (d *DB) ListWorktreesForBranchMatch(ctx context.Context) ([]WorktreeRepoRef, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT w.path, w.branch,
 		       r.id, r.platform, r.platform_host, r.owner, r.name
 		FROM forge_project_worktrees w
@@ -93,7 +93,7 @@ type WorktreeLinkPR struct {
 // state and CI status current as of the last sync without re-deriving the
 // branch match at snapshot time.
 func (d *DB) ListWorktreeLinkPRs(ctx context.Context) ([]WorktreeLinkPR, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT l.worktree_key, m.number, m.state, m.is_draft, m.title, m.ci_status,
 		       m.review_decision, m.mergeable_state, m.additions, m.deletions, m.comment_count
 		FROM forge_mr_worktree_links l

--- a/internal/db/queries_dataset_progress.go
+++ b/internal/db/queries_dataset_progress.go
@@ -339,7 +339,7 @@ func (d *DB) GetDatasetProgress(
 	var nextRetryAt, lastErrorCode, lastErrorDetail sql.NullString
 	var startedAt, completedAt sql.NullString
 	var updatedAt string
-	err := d.ro.QueryRowContext(ctx, `
+	err := d.roQueryRowContext(ctx, `
 		SELECT repo_id, item_type, item_number, dataset,
 			parent_revision, scan_generation, next_cursor, last_input_cursor,
 			page_count, status, observed_count, attempt_count,

--- a/internal/db/queries_github_native_stacks.go
+++ b/internal/db/queries_github_native_stacks.go
@@ -67,7 +67,7 @@ func (d *DB) ReplaceGitHubNativeStack(ctx context.Context, stack GitHubNativeSta
 // ListGitHubNativeStacks returns cached native stacks for one repository,
 // newest stack number first and members bottom-to-top.
 func (d *DB) ListGitHubNativeStacks(ctx context.Context, repoID int64) ([]GitHubNativeStack, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT id, repo_id, github_id, stack_number, size, base_ref, is_open,
 		       github_created_at, content_fingerprint, last_observed_at
 		FROM github_native_stacks
@@ -99,7 +99,7 @@ func (d *DB) ListGitHubNativeStacks(ctx context.Context, repoID int64) ([]GitHub
 		return stacks, nil
 	}
 
-	memberRows, err := d.ro.QueryContext(ctx, `
+	memberRows, err := d.roQueryContext(ctx, `
 		SELECT m.stack_id, m.position, m.pull_request_number, m.state,
 		       m.is_draft, m.merged_at, m.head_ref, m.head_sha
 		FROM github_native_stack_members m

--- a/internal/db/queries_host_runtime.go
+++ b/internal/db/queries_host_runtime.go
@@ -52,7 +52,7 @@ func (d *DB) UpsertHostRuntimeTmuxSession(
 func (d *DB) ListHostRuntimeTmuxSessions(
 	ctx context.Context,
 ) ([]HostRuntimeTmuxSession, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT session_key, COALESCE(backend_session_key, ''), label, cwd,
 		       created_at
 		FROM forge_host_runtime_sessions

--- a/internal/db/queries_hot_merge_requests.go
+++ b/internal/db/queries_hot_merge_requests.go
@@ -63,7 +63,7 @@ func (d *DB) ListHotMergeRequestIDs(ctx context.Context, limit int) ([]int64, er
 	if limit <= 0 {
 		return []int64{}, nil
 	}
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT hot.merge_request_id
 		FROM forge_hot_merge_requests hot
 		JOIN forge_merge_requests mr ON mr.id = hot.merge_request_id

--- a/internal/db/queries_involvement.go
+++ b/internal/db/queries_involvement.go
@@ -36,7 +36,7 @@ func (d *DB) ListInvolvedWorkspaceSubjectKeys(
 			WHERE r.lifecycle_state = 'active'
 			  AND %[3]s
 			  AND %[4]s`, subject.alias, subject.table, candidateCondition, involvementCondition)
-		rows, err := d.ro.QueryContext(ctx, query, args...)
+		rows, err := d.roQueryContext(ctx, query, args...)
 		if err != nil {
 			return nil, fmt.Errorf("list involved workspace %s subjects: %w", subject.itemType, err)
 		}

--- a/internal/db/queries_kata_links.go
+++ b/internal/db/queries_kata_links.go
@@ -24,7 +24,7 @@ func (d *DB) CreateKataIssueLink(
 	var row *sql.Row
 	switch link.Subject.Kind {
 	case KataLinkSubjectPullRequest, KataLinkSubjectIssue:
-		row = d.rw.QueryRowContext(ctx, `
+		row = d.rwQueryRowContext(ctx, `
 			INSERT INTO kata_issue_links (
 				subject_kind, repo_id, provider_item_external_id, workspace_id,
 				daemon_id, project_uid, issue_uid
@@ -42,7 +42,7 @@ func (d *DB) CreateKataIssueLink(
 			link.DaemonID, link.ProjectUID, link.IssueUID,
 		)
 	case KataLinkSubjectWorkspace:
-		row = d.rw.QueryRowContext(ctx, `
+		row = d.rwQueryRowContext(ctx, `
 			INSERT INTO kata_issue_links (
 				subject_kind, repo_id, provider_item_external_id, workspace_id,
 				daemon_id, project_uid, issue_uid
@@ -81,14 +81,14 @@ func (d *DB) ListKataIssueLinks(
 	var rows *sql.Rows
 	switch subject.Kind {
 	case KataLinkSubjectPullRequest, KataLinkSubjectIssue:
-		rows, err = d.ro.QueryContext(ctx, kataIssueLinkSelect+`
+		rows, err = d.roQueryContext(ctx, kataIssueLinkSelect+`
 			WHERE subject_kind = ?
 			  AND repo_id = ?
 			  AND provider_item_external_id = ?
 			  AND workspace_id IS NULL
 			ORDER BY id`, subject.Kind, subject.RepoID, subject.ProviderItemExternalID)
 	case KataLinkSubjectWorkspace:
-		rows, err = d.ro.QueryContext(ctx, kataIssueLinkSelect+`
+		rows, err = d.roQueryContext(ctx, kataIssueLinkSelect+`
 			WHERE subject_kind = ?
 			  AND repo_id IS NULL
 			  AND provider_item_external_id IS NULL
@@ -132,7 +132,7 @@ func (d *DB) DeleteKataIssueLink(
 	var result sql.Result
 	switch subject.Kind {
 	case KataLinkSubjectPullRequest, KataLinkSubjectIssue:
-		result, err = d.rw.ExecContext(ctx, `
+		result, err = d.rwExecContext(ctx, `
 			DELETE FROM kata_issue_links
 			WHERE id = ?
 			  AND subject_kind = ?
@@ -142,7 +142,7 @@ func (d *DB) DeleteKataIssueLink(
 			linkID, subject.Kind, subject.RepoID, subject.ProviderItemExternalID,
 		)
 	case KataLinkSubjectWorkspace:
-		result, err = d.rw.ExecContext(ctx, `
+		result, err = d.rwExecContext(ctx, `
 			DELETE FROM kata_issue_links
 			WHERE id = ?
 			  AND subject_kind = ?

--- a/internal/db/queries_notifications.go
+++ b/internal/db/queries_notifications.go
@@ -393,7 +393,7 @@ func (d *DB) LatestOpenPRNotificationActivity(
 	ctx context.Context,
 	since time.Time,
 ) ([]MergeRequestNotificationActivity, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT mr.id, MAX(n.source_updated_at)
 		FROM forge_notification_items n
 		LEFT JOIN forge_repo_routes rr
@@ -445,7 +445,7 @@ func (d *DB) FilterNotificationIDs(ctx context.Context, ids []int64, repos []Not
 	for _, id := range ids {
 		args = append(args, id)
 	}
-	rows, err := d.ro.QueryContext(ctx, fmt.Sprintf("SELECT n.id FROM forge_notification_items n WHERE %s AND n.id IN (%s)", where, sqlPlaceholders(len(ids))), args...)
+	rows, err := d.roQueryContext(ctx, fmt.Sprintf("SELECT n.id FROM forge_notification_items n WHERE %s AND n.id IN (%s)", where, sqlPlaceholders(len(ids))), args...)
 	if err != nil {
 		return nil, fmt.Errorf("filter notification ids: %w", err)
 	}
@@ -650,7 +650,7 @@ func (d *DB) ListNotifications(ctx context.Context, opts ListNotificationsOpts) 
 	}
 	query := fmt.Sprintf("SELECT %s FROM forge_notification_items n WHERE %s ORDER BY %s LIMIT ? OFFSET ?", notificationSelectColumns, where, notificationOrder(opts.Sort))
 	args = append(args, limit, opts.Offset)
-	rows, err := d.ro.QueryContext(ctx, query, args...)
+	rows, err := d.roQueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list notifications: %w", err)
 	}
@@ -673,7 +673,7 @@ func (d *DB) NotificationSummary(ctx context.Context, opts ListNotificationsOpts
 		return NotificationSummary{}, err
 	}
 	summary := NotificationSummary{ByReason: map[string]int{}, ByRepo: map[string]int{}}
-	row := d.ro.QueryRowContext(ctx, fmt.Sprintf(`SELECT
+	row := d.roQueryRowContext(ctx, fmt.Sprintf(`SELECT
 		COALESCE(SUM(CASE WHEN n.done_at IS NULL THEN 1 ELSE 0 END), 0),
 		COALESCE(SUM(CASE WHEN n.done_at IS NULL AND n.unread = 1 THEN 1 ELSE 0 END), 0),
 		COALESCE(SUM(CASE WHEN n.done_at IS NOT NULL THEN 1 ELSE 0 END), 0)
@@ -681,12 +681,12 @@ func (d *DB) NotificationSummary(ctx context.Context, opts ListNotificationsOpts
 	if err := row.Scan(&summary.TotalActive, &summary.Unread, &summary.Done); err != nil {
 		return summary, fmt.Errorf("notification summary totals: %w", err)
 	}
-	if err := scanNotificationCounts(ctx, d.ro, fmt.Sprintf("SELECT n.reason, COUNT(*) FROM forge_notification_items n WHERE %s GROUP BY n.reason", where), args, summary.ByReason); err != nil {
+	if err := scanNotificationCounts(ctx, d.roStmts, fmt.Sprintf("SELECT n.reason, COUNT(*) FROM forge_notification_items n WHERE %s GROUP BY n.reason", where), args, summary.ByReason); err != nil {
 		return summary, err
 	}
 	// Linked rows group under their canonical route so renames don't split
 	// counts between old and new names; cached fields serve unlinked rows.
-	if err := scanNotificationCounts(ctx, d.ro, fmt.Sprintf(`SELECT
+	if err := scanNotificationCounts(ctx, d.roStmts, fmt.Sprintf(`SELECT
 		COALESCE(
 			r.platform_host || '/' || r.owner_key || '/' || r.name_key,
 			n.platform_host || '/' || n.repo_owner || '/' || n.repo_name
@@ -735,7 +735,7 @@ func (d *DB) MarkNotificationsDone(ctx context.Context, ids []int64, doneAt time
 	for _, id := range ids {
 		args = append(args, id)
 	}
-	rows, err := d.rw.QueryContext(ctx, fmt.Sprintf("UPDATE forge_notification_items SET done_at = ?, done_reason = CASE WHEN done_reason = '' THEN 'user' ELSE done_reason END%s WHERE id IN (%s) RETURNING id", setRead, sqlPlaceholders(len(ids))), args...)
+	rows, err := d.rwQueryContext(ctx, fmt.Sprintf("UPDATE forge_notification_items SET done_at = ?, done_reason = CASE WHEN done_reason = '' THEN 'user' ELSE done_reason END%s WHERE id IN (%s) RETURNING id", setRead, sqlPlaceholders(len(ids))), args...)
 	if err != nil {
 		return nil, fmt.Errorf("mark notifications done: %w", err)
 	}
@@ -750,7 +750,7 @@ func (d *DB) MarkNotificationsUndone(ctx context.Context, ids []int64) ([]int64,
 	for _, id := range ids {
 		args = append(args, id)
 	}
-	rows, err := d.rw.QueryContext(ctx, fmt.Sprintf("UPDATE forge_notification_items SET done_at = NULL, done_reason = '' WHERE id IN (%s) RETURNING id", sqlPlaceholders(len(ids))), args...)
+	rows, err := d.rwQueryContext(ctx, fmt.Sprintf("UPDATE forge_notification_items SET done_at = NULL, done_reason = '' WHERE id IN (%s) RETURNING id", sqlPlaceholders(len(ids))), args...)
 	if err != nil {
 		return nil, fmt.Errorf("mark notifications undone: %w", err)
 	}
@@ -765,7 +765,7 @@ func (d *DB) MarkNotificationIDsReadLocal(ctx context.Context, ids []int64) ([]i
 	for _, id := range ids {
 		args = append(args, id)
 	}
-	rows, err := d.rw.QueryContext(ctx, fmt.Sprintf(`UPDATE forge_notification_items
+	rows, err := d.rwQueryContext(ctx, fmt.Sprintf(`UPDATE forge_notification_items
 		SET unread = 0, source_ack_queued_at = NULL, source_ack_synced_at = NULL, source_ack_generation_at = NULL,
 		    source_ack_error = '', source_ack_attempts = 0, source_ack_last_attempt_at = NULL, source_ack_next_attempt_at = NULL
 		WHERE id IN (%s)
@@ -785,7 +785,7 @@ func (d *DB) QueueNotificationIDsRead(ctx context.Context, ids []int64, readAt t
 	for _, id := range ids {
 		args = append(args, id)
 	}
-	rows, err := d.rw.QueryContext(ctx, fmt.Sprintf(`UPDATE forge_notification_items
+	rows, err := d.rwQueryContext(ctx, fmt.Sprintf(`UPDATE forge_notification_items
 		SET unread = 0, source_ack_queued_at = ?, source_ack_synced_at = NULL, source_ack_generation_at = source_updated_at,
 		    source_ack_error = '', source_ack_attempts = 0, source_ack_last_attempt_at = NULL, source_ack_next_attempt_at = NULL
 		WHERE id IN (%s)
@@ -833,7 +833,7 @@ func (d *DB) GetNotificationSyncWatermark(ctx context.Context, platform, host, o
 	}
 	var rawLastSuccessful string
 	var rawLastFull sql.NullString
-	err = d.ro.QueryRowContext(ctx, `
+	err = d.roQueryRowContext(ctx, `
 		SELECT last_successful_sync_at, last_full_sync_at
 		FROM forge_notification_sync_watermarks
 		WHERE platform = ? AND platform_host = ? AND repo_owner = ? AND repo_name = ?`,
@@ -983,7 +983,7 @@ func (d *DB) ListQueuedNotificationAcks(ctx context.Context, platform, host stri
 		return nil, err
 	}
 	limit = normalizedNotificationLimit(limit)
-	rows, err := d.ro.QueryContext(ctx, fmt.Sprintf(`SELECT %s FROM forge_notification_items n
+	rows, err := d.roQueryContext(ctx, fmt.Sprintf(`SELECT %s FROM forge_notification_items n
 		JOIN forge_notification_ack_admissions admission
 		  ON admission.notification_id = n.id
 		JOIN forge_spoke_preparation preparation
@@ -1059,7 +1059,7 @@ func (d *DB) ListQueuedNotificationAcks(ctx context.Context, platform, host stri
 
 func (d *DB) NotificationAckPropagationCurrent(ctx context.Context, id int64, queuedAt *time.Time, sourceUpdatedAt time.Time) (bool, error) {
 	var matched int
-	err := d.ro.QueryRowContext(ctx, `SELECT 1 FROM forge_notification_items
+	err := d.roQueryRowContext(ctx, `SELECT 1 FROM forge_notification_items
 		WHERE id = ?
 		  AND source_ack_queued_at = ?
 		  AND source_updated_at = ?

--- a/internal/db/queries_projects.go
+++ b/internal/db/queries_projects.go
@@ -137,7 +137,7 @@ const projectFromJoin = `FROM forge_projects p
 // GetProjectByID returns one project by its server-assigned id, joining the
 // linked forge_repos row to populate PlatformIdentity when present.
 func (d *DB) GetProjectByID(ctx context.Context, id string) (*Project, error) {
-	row := d.ro.QueryRowContext(ctx,
+	row := d.roQueryRowContext(ctx,
 		`SELECT `+projectSelectColumns+` `+projectFromJoin+`
 		 WHERE p.id = ?`,
 		id,
@@ -148,7 +148,7 @@ func (d *DB) GetProjectByID(ctx context.Context, id string) (*Project, error) {
 // GetProjectByLocalPath returns the project registered at the given absolute
 // path, or ErrProjectNotFound if no record matches.
 func (d *DB) GetProjectByLocalPath(ctx context.Context, localPath string) (*Project, error) {
-	row := d.ro.QueryRowContext(ctx,
+	row := d.roQueryRowContext(ctx,
 		`SELECT `+projectSelectColumns+` `+projectFromJoin+`
 		 WHERE p.local_path = ?`,
 		localPath,
@@ -158,7 +158,7 @@ func (d *DB) GetProjectByLocalPath(ctx context.Context, localPath string) (*Proj
 
 // ListProjects returns all registered projects ordered by display_name.
 func (d *DB) ListProjects(ctx context.Context) ([]Project, error) {
-	rows, err := d.ro.QueryContext(ctx,
+	rows, err := d.roQueryContext(ctx,
 		`SELECT `+projectSelectColumns+` `+projectFromJoin+`
 		 ORDER BY p.display_name COLLATE NOCASE, p.id`,
 	)
@@ -284,7 +284,7 @@ func (d *DB) adoptProjectWorktreeByPath(
 	ctx context.Context, projectID, branch, path string,
 ) (*ProjectWorktree, error) {
 	var id, owner string
-	if err := d.ro.QueryRowContext(ctx,
+	if err := d.roQueryRowContext(ctx,
 		`SELECT id, project_id FROM forge_project_worktrees WHERE path = ?`,
 		path,
 	).Scan(&id, &owner); err != nil {
@@ -306,7 +306,7 @@ func (d *DB) adoptProjectWorktreeByPath(
 
 // GetProjectWorktreeByID returns one worktree by id.
 func (d *DB) GetProjectWorktreeByID(ctx context.Context, id string) (*ProjectWorktree, error) {
-	row := d.ro.QueryRowContext(ctx,
+	row := d.roQueryRowContext(ctx,
 		`SELECT id, project_id, branch, path, is_stale, is_hidden, session_backend, linked_issue_numbers, created_at, updated_at
 		 FROM forge_project_worktrees WHERE id = ?`,
 		id,
@@ -318,7 +318,7 @@ func (d *DB) GetProjectWorktreeByID(ctx context.Context, id string) (*ProjectWor
 // unique across the registry, so the owning project need not be known — the
 // stale-removal route resolves a worktree from its fleet scoped key this way.
 func (d *DB) GetProjectWorktreeByPath(ctx context.Context, path string) (*ProjectWorktree, error) {
-	row := d.ro.QueryRowContext(ctx,
+	row := d.roQueryRowContext(ctx,
 		`SELECT id, project_id, branch, path, is_stale, is_hidden, session_backend, linked_issue_numbers, created_at, updated_at
 		 FROM forge_project_worktrees WHERE path = ?`,
 		path,
@@ -332,7 +332,7 @@ func (d *DB) ListProjectWorktrees(ctx context.Context, projectID string) ([]Proj
 	if _, err := d.GetProjectByID(ctx, projectID); err != nil {
 		return nil, err
 	}
-	rows, err := d.ro.QueryContext(ctx,
+	rows, err := d.roQueryContext(ctx,
 		`SELECT id, project_id, branch, path, is_stale, is_hidden, session_backend, linked_issue_numbers, created_at, updated_at
 		 FROM forge_project_worktrees
 		 WHERE project_id = ?
@@ -586,7 +586,7 @@ func (d *DB) ListProjectWorktreeTmuxSessions(
 	ctx context.Context,
 	worktreeID string,
 ) ([]ProjectWorktreeTmuxSession, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT s.worktree_id, s.session_key, COALESCE(s.backend_session_key, ''),
 		       s.target_key,
 		       s.label, s.created_at, w.path, w.project_id
@@ -620,7 +620,7 @@ func (d *DB) ListProjectWorktreeTmuxSessions(
 func (d *DB) ListAllProjectWorktreeTmuxSessions(
 	ctx context.Context,
 ) ([]ProjectWorktreeTmuxSession, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT s.worktree_id, s.session_key, COALESCE(s.backend_session_key, ''),
 		       s.target_key,
 		       s.label, s.created_at, w.path, w.project_id

--- a/internal/db/queries_provider_state_handoff.go
+++ b/internal/db/queries_provider_state_handoff.go
@@ -243,7 +243,7 @@ func (d *DB) ListProviderStateForHandoff(
 func (d *DB) listReviewDraftStateForHandoff(
 	ctx context.Context,
 ) ([]ProviderStateRecord, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT draft.id, r.platform, r.platform_host, r.platform_repo_id,
 		       r.owner, r.name, mr.number, draft.body, draft.action
 		FROM forge_mr_review_drafts draft
@@ -294,7 +294,7 @@ func (d *DB) listReviewDraftStateForHandoff(
 func (d *DB) listWorkflowStateForHandoff(
 	ctx context.Context,
 ) ([]ProviderStateRecord, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT r.platform, r.platform_host, r.platform_repo_id,
 		       r.owner, r.name, state.item_type, state.item_number,
 		       state.status, state.updated_source, state.updated_actor,

--- a/internal/db/queries_repo_summaries.go
+++ b/internal/db/queries_repo_summaries.go
@@ -43,7 +43,7 @@ func (d *DB) loadRepoSummaryStats(
 	ctx context.Context,
 	summaryByRepoID map[int64]*RepoSummary,
 ) error {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		WITH pr_stats AS (
 			SELECT repo_id,
 			       COUNT(*) AS cached_pr_count,
@@ -278,7 +278,7 @@ func (d *DB) loadRepoSummaryOverviews(
 	ctx context.Context,
 	summaryByRepoID map[int64]*RepoSummary,
 ) error {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT repo_id,
 		       latest_release_tag,
 		       latest_release_name,
@@ -431,7 +431,7 @@ func (d *DB) loadRepoSummaryAuthors(
 	ctx context.Context,
 	summaryByRepoID map[int64]*RepoSummary,
 ) error {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		WITH author_items AS (
 			SELECT repo_id, author, last_activity_at
 			FROM forge_merge_requests
@@ -510,7 +510,7 @@ func (d *DB) loadRepoSummaryIssues(
 	ctx context.Context,
 	summaryByRepoID map[int64]*RepoSummary,
 ) error {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		WITH ranked AS (
 			SELECT repo_id,
 			       number,

--- a/internal/db/queries_review.go
+++ b/internal/db/queries_review.go
@@ -61,7 +61,7 @@ func (d *DB) GetOrCreateMRReviewDraft(ctx context.Context, mrID int64) (*MRRevie
 func (d *DB) GetMRReviewDraft(ctx context.Context, mrID int64) (*MRReviewDraft, error) {
 	var draft MRReviewDraft
 	var createdAt, updatedAt string
-	err := d.ro.QueryRowContext(ctx, `
+	err := d.roQueryRowContext(ctx, `
 		SELECT id, merge_request_id, body, action, created_at, updated_at
 		FROM forge_mr_review_drafts
 		WHERE merge_request_id = ?`,
@@ -91,7 +91,7 @@ func (d *DB) GetMRReviewDraft(ctx context.Context, mrID int64) (*MRReviewDraft, 
 }
 
 func (d *DB) ListMRReviewDraftComments(ctx context.Context, draftID int64) ([]MRReviewDraftComment, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT id, draft_id, body, path, old_path, side, start_side, start_line,
 			line, old_line, new_line, line_type, diff_head_sha, commit_sha,
 			created_at, updated_at
@@ -222,7 +222,7 @@ func (d *DB) DeleteMRReviewDraft(ctx context.Context, mrID int64) error {
 }
 
 func (d *DB) getMRReviewDraftComment(ctx context.Context, draftID, commentID int64) (*MRReviewDraftComment, error) {
-	row := d.ro.QueryRowContext(ctx, `
+	row := d.roQueryRowContext(ctx, `
 		SELECT id, draft_id, body, path, old_path, side, start_side, start_line,
 			line, old_line, new_line, line_type, diff_head_sha, commit_sha,
 			created_at, updated_at
@@ -383,7 +383,7 @@ func deleteMissingMRReviewThreadsTx(
 }
 
 func (d *DB) ListMRReviewThreads(ctx context.Context, mrID int64) ([]MRReviewThread, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT id, merge_request_id, provider_thread_id, provider_review_id,
 			provider_comment_id, path, old_path, side, start_side, start_line,
 			line, old_line, new_line, line_type, diff_head_sha, commit_sha,
@@ -414,7 +414,7 @@ func (d *DB) ListMRReviewThreads(ctx context.Context, mrID int64) ([]MRReviewThr
 }
 
 func (d *DB) GetMRReviewThread(ctx context.Context, mrID, threadID int64) (*MRReviewThread, error) {
-	row := d.ro.QueryRowContext(ctx, `
+	row := d.roQueryRowContext(ctx, `
 		SELECT id, merge_request_id, provider_thread_id, provider_review_id,
 			provider_comment_id, path, old_path, side, start_side, start_line,
 			line, old_line, new_line, line_type, diff_head_sha, commit_sha,

--- a/internal/db/queries_spoke_preparation.go
+++ b/internal/db/queries_spoke_preparation.go
@@ -88,7 +88,7 @@ func (d *DB) GetSpokePreparation(
 	var drain sql.NullInt64
 	var started, sealed sql.NullString
 	var updated string
-	err := d.ro.QueryRowContext(ctx, `
+	err := d.roQueryRowContext(ctx, `
 		SELECT phase, enrollment_id, hub_node_id, local_node_id,
 		       protocol_version, migration_version, ack_generation,
 		       drain_ack_generation, preparation_digest, preparation_seal,
@@ -236,7 +236,7 @@ func (d *DB) CountUndrainedNotificationAcks(
 	ctx context.Context,
 ) (int, error) {
 	var count int
-	err := d.ro.QueryRowContext(ctx, `
+	err := d.roQueryRowContext(ctx, `
 		SELECT COUNT(*)
 		FROM forge_notification_ack_admissions admission
 		JOIN forge_notification_items notification
@@ -271,7 +271,7 @@ func (d *DB) RecordSpokePreparationReceipt(
 	if receipt.ImportedAt.IsZero() {
 		receipt.ImportedAt = time.Now().UTC()
 	}
-	result, err := d.rw.ExecContext(ctx, `
+	result, err := d.rwExecContext(ctx, `
 		INSERT INTO forge_spoke_preparation_receipts (
 			state_kind, source_key, content_digest,
 			hub_receipt, imported_at
@@ -301,7 +301,7 @@ func (d *DB) RecordSpokePreparationReceipt(
 func (d *DB) ListSpokePreparationReceipts(
 	ctx context.Context,
 ) ([]SpokePreparationReceipt, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT state_kind, source_key, content_digest,
 		       hub_receipt, imported_at
 		FROM forge_spoke_preparation_receipts
@@ -390,7 +390,7 @@ func (d *DB) IssueSpokePreparationSeal(
 		SpokePreparationSealRequest: request,
 		Seal:                        hex.EncodeToString(raw), CreatedAt: time.Now().UTC(),
 	}
-	_, err = d.rw.ExecContext(ctx, `
+	_, err = d.rwExecContext(ctx, `
 		INSERT INTO forge_spoke_preparation_seals (
 			enrollment_id, node_id, hub_node_id,
 			protocol_version, migration_version, receipts_digest,
@@ -420,7 +420,7 @@ func (d *DB) GetSpokePreparationSeal(
 ) (*SpokePreparationSeal, error) {
 	var seal SpokePreparationSeal
 	var createdAt string
-	err := d.ro.QueryRowContext(ctx, `
+	err := d.roQueryRowContext(ctx, `
 		SELECT enrollment_id, node_id, hub_node_id,
 		       protocol_version, migration_version, receipts_digest,
 		       drained_ack_generation, preparation_digest,
@@ -456,7 +456,7 @@ func (d *DB) StoreLocalSpokePreparationSeal(
 		return errors.New("spoke preparation digest and seal are required")
 	}
 	now := time.Now().UTC().Format(time.RFC3339Nano)
-	result, err := d.rw.ExecContext(ctx, `
+	result, err := d.rwExecContext(ctx, `
 		UPDATE forge_spoke_preparation
 		SET phase = 'sealed', preparation_digest = ?, preparation_seal = ?,
 		    sealed_at = COALESCE(sealed_at, ?), updated_at = ?

--- a/internal/db/queries_stacks.go
+++ b/internal/db/queries_stacks.go
@@ -21,7 +21,7 @@ func (d *DB) ListPRsForNativeStackMembers(ctx context.Context, repoID int64) ([]
 }
 
 func (d *DB) listPRsForStacks(ctx context.Context, repoID int64, stateFilter string) ([]MergeRequest, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT id, number, title, head_branch, base_branch, state, ci_status, review_decision,
 		       head_repo_clone_url
 		FROM forge_merge_requests
@@ -70,7 +70,7 @@ func (d *DB) UpsertStack(ctx context.Context, repoID int64, baseNumber int, name
 		return 0, fmt.Errorf("upsert stack: %w", err)
 	}
 	var id int64
-	err = d.ro.QueryRowContext(ctx,
+	err = d.roQueryRowContext(ctx,
 		`SELECT id FROM forge_stacks WHERE repo_id = ? AND base_number = ?`,
 		repoID, baseNumber,
 	).Scan(&id)
@@ -131,7 +131,7 @@ func (d *DB) ListStacksWithMembers(ctx context.Context, repoFilter string) ([]St
 		}
 		if strings.Count(pathKey, "/") > 1 {
 			var exists int
-			err := d.ro.QueryRowContext(ctx,
+			err := d.roQueryRowContext(ctx,
 				`SELECT 1 FROM forge_repos
 				 WHERE repo_path_key = ? AND lifecycle_state = 'active'
 				 LIMIT 1`,
@@ -170,7 +170,7 @@ func (d *DB) ListStacksWithMembers(ctx context.Context, repoFilter string) ([]St
 		%s
 		ORDER BY s.updated_at DESC`, where)
 
-	rows, err := d.ro.QueryContext(ctx, stackQuery, args...)
+	rows, err := d.roQueryContext(ctx, stackQuery, args...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("list stacks: %w", err)
 	}
@@ -216,7 +216,7 @@ func (d *DB) ListStacksWithMembers(ctx context.Context, repoFilter string) ([]St
 		  )
 		ORDER BY sm.stack_id, sm.position`
 
-	mRows, err := d.ro.QueryContext(ctx, memberQuery, memberArgs...)
+	mRows, err := d.roQueryContext(ctx, memberQuery, memberArgs...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("list stack members: %w", err)
 	}
@@ -307,7 +307,7 @@ func (d *DB) GetStackForPRByRepoID(ctx context.Context, repoID int64, number int
 
 func (d *DB) getStackForPRWhere(ctx context.Context, where string, args ...any) (*Stack, []StackMemberWithPR, error) {
 	var stack Stack
-	err := d.ro.QueryRowContext(ctx, `
+	err := d.roQueryRowContext(ctx, `
 		SELECT s.id, s.repo_id, s.base_number, s.name, s.created_at, s.updated_at
 		FROM forge_stacks s
 		JOIN forge_stack_members sm ON sm.stack_id = s.id
@@ -323,7 +323,7 @@ func (d *DB) getStackForPRWhere(ctx context.Context, where string, args ...any) 
 		return nil, nil, fmt.Errorf("get stack for pr: %w", err)
 	}
 
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT sm.stack_id, sm.merge_request_id, sm.position,
 		       p.number, p.title, p.state, p.ci_status, p.review_decision,
 		       p.is_draft, p.base_branch, p.mergeable_state
@@ -374,7 +374,7 @@ func (d *DB) ListMRsBlockedByStackConflicts(ctx context.Context, mrIDs []int64) 
 		args[i] = id
 	}
 
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT DISTINCT target.merge_request_id
 		FROM forge_stack_members target
 		JOIN forge_merge_requests target_pr ON target_pr.id = target.merge_request_id

--- a/internal/db/queries_workflow.go
+++ b/internal/db/queries_workflow.go
@@ -45,7 +45,7 @@ func (d *DB) GetItemWorkflowState(
 		return nil, err
 	}
 	var w ItemWorkflowState
-	err := d.ro.QueryRowContext(ctx,
+	err := d.roQueryRowContext(ctx,
 		`SELECT repo_id, item_type, item_number, status, updated_at,
 		        updated_source, updated_actor, updated_reason
 		   FROM forge_item_workflow_state
@@ -382,7 +382,7 @@ func (d *DB) ListItemWorkflowStates(
 		         t.platform, t.platform_host, t.owner, t.name, t.item_type, t.number
 		LIMIT ?`, prWhere, issueWhere, where)
 
-	rows, err := d.ro.QueryContext(ctx, query, args...)
+	rows, err := d.roQueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, "", fmt.Errorf("list item workflow states: %w", err)
 	}

--- a/internal/db/queries_workspace_launch_specs.go
+++ b/internal/db/queries_workspace_launch_specs.go
@@ -152,7 +152,7 @@ func (d *DB) PutWorkspaceLaunchSpec(
 	); err != nil {
 		return err
 	}
-	return insertWorkspaceLaunchSpec(ctx, d.rw, workspaceID, spec)
+	return insertWorkspaceLaunchSpec(ctx, d.rwStmts, workspaceID, spec)
 }
 
 // GetWorkspaceByLaunchSpecIdentity finds a provider-backed workspace by the
@@ -171,7 +171,7 @@ func (d *DB) GetWorkspaceByLaunchSpecIdentity(
 		itemType == "" || itemKey == "" {
 		return nil, nil
 	}
-	workspace, err := d.scanWorkspace(ctx, d.ro.QueryRowContext(ctx, `
+	workspace, err := d.scanWorkspace(ctx, d.roQueryRowContext(ctx, `
 		SELECT w.id, w.platform, w.platform_host, w.repo_owner, w.repo_name,
 		       w.repo_id,
 		       w.item_type, w.item_number, w.item_key, w.associated_pr_number,
@@ -207,7 +207,7 @@ func (d *DB) ResolveUnambiguousHistoricalWorkspaceRepoID(
 	platform = strings.ToLower(strings.TrimSpace(platform))
 	platformHost, owner, name = canonicalRepoLookupIdentifier(platformHost, owner, name)
 	var platformRepoID string
-	err := d.ro.QueryRowContext(ctx, `
+	err := d.roQueryRowContext(ctx, `
 		SELECT r.platform_repo_id
 		FROM forge_repo_routes route
 		JOIN forge_repos r ON r.id = route.repo_id
@@ -381,7 +381,7 @@ func (d *DB) GetWorkspaceLaunchSpec(
 	var version int
 	var encoded string
 	var visibleUntil, createdAt string
-	err := d.ro.QueryRowContext(ctx, `
+	err := d.roQueryRowContext(ctx, `
 		SELECT version, spec_json, source_visible_until, created_at
 		FROM forge_workspace_launch_specs
 		WHERE workspace_id = ?`, workspaceID,
@@ -428,7 +428,7 @@ func (d *DB) ListUnpreparedProviderWorkspacesAt(
 	ctx context.Context,
 	now time.Time,
 ) ([]UnpreparedWorkspace, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT id, platform, platform_host, repo_owner, repo_name, repo_id,
 		       item_type, item_number, item_key, associated_pr_number,
 		       git_head_ref, mr_head_repo, workspace_branch,
@@ -500,7 +500,7 @@ func (d *DB) ListUnpreparedProviderWorkspacesAt(
 
 func (d *DB) CountProviderBackedWorkspaces(ctx context.Context) (int, error) {
 	var count int
-	err := d.ro.QueryRowContext(ctx, `
+	err := d.roQueryRowContext(ctx, `
 		SELECT COUNT(*) FROM forge_workspaces
 		WHERE item_type IN ('pull_request', 'issue')`).Scan(&count)
 	if err != nil {

--- a/internal/db/queries_worktree_stats.go
+++ b/internal/db/queries_worktree_stats.go
@@ -43,7 +43,7 @@ func (d *DB) UpsertWorktreeStats(
 	}
 
 	var prev WorktreeGitStats
-	readErr := d.ro.QueryRowContext(ctx, `
+	readErr := d.roQueryRowContext(ctx, `
 		SELECT diff_added, diff_removed, sync_ahead, sync_behind
 		FROM forge_worktree_stats WHERE path = ?`, path,
 	).Scan(&prev.DiffAdded, &prev.DiffRemoved, &prev.SyncAhead, &prev.SyncBehind)
@@ -89,7 +89,7 @@ func worktreeStatsCountsEqual(a, b WorktreeGitStats) bool {
 func (d *DB) ListWorktreeStats(
 	ctx context.Context,
 ) (map[string]WorktreeGitStats, error) {
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT path, diff_added, diff_removed, sync_ahead, sync_behind, sampled_at
 		FROM forge_worktree_stats`,
 	)

--- a/internal/db/repo_ui_visibility.go
+++ b/internal/db/repo_ui_visibility.go
@@ -15,7 +15,7 @@ func (d *DB) SetRepoHiddenFromUI(
 	ctx context.Context, repoID int64, hidden bool,
 ) error {
 	if hidden {
-		if _, err := d.rw.ExecContext(ctx,
+		if _, err := d.rwExecContext(ctx,
 			`INSERT INTO forge_hidden_repos (repo_id) VALUES (?)
 			 ON CONFLICT(repo_id) DO NOTHING`,
 			repoID,
@@ -24,7 +24,7 @@ func (d *DB) SetRepoHiddenFromUI(
 		}
 		return nil
 	}
-	if _, err := d.rw.ExecContext(ctx,
+	if _, err := d.rwExecContext(ctx,
 		`DELETE FROM forge_hidden_repos WHERE repo_id = ?`, repoID,
 	); err != nil {
 		return fmt.Errorf("show repo %d in UI: %w", repoID, err)
@@ -37,7 +37,7 @@ func (d *DB) SetRepoHiddenFromUI(
 // to exclude repositories from interactive catalogs and to mark configured
 // entries as hidden on the settings surface.
 func (d *DB) HiddenRepos(ctx context.Context) ([]Repo, error) {
-	rows, err := d.ro.QueryContext(ctx,
+	rows, err := d.roQueryContext(ctx,
 		`SELECT r.id, r.platform, r.platform_host, r.platform_repo_id,
 		        r.owner, r.name, r.repo_path
 		 FROM forge_repos r

--- a/internal/db/repository_catalog.go
+++ b/internal/db/repository_catalog.go
@@ -166,7 +166,7 @@ func (d *DB) getRepositoryByProviderID(
 	})
 	return loadRepositoryCatalogEntry(
 		ctx,
-		d.ro,
+		d.roStmts,
 		`r.platform = ? AND r.platform_host = ? AND r.platform_repo_id = ?`,
 		identity.Platform,
 		identity.PlatformHost,
@@ -265,7 +265,7 @@ func (d *DB) GetPullDiffProviderSnapshotUnderRepositoryReconciliationRead(
 			Route:      route,
 		},
 	}
-	err = d.ro.QueryRowContext(ctx, `
+	err = d.roQueryRowContext(ctx, `
 		SELECT p.number, p.snapshot_revision,
 		       p.platform_head_sha, p.platform_base_sha,
 		       p.diff_head_sha, p.diff_base_sha, p.merge_base_sha, p.state
@@ -334,7 +334,7 @@ func (d *DB) ResolveCurrentRepositoryRouteFence(
 	defer release()
 
 	fence, found, err := currentRepositoryRouteFence(
-		ctx, d.ro, identity,
+		ctx, d.roStmts, identity,
 	)
 	if err != nil {
 		return RepositoryRouteFence{}, false, err
@@ -350,7 +350,7 @@ func (d *DB) RepositoryRouteFenceMatchesUnderRepositoryReconciliationRead(
 	fence RepositoryRouteFence,
 ) (bool, error) {
 	identity = canonicalRepoIdentity(identity)
-	current, found, err := currentRepositoryRouteFence(ctx, d.ro, identity)
+	current, found, err := currentRepositoryRouteFence(ctx, d.roStmts, identity)
 	if err != nil || !found {
 		return false, err
 	}
@@ -375,7 +375,7 @@ func (d *DB) resolveActiveRepositoryRoute(
 	}
 	return loadRepositoryCatalogEntry(
 		ctx,
-		d.ro,
+		d.roStmts,
 		`r.lifecycle_state = 'active' AND EXISTS (
 			SELECT 1
 			FROM forge_repo_routes rr
@@ -485,7 +485,7 @@ func (d *DB) ListRepositoryCatalog(
 		query += " WHERE " + strings.Join(clauses, " AND ")
 	}
 	query += ` ORDER BY r.platform, r.platform_host, r.owner_key, r.name_key, r.id`
-	rows, err := d.ro.QueryContext(ctx, query, args...)
+	rows, err := d.roQueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list repository catalog: %w", err)
 	}
@@ -504,7 +504,7 @@ func (d *DB) ListRepositoryCatalog(
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate repository catalog: %w", err)
 	}
-	routes, err := loadRepositoryRoutes(ctx, d.ro, repoIDs)
+	routes, err := loadRepositoryRoutes(ctx, d.roStmts, repoIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -837,7 +837,7 @@ func (d *DB) RepositoryRouteHasOtherRepository(
 		return false, err
 	}
 	defer release()
-	return repositoryRouteHasOtherRepository(ctx, d.ro, identity, repoID)
+	return repositoryRouteHasOtherRepository(ctx, d.roStmts, identity, repoID)
 }
 
 // AdoptLegacyClonesIfSafe runs adopt while repoID remains the verified current
@@ -864,7 +864,7 @@ func (d *DB) AdoptLegacyClonesIfSafe(
 	defer release()
 
 	var allowed bool
-	err = d.ro.QueryRowContext(ctx, `
+	err = d.roQueryRowContext(ctx, `
 		SELECT EXISTS (
 			SELECT 1
 			FROM forge_repo_routes AS current

--- a/internal/db/stmt_cache.go
+++ b/internal/db/stmt_cache.go
@@ -42,12 +42,19 @@ type stmtCacheEntry struct {
 	evicted bool
 }
 
+// newStmtCache wraps pool. A limit of zero or less disables caching: every
+// call goes straight to the pool, which compiles and finalizes per call.
 func newStmtCache(pool *sql.DB, limit int) *stmtCache {
 	return &stmtCache{pool: pool, limit: limit, entries: make(map[string]*list.Element)}
 }
 
+func (c *stmtCache) disabled() bool { return c.limit <= 0 }
+
 // ExecContext executes query through a cached prepared statement.
 func (c *stmtCache) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	if c.disabled() {
+		return c.pool.ExecContext(ctx, query, args...)
+	}
 	stmt, release, err := c.acquire(ctx, query)
 	if err != nil {
 		return nil, err
@@ -60,6 +67,9 @@ func (c *stmtCache) ExecContext(ctx context.Context, query string, args ...any) 
 // rows keep the statement alive inside database/sql until they are closed, so
 // a later eviction cannot invalidate an open result set.
 func (c *stmtCache) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	if c.disabled() {
+		return c.pool.QueryContext(ctx, query, args...)
+	}
 	stmt, release, err := c.acquire(ctx, query)
 	if err != nil {
 		return nil, err
@@ -71,6 +81,9 @@ func (c *stmtCache) QueryContext(ctx context.Context, query string, args ...any)
 // QueryRowContext runs query through a cached prepared statement. A prepare
 // failure is surfaced by the row's Scan, matching *sql.DB.QueryRowContext.
 func (c *stmtCache) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	if c.disabled() {
+		return c.pool.QueryRowContext(ctx, query, args...)
+	}
 	stmt, release, err := c.acquire(ctx, query)
 	if err != nil {
 		// database/sql exposes no way to build a *sql.Row carrying err, so

--- a/internal/db/stmt_cache.go
+++ b/internal/db/stmt_cache.go
@@ -1,0 +1,193 @@
+package db
+
+import (
+	"container/list"
+	"context"
+	"database/sql"
+	"errors"
+	"sync"
+	"sync/atomic"
+)
+
+// stmtCacheLimit bounds the number of distinct SQL texts each pool keeps
+// prepared. The package has a few hundred static statements; the bound only
+// matters for queries that splice a variable number of placeholders into the
+// text, which cycle through the least recently used slots.
+const stmtCacheLimit = 512
+
+// stmtCache memoizes *sql.Stmt handles by SQL text for one connection pool.
+// database/sql statements are pool-aware: each handle keeps one compiled
+// statement per connection it has run on, so with idle connections pinned to
+// the pool size every hot query compiles once per connection for the life of
+// the process instead of once per call.
+//
+// The cache is a transparent layer: it never rewrites SQL, and it exposes the
+// same ExecContext, QueryContext, and QueryRowContext shape as *sql.DB so the
+// package's queryer interfaces accept it in place of the raw pool.
+type stmtCache struct {
+	pool  *sql.DB
+	limit int
+
+	mu       sync.Mutex
+	closed   bool
+	entries  map[string]*list.Element
+	lru      list.List // front is most recently used
+	prepared atomic.Int64
+}
+
+type stmtCacheEntry struct {
+	query   string
+	stmt    *sql.Stmt
+	inUse   int
+	evicted bool
+}
+
+func newStmtCache(pool *sql.DB, limit int) *stmtCache {
+	return &stmtCache{pool: pool, limit: limit, entries: make(map[string]*list.Element)}
+}
+
+// ExecContext executes query through a cached prepared statement.
+func (c *stmtCache) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	stmt, release, err := c.acquire(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	return stmt.ExecContext(ctx, args...)
+}
+
+// QueryContext runs query through a cached prepared statement. The returned
+// rows keep the statement alive inside database/sql until they are closed, so
+// a later eviction cannot invalidate an open result set.
+func (c *stmtCache) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	stmt, release, err := c.acquire(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	return stmt.QueryContext(ctx, args...)
+}
+
+// QueryRowContext runs query through a cached prepared statement. A prepare
+// failure is surfaced by the row's Scan, matching *sql.DB.QueryRowContext.
+func (c *stmtCache) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	stmt, release, err := c.acquire(ctx, query)
+	if err != nil {
+		// database/sql exposes no way to build a *sql.Row carrying err, so
+		// let the pool repeat the failing prepare and report it from Scan.
+		return c.pool.QueryRowContext(ctx, query, args...)
+	}
+	defer release()
+	return stmt.QueryRowContext(ctx, args...)
+}
+
+// acquire returns the cached statement for query, preparing it on a miss. The
+// release function must be called once the statement call has returned; an
+// entry evicted while calls are still in flight is closed by the last release.
+func (c *stmtCache) acquire(ctx context.Context, query string) (*sql.Stmt, func(), error) {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil, nil, errStmtCacheClosed
+	}
+	if element, ok := c.entries[query]; ok {
+		c.lru.MoveToFront(element)
+		entry := element.Value.(*stmtCacheEntry)
+		entry.inUse++
+		c.mu.Unlock()
+		return entry.stmt, func() { c.release(entry) }, nil
+	}
+	c.mu.Unlock()
+
+	// Compile outside the lock so one slow prepare does not stall unrelated
+	// queries; a concurrent miss on the same text loses the race below.
+	stmt, err := c.pool.PrepareContext(ctx, query)
+	if err != nil {
+		return nil, nil, err
+	}
+	c.prepared.Add(1)
+
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		stmt.Close()
+		return nil, nil, errStmtCacheClosed
+	}
+	if element, ok := c.entries[query]; ok {
+		c.lru.MoveToFront(element)
+		entry := element.Value.(*stmtCacheEntry)
+		entry.inUse++
+		c.mu.Unlock()
+		stmt.Close()
+		return entry.stmt, func() { c.release(entry) }, nil
+	}
+	entry := &stmtCacheEntry{query: query, stmt: stmt, inUse: 1}
+	c.entries[query] = c.lru.PushFront(entry)
+	var closers []*sql.Stmt
+	for c.lru.Len() > c.limit {
+		oldest := c.lru.Back()
+		victim := oldest.Value.(*stmtCacheEntry)
+		c.lru.Remove(oldest)
+		delete(c.entries, victim.query)
+		victim.evicted = true
+		if victim.inUse == 0 {
+			closers = append(closers, victim.stmt)
+		}
+	}
+	c.mu.Unlock()
+	for _, closer := range closers {
+		closer.Close()
+	}
+	return stmt, func() { c.release(entry) }, nil
+}
+
+func (c *stmtCache) release(entry *stmtCacheEntry) {
+	c.mu.Lock()
+	entry.inUse--
+	closeNow := entry.evicted && entry.inUse == 0
+	c.mu.Unlock()
+	if closeNow {
+		entry.stmt.Close()
+	}
+}
+
+// Close finalizes every cached statement. It must run before the owning pool
+// closes so statement handles are released deliberately rather than as a side
+// effect of connection teardown.
+func (c *stmtCache) Close() error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	stmts := make([]*sql.Stmt, 0, len(c.entries))
+	for element := c.lru.Front(); element != nil; element = element.Next() {
+		stmts = append(stmts, element.Value.(*stmtCacheEntry).stmt)
+	}
+	c.entries = nil
+	c.lru.Init()
+	c.mu.Unlock()
+
+	var errs []error
+	for _, stmt := range stmts {
+		if err := stmt.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// len reports the number of cached statements.
+func (c *stmtCache) len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.entries)
+}
+
+// preparedCount reports how many statements the cache has compiled so far.
+func (c *stmtCache) preparedCount() int64 {
+	return c.prepared.Load()
+}
+
+var errStmtCacheClosed = errors.New("statement cache closed")

--- a/internal/db/stmt_cache_test.go
+++ b/internal/db/stmt_cache_test.go
@@ -205,9 +205,8 @@ func TestDBCloseFinalizesCachedStatements(t *testing.T) {
 }
 
 // BenchmarkRepositoryCatalogLookup compares a hot read with the per-pool
-// statement cache against the previous behavior of compiling every statement
-// on each call. The uncached variant uses a zero-capacity cache, which
-// prepares and finalizes on every call exactly like a raw *sql.DB query.
+// statement cache against the previous behavior of querying the pool
+// directly, which compiles and finalizes every statement on each call.
 func BenchmarkRepositoryCatalogLookup(b *testing.B) {
 	for _, variant := range []struct {
 		name  string
@@ -229,8 +228,6 @@ func BenchmarkRepositoryCatalogLookup(b *testing.B) {
 				_, err := d.GetRepoByIdentity(ctx, identity)
 				require.NoError(b, err)
 			}
-			b.StopTimer()
-			b.ReportMetric(float64(d.roStmts.preparedCount())/float64(b.N), "prepares/op")
 		})
 	}
 }

--- a/internal/db/stmt_cache_test.go
+++ b/internal/db/stmt_cache_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestOpenAppliesConnectionPragmasToEveryPooledConnection(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	d := openTestDB(t)
 	ctx := t.Context()
 
@@ -21,7 +23,7 @@ func TestOpenAppliesConnectionPragmasToEveryPooledConnection(t *testing.T) {
 		got := map[string]int64{}
 		for _, name := range []string{"cache_size", "mmap_size", "temp_store", "foreign_keys", "synchronous"} {
 			var value int64
-			require.NoError(t, conn.QueryRowContext(ctx, "PRAGMA "+name).Scan(&value))
+			require.NoError(conn.QueryRowContext(ctx, "PRAGMA "+name).Scan(&value))
 			got[name] = value
 		}
 		return got
@@ -39,22 +41,22 @@ func TestOpenAppliesConnectionPragmasToEveryPooledConnection(t *testing.T) {
 	var readConns []*sql.Conn
 	for range readPoolSize {
 		conn, err := d.ReadDB().Conn(ctx)
-		require.NoError(t, err)
+		require.NoError(err)
 		readConns = append(readConns, conn)
 	}
 	for i, conn := range readConns {
-		assert.Equal(t, want, readPragmas(t, conn), "read connection %d", i)
-		require.NoError(t, conn.Close())
+		assert.Equal(want, readPragmas(t, conn), "read connection %d", i)
+		require.NoError(conn.Close())
 	}
 
 	writeConn, err := d.WriteDB().Conn(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, want, readPragmas(t, writeConn), "write connection")
-	require.NoError(t, writeConn.Close())
+	require.NoError(err)
+	assert.Equal(want, readPragmas(t, writeConn), "write connection")
+	require.NoError(writeConn.Close())
 
-	assert.Equal(t, readPoolSize, d.ReadDB().Stats().MaxOpenConnections)
-	assert.Equal(t, writePoolSize, d.WriteDB().Stats().MaxOpenConnections)
-	assert.Zero(t, d.ReadDB().Stats().MaxIdleClosed, "read pool must not close idle connections")
+	assert.Equal(readPoolSize, d.ReadDB().Stats().MaxOpenConnections)
+	assert.Equal(writePoolSize, d.WriteDB().Stats().MaxOpenConnections)
+	assert.Zero(d.ReadDB().Stats().MaxIdleClosed, "read pool must not close idle connections")
 }
 
 func seedStatementCacheRepos(t testing.TB, d *DB) RepoIdentity {
@@ -74,13 +76,14 @@ func seedStatementCacheRepos(t testing.TB, d *DB) RepoIdentity {
 
 func TestRepositoryLookupCompilesEachStatementOncePerConnection(t *testing.T) {
 	assert := assert.New(t)
+	require := require.New(t)
 	d := openTestDB(t)
 	ctx := t.Context()
 	identity := seedStatementCacheRepos(t, d)
 
 	repo, err := d.GetRepoByIdentity(ctx, identity)
-	require.NoError(t, err)
-	require.NotNil(t, repo)
+	require.NoError(err)
+	require.NotNil(repo)
 	warm := d.roStmts.preparedCount()
 	assert.Positive(warm)
 	assert.Equal(int(warm), d.roStmts.len())
@@ -88,8 +91,8 @@ func TestRepositoryLookupCompilesEachStatementOncePerConnection(t *testing.T) {
 	const repeats = 200
 	for range repeats {
 		again, err := d.GetRepoByIdentity(ctx, identity)
-		require.NoError(t, err)
-		require.Equal(t, repo, again)
+		require.NoError(err)
+		require.Equal(repo, again)
 	}
 	assert.Equal(warm, d.roStmts.preparedCount(),
 		"%d repeated lookups must reuse the statements compiled by the first", repeats)
@@ -185,19 +188,20 @@ func TestStmtCacheServesConcurrentCallersUnderEviction(t *testing.T) {
 
 func TestDBCloseFinalizesCachedStatements(t *testing.T) {
 	assert := assert.New(t)
+	require := require.New(t)
 	d := openTestDB(t)
 	ctx := t.Context()
 	identity := seedStatementCacheRepos(t, d)
 	_, err := d.GetRepoByIdentity(ctx, identity)
-	require.NoError(t, err)
-	require.Positive(t, d.roStmts.len())
+	require.NoError(err)
+	require.Positive(d.roStmts.len())
 
-	require.NoError(t, d.Close())
+	require.NoError(d.Close())
 	assert.Zero(d.roStmts.len())
 	assert.Zero(d.rwStmts.len())
 	_, _, err = d.roStmts.acquire(ctx, "SELECT 1")
-	require.ErrorIs(t, err, errStmtCacheClosed)
-	require.NoError(t, d.Close(), "closing twice stays safe for test cleanup")
+	require.ErrorIs(err, errStmtCacheClosed)
+	require.NoError(d.Close(), "closing twice stays safe for test cleanup")
 }
 
 // BenchmarkRepositoryCatalogLookup compares a hot read with the per-pool

--- a/internal/db/stmt_cache_test.go
+++ b/internal/db/stmt_cache_test.go
@@ -1,0 +1,232 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAppliesConnectionPragmasToEveryPooledConnection(t *testing.T) {
+	d := openTestDB(t)
+	ctx := t.Context()
+
+	readPragmas := func(t *testing.T, conn *sql.Conn) map[string]int64 {
+		t.Helper()
+		got := map[string]int64{}
+		for _, name := range []string{"cache_size", "mmap_size", "temp_store", "foreign_keys", "synchronous"} {
+			var value int64
+			require.NoError(t, conn.QueryRowContext(ctx, "PRAGMA "+name).Scan(&value))
+			got[name] = value
+		}
+		return got
+	}
+	want := map[string]int64{
+		"cache_size":   -65536,
+		"mmap_size":    268435456,
+		"temp_store":   2, // MEMORY
+		"foreign_keys": 1,
+		"synchronous":  2, // FULL: unchanged WAL default
+	}
+
+	// Hold every read connection open at once so each one is a distinct
+	// SQLite connection that had to apply the DSN pragmas on its own.
+	var readConns []*sql.Conn
+	for range readPoolSize {
+		conn, err := d.ReadDB().Conn(ctx)
+		require.NoError(t, err)
+		readConns = append(readConns, conn)
+	}
+	for i, conn := range readConns {
+		assert.Equal(t, want, readPragmas(t, conn), "read connection %d", i)
+		require.NoError(t, conn.Close())
+	}
+
+	writeConn, err := d.WriteDB().Conn(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, want, readPragmas(t, writeConn), "write connection")
+	require.NoError(t, writeConn.Close())
+
+	assert.Equal(t, readPoolSize, d.ReadDB().Stats().MaxOpenConnections)
+	assert.Equal(t, writePoolSize, d.WriteDB().Stats().MaxOpenConnections)
+	assert.Zero(t, d.ReadDB().Stats().MaxIdleClosed, "read pool must not close idle connections")
+}
+
+func seedStatementCacheRepos(t testing.TB, d *DB) RepoIdentity {
+	t.Helper()
+	ctx := context.Background()
+	var first RepoIdentity
+	for i := range 25 {
+		identity := verifiedTestRepoIdentity("github", "github.com", "acme", fmt.Sprintf("widget-%02d", i))
+		if i == 0 {
+			first = identity
+		}
+		_, err := d.UpsertRepo(ctx, identity)
+		require.NoError(t, err)
+	}
+	return first
+}
+
+func TestRepositoryLookupCompilesEachStatementOncePerConnection(t *testing.T) {
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	identity := seedStatementCacheRepos(t, d)
+
+	repo, err := d.GetRepoByIdentity(ctx, identity)
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+	warm := d.roStmts.preparedCount()
+	assert.Positive(warm)
+	assert.Equal(int(warm), d.roStmts.len())
+
+	const repeats = 200
+	for range repeats {
+		again, err := d.GetRepoByIdentity(ctx, identity)
+		require.NoError(t, err)
+		require.Equal(t, repo, again)
+	}
+	assert.Equal(warm, d.roStmts.preparedCount(),
+		"%d repeated lookups must reuse the statements compiled by the first", repeats)
+	assert.Equal(int(warm), d.roStmts.len())
+}
+
+func TestStmtCacheEvictsLeastRecentlyUsedBeyondLimit(t *testing.T) {
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	cache := newStmtCache(d.ReadDB(), 2)
+	t.Cleanup(func() { require.NoError(t, cache.Close()) })
+
+	scanOne := func(query string) int64 {
+		var value int64
+		require.NoError(t, cache.QueryRowContext(ctx, query).Scan(&value))
+		return value
+	}
+	assert.Equal(int64(1), scanOne("SELECT 1"))
+	assert.Equal(int64(2), scanOne("SELECT 2"))
+	assert.Equal(int64(1), scanOne("SELECT 1")) // refresh: 2 is now oldest
+	assert.Equal(int64(3), scanOne("SELECT 3"))
+	assert.Equal(2, cache.len())
+	assert.Equal(int64(3), cache.preparedCount())
+
+	cache.mu.Lock()
+	_, hasOne := cache.entries["SELECT 1"]
+	_, hasTwo := cache.entries["SELECT 2"]
+	cache.mu.Unlock()
+	assert.True(hasOne, "most recently used statement stays cached")
+	assert.False(hasTwo, "least recently used statement is evicted")
+
+	assert.Equal(int64(2), scanOne("SELECT 2"))
+	assert.Equal(int64(4), cache.preparedCount(), "an evicted statement is compiled again on demand")
+	assert.Equal(2, cache.len())
+}
+
+func TestStmtCacheClosesEvictedStatementOnlyAfterInFlightCalls(t *testing.T) {
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	cache := newStmtCache(d.ReadDB(), 1)
+	t.Cleanup(func() { require.NoError(t, cache.Close()) })
+
+	held, release, err := cache.acquire(ctx, "SELECT 1")
+	require.NoError(t, err)
+
+	var value int64
+	require.NoError(t, cache.QueryRowContext(ctx, "SELECT 2").Scan(&value))
+	assert.Equal(int64(2), value)
+	assert.Equal(1, cache.len())
+
+	require.NoError(t, held.QueryRowContext(ctx).Scan(&value),
+		"an evicted statement stays usable while a call still holds it")
+	assert.Equal(int64(1), value)
+
+	release()
+	assert.ErrorContains(held.QueryRowContext(ctx).Scan(&value), "statement is closed")
+}
+
+func TestStmtCacheServesConcurrentCallersUnderEviction(t *testing.T) {
+	d := openTestDB(t)
+	ctx := t.Context()
+	cache := newStmtCache(d.ReadDB(), 2)
+	t.Cleanup(func() { require.NoError(t, cache.Close()) })
+
+	const workers, iterations, distinct = 8, 100, 5
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for worker := range workers {
+		wg.Go(func() {
+			for i := range iterations {
+				want := int64((worker + i) % distinct)
+				var got int64
+				if err := cache.QueryRowContext(ctx, fmt.Sprintf("SELECT %d", want)).Scan(&got); err != nil {
+					errs <- err
+					return
+				}
+				if got != want {
+					errs <- fmt.Errorf("SELECT %d returned %d", want, got)
+					return
+				}
+			}
+		})
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	assert.LessOrEqual(t, cache.len(), 2)
+}
+
+func TestDBCloseFinalizesCachedStatements(t *testing.T) {
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	identity := seedStatementCacheRepos(t, d)
+	_, err := d.GetRepoByIdentity(ctx, identity)
+	require.NoError(t, err)
+	require.Positive(t, d.roStmts.len())
+
+	require.NoError(t, d.Close())
+	assert.Zero(d.roStmts.len())
+	assert.Zero(d.rwStmts.len())
+	_, _, err = d.roStmts.acquire(ctx, "SELECT 1")
+	require.ErrorIs(t, err, errStmtCacheClosed)
+	require.NoError(t, d.Close(), "closing twice stays safe for test cleanup")
+}
+
+// BenchmarkRepositoryCatalogLookup compares a hot read with the per-pool
+// statement cache against the previous behavior of compiling every statement
+// on each call. The uncached variant uses a zero-capacity cache, which
+// prepares and finalizes on every call exactly like a raw *sql.DB query.
+func BenchmarkRepositoryCatalogLookup(b *testing.B) {
+	for _, variant := range []struct {
+		name  string
+		limit int
+	}{
+		{name: "uncached", limit: 0},
+		{name: "cached", limit: stmtCacheLimit},
+	} {
+		b.Run(variant.name, func(b *testing.B) {
+			d, err := Open(filepath.Join(b.TempDir(), "bench.db"))
+			require.NoError(b, err)
+			b.Cleanup(func() { require.NoError(b, d.Close()) })
+			ctx := context.Background()
+			identity := seedStatementCacheRepos(b, d)
+			d.roStmts = newStmtCache(d.ReadDB(), variant.limit)
+
+			b.ResetTimer()
+			for b.Loop() {
+				_, err := d.GetRepoByIdentity(ctx, identity)
+				require.NoError(b, err)
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(d.roStmts.preparedCount())/float64(b.N), "prepares/op")
+		})
+	}
+}

--- a/internal/db/workspace_agent_usage.go
+++ b/internal/db/workspace_agent_usage.go
@@ -91,7 +91,7 @@ func (d *DB) PreferredWorkspaceAgentTarget(
 		return "", false, nil
 	}
 
-	rows, err := d.ro.QueryContext(ctx, `
+	rows, err := d.roQueryContext(ctx, `
 		SELECT target_key
 		FROM forge_workspace_agent_launches
 		WHERE created_at >= ?

--- a/internal/db/workspace_subjects.go
+++ b/internal/db/workspace_subjects.go
@@ -93,7 +93,7 @@ func (d *DB) ListWorkspaceSubjectMetadata(
 			  AND w.item_number = q.item_number
 			  AND json_extract(launch.spec_json, '$.source_visible') = 1
 		)`
-	rows, err := d.ro.QueryContext(ctx, query, string(requestedJSON))
+	rows, err := d.roQueryContext(ctx, query, string(requestedJSON))
 	if err != nil {
 		return nil, fmt.Errorf("list workspace subject metadata: %w", err)
 	}


### PR DESCRIPTION
An idle daemon with a large store spent about a third of its CPU in SQLite's page cache and `pread`, and re-compiled the same statements many times per second. Two causes in `internal/db`: 2 MB per-connection cache with no mmap against a file over 100 MB, and the pure-Go driver preparing every statement on every call.

**Connection pragmas** (`internal/db/db.go::connectionDSN`)
- Every pooled connection opens with `cache_size` 64 MiB, `mmap_size` 256 MiB, `temp_store=MEMORY`.
- Idle limits equal open limits so the read pool stops churning connections.
- `synchronous` stays at FULL; durability is unchanged. `wal_autocheckpoint` untouched.
- Memory ceiling is 5 x 64 MiB of private cache, but with mmap only written pages land there.

**Statement cache** (`internal/db/stmt_cache.go`)
- Bounded LRU of `*sql.Stmt` per pool, keyed by SQL text, safe for concurrent use.
- Every package query helper routes through it. SQL text and locking semantics are unchanged.
- Evicted statements close after in-flight calls finish; `DB.Close` finalizes the rest.

**Measured** on a copy of a real 158 MB store (50 repos, 7,303 merge requests, 108,685 events). Baseline queries the raw pools as production did. Mean of three runs:

| read | baseline | pragmas only | stmt cache only | both |
| --- | ---: | ---: | ---: | ---: |
| Merge request detail + timeline | 13.4 ms | 3.2 ms | 11.8 ms | 2.7 ms |
| Activity feed (50) | 563 ms | 475 ms | 480 ms | 345 ms |
| Repository summaries | 72 ms | 44 ms | 74 ms | 46 ms |
| Open merge request list | 1.8 ms | 1.8 ms | 2.3 ms | 2.0 ms |

The pragmas carry anything that touches the 93 MB event table; the cache adds on top for reads that issue several statements. The merge request list is within noise.

`BenchmarkHotReads` accepts `KENN_FORGE_BENCH_DB`, a SQLite backup of a real store, and benchmarks a private copy of it.

Verified with `internal/db` (with and without `-race`), `projecttest`, `e2etest`, `apitest`, `testutil`, `config`, `archive`, and `github`. The `internal/db` race lane went from 226 s to 269 s locally; the new tests account for part of that.

Follow-ups: #1021 stacks planner statistics on this. Callers outside `internal/db` using `ReadDB()` or `WriteDB()` directly still compile per call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154kRCfHFrvN6miSWqys445
