### PR TITLE
perf: give the SQLite planner statistics so large stores stop scanning the event table

### DIFF
--- a/cmd/kenn-forge/main.go
+++ b/cmd/kenn-forge/main.go
@@ -515,7 +515,7 @@ func run(opts serve.Options) error {
 	var syncer *ghclient.Syncer
 	var telemetryReporter *telemetry.Reporter
 	var profilerSrv *profiler.Server
-	var notificationLoops *notificationLoopHandle
+	var backgroundLoops *backgroundLoopHandle
 	defer func() {
 		if err := waitForRuntimeShutdownDelay(); err != nil {
 			slog.Warn("test shutdown delay", "err", err)
@@ -524,11 +524,11 @@ func run(opts serve.Options) error {
 			context.Background(),
 			mainShutdownCallbacks{
 				StopSignals: stopSignalsOnce,
-				StopNotificationLoops: func(ctx context.Context) error {
-					if notificationLoops == nil {
+				StopBackgroundLoops: func(ctx context.Context) error {
+					if backgroundLoops == nil {
 						return nil
 					}
-					return notificationLoops.Stop(ctx)
+					return backgroundLoops.Stop(ctx)
 				},
 				ShutdownMCPHTTP: func(shutdownCtx context.Context) error {
 					if mcpHTTPSrv == nil {
@@ -640,6 +640,7 @@ func run(opts serve.Options) error {
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
+	backgroundLoops = startBackgroundLoops(ctx, database)
 	tokenSources := tokenauth.NewSourceSet(tokenauth.Options{
 		GitHubCLI: config.GitHubCLITokenForHost,
 		GitHubApp: func(
@@ -797,7 +798,7 @@ func run(opts serve.Options) error {
 		)
 		syncer.Start(ctx)
 		if !opts.DisableSync && cfg.NotificationsEnabled() {
-			notificationLoops = startNotificationLoops(ctx, syncer, cfg)
+			startNotificationLoops(backgroundLoops, syncer, cfg)
 		}
 	}
 
@@ -872,15 +873,15 @@ func waitForRuntimeGate(ctx context.Context, gatePath, phase string) error {
 }
 
 type mainShutdownCallbacks struct {
-	StopSignals           func()
-	StopNotificationLoops func(context.Context) error
-	ShutdownMCPHTTP       func(context.Context) error
-	ShutdownPrimaryHTTP   func(context.Context) error
-	StopSyncer            func()
-	ShutdownProfiler      func(context.Context) error
-	CloseTelemetry        func() error
-	CloseMCP              func() error
-	CloseDatabase         func() error
+	StopSignals         func()
+	StopBackgroundLoops func(context.Context) error
+	ShutdownMCPHTTP     func(context.Context) error
+	ShutdownPrimaryHTTP func(context.Context) error
+	StopSyncer          func()
+	ShutdownProfiler    func(context.Context) error
+	CloseTelemetry      func() error
+	CloseMCP            func() error
+	CloseDatabase       func() error
 }
 
 type mainShutdownError struct {
@@ -896,13 +897,13 @@ func runMainShutdown(
 	if callbacks.StopSignals != nil {
 		callbacks.StopSignals()
 	}
-	if callbacks.StopNotificationLoops != nil {
+	if callbacks.StopBackgroundLoops != nil {
 		if err := runContextShutdown(
-			ctx, shutdownbudget.NotificationLoop,
-			callbacks.StopNotificationLoops,
+			ctx, shutdownbudget.BackgroundLoops,
+			callbacks.StopBackgroundLoops,
 		); err != nil {
 			errs = append(errs, mainShutdownError{
-				message: "notification loops shutdown",
+				message: "background loops shutdown",
 				err:     err,
 			})
 		}

--- a/cmd/kenn-forge/main_test.go
+++ b/cmd/kenn-forge/main_test.go
@@ -142,8 +142,8 @@ func TestRunMainShutdownStopsSignalsBeforeLongCleanup(t *testing.T) {
 		StopSignals: func() {
 			record("signals")
 		},
-		StopNotificationLoops: func(context.Context) error {
-			record("notifications")
+		StopBackgroundLoops: func(context.Context) error {
+			record("background")
 			return nil
 		},
 		ShutdownMCPHTTP: func(context.Context) error {
@@ -178,7 +178,7 @@ func TestRunMainShutdownStopsSignalsBeforeLongCleanup(t *testing.T) {
 	assert.Empty(t, errs)
 	assert.Equal(t, []string{
 		"signals",
-		"notifications",
+		"background",
 		"mcp-http",
 		"primary-http",
 		"syncer",

--- a/cmd/kenn-forge/notifications.go
+++ b/cmd/kenn-forge/notifications.go
@@ -7,10 +7,13 @@ import (
 	"time"
 
 	"go.kenn.io/forge/internal/config"
+	"go.kenn.io/forge/internal/db"
 	ghclient "go.kenn.io/forge/internal/github"
 )
 
-type notificationLoopHandle struct {
+const databaseOptimizeInterval = 24 * time.Hour
+
+type backgroundLoopHandle struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
@@ -22,7 +25,7 @@ type notificationLoopSettings struct {
 	batchSize           int
 }
 
-func (h *notificationLoopHandle) Stop(ctx context.Context) error {
+func (h *backgroundLoopHandle) Stop(ctx context.Context) error {
 	if h == nil {
 		return nil
 	}
@@ -40,8 +43,13 @@ func (h *notificationLoopHandle) Stop(ctx context.Context) error {
 	}
 }
 
-func startNotificationLoops(ctx context.Context, syncer *ghclient.Syncer, cfg *config.Config) *notificationLoopHandle {
-	handle := newNotificationLoopHandle(ctx)
+func startBackgroundLoops(ctx context.Context, database *db.DB) *backgroundLoopHandle {
+	handle := newBackgroundLoopHandle(ctx)
+	handle.startTickerAfterInterval("database optimize", databaseOptimizeInterval, database.Optimize)
+	return handle
+}
+
+func startNotificationLoops(handle *backgroundLoopHandle, syncer *ghclient.Syncer, cfg *config.Config) {
 	settings := notificationLoopSettingsFromConfig(cfg)
 	handle.startTicker("notification sync", settings.syncInterval, func(runCtx context.Context) error {
 		return syncer.RunNotificationSync(runCtx)
@@ -49,7 +57,6 @@ func startNotificationLoops(ctx context.Context, syncer *ghclient.Syncer, cfg *c
 	handle.startTicker("notification read propagation", settings.propagationInterval, func(runCtx context.Context) error {
 		return syncer.ProcessQueuedNotificationReadsForAllHosts(runCtx, settings.batchSize)
 	})
-	return handle
 }
 
 func notificationLoopSettingsFromConfig(cfg *config.Config) notificationLoopSettings {
@@ -60,12 +67,29 @@ func notificationLoopSettingsFromConfig(cfg *config.Config) notificationLoopSett
 	}
 }
 
-func newNotificationLoopHandle(parent context.Context) *notificationLoopHandle {
+func newBackgroundLoopHandle(parent context.Context) *backgroundLoopHandle {
 	ctx, cancel := context.WithCancel(parent)
-	return &notificationLoopHandle{ctx: ctx, cancel: cancel}
+	return &backgroundLoopHandle{ctx: ctx, cancel: cancel}
 }
 
-func (h *notificationLoopHandle) startTicker(name string, interval time.Duration, run func(context.Context) error) {
+func (h *backgroundLoopHandle) startTicker(name string, interval time.Duration, run func(context.Context) error) {
+	h.startTickerLoop(name, interval, true, run)
+}
+
+func (h *backgroundLoopHandle) startTickerAfterInterval(
+	name string,
+	interval time.Duration,
+	run func(context.Context) error,
+) {
+	h.startTickerLoop(name, interval, false, run)
+}
+
+func (h *backgroundLoopHandle) startTickerLoop(
+	name string,
+	interval time.Duration,
+	runImmediately bool,
+	run func(context.Context) error,
+) {
 	h.wg.Go(func() {
 		ctx := h.ctx
 		runOnce := func() {
@@ -76,9 +100,11 @@ func (h *notificationLoopHandle) startTicker(name string, interval time.Duration
 		if ctx.Err() != nil {
 			return
 		}
-		runOnce()
-		if ctx.Err() != nil {
-			return
+		if runImmediately {
+			runOnce()
+			if ctx.Err() != nil {
+				return
+			}
 		}
 
 		ticker := time.NewTicker(interval)

--- a/cmd/kenn-forge/notifications_test.go
+++ b/cmd/kenn-forge/notifications_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -14,7 +16,7 @@ func TestNotificationLoopStopWaitsForInFlightRun(t *testing.T) {
 	require := require.New(t)
 	parent, cancel := context.WithCancel(t.Context())
 	defer cancel()
-	handle := newNotificationLoopHandle(parent)
+	handle := newBackgroundLoopHandle(parent)
 	started := make(chan struct{})
 	release := make(chan struct{})
 	finished := make(chan struct{})
@@ -62,7 +64,7 @@ func TestNotificationLoopStopWaitsForInFlightRun(t *testing.T) {
 
 func TestNotificationLoopStopHonorsDeadline(t *testing.T) {
 	require := require.New(t)
-	handle := newNotificationLoopHandle(t.Context())
+	handle := newBackgroundLoopHandle(t.Context())
 	started := make(chan struct{})
 	release := make(chan struct{})
 	t.Cleanup(func() { close(release) })
@@ -87,7 +89,7 @@ func TestNotificationLoopStopHonorsDeadline(t *testing.T) {
 func TestNotificationLoopRunsBeforeFirstTickerInterval(t *testing.T) {
 	parent, cancel := context.WithCancel(t.Context())
 	defer cancel()
-	handle := newNotificationLoopHandle(parent)
+	handle := newBackgroundLoopHandle(parent)
 	defer func() { require.NoError(t, handle.Stop(t.Context())) }()
 
 	started := make(chan struct{})
@@ -105,6 +107,26 @@ func TestNotificationLoopRunsBeforeFirstTickerInterval(t *testing.T) {
 			return false
 		}
 	}, 200*time.Millisecond, 10*time.Millisecond, "notification loop should run before first ticker interval")
+}
+
+func TestBackgroundLoopWaitsForFirstTickerInterval(t *testing.T) {
+	require.Equal(t, 24*time.Hour, databaseOptimizeInterval)
+
+	synctest.Test(t, func(t *testing.T) {
+		handle := newBackgroundLoopHandle(t.Context())
+		var calls atomic.Int64
+		handle.startTickerAfterInterval("test maintenance", 24*time.Hour, func(context.Context) error {
+			calls.Add(1)
+			return nil
+		})
+
+		synctest.Wait()
+		require.Zero(t, calls.Load())
+		time.Sleep(24 * time.Hour)
+		synctest.Wait()
+		require.Equal(t, int64(1), calls.Load())
+		require.NoError(t, handle.Stop(t.Context()))
+	})
 }
 
 func TestNotificationLoopSettingsSnapshotConfig(t *testing.T) {

--- a/context/db-migrations.md
+++ b/context/db-migrations.md
@@ -56,8 +56,8 @@ schema migrations.
   limits so pooled connections and their compiled statements persist
   (`internal/db/db.go::openPool`).
 - `Open` refreshes planner statistics with `PRAGMA optimize`, and the daemon
-  repeats it every 24 hours so databases populated after startup gain statistics
-  (`internal/db/db.go::Optimize`, `cmd/kenn-forge/notifications.go::startBackgroundLoops`).
+  repeats it every 24 hours through the read pool; the bare pragma uses its
+  connection's query history (`internal/db/db.go::Optimize`, `cmd/kenn-forge/notifications.go::startBackgroundLoops`).
 - Migrations must never drop or rebuild `sqlite_stat1`, and a query-plan assertion
   needs seeded rows plus `DB.Optimize` first (`internal/db/db.go::Optimize`).
 

--- a/context/db-migrations.md
+++ b/context/db-migrations.md
@@ -56,8 +56,8 @@ schema migrations.
   limits so pooled connections and their compiled statements persist
   (`internal/db/db.go::openPool`).
 - `Open` refreshes planner statistics with `PRAGMA optimize`, and the daemon
-  repeats it every 24 hours through the read pool; the bare pragma uses its
-  connection's query history (`internal/db/db.go::Optimize`, `cmd/kenn-forge/notifications.go::startBackgroundLoops`).
+  repeats it every 24 hours. Optimization checks every table, then every pooled
+  reader reloads the stored statistics (`internal/db/db.go::Optimize`).
 - Migrations must never drop or rebuild `sqlite_stat1`, and a query-plan assertion
   needs seeded rows plus `DB.Optimize` first (`internal/db/db.go::Optimize`).
 

--- a/context/db-migrations.md
+++ b/context/db-migrations.md
@@ -55,6 +55,9 @@ schema migrations.
 - Per-connection pragmas live only in `connectionDSN`; idle limits equal open
   limits so pooled connections and their compiled statements persist
   (`internal/db/db.go::openPool`).
+- `Open` refreshes planner statistics with `PRAGMA optimize`; migrations must
+  never drop or rebuild `sqlite_stat1`, and a query-plan assertion needs seeded
+  rows plus `DB.Optimize` first (`internal/db/db.go::Optimize`).
 
 ## Federation Spoke Preparation
 

--- a/context/db-migrations.md
+++ b/context/db-migrations.md
@@ -55,9 +55,11 @@ schema migrations.
 - Per-connection pragmas live only in `connectionDSN`; idle limits equal open
   limits so pooled connections and their compiled statements persist
   (`internal/db/db.go::openPool`).
-- `Open` refreshes planner statistics with `PRAGMA optimize`; migrations must
-  never drop or rebuild `sqlite_stat1`, and a query-plan assertion needs seeded
-  rows plus `DB.Optimize` first (`internal/db/db.go::Optimize`).
+- `Open` refreshes planner statistics with `PRAGMA optimize`, and the daemon
+  repeats it every 24 hours so databases populated after startup gain statistics
+  (`internal/db/db.go::Optimize`, `cmd/kenn-forge/notifications.go::startBackgroundLoops`).
+- Migrations must never drop or rebuild `sqlite_stat1`, and a query-plan assertion
+  needs seeded rows plus `DB.Optimize` first (`internal/db/db.go::Optimize`).
 
 ## Federation Spoke Preparation
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -171,7 +171,7 @@ func (d *DB) init() error {
 // planner guesses, and on a large event table it guessed wrong for the
 // activity feed and merge request detail reads.
 func (d *DB) Optimize(ctx context.Context) error {
-	if _, err := d.rw.ExecContext(ctx, "PRAGMA optimize"); err != nil {
+	if _, err := d.ro.ExecContext(ctx, "PRAGMA optimize"); err != nil {
 		return fmt.Errorf("optimize db: %w", err)
 	}
 	return nil

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -170,9 +170,36 @@ func (d *DB) init() error {
 // matter and returns in well under a millisecond. Without statistics the
 // planner guesses, and on a large event table it guessed wrong for the
 // activity feed and merge request detail reads.
-func (d *DB) Optimize(ctx context.Context) error {
-	if _, err := d.ro.ExecContext(ctx, "PRAGMA optimize"); err != nil {
+func (d *DB) Optimize(ctx context.Context) (err error) {
+	// Hold every reader so database/sql cannot select the same underlying
+	// connection twice. SQLite persists statistics in the database but loads
+	// and applies them separately on each connection.
+	connections := make([]*sql.Conn, 0, readPoolSize)
+	defer func() {
+		var closeErr error
+		for _, connection := range connections {
+			closeErr = errors.Join(closeErr, connection.Close())
+		}
+		if closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("release read connections: %w", closeErr))
+		}
+	}()
+
+	for range readPoolSize {
+		connection, connErr := d.ro.Conn(ctx)
+		if connErr != nil {
+			return fmt.Errorf("reserve read connections: %w", connErr)
+		}
+		connections = append(connections, connection)
+	}
+
+	if _, err := connections[0].ExecContext(ctx, "PRAGMA optimize=0x10002"); err != nil {
 		return fmt.Errorf("optimize db: %w", err)
+	}
+	for _, connection := range connections {
+		if _, err := connection.ExecContext(ctx, "ANALYZE sqlite_schema"); err != nil {
+			return fmt.Errorf("reload planner statistics: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -160,6 +160,20 @@ func (d *DB) init() error {
 			return fmt.Errorf("repair legacy timestamp storage: %w", err)
 		}
 	}
+	return d.Optimize(context.Background())
+}
+
+// Optimize refreshes the statistics the SQLite query planner uses to choose
+// indexes. A store that has never been analyzed gets a full ANALYZE, which
+// takes a few hundred milliseconds on a 160 MB file; once sqlite_stat1
+// exists the pragma only re-analyzes tables whose shape changed enough to
+// matter and returns in well under a millisecond. Without statistics the
+// planner guesses, and on a large event table it guessed wrong for the
+// activity feed and merge request detail reads.
+func (d *DB) Optimize(ctx context.Context) error {
+	if _, err := d.rw.ExecContext(ctx, "PRAGMA optimize"); err != nil {
+		return fmt.Errorf("optimize db: %w", err)
+	}
 	return nil
 }
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1081,39 +1081,16 @@ func TestActivityEventMutationRevisionMigrationUpgradesPopulatedV50Database(t *t
 	assert.Equal(11, issueRevision)
 	assert.Equal(2, emptyIssueRevision)
 
-	planRows, err := database.ReadDB().Query(`
-		EXPLAIN QUERY PLAN
-		SELECT MAX(n.source_updated_at)
-		FROM forge_notification_items n
-		WHERE n.item_type = 'pr'
-		  AND n.item_number = 1
-		  AND n.reason != 'author'
-		  AND (
-			n.repo_id = 1
-			OR (
-				n.repo_id IS NULL
-				AND n.platform = 'github'
-				AND n.platform_host = 'github.com'
-				AND n.repo_owner = 'acme'
-				AND n.repo_name = 'widgets'
-			)
-		  )
-	`)
-	require.NoError(err)
-	defer planRows.Close()
-	var planDetails []string
-	for planRows.Next() {
-		var id, parent, notUsed int
-		var detail string
-		require.NoError(planRows.Scan(&id, &parent, &notUsed, &detail))
-		planDetails = append(planDetails, detail)
-	}
-	require.NoError(planRows.Err())
-	assert.Contains(
-		strings.Join(planDetails, "\n"),
-		"idx_forge_notification_items_activity_parent",
-		"notification recency lookup should use the parent index",
-	)
+	// The fixture holds only a couple of notification rows, and Open now
+	// leaves real planner statistics behind, so the planner rightly scans
+	// them instead of probing the index. Assert the migration created the
+	// index rather than a plan choice that only holds at scale.
+	var parentIndexes int
+	require.NoError(database.ReadDB().QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master
+		 WHERE type = 'index' AND name = 'idx_forge_notification_items_activity_parent'`,
+	).Scan(&parentIndexes))
+	assert.Equal(1, parentIndexes, "migration must add the notification parent index")
 	assertDatabaseIntegrityForTest(t, database.ReadDB())
 }
 

--- a/internal/db/hot_reads_bench_test.go
+++ b/internal/db/hot_reads_bench_test.go
@@ -150,6 +150,7 @@ func BenchmarkHotReads(b *testing.B) {
 	activity, err := probe.ListActivity(ctx, ListActivityOpts{Limit: 50})
 	require.NoError(b, err)
 	require.NotEmpty(b, activity, "benchmark store needs activity rows")
+	windowStart := activity[0].CreatedAt.AddDate(0, 0, -7)
 	require.NoError(b, probe.Close())
 	b.Logf("store: %d repos, %d merge requests, %d events, %.1f MB; newest activity is %q",
 		repos, mrs, events, float64(info.Size())/1e6, activity[0].ActivityType)
@@ -176,6 +177,12 @@ func BenchmarkHotReads(b *testing.B) {
 		}},
 		{name: "ListActivity", run: func(d *DB) error {
 			_, err := d.ListActivity(ctx, ListActivityOpts{Limit: 50})
+			return err
+		}},
+		// The activity route always applies a seven-day window unless the
+		// caller supplies one, so this is the shape production runs.
+		{name: "ActivityFeedWindowed", run: func(d *DB) error {
+			_, err := d.ListActivity(ctx, ListActivityOpts{Limit: 50, Since: &windowStart})
 			return err
 		}},
 	}

--- a/internal/db/optimize_test.go
+++ b/internal/db/optimize_test.go
@@ -1,0 +1,43 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func plannerStatisticsRows(t *testing.T, d *DB, table string) int {
+	t.Helper()
+	var rows int
+	require.NoError(t, d.ReadDB().QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM sqlite_stat1 WHERE tbl = ?", table).Scan(&rows))
+	return rows
+}
+
+func TestOpenCreatesPlannerStatistics(t *testing.T) {
+	d := openDBWithMigrations(t)
+	var tables int
+	require.NoError(t, d.ReadDB().QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'sqlite_stat1'").Scan(&tables))
+	assert.Equal(t, 1, tables, "opening a store must leave planner statistics behind")
+}
+
+func TestOptimizeRecordsStatisticsForPopulatedTables(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	require.Zero(plannerStatisticsRows(t, d, "forge_merge_requests"),
+		"the copied template fixture starts without merge request statistics")
+
+	repoID, err := d.UpsertRepo(ctx, verifiedTestRepoIdentity("github", "github.com", "acme", "widget"))
+	require.NoError(err)
+	for number := 1; number <= 20; number++ {
+		insertTestMR(t, d, repoID, number, "change", baseTime())
+	}
+	require.NoError(d.Optimize(ctx))
+
+	assert.Positive(plannerStatisticsRows(t, d, "forge_merge_requests"))
+	assert.Positive(plannerStatisticsRows(t, d, "forge_repos"))
+}

--- a/internal/db/optimize_test.go
+++ b/internal/db/optimize_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"database/sql"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,4 +41,72 @@ func TestOptimizeRecordsStatisticsForPopulatedTables(t *testing.T) {
 
 	assert.Positive(plannerStatisticsRows(t, d, "forge_merge_requests"))
 	assert.Positive(plannerStatisticsRows(t, d, "forge_repos"))
+}
+
+func TestOptimizeReloadsStatisticsOnEveryReadConnection(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	var readConnections []*sql.Conn
+	t.Cleanup(func() {
+		for _, connection := range readConnections {
+			require.NoError(connection.Close())
+		}
+	})
+	_, err := d.WriteDB().ExecContext(ctx, `
+		CREATE TABLE planner_probe(a INTEGER, b INTEGER);
+		CREATE INDEX planner_probe_a ON planner_probe(a);
+		CREATE INDEX planner_probe_b ON planner_probe(b);
+		WITH RECURSIVE rows(n) AS (
+			VALUES(1)
+			UNION ALL
+			SELECT n + 1 FROM rows WHERE n < 1000
+		)
+		INSERT INTO planner_probe SELECT 1, n FROM rows;
+		ANALYZE planner_probe;
+		DELETE FROM sqlite_stat4 WHERE tbl = 'planner_probe';
+		UPDATE sqlite_stat1 SET stat = '10 1' WHERE idx = 'planner_probe_a';
+		UPDATE sqlite_stat1 SET stat = '10 10' WHERE idx = 'planner_probe_b';
+	`)
+	require.NoError(err)
+
+	readConnections = make([]*sql.Conn, 0, readPoolSize)
+	for range readPoolSize {
+		connection, err := d.ReadDB().Conn(ctx)
+		require.NoError(err)
+		readConnections = append(readConnections, connection)
+		_, err = connection.ExecContext(ctx, "ANALYZE sqlite_schema")
+		require.NoError(err)
+	}
+	for len(readConnections) > 0 {
+		connection := readConnections[0]
+		var id, parent, unused int
+		var detail string
+		require.NoError(connection.QueryRowContext(ctx,
+			"EXPLAIN QUERY PLAN SELECT * FROM planner_probe WHERE a = ? AND b = ?", 1, 1,
+		).Scan(&id, &parent, &unused, &detail))
+		assert.Contains(t, detail, "planner_probe_a")
+		require.NoError(connection.Close())
+		readConnections = readConnections[1:]
+	}
+
+	require.NoError(d.Optimize(ctx))
+
+	readConnections = readConnections[:0]
+	for range readPoolSize {
+		connection, err := d.ReadDB().Conn(ctx)
+		require.NoError(err)
+		readConnections = append(readConnections, connection)
+	}
+	for len(readConnections) > 0 {
+		connection := readConnections[0]
+		var id, parent, unused int
+		var detail string
+		require.NoError(connection.QueryRowContext(ctx,
+			"EXPLAIN QUERY PLAN SELECT * FROM planner_probe WHERE a = ? AND b = ?", 1, 1,
+		).Scan(&id, &parent, &unused, &detail))
+		assert.Contains(t, detail, "planner_probe_b")
+		require.NoError(connection.Close())
+		readConnections = readConnections[1:]
+	}
 }

--- a/internal/shutdownbudget/budget.go
+++ b/internal/shutdownbudget/budget.go
@@ -4,7 +4,7 @@ import "time"
 
 const (
 	OpenTelemetry     = 5 * time.Second
-	NotificationLoop  = 5 * time.Second
+	BackgroundLoops   = 5 * time.Second
 	MCPHTTP           = 5 * time.Second
 	PrimaryHTTP       = 10 * time.Second
 	Syncer            = 30 * time.Second
@@ -15,6 +15,6 @@ const (
 	ProcessExitMargin = 5 * time.Second
 
 	// Total covers every bounded shutdown phase plus process exit.
-	Total = OpenTelemetry + NotificationLoop + MCPHTTP + PrimaryHTTP + Syncer +
+	Total = OpenTelemetry + BackgroundLoops + MCPHTTP + PrimaryHTTP + Syncer +
 		Profiler + TelemetryReporter + MCPStore + Database + ProcessExitMargin
 )


### PR DESCRIPTION
A 158 MB store with 108,685 timeline events had never been analyzed. Without `sqlite_stat1`, the query planner guessed row counts and chose slow plans for the activity feed and merge request detail.

`DB.Open` now runs `PRAGMA optimize` after migrations. A long-running daemon repeats it every 24 hours, so a new store gains statistics after its first sync and a growing store refreshes them without a restart. The first analysis of the measured store took about 300 ms; later calls returned in under a millisecond. No query or schema changes are needed.

Measured on a copy of that store, mean of three runs:

| read | before | after |
| --- | ---: | ---: |
| Merge request detail + timeline | 2.3 ms | 0.12 ms |
| Activity feed, 7-day window | 58 ms | 34 ms |
| Repository summaries | 44 ms | 30 ms |
| Activity feed, unwindowed | 317 ms | 204 ms |

`created_at` indexes on the event tables did not help the production-shaped windowed feed, so this change adds no migration. A migration test that asserted a planner choice on two rows now checks that the migration created its index instead.
