### PR TITLE
fix: submit agent handoff prompts instead of leaving them in the input box

### DIFF
--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -258,9 +258,12 @@ still exists.
   and paste DEC modes from session-wide PTY state, not bounded screen replay
   (`internal/workspace/localruntime/manager.go::session.subscribe`).
 - Initial agent handoff requires observed bracketed-paste mode, then sends the
-  opening frame, prompt, closing frame, and Enter in one bounded terminal write.
-  Do not gate Enter on terminal echo: Claude renders pasted input only after the
-  Enter event (`internal/workspace/localruntime/manager.go::session.submitInitialMessage`).
+  opening frame, prompt, and closing frame in one bounded terminal write and,
+  after a short fixed settle delay, Enter as a separate write. Agent TUIs treat
+  bytes in the same chunk as the paste-end marker as part of the paste, so an
+  Enter in that chunk leaves the prompt unsubmitted. Do not gate Enter on
+  terminal echo: Claude renders pasted input only after the Enter event
+  (`internal/workspace/localruntime/manager.go::session.submitInitialMessage`).
 - Mode transitions precede one session-wide UTF-8-aware VT tail even in the
   alternate screen; retain split-rune introducers and decoded C1 controls/ST
   (`internal/workspace/localruntime/terminal_sequence_tail.go::trailingIncompleteTerminalDataLen`).

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -258,12 +258,14 @@ still exists.
   and paste DEC modes from session-wide PTY state, not bounded screen replay
   (`internal/workspace/localruntime/manager.go::session.subscribe`).
 - Initial agent handoff requires observed bracketed-paste mode, then sends the
-  opening frame, prompt, and closing frame in one bounded terminal write and,
-  after a short fixed settle delay, Enter as a separate write. Agent TUIs treat
-  bytes in the same chunk as the paste-end marker as part of the paste, so an
-  Enter in that chunk leaves the prompt unsubmitted. Do not gate Enter on
-  terminal echo: Claude renders pasted input only after the Enter event
-  (`internal/workspace/localruntime/manager.go::session.submitInitialMessage`).
+  opening frame, prompt, and closing frame in one terminal write and, after a
+  short fixed settle delay, Enter as a separate write. Agent TUIs treat bytes
+  in the same chunk as the paste-end marker as part of the paste, so an Enter
+  in that chunk leaves the prompt unsubmitted. The paste-delay-Enter sequence
+  holds the session input lock that attachment writes also take, and it runs
+  to completion even when the caller's deadline expires first. Do not gate
+  Enter on terminal echo: Claude renders pasted input only after the Enter
+  event (`internal/workspace/localruntime/manager.go::session.submitInitialMessage`).
 - Mode transitions precede one session-wide UTF-8-aware VT tail even in the
   alternate screen; retain split-rune introducers and decoded C1 controls/ST
   (`internal/workspace/localruntime/terminal_sequence_tail.go::trailingIncompleteTerminalDataLen`).

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -38,6 +38,12 @@ const (
 
 const initialMessageWriteTimeout = 30 * time.Second
 
+// initialMessageEnterDelay separates the bracketed paste from the Enter
+// keystroke that submits it. Terminal UIs that collapse a multi-line paste
+// treat bytes arriving in the same chunk as the paste-end marker as part of
+// the paste, so a carriage return in that chunk never submits the prompt.
+const initialMessageEnterDelay = 150 * time.Millisecond
+
 var (
 	errManagerShutdown    = errors.New("runtime manager is shut down")
 	ErrSessionNotFound    = errors.New("runtime session not found")
@@ -2952,10 +2958,10 @@ func (s *session) submitInitialMessage(ctx context.Context, message string) erro
 		s.mu.Unlock()
 		return ErrBracketedPasteInactive
 	}
-	data := make([]byte, 0, len(message)+13)
-	data = append(data, "\x1b[200~"...)
-	data = append(data, message...)
-	data = append(data, "\x1b[201~\r"...)
+	paste := make([]byte, 0, len(message)+12)
+	paste = append(paste, "\x1b[200~"...)
+	paste = append(paste, message...)
+	paste = append(paste, "\x1b[201~"...)
 	pty := s.pty
 	ptmx := s.ptmx
 	s.mu.Unlock()
@@ -2974,19 +2980,28 @@ func (s *session) submitInitialMessage(ctx context.Context, message string) erro
 	if err := context.Cause(writeCtx); err != nil {
 		return fmt.Errorf("%w: %w", ErrInitialMessageNotWritten, err)
 	}
-	result := make(chan error, 1)
-	go func() {
-		if pty != nil {
-			result <- pty.Write(data)
-			return
+	write := func(data []byte) error {
+		result := make(chan error, 1)
+		go func() {
+			if pty != nil {
+				result <- pty.Write(data)
+				return
+			}
+			_, err := ptmx.Write(data)
+			result <- err
+		}()
+		select {
+		case err := <-result:
+			return err
+		case <-writeCtx.Done():
+			return context.Cause(writeCtx)
 		}
-		_, err := ptmx.Write(data)
-		result <- err
-	}()
-	select {
-	case err := <-result:
-		return err
-	case <-writeCtx.Done():
-		return context.Cause(writeCtx)
 	}
+	if err := write(paste); err != nil {
+		return err
+	}
+	// The paste is on the terminal now; only the submitting keystroke
+	// remains, so the settle delay is bounded and not cancellable.
+	time.Sleep(initialMessageEnterDelay)
+	return write([]byte("\r"))
 }

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -199,7 +199,10 @@ var (
 )
 
 type session struct {
-	mu                        sync.Mutex
+	mu sync.Mutex
+	// inputMu serializes terminal input so an initial-message handoff owns
+	// the PTY from its paste through its Enter keystroke.
+	inputMu                   sync.Mutex
 	info                      SessionInfo
 	cmd                       *exec.Cmd
 	ptmx                      *os.File
@@ -2899,11 +2902,9 @@ func attachToSession(
 		Done:   s.done,
 		info:   s.snapshot,
 		write: func(data []byte) error {
-			if s.pty != nil {
-				return s.pty.Write(data)
-			}
-			_, err := s.ptmx.Write(data)
-			return err
+			s.inputMu.Lock()
+			defer s.inputMu.Unlock()
+			return s.writeInput(data)
 		},
 		submitInitialMessage: s.submitInitialMessage,
 		resize: func(geometry ptysize.Geometry) error {
@@ -2962,8 +2963,6 @@ func (s *session) submitInitialMessage(ctx context.Context, message string) erro
 	paste = append(paste, "\x1b[200~"...)
 	paste = append(paste, message...)
 	paste = append(paste, "\x1b[201~"...)
-	pty := s.pty
-	ptmx := s.ptmx
 	s.mu.Unlock()
 
 	if err := context.Cause(ctx); err != nil {
@@ -2980,28 +2979,33 @@ func (s *session) submitInitialMessage(ctx context.Context, message string) erro
 	if err := context.Cause(writeCtx); err != nil {
 		return fmt.Errorf("%w: %w", ErrInitialMessageNotWritten, err)
 	}
-	write := func(data []byte) error {
-		result := make(chan error, 1)
-		go func() {
-			if pty != nil {
-				result <- pty.Write(data)
-				return
-			}
-			_, err := ptmx.Write(data)
+	// The paste, settle delay, and Enter run as one operation that outlives
+	// a caller which stops waiting: a paste that lands after the deadline
+	// without its Enter would leave the prompt sitting in the input box.
+	result := make(chan error, 1)
+	go func() {
+		s.inputMu.Lock()
+		defer s.inputMu.Unlock()
+		if err := s.writeInput(paste); err != nil {
 			result <- err
-		}()
-		select {
-		case err := <-result:
-			return err
-		case <-writeCtx.Done():
-			return context.Cause(writeCtx)
+			return
 		}
-	}
-	if err := write(paste); err != nil {
+		time.Sleep(initialMessageEnterDelay)
+		result <- s.writeInput([]byte("\r"))
+	}()
+	select {
+	case err := <-result:
 		return err
+	case <-writeCtx.Done():
+		return context.Cause(writeCtx)
 	}
-	// The paste is on the terminal now; only the submitting keystroke
-	// remains, so the settle delay is bounded and not cancellable.
-	time.Sleep(initialMessageEnterDelay)
-	return write([]byte("\r"))
+}
+
+// writeInput writes terminal input to the session PTY. Callers hold inputMu.
+func (s *session) writeInput(data []byte) error {
+	if s.pty != nil {
+		return s.pty.Write(data)
+	}
+	_, err := s.ptmx.Write(data)
+	return err
 }

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -2462,6 +2462,97 @@ func TestManagerSubmitInitialMessageHonorsContextWithoutHoldingSessionLock(t *te
 	}
 }
 
+func TestManagerSubmitInitialMessageStillSendsEnterWhenCallerStopsWaiting(t *testing.T) {
+	require := require.New(t)
+	writeRelease := make(chan struct{})
+	writeObserved := make(chan []byte)
+	pty := &fakeRuntimePTY{
+		output: make(chan []byte), done: make(chan struct{}),
+		writeRelease: writeRelease, writeObserved: writeObserved,
+	}
+	s := &session{
+		info: SessionInfo{
+			Key: "agent-1", WorkspaceID: "ws-1", Kind: LaunchTargetAgent,
+			Status: SessionStatusRunning,
+		},
+		pty: pty, done: make(chan struct{}),
+		subscribers: make(map[chan []byte]struct{}),
+	}
+	mgr := NewManager(Options{})
+	mgr.sessions[s.info.Key] = s
+	s.broadcast([]byte("\x1b[?2004h"))
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		result <- mgr.SubmitInitialMessage(ctx, "ws-1", "agent-1", "review this")
+	}()
+	select {
+	case err := <-result:
+		require.ErrorIs(err, context.DeadlineExceeded)
+	case <-time.After(time.Second):
+		require.FailNow("initial message write ignored context deadline")
+	}
+
+	// The paste completes after the caller gave up. A paste without its
+	// Enter leaves the prompt sitting in the agent's input box, so the
+	// keystroke must still follow.
+	close(writeRelease)
+	observe := func() []byte {
+		select {
+		case data := <-writeObserved:
+			return data
+		case <-time.After(2 * time.Second):
+			require.FailNow("expected a terminal write after the caller stopped waiting")
+			return nil
+		}
+	}
+	require.Equal([]byte("\x1b[200~review this\x1b[201~"), observe())
+	require.Equal([]byte("\r"), observe())
+}
+
+func TestManagerSubmitInitialMessageSerializesAttachmentInputUntilEnter(t *testing.T) {
+	require := require.New(t)
+	writeObserved := make(chan []byte)
+	pty := &fakeRuntimePTY{
+		output: make(chan []byte), done: make(chan struct{}),
+		writeObserved: writeObserved,
+	}
+	s := &session{
+		info: SessionInfo{
+			Key: "agent-1", WorkspaceID: "ws-1", Kind: LaunchTargetAgent,
+			Status: SessionStatusRunning,
+		},
+		pty: pty, done: make(chan struct{}),
+		subscribers: make(map[chan []byte]struct{}),
+	}
+	mgr := NewManager(Options{})
+	mgr.sessions[s.info.Key] = s
+	s.broadcast([]byte("\x1b[?2004h"))
+	attachment, err := attachToSession(s, "ws-1", "agent-1", nil, AttachSessionOptions{})
+	require.NoError(err)
+	defer attachment.Close()
+
+	go func() {
+		_ = mgr.SubmitInitialMessage(t.Context(), "ws-1", "agent-1", "review this")
+	}()
+	observe := func() []byte {
+		select {
+		case data := <-writeObserved:
+			return data
+		case <-time.After(2 * time.Second):
+			require.FailNow("expected a terminal write")
+			return nil
+		}
+	}
+	require.Equal([]byte("\x1b[200~review this\x1b[201~"), observe())
+	// Typed input arriving during the settle window must not land between
+	// the paste and its Enter, where it would alter or submit the prompt.
+	go func() { _ = attachment.Write([]byte("x")) }()
+	require.Equal([]byte("\r"), observe())
+	require.Equal([]byte("x"), observe())
+}
+
 func TestManagerSubmitInitialMessageRejectsMultilineWithoutBracketedPaste(t *testing.T) {
 	require := require.New(t)
 	pty := &fakeRuntimePTY{output: make(chan []byte), done: make(chan struct{})}
@@ -2612,7 +2703,14 @@ func (f *fakeRuntimePTY) Write(data []byte) error {
 		writeObserved <- slices.Clone(data)
 	}
 	if writeFinished != nil {
-		close(writeFinished)
+		// A handoff may write again after the caller stopped waiting, so
+		// signal completion of the blocked write only once.
+		f.mu.Lock()
+		if f.writeFinished == writeFinished {
+			f.writeFinished = nil
+			close(writeFinished)
+		}
+		f.mu.Unlock()
 	}
 	return nil
 }

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -2360,7 +2360,7 @@ func TestAttachmentResizeOwnerFallbackRestoresLatestRemainingClaim(t *testing.T)
 	}, pty.resizes())
 }
 
-func TestManagerSubmitInitialMessageWritesFramedPromptAndEnterTogether(t *testing.T) {
+func TestManagerSubmitInitialMessageWritesEnterAsSeparateKeystrokeAfterPaste(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	pty := &fakeRuntimePTY{
@@ -2384,14 +2384,17 @@ func TestManagerSubmitInitialMessageWritesFramedPromptAndEnterTogether(t *testin
 	s.broadcast([]byte("\x1b[?2004h"))
 	submit := func(message, framed string) {
 		pty.resetWrites()
-		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		require.NoError(mgr.SubmitInitialMessage(ctx, "ws-1", "agent-1", message))
 		pty.mu.Lock()
 		writeCalls := slices.Clone(pty.writeCalls)
 		pty.mu.Unlock()
-		assert.Equal([][]byte{[]byte(framed + "\r")}, writeCalls)
+		// A terminal UI that collapses a multi-line paste treats bytes arriving
+		// in the same chunk as the paste-end marker as part of the paste, so
+		// the Enter keystroke must arrive as its own later write.
+		assert.Equal([][]byte{[]byte(framed), []byte("\r")}, writeCalls)
 	}
 
 	submit("review this", "\x1b[200~review this\x1b[201~")


### PR DESCRIPTION
An agent launched through the MCP spawn tool, or any other initial-message handoff, received its prompt but never started working. The prompt sat in the agent's input box until someone pressed Enter, while the handoff reported the message as delivered and the coding session as observed.

The runtime wrote the bracketed paste and the Enter keystroke in one terminal write. Claude Code collapses a multi-line paste into a placeholder and treats every byte in the same chunk as the paste-end marker as part of the paste, so the carriage return was swallowed instead of read as a keystroke. The existing unit test only asserted the combined byte string, so it passed.

- The paste and the Enter are now separate writes with a short fixed settle delay between them.
- The paste, delay, and Enter run as one operation that finishes even if the caller's deadline expires first, so a late paste never lands without its Enter.
- A per-session input lock, separate from the state mutex, is held across that sequence and taken by attachment writes, so input typed during the settle delay cannot alter the prompt or submit it early.
- The unit tests assert two writes with Enter last, Enter after a caller timeout, and serialized attachment input; the runtime lifecycle context doc records the rules.
- Unchanged: the handoff still cannot tell whether the agent accepted the prompt. `delivered` means bytes written and `coding_session_observed` means the session-start hook fired. A distinct submitted state keyed on the agent's first user-prompt hook is a possible follow-up.

<sup>generated by a clanker</sup>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
