### PR TITLE
fix: repair stale notification admission triggers

### DIFF
--- a/context/db-migrations.md
+++ b/context/db-migrations.md
@@ -75,6 +75,9 @@ generations.
   rewrite provider, workspace, review, workflow, or notification source rows.
 - Review drafts and workflow rows remain on the source spoke as an audit trail
   after handoff; the active spoke runtime stops reading them in the role switch.
+- Migration `000056_repair_notification_admission_triggers` recreates admission
+  triggers against `forge_spoke_preparation` for preview databases that applied
+  migration 54 before the node-to-spoke naming change.
 
 ## Migration Review Checklist
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -571,6 +571,122 @@ func TestWorkspaceRepositoryIdentityMigration55BackfillsOnlyUnambiguousRoutes(
 	require.NoError(raw.Close())
 }
 
+func TestMigration56RepairsNotificationAdmissionTriggers(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	dbPath := filepath.Join(t.TempDir(), "notification-admission-trigger-v55.db")
+	notificationInsert := `
+		INSERT INTO forge_notification_items (
+			platform, platform_host, platform_notification_id,
+			repo_owner, repo_name, subject_type, subject_title,
+			item_number, item_type, reason, unread,
+			source_updated_at, synced_at, source_ack_queued_at
+		) VALUES (
+			'github', 'github.com', ?,
+			'acme', 'widget', 'PullRequest', 'Trigger repair',
+			1, 'pr', 'mention', 1,
+			'2026-09-02T23:00:00Z', '2026-09-02T23:00:00Z', ?
+		)`
+
+	openAtVersionForTest(t, dbPath, 55, func(raw *sql.DB) {
+		_, err := raw.Exec(`
+			DROP TRIGGER forge_notification_ack_admission_update;
+			DROP TRIGGER forge_notification_ack_admission_insert;
+
+			CREATE TRIGGER forge_notification_ack_admission_insert
+			AFTER INSERT ON forge_notification_items
+			WHEN NEW.source_ack_queued_at IS NOT NULL
+			 AND NEW.source_ack_synced_at IS NULL
+			BEGIN
+				UPDATE forge_node_preparation
+				SET ack_generation = ack_generation + 1,
+					updated_at = datetime('now')
+				WHERE singleton_id = 1;
+
+				INSERT INTO forge_notification_ack_admissions (
+					notification_id, generation, queued_at
+				)
+				SELECT NEW.id, ack_generation, NEW.source_ack_queued_at
+				FROM forge_node_preparation
+				WHERE singleton_id = 1
+				ON CONFLICT(notification_id) DO UPDATE SET
+					generation = excluded.generation,
+					queued_at = excluded.queued_at;
+			END;
+
+			CREATE TRIGGER forge_notification_ack_admission_update
+			AFTER UPDATE OF source_ack_queued_at, source_ack_synced_at
+			ON forge_notification_items
+			WHEN NEW.source_ack_queued_at IS NOT NULL
+			 AND NEW.source_ack_synced_at IS NULL
+			 AND (
+				 OLD.source_ack_queued_at IS NULL
+				 OR OLD.source_ack_synced_at IS NOT NULL
+				 OR OLD.source_ack_queued_at <> NEW.source_ack_queued_at
+			 )
+			BEGIN
+				UPDATE forge_node_preparation
+				SET ack_generation = ack_generation + 1,
+					updated_at = datetime('now')
+				WHERE singleton_id = 1;
+
+				INSERT INTO forge_notification_ack_admissions (
+					notification_id, generation, queued_at
+				)
+				SELECT NEW.id, ack_generation, NEW.source_ack_queued_at
+				FROM forge_node_preparation
+				WHERE singleton_id = 1
+				ON CONFLICT(notification_id) DO UPDATE SET
+					generation = excluded.generation,
+					queued_at = excluded.queued_at;
+			END;
+		`)
+		require.NoError(err)
+		_, err = raw.Exec(notificationInsert, "stale-trigger", "2026-09-02T23:00:00Z")
+		require.ErrorContains(err, "no such table: main.forge_node_preparation")
+	})
+
+	database, err := Open(dbPath)
+	require.NoError(err)
+	_, err = database.WriteDB().Exec(
+		notificationInsert, "insert-admission", "2026-09-02T23:01:00Z",
+	)
+	require.NoError(err)
+	_, err = database.WriteDB().Exec(notificationInsert, "update-admission", nil)
+	require.NoError(err)
+	_, err = database.WriteDB().Exec(`
+		UPDATE forge_notification_items
+		SET source_ack_queued_at = '2026-09-02T23:02:00Z'
+		WHERE platform_notification_id = 'update-admission'
+	`)
+	require.NoError(err)
+
+	var ackGeneration int64
+	require.NoError(database.ReadDB().QueryRow(`
+		SELECT ack_generation
+		FROM forge_spoke_preparation
+		WHERE singleton_id = 1
+	`).Scan(&ackGeneration))
+	require.Equal(int64(2), ackGeneration)
+	var admissionCount int
+	require.NoError(database.ReadDB().QueryRow(`
+		SELECT COUNT(*)
+		FROM forge_notification_ack_admissions
+	`).Scan(&admissionCount))
+	require.Equal(2, admissionCount)
+	assertDatabaseIntegrityForTest(t, database.ReadDB())
+	require.NoError(database.Close())
+
+	raw, migrator := openMigratorForTest(t, dbPath)
+	require.NoError(migrator.Migrate(55))
+	_, err = raw.Exec(
+		notificationInsert, "downgraded-admission", "2026-09-02T23:03:00Z",
+	)
+	require.NoError(err)
+	assertDatabaseIntegrityForTest(t, raw)
+	require.NoError(raw.Close())
+}
+
 func TestKataIssueLinksMigration48IsReversible(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)

--- a/internal/db/migrations/000056_repair_notification_admission_triggers.down.sql
+++ b/internal/db/migrations/000056_repair_notification_admission_triggers.down.sql
@@ -1,0 +1,53 @@
+-- Migration 55's valid trigger contract already targets spoke preparation.
+-- Preserve that contract on downgrade instead of restoring the broken preview
+-- reference to forge_node_preparation.
+DROP TRIGGER forge_notification_ack_admission_update;
+DROP TRIGGER forge_notification_ack_admission_insert;
+
+CREATE TRIGGER forge_notification_ack_admission_insert
+AFTER INSERT ON forge_notification_items
+WHEN NEW.source_ack_queued_at IS NOT NULL
+ AND NEW.source_ack_synced_at IS NULL
+BEGIN
+    UPDATE forge_spoke_preparation
+    SET ack_generation = ack_generation + 1,
+        updated_at = datetime('now')
+    WHERE singleton_id = 1;
+
+    INSERT INTO forge_notification_ack_admissions (
+        notification_id, generation, queued_at
+    )
+    SELECT NEW.id, ack_generation, NEW.source_ack_queued_at
+    FROM forge_spoke_preparation
+    WHERE singleton_id = 1
+    ON CONFLICT(notification_id) DO UPDATE SET
+        generation = excluded.generation,
+        queued_at = excluded.queued_at;
+END;
+
+CREATE TRIGGER forge_notification_ack_admission_update
+AFTER UPDATE OF source_ack_queued_at, source_ack_synced_at
+ON forge_notification_items
+WHEN NEW.source_ack_queued_at IS NOT NULL
+ AND NEW.source_ack_synced_at IS NULL
+ AND (
+     OLD.source_ack_queued_at IS NULL
+     OR OLD.source_ack_synced_at IS NOT NULL
+     OR OLD.source_ack_queued_at <> NEW.source_ack_queued_at
+ )
+BEGIN
+    UPDATE forge_spoke_preparation
+    SET ack_generation = ack_generation + 1,
+        updated_at = datetime('now')
+    WHERE singleton_id = 1;
+
+    INSERT INTO forge_notification_ack_admissions (
+        notification_id, generation, queued_at
+    )
+    SELECT NEW.id, ack_generation, NEW.source_ack_queued_at
+    FROM forge_spoke_preparation
+    WHERE singleton_id = 1
+    ON CONFLICT(notification_id) DO UPDATE SET
+        generation = excluded.generation,
+        queued_at = excluded.queued_at;
+END;

--- a/internal/db/migrations/000056_repair_notification_admission_triggers.up.sql
+++ b/internal/db/migrations/000056_repair_notification_admission_triggers.up.sql
@@ -1,0 +1,53 @@
+-- Early fleet previews applied migration 54 while the preparation table still
+-- used the node name. Recreate the two admission triggers so those databases
+-- match the shipped forge_spoke_preparation schema.
+DROP TRIGGER forge_notification_ack_admission_update;
+DROP TRIGGER forge_notification_ack_admission_insert;
+
+CREATE TRIGGER forge_notification_ack_admission_insert
+AFTER INSERT ON forge_notification_items
+WHEN NEW.source_ack_queued_at IS NOT NULL
+ AND NEW.source_ack_synced_at IS NULL
+BEGIN
+    UPDATE forge_spoke_preparation
+    SET ack_generation = ack_generation + 1,
+        updated_at = datetime('now')
+    WHERE singleton_id = 1;
+
+    INSERT INTO forge_notification_ack_admissions (
+        notification_id, generation, queued_at
+    )
+    SELECT NEW.id, ack_generation, NEW.source_ack_queued_at
+    FROM forge_spoke_preparation
+    WHERE singleton_id = 1
+    ON CONFLICT(notification_id) DO UPDATE SET
+        generation = excluded.generation,
+        queued_at = excluded.queued_at;
+END;
+
+CREATE TRIGGER forge_notification_ack_admission_update
+AFTER UPDATE OF source_ack_queued_at, source_ack_synced_at
+ON forge_notification_items
+WHEN NEW.source_ack_queued_at IS NOT NULL
+ AND NEW.source_ack_synced_at IS NULL
+ AND (
+     OLD.source_ack_queued_at IS NULL
+     OR OLD.source_ack_synced_at IS NOT NULL
+     OR OLD.source_ack_queued_at <> NEW.source_ack_queued_at
+ )
+BEGIN
+    UPDATE forge_spoke_preparation
+    SET ack_generation = ack_generation + 1,
+        updated_at = datetime('now')
+    WHERE singleton_id = 1;
+
+    INSERT INTO forge_notification_ack_admissions (
+        notification_id, generation, queued_at
+    )
+    SELECT NEW.id, ack_generation, NEW.source_ack_queued_at
+    FROM forge_spoke_preparation
+    WHERE singleton_id = 1
+    ON CONFLICT(notification_id) DO UPDATE SET
+        generation = excluded.generation,
+        queued_at = excluded.queued_at;
+END;


### PR DESCRIPTION
Notification sync could fail after upgrading a database that had applied an early migration 54 definition. Two persisted triggers continued to reference a retired preparation table even though the current schema uses the spoke preparation table.

This adds forward migration 56 to recreate both triggers against the current table. A real SQLite upgrade regression test covers notification admission through both insert and update paths and confirms that downgrade retains the valid trigger contract.
