### PR TITLE
perf: preserve status motion without repeated shadow paints

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
         "@codemirror/view": "^6.43.0",
         "@effect/platform-browser": "4.0.0-beta.107",
         "@kenn-io/kata-ui": "github:kenn-io/kata#v0.14.3",
-        "@kenn-io/kit-ui": "github:kenn-io/kit-ui#5d93a31b3354d59cf505de4f3676f89278f73849",
+        "@kenn-io/kit-ui": "github:kenn-io/kit-ui#2f7ae2002ba15825bc89cf6b7f2d1eaceef0f4a3",
         "@lucide/svelte": "1.31.0",
         "@pierre/diffs": "1.3.5",
         "@pierre/trees": "1.0.0-beta.6",
@@ -230,7 +230,7 @@
 
     "@kenn-io/kata-ui": ["kata@github:kenn-io/kata#c668572", {}, "kenn-io-kata-c668572", "sha512-WiP4SeduGPD2HdCXRFflDNHv2EEOuoxIbSkVMxmwsT/6liW4kBwUI43oUMssdj8jygEsAlxkv7/u8VLPYZQQEQ=="],
 
-    "@kenn-io/kit-ui": ["@kenn-io/kit-ui@github:kenn-io/kit-ui#5d93a31", { "peerDependencies": { "@lucide/svelte": ">=1.0.0", "dompurify": "^3.2.0", "marked": "^18.0.0", "mermaid": ">=11.15.0 <12", "shiki": "^4.0.0", "svelte": "^5.29.0" }, "optionalPeers": ["mermaid"], "bin": { "kit-ui-check": "./bin/kit-ui-check.mjs" } }, "kenn-io-kit-ui-5d93a31", "sha512-JbqfHbkKDRJl+FNWO3aGSkOHjJmWNuLCaq4WUBr1G1gzwmfTTt0sf+g/lIexLBRsNaE/kqMVTecF7se5bKMfFw=="],
+    "@kenn-io/kit-ui": ["@kenn-io/kit-ui@github:kenn-io/kit-ui#2f7ae20", { "peerDependencies": { "@lucide/svelte": ">=1.0.0", "dompurify": "^3.2.0", "marked": "^18.0.0", "mermaid": ">=11.15.0 <12", "shiki": "^4.0.0", "svelte": "^5.29.0" }, "optionalPeers": ["mermaid"], "bin": { "kit-ui-check": "./bin/kit-ui-check.mjs" } }, "kenn-io-kit-ui-2f7ae20", "sha512-V5I/laRgvVDINK9Ek3tYFtV4ToO2jk7kciuFKUn4KJqUgwmVNKfV0AEsC4ZS8WLANmPLIakYJcdbmknj5krw4g=="],
 
     "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "@codemirror/view": "^6.43.0",
     "@effect/platform-browser": "4.0.0-beta.107",
     "@kenn-io/kata-ui": "github:kenn-io/kata#v0.14.3",
-    "@kenn-io/kit-ui": "github:kenn-io/kit-ui#5d93a31b3354d59cf505de4f3676f89278f73849",
+    "@kenn-io/kit-ui": "github:kenn-io/kit-ui#2f7ae2002ba15825bc89cf6b7f2d1eaceef0f4a3",
     "@lucide/svelte": "1.31.0",
     "@pierre/diffs": "1.3.5",
     "@pierre/trees": "1.0.0-beta.6",

--- a/frontend/src/lib/components/detail/IssueDetail.svelte
+++ b/frontend/src/lib/components/detail/IssueDetail.svelte
@@ -1209,7 +1209,7 @@
       {/if}
       {#if issues.isIssueStaleRefreshing() && !manualRefreshPending}
         <div class="refresh-banner">
-          <StatusDot status="working" label="Refreshing issue details" size={5} />
+          <StatusDot status="working" label="Refreshing issue details" size={5} animated />
           <span aria-hidden="true">Refreshing...</span>
         </div>
       {/if}

--- a/frontend/src/lib/components/diff/CommitListItem.svelte
+++ b/frontend/src/lib/components/diff/CommitListItem.svelte
@@ -39,6 +39,7 @@
   title={commit.message}
 >
   <StatusDot
+    animated
     status={commit.pushed === false ? "stale" : "quiet"}
     label={commit.pushed === false ? "Not pushed to remote" : ""}
     size={6}

--- a/frontend/src/lib/components/layout/ForgeSelector.svelte
+++ b/frontend/src/lib/components/layout/ForgeSelector.svelte
@@ -118,6 +118,7 @@
   >
     <summary aria-label={`Current Forge: ${hostName(currentHost)}`}>
       <StatusDot
+        animated
         status={statusDot(hostStatus(currentHost))}
         label={`${hostName(currentHost)} is ${hostStatus(currentHost)}`}
         size={9}
@@ -135,7 +136,7 @@
             aria-current={host.kind === "self" ? "page" : undefined}
             title={diagnostic || `Open ${hostName(host)}`}
           >
-            <StatusDot status={statusDot(status)} label={`${hostName(host)} is ${status}`} size={9} />
+            <StatusDot status={statusDot(status)} label={`${hostName(host)} is ${status}`} size={9} animated />
             <span class="host-copy">
               <span class="host-heading">
                 <strong>{hostName(host)}</strong>

--- a/frontend/src/lib/components/layout/StatusBar.svelte
+++ b/frontend/src/lib/components/layout/StatusBar.svelte
@@ -298,7 +298,7 @@
         class="status-item status-item--error status-item--provider-unavailable"
         title="This Forge spoke cannot reach its federation hub"
       >
-        <StatusDot status="stale" label="Provider unavailable" size={5} />
+        <StatusDot status="stale" label="Provider unavailable" size={5} animated />
         provider unavailable
       </span>
       <span class="status-sep">&middot;</span>
@@ -321,12 +321,12 @@
           title={events.getLastError() ?? "Reconnect live updates"}
           onclick={events.reconnect}
         >
-          <StatusDot status="stale" label="Live updates disconnected" size={5} />
+          <StatusDot status="stale" label="Live updates disconnected" size={5} animated />
           live updates disconnected
         </button>
       {:else}
         <span class="status-item status-item--live-updates">
-          <StatusDot status="working" label="Reconnecting live updates" size={5} />
+          <StatusDot status="working" label="Reconnecting live updates" size={5} animated />
           live updates reconnecting
         </span>
       {/if}
@@ -335,7 +335,7 @@
     {#if sync.getProviderAvailable()}
       <span class="status-item" class:status-item--active={sync.getSyncState()?.running}>
         {#if sync.getSyncState()?.running}
-          <StatusDot status="working" label="Syncing" size={5} />
+          <StatusDot status="working" label="Syncing" size={5} animated />
         {/if}
         {syncText()}
       </span>

--- a/frontend/src/lib/components/mobile/MobileWorkspaceList.svelte
+++ b/frontend/src/lib/components/mobile/MobileWorkspaceList.svelte
@@ -511,7 +511,7 @@
       onclick={() => openWorkspace(workspace)}
     >
       <span class="mobile-workspace-row__title">
-        <StatusDot status={status(workspace)} label={statusLabel(workspace)} size={7} />
+        <StatusDot status={status(workspace)} label={statusLabel(workspace)} size={7} animated />
         <strong>{mobileWorkspaceDisplayName(workspace)}</strong>
         {#if agentState}
           <span

--- a/frontend/src/lib/components/onboarding/OnboardingFlow.svelte
+++ b/frontend/src/lib/components/onboarding/OnboardingFlow.svelte
@@ -725,6 +725,7 @@
               <span>{syncState?.progress || "Pull requests, issues, CI, and activity"}</span>
             </div>
             <StatusDot
+              animated
               status={syncError ? "stale" : syncState?.running ? "working" : "idle"}
               label={syncError ? "Sync failed" : syncState?.running ? "Syncing" : "Starting"}
               size={7}

--- a/frontend/src/lib/components/roborev/LogViewer.svelte
+++ b/frontend/src/lib/components/roborev/LogViewer.svelte
@@ -44,7 +44,7 @@
   <div class="log-toolbar">
     <span class="log-status">
       {#if isStreaming}
-        <StatusDot status="working" label="Streaming review log" size={6} />
+        <StatusDot status="working" label="Streaming review log" size={6} animated />
         <span aria-hidden="true">Streaming...</span>
       {:else}
         {lineCount} lines

--- a/frontend/src/lib/components/shared/TabbedPanelTree.svelte
+++ b/frontend/src/lib/components/shared/TabbedPanelTree.svelte
@@ -686,6 +686,7 @@
               <span class="tabbed-panel-tab-label">{tab.label}</span>
               {#if tab.status}
                 <StatusDot
+                  animated
                   status={tab.status.value}
                   label={tab.status.label}
                   size={6}

--- a/frontend/src/lib/components/sidebar/IssueList.svelte
+++ b/frontend/src/lib/components/sidebar/IssueList.svelte
@@ -328,7 +328,7 @@
       <p class="state-message state-message--error">Error: {issues.getIssuesError()}</p>
     {:else if issues.getIssues().length === 0 && sync.getSyncState()?.running}
       <div class="state-message sync-message">
-        <StatusDot status="working" label="Syncing issues from GitHub" size={6} />
+        <StatusDot status="working" label="Syncing issues from GitHub" size={6} animated />
         <span aria-hidden="true">Syncing from GitHub…</span>
       </div>
     {:else if issues.getIssues().length === 0 && !sync.getSyncState()?.last_run_at}

--- a/frontend/src/lib/components/sidebar/PullList.svelte
+++ b/frontend/src/lib/components/sidebar/PullList.svelte
@@ -517,7 +517,7 @@
       <p class="state-message state-message--error">Error: {pulls.getError()}</p>
     {:else if visiblePulls.length === 0 && sync.getSyncState()?.running && pulls.getPulls().length === 0}
       <div class="state-message sync-message">
-        <StatusDot status="working" label="Syncing pull requests from GitHub" size={6} />
+        <StatusDot status="working" label="Syncing pull requests from GitHub" size={6} animated />
         <span aria-hidden="true">Syncing from GitHub…</span>
       </div>
     {:else if visiblePulls.length === 0 && !sync.getSyncState()?.last_run_at && pulls.getPulls().length === 0}

--- a/frontend/src/lib/components/terminal/ToolingStatusBlock.svelte
+++ b/frontend/src/lib/components/terminal/ToolingStatusBlock.svelte
@@ -154,6 +154,7 @@
       <li class="tooling-row" data-status={gitStatus}>
         <div class="tooling-row__main">
           <StatusDot
+            animated
             status={semanticStatuses[gitStatus]}
             label={gitStatusLabel(gitStatus)}
             size={8}
@@ -172,6 +173,7 @@
       <li class="tooling-row" data-status={providerCliStatus}>
         <div class="tooling-row__main">
           <StatusDot
+            animated
             status={semanticStatuses[providerCliStatus]}
             label={providerStatusLabel(providerCliStatus)}
             size={8}

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -1382,6 +1382,7 @@
             <div class="ws-row-text">
               <div class="ws-row-title">
                 <StatusDot
+                  animated
                   status={workspaceStatus(ws)}
                   label={workspaceStatusLabel(ws)}
                   size={6}
@@ -1405,6 +1406,7 @@
                     title={`Agent ${agentState.label.toLowerCase()}`}
                   >
                     <StatusDot
+                      animated
                       status={agentState.status}
                       label={`Agent ${agentState.label.toLowerCase()}`}
                       size={6}
@@ -1412,9 +1414,9 @@
                     <span>{agentState.label}</span>
                   </span>
                 {:else if workspaceActionMatches(ws)}
-                  <StatusDot status="working" label={workspaceBusyLabel(ws)} size={6} />
+                  <StatusDot status="working" label={workspaceBusyLabel(ws)} size={6} animated />
                 {:else if ws.agent_state == null && ws.tmux_working}
-                  <StatusDot status="working" label={workingTitle(ws)} size={6} />
+                  <StatusDot status="working" label={workingTitle(ws)} size={6} animated />
                 {/if}
               </div>
               <div class="ws-row-meta">

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -2011,7 +2011,7 @@ describe("WorkspaceListSidebar", () => {
     ["deleting", "Deleting workspace", "kit-status-dot--working"],
     ["deletion_failed", "Deletion failed", "kit-status-dot--unclean"],
     ["pending", "Workspace pending", "kit-status-dot--stale"],
-  ] as const)("maps %s workspace state to the shared semantic status", async (status, label, className) => {
+  ] as const)("maps %s workspace state to the animated semantic status", async (status, label, className) => {
     mockGet.mockResolvedValue({
       data: {
         workspaces: [
@@ -2032,7 +2032,9 @@ describe("WorkspaceListSidebar", () => {
       props: { selectedId: `ws-${status}` },
     });
 
-    expect((await screen.findByLabelText(label)).classList.contains(className)).toBe(true);
+    const statusDot = await screen.findByLabelText(label);
+    expect(statusDot.classList.contains(className)).toBe(true);
+    expect(statusDot.classList.contains("kit-status-dot--animated")).toBe(true);
   });
 
   it("opens a failed issue workspace for retry and confirmed force-delete recovery", async () => {

--- a/frontend/src/lib/views/FocusListView.svelte
+++ b/frontend/src/lib/views/FocusListView.svelte
@@ -470,7 +470,7 @@
         </p>
       {:else if prItems.length === 0 && sync.getSyncState()?.running}
         <div class="state-message sync-message">
-          <StatusDot status="working" label="Syncing pull requests" size={6} />
+          <StatusDot status="working" label="Syncing pull requests" size={6} animated />
           <span aria-hidden="true">Syncing...</span>
         </div>
       {:else if prItems.length === 0 && !sync.getSyncState()?.last_run_at}
@@ -528,7 +528,7 @@
         </p>
       {:else if issueItems.length === 0 && sync.getSyncState()?.running}
         <div class="state-message sync-message">
-          <StatusDot status="working" label="Syncing issues" size={6} />
+          <StatusDot status="working" label="Syncing issues" size={6} animated />
           <span aria-hidden="true">Syncing...</span>
         </div>
       {:else if issueItems.length === 0 && !sync.getSyncState()?.last_run_at}


### PR DESCRIPTION
Forge now pins the merged kit-ui revision that makes `StatusDot` motion explicit. All Forge status indicators opt into motion, preserving the existing active-state appearance across workspace, sync, and status surfaces.

The working glow now fades a pre-painted pseudo-element with opacity instead of changing `box-shadow` on every frame. The waiting bubble also remains opacity-only, and both animations honor reduced-motion preferences. This retains the progress cue without returning to repeated shadow paints.
