### PR TITLE
fix: keep wrapped branch relationships together

### DIFF
--- a/context/mobile-ux.md
+++ b/context/mobile-ux.md
@@ -153,7 +153,7 @@ Minimum expectations for meaningful mobile UI changes:
 - Assert the phone route renders a phone shell/component and not the desktop layout.
 - Assert no document-level horizontal overflow.
 - Check key element bounds for cards, filters, tabs, branch names, and action buttons; element clipping can happen even when document width is fine.
-- Keep the PR branch icon on the head branch's first line and the unbroken arrow/base pair on its final line (`frontend/src/lib/components/detail/PullDetail.svelte::.branch-target`).
+- Keep the PR branch icon on the head branch's first line, with the unbroken arrow/base pair immediately following its final text (`frontend/src/lib/components/detail/PullDetail.svelte::.branch-target`).
 - Assert source sizing remains token/rem-based for the changed mobile surface.
 - Cover click/tap flows that move from mobile lists into focused detail routes.
 - When testing through Tailscale Serve or another proxy, confirm the proxy target and server process so screenshots are not from stale embedded assets.

--- a/context/mobile-ux.md
+++ b/context/mobile-ux.md
@@ -153,7 +153,7 @@ Minimum expectations for meaningful mobile UI changes:
 - Assert the phone route renders a phone shell/component and not the desktop layout.
 - Assert no document-level horizontal overflow.
 - Check key element bounds for cards, filters, tabs, branch names, and action buttons; element clipping can happen even when document width is fine.
-- Keep the PR branch icon attached to the first line of the head branch name; the arrow and base branch may wrap independently (`frontend/src/lib/components/detail/PullDetail.svelte::.branch-head`).
+- Keep the PR branch icon on the head branch's first line and the unbroken arrow/base pair on its final line (`frontend/src/lib/components/detail/PullDetail.svelte::.branch-target`).
 - Assert source sizing remains token/rem-based for the changed mobile surface.
 - Cover click/tap flows that move from mobile lists into focused detail routes.
 - When testing through Tailscale Serve or another proxy, confirm the proxy target and server process so screenshots are not from stale embedded assets.

--- a/context/mobile-ux.md
+++ b/context/mobile-ux.md
@@ -153,6 +153,7 @@ Minimum expectations for meaningful mobile UI changes:
 - Assert the phone route renders a phone shell/component and not the desktop layout.
 - Assert no document-level horizontal overflow.
 - Check key element bounds for cards, filters, tabs, branch names, and action buttons; element clipping can happen even when document width is fine.
+- Keep the PR branch icon attached to the first line of the head branch name; the arrow and base branch may wrap independently (`frontend/src/lib/components/detail/PullDetail.svelte::.branch-head`).
 - Assert source sizing remains token/rem-based for the changed mobile surface.
 - Cover click/tap flows that move from mobile lists into focused detail routes.
 - When testing through Tailscale Serve or another proxy, confirm the proxy target and server process so screenshots are not from stale embedded assets.

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1796,11 +1796,13 @@
   }
 
   .focus-layout--phone :global(.meta-branch) {
-    display: inline-flex;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) max-content;
+    align-items: end;
+    column-gap: var(--space-1);
     flex: 1 1 100%;
     min-width: 0;
     max-width: 100%;
-    flex-wrap: wrap;
     overflow-wrap: anywhere;
     white-space: normal;
   }
@@ -1811,6 +1813,11 @@
     overflow-wrap: anywhere;
     word-break: break-word;
     text-align: left;
+  }
+
+  .focus-layout--phone :global(.branch-name-btn--head) {
+    display: block;
+    max-width: none;
   }
 
   .focus-layout--phone :global(.meta-item),

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1796,10 +1796,7 @@
   }
 
   .focus-layout--phone :global(.meta-branch) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) max-content;
-    align-items: end;
-    column-gap: var(--space-1);
+    display: block;
     flex: 1 1 100%;
     min-width: 0;
     max-width: 100%;
@@ -1816,8 +1813,12 @@
   }
 
   .focus-layout--phone :global(.branch-name-btn--head) {
-    display: block;
+    display: inline;
     max-width: none;
+  }
+
+  .focus-layout--phone :global(.branch-target) {
+    margin-left: var(--space-1);
   }
 
   .focus-layout--phone :global(.meta-item),

--- a/frontend/src/lib/components/detail/PullDetail.svelte
+++ b/frontend/src/lib/components/detail/PullDetail.svelte
@@ -2195,24 +2195,26 @@
         {#if pr.HeadBranch}
           <span class="meta-sep meta-sep--branch">·</span>
           <span class="meta-branch">
-            <span class="branch-head">
+            <button
+              class="branch-name-btn branch-name-btn--head"
+              class:branch-name-btn--copied={copiedBranch === pr.HeadBranch}
+              title={copiedBranch === pr.HeadBranch ? "Copied!" : "Click to copy"}
+              onclick={() => copyBranch(pr.HeadBranch)}
+            >
               <svg class="branch-icon" width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
                 <path d="M11.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122V6c0 .73-.593 1.322-1.325 1.322H9.457A4.377 4.377 0 006.5 8.579V11.128a2.251 2.251 0 11-1.5 0V4.872a2.251 2.251 0 111.5 0v1.836A5.877 5.877 0 0111.175 5.5h.075V5.372A2.25 2.25 0 019.5 3.25zM4.75 12a.75.75 0 100 1.5.75.75 0 000-1.5zM4 3.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0z"/>
               </svg>
+              {pr.HeadBranch}
+            </button>
+            <span class="branch-target">
+              <span class="branch-arrow">&rarr;</span>
               <button
                 class="branch-name-btn"
-                class:branch-name-btn--copied={copiedBranch === pr.HeadBranch}
-                title={copiedBranch === pr.HeadBranch ? "Copied!" : "Click to copy"}
-                onclick={() => copyBranch(pr.HeadBranch)}
-              >{pr.HeadBranch}</button>
+                class:branch-name-btn--copied={copiedBranch === pr.BaseBranch}
+                title={copiedBranch === pr.BaseBranch ? "Copied!" : "Click to copy"}
+                onclick={() => copyBranch(pr.BaseBranch)}
+              >{pr.BaseBranch}</button>
             </span>
-            <span class="branch-arrow">&rarr;</span>
-            <button
-              class="branch-name-btn"
-              class:branch-name-btn--copied={copiedBranch === pr.BaseBranch}
-              title={copiedBranch === pr.BaseBranch ? "Copied!" : "Click to copy"}
-              onclick={() => copyBranch(pr.BaseBranch)}
-            >{pr.BaseBranch}</button>
           </span>
         {/if}
         {#if detailStore.isDetailSyncing() && !manualRefreshPending && !phonePresentation}
@@ -3482,15 +3484,15 @@
 
   .branch-icon {
     color: var(--text-muted);
-    flex-shrink: 0;
+    margin-right: var(--space-1);
+    vertical-align: -0.1em;
   }
 
-  .branch-head {
+  .branch-target {
     display: inline-flex;
-    align-items: flex-start;
+    align-items: baseline;
     gap: var(--space-1);
-    min-width: 0;
-    max-width: 100%;
+    white-space: nowrap;
   }
 
   .branch-name-btn {

--- a/frontend/src/lib/components/detail/PullDetail.svelte
+++ b/frontend/src/lib/components/detail/PullDetail.svelte
@@ -2195,15 +2195,17 @@
         {#if pr.HeadBranch}
           <span class="meta-sep meta-sep--branch">·</span>
           <span class="meta-branch">
-            <svg class="branch-icon" width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-              <path d="M11.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122V6c0 .73-.593 1.322-1.325 1.322H9.457A4.377 4.377 0 006.5 8.579V11.128a2.251 2.251 0 11-1.5 0V4.872a2.251 2.251 0 111.5 0v1.836A5.877 5.877 0 0111.175 5.5h.075V5.372A2.25 2.25 0 019.5 3.25zM4.75 12a.75.75 0 100 1.5.75.75 0 000-1.5zM4 3.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0z"/>
-            </svg>
-            <button
-              class="branch-name-btn"
-              class:branch-name-btn--copied={copiedBranch === pr.HeadBranch}
-              title={copiedBranch === pr.HeadBranch ? "Copied!" : "Click to copy"}
-              onclick={() => copyBranch(pr.HeadBranch)}
-            >{pr.HeadBranch}</button>
+            <span class="branch-head">
+              <svg class="branch-icon" width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M11.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122V6c0 .73-.593 1.322-1.325 1.322H9.457A4.377 4.377 0 006.5 8.579V11.128a2.251 2.251 0 11-1.5 0V4.872a2.251 2.251 0 111.5 0v1.836A5.877 5.877 0 0111.175 5.5h.075V5.372A2.25 2.25 0 019.5 3.25zM4.75 12a.75.75 0 100 1.5.75.75 0 000-1.5zM4 3.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0z"/>
+              </svg>
+              <button
+                class="branch-name-btn"
+                class:branch-name-btn--copied={copiedBranch === pr.HeadBranch}
+                title={copiedBranch === pr.HeadBranch ? "Copied!" : "Click to copy"}
+                onclick={() => copyBranch(pr.HeadBranch)}
+              >{pr.HeadBranch}</button>
+            </span>
             <span class="branch-arrow">&rarr;</span>
             <button
               class="branch-name-btn"
@@ -3483,7 +3485,16 @@
     flex-shrink: 0;
   }
 
+  .branch-head {
+    display: inline-flex;
+    align-items: flex-start;
+    gap: var(--space-1);
+    min-width: 0;
+    max-width: 100%;
+  }
+
   .branch-name-btn {
+    min-width: 0;
     position: relative;
     color: var(--text-secondary);
     font-family: var(--font-mono);

--- a/frontend/src/lib/components/detail/PullDetail.svelte
+++ b/frontend/src/lib/components/detail/PullDetail.svelte
@@ -766,6 +766,12 @@
     );
   }
 
+  function onBranchCopyKeydown(event: KeyboardEvent, text: string): void {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    copyBranch(text);
+  }
+
   let stateSubmitting = $state(false);
 
   // Title editing
@@ -2195,18 +2201,20 @@
         {#if pr.HeadBranch}
           <span class="meta-sep meta-sep--branch">·</span>
           <span class="meta-branch">
-            <button
+            <span
+              role="button"
+              tabindex="0"
               class="branch-name-btn branch-name-btn--head"
               class:branch-name-btn--copied={copiedBranch === pr.HeadBranch}
               title={copiedBranch === pr.HeadBranch ? "Copied!" : "Click to copy"}
               onclick={() => copyBranch(pr.HeadBranch)}
+              onkeydown={(event) => onBranchCopyKeydown(event, pr.HeadBranch)}
             >
               <svg class="branch-icon" width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
                 <path d="M11.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122V6c0 .73-.593 1.322-1.325 1.322H9.457A4.377 4.377 0 006.5 8.579V11.128a2.251 2.251 0 11-1.5 0V4.872a2.251 2.251 0 111.5 0v1.836A5.877 5.877 0 0111.175 5.5h.075V5.372A2.25 2.25 0 019.5 3.25zM4.75 12a.75.75 0 100 1.5.75.75 0 000-1.5zM4 3.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0z"/>
               </svg>
               {pr.HeadBranch}
-            </button>
-            <span class="branch-target">
+            </span><span class="branch-target">&#8288;
               <span class="branch-arrow">&rarr;</span>
               <button
                 class="branch-name-btn"

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -580,7 +580,7 @@ test.describe("phone routes", () => {
     await expect(page.locator(".mobile-shell .mobile-detail-header__badge")).toHaveText("PR #1");
   });
 
-  test("long PR head branches keep the branch icon on the first text line", async ({ page }) => {
+  test("long PR branch relationships stay inline with the wrapped head branch", async ({ page }) => {
     await page.route("**/api/v1/pulls/github/acme/widgets/1", async (route) => {
       const response = await route.fetch();
       const detail = await response.json();
@@ -632,6 +632,7 @@ test.describe("phone routes", () => {
     expect(alignment.iconBottom).toBeLessThanOrEqual(alignment.firstLineBottom + 1);
     expect(Math.abs(alignment.targetTop - alignment.lastLineTop)).toBeLessThan(5);
     expect(alignment.targetLeft).toBeGreaterThanOrEqual(alignment.lastLineRight - 1);
+    expect(alignment.targetLeft - alignment.lastLineRight).toBeLessThan(16);
   });
 
   test("long description collapse toggle has a phone-sized hit target", async ({ page }) => {

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -580,6 +580,42 @@ test.describe("phone routes", () => {
     await expect(page.locator(".mobile-shell .mobile-detail-header__badge")).toHaveText("PR #1");
   });
 
+  test("long PR head branches keep the branch icon on the first text line", async ({ page }) => {
+    await page.route("**/api/v1/pulls/github/acme/widgets/1", async (route) => {
+      const response = await route.fetch();
+      const detail = await response.json();
+      detail.merge_request.HeadBranch = "feature/keep-branch-icon-attached-to-long-wrapped-branch-name";
+      await route.fulfill({ response, json: detail });
+    });
+
+    await page.goto("/pulls/github/acme/widgets/1");
+
+    const headBranch = page.locator(".meta-branch .branch-name-btn").first();
+    const branchIcon = page.locator(".meta-branch .branch-icon");
+    await expect(headBranch).toBeVisible();
+    await expect(branchIcon).toBeVisible();
+
+    const alignment = await page.locator(".meta-branch").evaluate((metaBranch) => {
+      const icon = metaBranch.querySelector(".branch-icon");
+      const head = metaBranch.querySelector(".branch-name-btn");
+      if (!icon || !head) throw new Error("branch metadata is incomplete");
+
+      const iconBounds = icon.getBoundingClientRect();
+      const headBounds = head.getBoundingClientRect();
+      const firstLineBottom = headBounds.top + Number.parseFloat(getComputedStyle(head).lineHeight);
+      return {
+        headWraps: headBounds.height > Number.parseFloat(getComputedStyle(head).lineHeight) * 1.5,
+        iconTop: iconBounds.top,
+        firstLineTop: headBounds.top,
+        firstLineBottom,
+      };
+    });
+
+    expect(alignment.headWraps).toBe(true);
+    expect(alignment.iconTop).toBeGreaterThanOrEqual(alignment.firstLineTop - 1);
+    expect(alignment.iconTop).toBeLessThan(alignment.firstLineBottom);
+  });
+
   test("long description collapse toggle has a phone-sized hit target", async ({ page }) => {
     const server = await startIsolatedE2EServerWithOptions();
     try {

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -597,23 +597,41 @@ test.describe("phone routes", () => {
 
     const alignment = await page.locator(".meta-branch").evaluate((metaBranch) => {
       const icon = metaBranch.querySelector(".branch-icon");
-      const head = metaBranch.querySelector(".branch-name-btn");
-      if (!icon || !head) throw new Error("branch metadata is incomplete");
+      const head = metaBranch.querySelector(".branch-name-btn--head");
+      const target = metaBranch.querySelector(".branch-target");
+      if (!icon || !head || !target) throw new Error("branch metadata is incomplete");
 
       const iconBounds = icon.getBoundingClientRect();
-      const headBounds = head.getBoundingClientRect();
-      const firstLineBottom = headBounds.top + Number.parseFloat(getComputedStyle(head).lineHeight);
+      const headText = [...head.childNodes].find(
+        (node) => node.nodeType === Node.TEXT_NODE && node.textContent?.trim(),
+      );
+      if (!headText) throw new Error("head branch text did not render");
+      const headTextRange = document.createRange();
+      headTextRange.selectNodeContents(headText);
+      const headLines = [...headTextRange.getClientRects()];
+      const firstHeadLine = headLines.at(0);
+      const lastHeadLine = headLines.at(-1);
+      const targetBounds = target.getBoundingClientRect();
+      if (!firstHeadLine || !lastHeadLine) throw new Error("head branch did not render");
+
       return {
-        headWraps: headBounds.height > Number.parseFloat(getComputedStyle(head).lineHeight) * 1.5,
+        headLineCount: headLines.length,
         iconTop: iconBounds.top,
-        firstLineTop: headBounds.top,
-        firstLineBottom,
+        iconBottom: iconBounds.bottom,
+        firstLineTop: firstHeadLine.top,
+        firstLineBottom: firstHeadLine.bottom,
+        lastLineTop: lastHeadLine.top,
+        lastLineRight: lastHeadLine.right,
+        targetTop: targetBounds.top,
+        targetLeft: targetBounds.left,
       };
     });
 
-    expect(alignment.headWraps).toBe(true);
+    expect(alignment.headLineCount).toBeGreaterThan(1);
     expect(alignment.iconTop).toBeGreaterThanOrEqual(alignment.firstLineTop - 1);
-    expect(alignment.iconTop).toBeLessThan(alignment.firstLineBottom);
+    expect(alignment.iconBottom).toBeLessThanOrEqual(alignment.firstLineBottom + 1);
+    expect(Math.abs(alignment.targetTop - alignment.lastLineTop)).toBeLessThan(5);
+    expect(alignment.targetLeft).toBeGreaterThanOrEqual(alignment.lastLineRight - 1);
   });
 
   test("long description collapse toggle has a phone-sized hit target", async ({ page }) => {


### PR DESCRIPTION
Long source branch names on phone layouts could strand the branch icon or make the target look detached from the branch relationship. The branch metadata now keeps the icon beside the source's first line and places the unbroken arrow/target pair immediately after its final text while allowing the full source name to wrap.

![The branch icon remains beside the first source line, and the target follows its final text.](https://github.com/user-attachments/assets/9ded3d5b-d138-4656-aa53-b8e73859e242)
