### PR TITLE
test: split more slow server test groups

### DIFF
--- a/internal/docs/git_publish_integration_test.go
+++ b/internal/docs/git_publish_integration_test.go
@@ -13,82 +13,32 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/config"
-	"go.kenn.io/forge/internal/procutil"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 	"go.kenn.io/forge/internal/testutil/gitsafe"
 )
 
 type gitRepo struct {
-	dir      string
-	remote   string
+	*gitfixture.Repository
 	registry *Registry
 	folderID string
 }
 
 func newGitRepo(t *testing.T) *gitRepo {
 	t.Helper()
-	if err := procutil.Command("git", "--version").Run(); err != nil {
-		t.Skip("git binary unavailable")
-	}
-	dir := t.TempDir()
-	remote := t.TempDir()
-	runGit(t, dir, "init", "-b", "main")
-	runGit(t, dir, "config", "user.email", "kenn-forge-fixture@example.invalid")
-	runGit(t, dir, "config", "user.name", "Kenn Forge Fixture")
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "seed.md"), []byte("seed\n"), 0o644))
-	runGit(t, dir, "add", "seed.md")
-	runGit(t, dir, "commit", "-m", "seed")
-	runGit(t, remote, "init", "--bare")
-	runGit(t, dir, "remote", "add", "origin", remote)
-	runGit(t, dir, "push", "-u", "origin", "main")
+	repo := gitfixture.NewRepository(t, true)
 	reg := NewRegistry([]config.DocFolder{
-		{ID: "f", Name: "F", Path: dir},
+		{ID: "f", Name: "F", Path: repo.Dir},
 	}, WithGitRunner(gitsafe.Runner()))
-	return &gitRepo{dir: dir, remote: remote, registry: reg, folderID: "f"}
+	return &gitRepo{Repository: repo, registry: reg, folderID: "f"}
 }
 
 func newGitRepoNoUpstream(t *testing.T) *gitRepo {
 	t.Helper()
-	if err := procutil.Command("git", "--version").Run(); err != nil {
-		t.Skip("git binary unavailable")
-	}
-	dir := t.TempDir()
-	runGit(t, dir, "init", "-b", "main")
-	runGit(t, dir, "config", "user.email", "kenn-forge-fixture@example.invalid")
-	runGit(t, dir, "config", "user.name", "Kenn Forge Fixture")
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "seed.md"), []byte("seed\n"), 0o644))
-	runGit(t, dir, "add", "seed.md")
-	runGit(t, dir, "commit", "-m", "seed")
+	repo := gitfixture.NewRepository(t, false)
 	reg := NewRegistry([]config.DocFolder{
-		{ID: "f", Name: "F", Path: dir},
+		{ID: "f", Name: "F", Path: repo.Dir},
 	}, WithGitRunner(gitsafe.Runner()))
-	return &gitRepo{dir: dir, registry: reg, folderID: "f"}
-}
-
-func (g *gitRepo) writeFile(t *testing.T, rel, body string) {
-	t.Helper()
-	full := filepath.Join(g.dir, filepath.FromSlash(rel))
-	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
-	require.NoError(t, os.WriteFile(full, []byte(body), 0o644))
-}
-
-func (g *gitRepo) stage(t *testing.T, paths ...string) {
-	t.Helper()
-	args := append([]string{"add", "--"}, paths...)
-	runGit(t, g.dir, args...)
-}
-
-func runGit(t *testing.T, dir string, args ...string) string {
-	t.Helper()
-	cmd := procutil.Command("git", args...)
-	cmd.Dir = dir
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, "git %s: %s", strings.Join(args, " "), string(out))
-	return string(out)
-}
-
-func gitOutput(t *testing.T, dir string, args ...string) string {
-	t.Helper()
-	return strings.TrimSpace(runGit(t, dir, args...))
+	return &gitRepo{Repository: repo, registry: reg, folderID: "f"}
 }
 
 func TestIntegrationGitChangesNotARepo(t *testing.T) {
@@ -125,9 +75,9 @@ func TestIntegrationGitChangesIncludesUntrackedAndModifiedMarkdown(t *testing.T)
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
-	g.writeFile(t, "new.md", "# new\n")
-	g.writeFile(t, "seed.md", "seed updated\n")
-	g.writeFile(t, "code.go", "package x\n")
+	g.Write(t, "new.md", "# new\n")
+	g.Write(t, "seed.md", "seed updated\n")
+	g.Write(t, "code.go", "package x\n")
 
 	res, err := g.registry.GitChanges(context.Background(), g.folderID)
 
@@ -158,8 +108,8 @@ func TestIntegrationGitPublishHappyPath(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
-	g.writeFile(t, "new.md", "# new\n")
-	g.writeFile(t, "seed.md", "seed updated\n")
+	g.Write(t, "new.md", "# new\n")
+	g.Write(t, "seed.md", "seed updated\n")
 
 	res, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: update 2 files\n\n- new.md\n- seed.md\n")
 
@@ -171,7 +121,7 @@ func TestIntegrationGitPublishHappyPath(t *testing.T) {
 	assert.Equal("origin/main", res.Upstream)
 	assert.True(res.Pushed)
 	assert.Len(res.Files, 2)
-	head := gitOutput(t, g.remote, "rev-parse", "main")
+	head := strings.TrimSpace(string(gitfixture.Run(t, g.Remote, "rev-parse", "main")))
 	assert.Equal(res.Commit, head)
 }
 
@@ -180,26 +130,26 @@ func TestIntegrationGitPublishPushesConfiguredUpstreamDespitePushDefaults(t *tes
 	require := require.New(t)
 	g := newGitRepo(t)
 	backup := t.TempDir()
-	runGit(t, backup, "init", "--bare")
-	runGit(t, g.dir, "remote", "add", "backup", backup)
-	runGit(t, g.dir, "push", "backup", "main:main")
-	backupInitial := gitOutput(t, backup, "rev-parse", "main")
-	runGit(t, g.dir, "config", "remote.pushDefault", "backup")
-	runGit(t, g.dir, "config", "push.default", "current")
-	g.writeFile(t, "new.md", "# new\n")
+	gitfixture.Run(t, backup, "init", "--bare")
+	gitfixture.Run(t, g.Dir, "remote", "add", "backup", backup)
+	gitfixture.Run(t, g.Dir, "push", "backup", "main:main")
+	backupInitial := strings.TrimSpace(string(gitfixture.Run(t, backup, "rev-parse", "main")))
+	gitfixture.Run(t, g.Dir, "config", "remote.pushDefault", "backup")
+	gitfixture.Run(t, g.Dir, "config", "push.default", "current")
+	g.Write(t, "new.md", "# new\n")
 
 	res, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: explicit upstream")
 
 	require.NoError(err)
-	originHead := gitOutput(t, g.remote, "rev-parse", "main")
+	originHead := strings.TrimSpace(string(gitfixture.Run(t, g.Remote, "rev-parse", "main")))
 	assert.Equal(res.Commit, originHead)
-	backupHead := gitOutput(t, backup, "rev-parse", "main")
+	backupHead := strings.TrimSpace(string(gitfixture.Run(t, backup, "rev-parse", "main")))
 	assert.Equal(backupInitial, backupHead)
 }
 
 func TestIntegrationGitPublishRefusesEmptyMessage(t *testing.T) {
 	g := newGitRepo(t)
-	g.writeFile(t, "new.md", "# new\n")
+	g.Write(t, "new.md", "# new\n")
 
 	_, err := g.registry.GitPublish(context.Background(), g.folderID, "   \n\t")
 
@@ -208,7 +158,7 @@ func TestIntegrationGitPublishRefusesEmptyMessage(t *testing.T) {
 
 func TestIntegrationGitPublishRefusesNoMarkdownChanges(t *testing.T) {
 	g := newGitRepo(t)
-	g.writeFile(t, "code.go", "package x\n")
+	g.Write(t, "code.go", "package x\n")
 
 	_, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: nothing")
 
@@ -226,9 +176,9 @@ func TestIntegrationGitPublishRefusesNotARepo(t *testing.T) {
 
 func TestIntegrationGitPublishRefusesIndexNotCleanUnrelatedStaged(t *testing.T) {
 	g := newGitRepo(t)
-	g.writeFile(t, "new.md", "# new\n")
-	g.writeFile(t, "code.go", "package x\n")
-	g.stage(t, "code.go")
+	g.Write(t, "new.md", "# new\n")
+	g.Write(t, "code.go", "package x\n")
+	g.Stage(t, "code.go")
 
 	_, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: x")
 
@@ -237,9 +187,9 @@ func TestIntegrationGitPublishRefusesIndexNotCleanUnrelatedStaged(t *testing.T) 
 
 func TestIntegrationGitPublishRefusesIndexNotCleanPartiallyStaged(t *testing.T) {
 	g := newGitRepo(t)
-	g.writeFile(t, "partial.md", "v1\n")
-	g.stage(t, "partial.md")
-	g.writeFile(t, "partial.md", "v2\n")
+	g.Write(t, "partial.md", "v1\n")
+	g.Stage(t, "partial.md")
+	g.Write(t, "partial.md", "v2\n")
 
 	_, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: x")
 
@@ -248,15 +198,13 @@ func TestIntegrationGitPublishRefusesIndexNotCleanPartiallyStaged(t *testing.T) 
 
 func TestIntegrationGitPublishRefusesConflict(t *testing.T) {
 	g := newGitRepo(t)
-	runGit(t, g.dir, "checkout", "-b", "side")
-	g.writeFile(t, "seed.md", "side version\n")
-	runGit(t, g.dir, "commit", "-am", "side")
-	runGit(t, g.dir, "checkout", "main")
-	g.writeFile(t, "seed.md", "main version\n")
-	runGit(t, g.dir, "commit", "-am", "main")
-	cmd := procutil.Command("git", "merge", "side")
-	cmd.Dir = g.dir
-	out, mergeErr := cmd.CombinedOutput()
+	gitfixture.Run(t, g.Dir, "checkout", "-b", "side")
+	g.Write(t, "seed.md", "side version\n")
+	gitfixture.Run(t, g.Dir, "commit", "-am", "side")
+	gitfixture.Run(t, g.Dir, "checkout", "main")
+	g.Write(t, "seed.md", "main version\n")
+	gitfixture.Run(t, g.Dir, "commit", "-am", "main")
+	out, _, mergeErr := gitsafe.Runner().Run(t.Context(), g.Dir, nil, "merge", "side")
 	require.Error(t, mergeErr, "expected merge conflict, got clean merge: %s", out)
 
 	_, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: x")
@@ -268,7 +216,7 @@ func TestIntegrationGitPublishRefusesNoUpstream(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepoNoUpstream(t)
-	g.writeFile(t, "new.md", "# new\n")
+	g.Write(t, "new.md", "# new\n")
 
 	_, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: x")
 
@@ -282,12 +230,12 @@ func TestIntegrationGitPublishStagesRenamePair(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
-	runGit(t, g.dir, "mv", "seed.md", "renamed.md")
+	gitfixture.Run(t, g.Dir, "mv", "seed.md", "renamed.md")
 
 	res, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: rename")
 
 	require.NoError(err)
-	out := gitOutput(t, g.dir, "ls-tree", "--name-only", res.Commit)
+	out := strings.TrimSpace(string(gitfixture.Run(t, g.Dir, "ls-tree", "--name-only", res.Commit)))
 	assert.NotContains(out, "seed.md")
 	assert.Contains(out, "renamed.md")
 }
@@ -296,15 +244,15 @@ func TestIntegrationGitPublishStagesWorktreeRename(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
-	require.NoError(os.Rename(filepath.Join(g.dir, "seed.md"), filepath.Join(g.dir, "moved.md")))
+	require.NoError(os.Rename(filepath.Join(g.Dir, "seed.md"), filepath.Join(g.Dir, "moved.md")))
 
 	res, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: rename in worktree")
 
 	require.NoError(err)
-	out := gitOutput(t, g.dir, "ls-tree", "--name-only", res.Commit)
+	out := strings.TrimSpace(string(gitfixture.Run(t, g.Dir, "ls-tree", "--name-only", res.Commit)))
 	assert.NotContains(out, "seed.md")
 	assert.Contains(out, "moved.md")
-	renames := gitOutput(t, g.dir, "show", "--name-status", "-M", "--format=", res.Commit)
+	renames := strings.TrimSpace(string(gitfixture.Run(t, g.Dir, "show", "--name-status", "-M", "--format=", res.Commit)))
 	assert.Contains(renames, "R")
 }
 
@@ -312,8 +260,8 @@ func TestIntegrationGitPublishPushFailedAfterCommit(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
-	g.writeFile(t, "new.md", "# new\n")
-	runGit(t, g.dir, "remote", "set-url", "origin", "/does/not/exist")
+	g.Write(t, "new.md", "# new\n")
+	gitfixture.Run(t, g.Dir, "remote", "set-url", "origin", "/does/not/exist")
 
 	_, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: x")
 
@@ -322,7 +270,7 @@ func TestIntegrationGitPublishPushFailedAfterCommit(t *testing.T) {
 	assert.NotEmpty(pushFailed.Commit)
 	assert.NotEmpty(pushFailed.Stderr)
 	assert.NotContains(pushFailed.Stderr, "exit status")
-	head := gitOutput(t, g.dir, "rev-parse", "HEAD")
+	head := strings.TrimSpace(string(gitfixture.Run(t, g.Dir, "rev-parse", "HEAD")))
 	assert.Equal(head, pushFailed.Commit)
 }
 
@@ -330,10 +278,10 @@ func TestIntegrationGitPublishDoesNotRunDocsRepoHooks(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
-	g.writeFile(t, "new.md", "# new\n")
+	g.Write(t, "new.md", "# new\n")
 	marker := filepath.Join(t.TempDir(), "hook-ran")
 	hookBody := "#!/bin/sh\necho hooked > \"" + marker + "\"\nexit 1\n"
-	hookDir := filepath.Join(g.dir, ".git", "hooks")
+	hookDir := filepath.Join(g.Dir, ".git", "hooks")
 	require.NoError(os.MkdirAll(hookDir, 0o755))
 	for _, name := range []string{"pre-commit", "commit-msg", "post-commit", "pre-push"} {
 		require.NoError(os.WriteFile(filepath.Join(hookDir, name), []byte(hookBody), 0o755))
@@ -350,12 +298,12 @@ func TestIntegrationGitPublishIgnoresRepoHooksPathOverride(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
-	g.writeFile(t, "new.md", "# new\n")
+	g.Write(t, "new.md", "# new\n")
 	marker := filepath.Join(t.TempDir(), "hook-ran")
 	hooksPath := t.TempDir()
 	hookBody := "#!/bin/sh\necho hooked > \"" + marker + "\"\nexit 1\n"
 	require.NoError(os.WriteFile(filepath.Join(hooksPath, "pre-commit"), []byte(hookBody), 0o755))
-	runGit(t, g.dir, "config", "core.hooksPath", hooksPath)
+	gitfixture.Run(t, g.Dir, "config", "core.hooksPath", hooksPath)
 
 	res, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: x")
 
@@ -392,8 +340,8 @@ func TestIntegrationGitPublishRejectsCommandBearingLocalConfig(t *testing.T) {
 			assert := assert.New(t)
 			require := require.New(t)
 			g := newGitRepo(t)
-			g.writeFile(t, "new.md", "# new\n")
-			runGit(t, g.dir, "config", tc.key, tc.value)
+			g.Write(t, "new.md", "# new\n")
+			gitfixture.Run(t, g.Dir, "config", tc.key, tc.value)
 
 			_, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: x")
 
@@ -408,13 +356,13 @@ func TestIntegrationGitPublishRejectsIncludedCommandBearingConfig(t *testing.T) 
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
-	g.writeFile(t, "new.md", "# new\n")
+	g.Write(t, "new.md", "# new\n")
 	// The attack the include gate exists for: the directive itself looks
 	// harmless, but the included file enables a signing program that a
 	// later `git commit` would execute.
 	included := filepath.Join(t.TempDir(), "evil.cfg")
 	require.NoError(os.WriteFile(included, []byte("[commit]\n\tgpgsign = true\n[gpg]\n\tprogram = /tmp/evil\n"), 0o644))
-	runGit(t, g.dir, "config", "include.path", included)
+	gitfixture.Run(t, g.Dir, "config", "include.path", included)
 
 	_, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: x")
 
@@ -429,13 +377,13 @@ func TestIntegrationGitPublishRejectsPushTargetInsideDocsFolder(t *testing.T) {
 		url  func(g *gitRepo) string
 	}{
 		{"relative path", func(g *gitRepo) string { return "./evil.git" }},
-		{"absolute path", func(g *gitRepo) string { return filepath.Join(g.dir, "evil.git") }},
-		{"file URL", func(g *gitRepo) string { return "file://" + filepath.Join(g.dir, "evil.git") }},
+		{"absolute path", func(g *gitRepo) string { return filepath.Join(g.Dir, "evil.git") }},
+		{"file URL", func(g *gitRepo) string { return "file://" + filepath.Join(g.Dir, "evil.git") }},
 		{"percent-encoded file URL", func(g *gitRepo) string {
 			// Git decodes %65 to 'e' and pushes into evil.git; the
 			// containment check decodes via net/url so it compares the
 			// same path git resolves rather than the escaped literal.
-			return "file://" + filepath.Join(g.dir, "%65vil.git")
+			return "file://" + filepath.Join(g.Dir, "%65vil.git")
 		}},
 	}
 	for _, tc := range cases {
@@ -443,21 +391,21 @@ func TestIntegrationGitPublishRejectsPushTargetInsideDocsFolder(t *testing.T) {
 			assert := assert.New(t)
 			require := require.New(t)
 			g := newGitRepo(t)
-			g.writeFile(t, "new.md", "# new\n")
-			runGit(t, g.dir, "init", "--bare", "evil.git")
+			g.Write(t, "new.md", "# new\n")
+			gitfixture.Run(t, g.Dir, "init", "--bare", "evil.git")
 			marker := filepath.Join(t.TempDir(), "hook-ran")
 			hook := "#!/bin/sh\necho hooked > \"" + marker + "\"\nexit 0\n"
-			require.NoError(os.MkdirAll(filepath.Join(g.dir, "evil.git", "hooks"), 0o755))
-			require.NoError(os.WriteFile(filepath.Join(g.dir, "evil.git", "hooks", "pre-receive"), []byte(hook), 0o755))
-			runGit(t, g.dir, "remote", "set-url", "origin", tc.url(g))
-			head := gitOutput(t, g.dir, "rev-parse", "HEAD")
+			require.NoError(os.MkdirAll(filepath.Join(g.Dir, "evil.git", "hooks"), 0o755))
+			require.NoError(os.WriteFile(filepath.Join(g.Dir, "evil.git", "hooks", "pre-receive"), []byte(hook), 0o755))
+			gitfixture.Run(t, g.Dir, "remote", "set-url", "origin", tc.url(g))
+			head := strings.TrimSpace(string(gitfixture.Run(t, g.Dir, "rev-parse", "HEAD")))
 
 			_, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: x")
 
 			var unsafe *UnsafeGitConfigError
 			require.ErrorAs(err, &unsafe)
 			assert.NoFileExists(marker, "in-folder remote pre-receive hook executed")
-			assert.Equal(head, gitOutput(t, g.dir, "rev-parse", "HEAD"),
+			assert.Equal(head, strings.TrimSpace(string(gitfixture.Run(t, g.Dir, "rev-parse", "HEAD"))),
 				"publish committed before rejecting the push target")
 		})
 	}
@@ -466,12 +414,12 @@ func TestIntegrationGitPublishRejectsPushTargetInsideDocsFolder(t *testing.T) {
 func TestIntegrationGitPublishRejectsPushInsteadOfRewriteIntoDocsFolder(t *testing.T) {
 	require := require.New(t)
 	g := newGitRepo(t)
-	g.writeFile(t, "new.md", "# new\n")
-	runGit(t, g.dir, "init", "--bare", "evil.git")
+	g.Write(t, "new.md", "# new\n")
+	gitfixture.Run(t, g.Dir, "init", "--bare", "evil.git")
 	// The remote URL itself looks like a safe network transport; the
 	// repo-local rewrite redirects the push into the folder.
-	runGit(t, g.dir, "remote", "set-url", "origin", "https://docs.example.invalid/repo.git")
-	runGit(t, g.dir, "config", "url../evil.git.pushInsteadOf", "https://docs.example.invalid/repo.git")
+	gitfixture.Run(t, g.Dir, "remote", "set-url", "origin", "https://docs.example.invalid/repo.git")
+	gitfixture.Run(t, g.Dir, "config", "url../evil.git.pushInsteadOf", "https://docs.example.invalid/repo.git")
 
 	_, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: x")
 
@@ -483,19 +431,19 @@ func TestIntegrationGitPublishRejectsMixedLocalAndNetworkPushURLs(t *testing.T) 
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
-	g.writeFile(t, "new.md", "# new\n")
+	g.Write(t, "new.md", "# new\n")
 	// One push invocation would contact both URLs; the local
 	// receive-pack hardening cannot be applied per-URL, so the set is
 	// refused before anything is committed.
-	runGit(t, g.dir, "config", "--add", "remote.origin.pushurl", g.remote)
-	runGit(t, g.dir, "config", "--add", "remote.origin.pushurl", "ssh://git@docs.example.invalid/repo.git")
-	head := gitOutput(t, g.dir, "rev-parse", "HEAD")
+	gitfixture.Run(t, g.Dir, "config", "--add", "remote.origin.pushurl", g.Remote)
+	gitfixture.Run(t, g.Dir, "config", "--add", "remote.origin.pushurl", "ssh://git@docs.example.invalid/repo.git")
+	head := strings.TrimSpace(string(gitfixture.Run(t, g.Dir, "rev-parse", "HEAD")))
 
 	_, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: x")
 
 	var unsafe *UnsafeGitConfigError
 	require.ErrorAs(err, &unsafe)
-	assert.Equal(head, gitOutput(t, g.dir, "rev-parse", "HEAD"),
+	assert.Equal(head, strings.TrimSpace(string(gitfixture.Run(t, g.Dir, "rev-parse", "HEAD"))),
 		"publish committed before rejecting the mixed push urls")
 }
 
@@ -503,9 +451,9 @@ func TestIntegrationGitPublishRejectsRemoteHelperPushTarget(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
-	g.writeFile(t, "new.md", "# new\n")
+	g.Write(t, "new.md", "# new\n")
 	marker := filepath.Join(t.TempDir(), "helper-ran")
-	runGit(t, g.dir, "remote", "set-url", "origin", `ext::sh -c "touch `+marker+`"`)
+	gitfixture.Run(t, g.Dir, "remote", "set-url", "origin", `ext::sh -c "touch `+marker+`"`)
 
 	_, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: x")
 
@@ -518,31 +466,31 @@ func TestIntegrationGitPublishNeutralizesLocalRemoteReceiveHooks(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
-	g.writeFile(t, "new.md", "# new\n")
+	g.Write(t, "new.md", "# new\n")
 	// Local-path remotes outside the docs folder remain supported, but
 	// the target repo's receive-side hooks must not run: receive-pack
 	// executes on this machine and a hook would be arbitrary code. The
 	// hook exits 1 so, if it ran, the push itself would also fail.
 	marker := filepath.Join(t.TempDir(), "hook-ran")
 	hook := "#!/bin/sh\necho hooked > \"" + marker + "\"\nexit 1\n"
-	require.NoError(os.WriteFile(filepath.Join(g.remote, "hooks", "pre-receive"), []byte(hook), 0o755))
+	require.NoError(os.WriteFile(filepath.Join(g.Remote, "hooks", "pre-receive"), []byte(hook), 0o755))
 
 	res, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: x")
 
 	require.NoError(err)
 	assert.True(res.Pushed)
 	assert.NoFileExists(marker, "local remote pre-receive hook executed during publish")
-	assert.Equal(res.Commit, gitOutput(t, g.remote, "rev-parse", "main"))
+	assert.Equal(res.Commit, strings.TrimSpace(string(gitfixture.Run(t, g.Remote, "rev-parse", "main"))))
 }
 
 func TestIntegrationGitPublishRejectsFilterAttributes(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
-	g.writeFile(t, "new.md", "# new\n")
+	g.Write(t, "new.md", "# new\n")
 	// Even when the driver is configured globally (here it is undefined),
 	// opting paths into a filter marks the repo as LFS-style and is refused.
-	g.writeFile(t, ".gitattributes", "*.md filter=lfs diff=lfs\n")
+	g.Write(t, ".gitattributes", "*.md filter=lfs diff=lfs\n")
 
 	_, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: x")
 
@@ -555,10 +503,10 @@ func TestIntegrationGitPublishRejectsSubdirectoryFilterAttributes(t *testing.T) 
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
-	g.writeFile(t, "sub/new.md", "# new\n")
+	g.Write(t, "sub/new.md", "# new\n")
 	// A .gitattributes nested below the root opts sub/*.md into a filter.
 	// A root-only scan would miss this; check-attr resolves it per path.
-	g.writeFile(t, "sub/.gitattributes", "*.md filter=lfs\n")
+	g.Write(t, "sub/.gitattributes", "*.md filter=lfs\n")
 
 	_, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: x")
 
@@ -573,29 +521,29 @@ func TestIntegrationGitPublishGatesAttributesBeforeStatusRunsFilter(t *testing.T
 	g := newGitRepo(t)
 	runner := gitsafe.MutableRunner(t)
 	g.registry = NewRegistry(
-		[]config.DocFolder{{ID: g.folderID, Name: "F", Path: g.dir}},
+		[]config.DocFolder{{ID: g.folderID, Name: "F", Path: g.Dir}},
 		WithGitRunner(runner),
 	)
 	marker := filepath.Join(t.TempDir(), "filter-ran")
 	// Simulate a globally-installed clean filter, as git-lfs would be on a
 	// victim's machine. The repo only chooses to route paths through it.
 	_, stderr, err := runner.Run(
-		t.Context(), g.dir, nil, "config", "--global", "filter.evil.clean",
+		t.Context(), g.Dir, nil, "config", "--global", "filter.evil.clean",
 		"sh -c 'echo ran > \""+marker+"\"; cat'",
 	)
 	require.NoError(err, string(stderr))
 	_, stderr, err = runner.Run(
-		t.Context(), g.dir, nil, "config", "--global", "filter.evil.smudge", "cat",
+		t.Context(), g.Dir, nil, "config", "--global", "filter.evil.smudge", "cat",
 	)
 	require.NoError(err, string(stderr))
 	// Attacker-controlled repo attributes opt markdown into that filter.
-	g.writeFile(t, ".gitattributes", "*.md filter=evil\n")
+	g.Write(t, ".gitattributes", "*.md filter=evil\n")
 	// Modify a tracked markdown to the same byte length as the committed
 	// blob and backdate it, so git must rehash (running the clean filter)
 	// to detect the change during `git status`.
-	g.writeFile(t, "seed.md", "xxxx\n")
+	g.Write(t, "seed.md", "xxxx\n")
 	old := time.Unix(1_000_000_000, 0)
-	require.NoError(os.Chtimes(filepath.Join(g.dir, "seed.md"), old, old))
+	require.NoError(os.Chtimes(filepath.Join(g.Dir, "seed.md"), old, old))
 
 	_, err = g.registry.GitPublish(context.Background(), g.folderID, "docs: x")
 
@@ -607,7 +555,7 @@ func TestIntegrationGitPublishGatesAttributesBeforeStatusRunsFilter(t *testing.T
 func TestIntegrationGitStatusRejectsFilterAttributes(t *testing.T) {
 	require := require.New(t)
 	g := newGitRepo(t)
-	g.writeFile(t, ".gitattributes", "*.md filter=lfs\n")
+	g.Write(t, ".gitattributes", "*.md filter=lfs\n")
 
 	_, err := g.registry.GitStatus(context.Background(), g.folderID)
 
@@ -618,8 +566,8 @@ func TestIntegrationGitStatusRejectsFilterAttributes(t *testing.T) {
 func TestIntegrationGitChangesRejectsFilterAttributes(t *testing.T) {
 	require := require.New(t)
 	g := newGitRepo(t)
-	g.writeFile(t, "sub/.gitattributes", "*.md diff=evil\n")
-	g.writeFile(t, "sub/new.md", "# new\n")
+	g.Write(t, "sub/.gitattributes", "*.md diff=evil\n")
+	g.Write(t, "sub/new.md", "# new\n")
 
 	_, err := g.registry.GitChanges(context.Background(), g.folderID)
 
@@ -630,11 +578,11 @@ func TestIntegrationGitChangesRejectsFilterAttributes(t *testing.T) {
 func TestIntegrationGitChangesRejectsCommandBearingLocalConfig(t *testing.T) {
 	require := require.New(t)
 	g := newGitRepo(t)
-	g.writeFile(t, "new.md", "# new\n")
+	g.Write(t, "new.md", "# new\n")
 	// The preview must apply the same config gate as publish so a folder
 	// with unsafe local config cannot preview as publishable and only
 	// fail on submit.
-	runGit(t, g.dir, "config", "gpg.program", "/tmp/evil")
+	gitfixture.Run(t, g.Dir, "config", "gpg.program", "/tmp/evil")
 
 	_, err := g.registry.GitChanges(context.Background(), g.folderID)
 
@@ -645,11 +593,11 @@ func TestIntegrationGitChangesRejectsCommandBearingLocalConfig(t *testing.T) {
 func TestIntegrationGitPublishAllowsBenignLocalConfig(t *testing.T) {
 	require := require.New(t)
 	g := newGitRepo(t)
-	g.writeFile(t, "new.md", "# new\n")
+	g.Write(t, "new.md", "# new\n")
 	// Signing explicitly off and benign attributes must not trip the gate.
-	runGit(t, g.dir, "config", "commit.gpgsign", "false")
-	runGit(t, g.dir, "config", "tag.gpgsign", "false")
-	g.writeFile(t, ".gitattributes", "*.md text=auto eol=lf\n")
+	gitfixture.Run(t, g.Dir, "config", "commit.gpgsign", "false")
+	gitfixture.Run(t, g.Dir, "config", "tag.gpgsign", "false")
+	g.Write(t, ".gitattributes", "*.md text=auto eol=lf\n")
 
 	res, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: x")
 
@@ -661,11 +609,11 @@ func TestIntegrationGitStatusDoesNotRunRepoFsmonitor(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
-	g.writeFile(t, "new.md", "# new\n")
+	g.Write(t, "new.md", "# new\n")
 	marker := filepath.Join(t.TempDir(), "fsmonitor-ran")
 	monitor := filepath.Join(t.TempDir(), "fsmonitor")
 	require.NoError(os.WriteFile(monitor, []byte("#!/bin/sh\necho ran > \""+marker+"\"\nexit 1\n"), 0o755))
-	runGit(t, g.dir, "config", "core.fsmonitor", monitor)
+	gitfixture.Run(t, g.Dir, "config", "core.fsmonitor", monitor)
 
 	// GitStatus runs `git status`, which honors core.fsmonitor.
 	_, err := g.registry.GitStatus(context.Background(), g.folderID)
@@ -678,15 +626,15 @@ func TestIntegrationGitPublishBlocksExtRemoteHelperOnPush(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
-	g.writeFile(t, "new.md", "# new\n")
+	g.Write(t, "new.md", "# new\n")
 	marker := filepath.Join(t.TempDir(), "helper-ran")
 	helper := filepath.Join(t.TempDir(), "evil")
 	require.NoError(os.WriteFile(helper, []byte("#!/bin/sh\necho ran > \""+marker+"\"\n"), 0o755))
 	// An attacker-controlled repo config can opt the ext transport back in
 	// (modern git blocks it by default) and point a remote at an arbitrary
 	// command, which push would execute without our protocol.ext override.
-	runGit(t, g.dir, "config", "protocol.ext.allow", "always")
-	runGit(t, g.dir, "remote", "set-url", "origin", "ext::"+helper)
+	gitfixture.Run(t, g.Dir, "config", "protocol.ext.allow", "always")
+	gitfixture.Run(t, g.Dir, "remote", "set-url", "origin", "ext::"+helper)
 
 	_, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: x")
 
@@ -698,9 +646,9 @@ func TestIntegrationGitPublishCommitFailurePreservesStderr(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
-	g.writeFile(t, "new.md", "# new\n")
-	runGit(t, g.dir, "config", "user.useConfigOnly", "true")
-	runGit(t, g.dir, "config", "--unset", "user.email")
+	g.Write(t, "new.md", "# new\n")
+	gitfixture.Run(t, g.Dir, "config", "user.useConfigOnly", "true")
+	gitfixture.Run(t, g.Dir, "config", "--unset", "user.email")
 
 	_, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: x")
 
@@ -714,13 +662,13 @@ func TestIntegrationGitPublishStagesLiteralPathspec(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
-	g.writeFile(t, "weird *.md", "# weird\n")
-	g.writeFile(t, "decoy.md", "# decoy\n")
+	g.Write(t, "weird *.md", "# weird\n")
+	g.Write(t, "decoy.md", "# decoy\n")
 
 	res, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: weird")
 
 	require.NoError(err)
-	out := gitOutput(t, g.dir, "ls-tree", "--name-only", res.Commit)
+	out := strings.TrimSpace(string(gitfixture.Run(t, g.Dir, "ls-tree", "--name-only", res.Commit)))
 	assert.Contains(out, "weird *.md")
 	assert.Contains(out, "decoy.md")
 }

--- a/internal/docs/git_pull_integration_test.go
+++ b/internal/docs/git_pull_integration_test.go
@@ -6,39 +6,20 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/config"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 )
-
-// remoteCommit advances the bare fixture remote by one commit created in a
-// scratch clone, returning the new remote head SHA. This simulates another
-// machine pushing docs changes. The explicit checkout matters: under the
-// isolated git env the bare remote's default HEAD is master, so a fresh
-// clone would otherwise sit on an unborn branch.
-func (g *gitRepo) remoteCommit(t *testing.T, rel, body string) string {
-	t.Helper()
-	clone := t.TempDir()
-	runGit(t, g.dir, "clone", g.remote, clone)
-	runGit(t, clone, "checkout", "main")
-	runGit(t, clone, "config", "user.email", "kenn-forge-fixture@example.invalid")
-	runGit(t, clone, "config", "user.name", "Kenn Forge Fixture")
-	full := filepath.Join(clone, filepath.FromSlash(rel))
-	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
-	require.NoError(t, os.WriteFile(full, []byte(body), 0o644))
-	runGit(t, clone, "add", "--", rel)
-	runGit(t, clone, "commit", "-m", "remote update")
-	runGit(t, clone, "push", "origin", "main")
-	return gitOutput(t, clone, "rev-parse", "HEAD")
-}
 
 func TestIntegrationGitPullFastForwards(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
-	want := g.remoteCommit(t, "remote.md", "# remote\n")
+	want := g.RemoteCommit(t, "remote.md", "# remote\n")
 
 	res, err := g.registry.GitPull(context.Background(), g.folderID)
 
@@ -48,12 +29,12 @@ func TestIntegrationGitPullFastForwards(t *testing.T) {
 	assert.Equal(want[:7], res.ShortCommit)
 	assert.Equal("main", res.Branch)
 	assert.Equal("origin/main", res.Upstream)
-	assert.Equal(want, gitOutput(t, g.dir, "rev-parse", "HEAD"))
+	assert.Equal(want, strings.TrimSpace(string(gitfixture.Run(t, g.Dir, "rev-parse", "HEAD"))))
 	// The source-only refspec fetch must still refresh the remote-tracking
 	// ref via git's opportunistic update, or origin/main would go stale and
 	// the branch would wrongly appear ahead of its upstream.
-	assert.Equal(want, gitOutput(t, g.dir, "rev-parse", "origin/main"))
-	body, readErr := os.ReadFile(filepath.Join(g.dir, "remote.md"))
+	assert.Equal(want, strings.TrimSpace(string(gitfixture.Run(t, g.Dir, "rev-parse", "origin/main"))))
+	body, readErr := os.ReadFile(filepath.Join(g.Dir, "remote.md"))
 	require.NoError(readErr)
 	assert.Equal("# remote\n", string(body))
 }
@@ -62,7 +43,7 @@ func TestIntegrationGitPullUpToDate(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
-	head := gitOutput(t, g.dir, "rev-parse", "HEAD")
+	head := strings.TrimSpace(string(gitfixture.Run(t, g.Dir, "rev-parse", "HEAD")))
 
 	res, err := g.registry.GitPull(context.Background(), g.folderID)
 
@@ -74,10 +55,10 @@ func TestIntegrationGitPullUpToDate(t *testing.T) {
 
 func TestIntegrationGitPullRefusesDiverged(t *testing.T) {
 	g := newGitRepo(t)
-	g.remoteCommit(t, "remote.md", "remote\n")
-	g.writeFile(t, "local.md", "local\n")
-	runGit(t, g.dir, "add", "--", "local.md")
-	runGit(t, g.dir, "commit", "-m", "local update")
+	g.RemoteCommit(t, "remote.md", "remote\n")
+	g.Write(t, "local.md", "local\n")
+	gitfixture.Run(t, g.Dir, "add", "--", "local.md")
+	gitfixture.Run(t, g.Dir, "commit", "-m", "local update")
 
 	_, err := g.registry.GitPull(context.Background(), g.folderID)
 
@@ -86,8 +67,8 @@ func TestIntegrationGitPullRefusesDiverged(t *testing.T) {
 
 func TestIntegrationGitPullRefusesOverwritingDirtyWorktree(t *testing.T) {
 	g := newGitRepo(t)
-	g.remoteCommit(t, "seed.md", "remote seed\n")
-	g.writeFile(t, "seed.md", "local dirty\n")
+	g.RemoteCommit(t, "seed.md", "remote seed\n")
+	g.Write(t, "seed.md", "local dirty\n")
 
 	_, err := g.registry.GitPull(context.Background(), g.folderID)
 
@@ -95,7 +76,7 @@ func TestIntegrationGitPullRefusesOverwritingDirtyWorktree(t *testing.T) {
 	require.ErrorAs(t, err, &pullFailed)
 	assert.Contains(t, pullFailed.Stderr, "overwritten")
 	// The dirty local edit must survive the refused pull.
-	body, readErr := os.ReadFile(filepath.Join(g.dir, "seed.md"))
+	body, readErr := os.ReadFile(filepath.Join(g.Dir, "seed.md"))
 	require.NoError(t, readErr)
 	assert.Equal(t, "local dirty\n", string(body))
 }

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -59,6 +59,7 @@ import (
 	"go.kenn.io/forge/internal/testutil"
 	"go.kenn.io/forge/internal/testutil/dbtest"
 	"go.kenn.io/forge/internal/testutil/gitfake"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 	"go.kenn.io/forge/internal/testutil/gitsafe"
 	"go.kenn.io/forge/internal/testutil/processjob"
 	"go.kenn.io/forge/internal/testutil/testsignal"
@@ -84,9 +85,8 @@ var (
 		0,
 		"PID of the test process that launched the PTY owner helper",
 	)
-	// Root keeps only Workspace tests that cross provider, config, Kata,
-	// runtime, terminal, Fleet, or agent-context composition boundaries.
-	// Bound their Git setup independently from the workspacetest binary.
+	// Bound Git-heavy root-package tests independently from the workspacetest
+	// binary.
 	rootWorkspaceGitSemaphore = semaphore.NewWeighted(2)
 )
 
@@ -2024,6 +2024,8 @@ func TestAPIInvolvesMeFiltersPullsIssuesAndActivity(t *testing.T) {
 }
 
 func TestAPIUnassignedFiltersPullsIssuesAndActivity(t *testing.T) {
+	runParallelServerTest(t)
+
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -5434,21 +5436,21 @@ func TestAPIGitHubSyncReadsCloneTokenFileAfterRotation(t *testing.T) {
 	dir := t.TempDir()
 
 	remote := filepath.Join(dir, "remote.git")
-	runGit(t, dir, "init", "--bare", "--initial-branch=main", remote)
+	gitfixture.Run(t, dir, "init", "--bare", "--initial-branch=main", remote)
 	work := filepath.Join(dir, "work")
-	runGit(t, dir, "clone", remote, work)
-	runGit(t, work, "config", "user.email", "test@test.com")
-	runGit(t, work, "config", "user.name", "Test")
+	gitfixture.Run(t, dir, "clone", remote, work)
+	gitfixture.Run(t, work, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, work, "config", "user.name", "Test")
 	require.NoError(os.WriteFile(filepath.Join(work, "base.txt"), []byte("base\n"), 0o644))
-	runGit(t, work, "add", ".")
-	runGit(t, work, "commit", "-m", "base commit")
-	runGit(t, work, "push", "origin", "main")
+	gitfixture.Run(t, work, "add", ".")
+	gitfixture.Run(t, work, "commit", "-m", "base commit")
+	gitfixture.Run(t, work, "push", "origin", "main")
 	baseSHA := gitOutput(t, work, "rev-parse", "HEAD")
-	runGit(t, work, "checkout", "-b", "feature/token-rotation")
+	gitfixture.Run(t, work, "checkout", "-b", "feature/token-rotation")
 	require.NoError(os.WriteFile(filepath.Join(work, "feature.txt"), []byte("feature\n"), 0o644))
-	runGit(t, work, "add", ".")
-	runGit(t, work, "commit", "-m", "feature commit")
-	runGit(t, work, "push", "origin", "feature/token-rotation")
+	gitfixture.Run(t, work, "add", ".")
+	gitfixture.Run(t, work, "commit", "-m", "feature commit")
+	gitfixture.Run(t, work, "push", "origin", "feature/token-rotation")
 	headSHA := gitOutput(t, work, "rev-parse", "HEAD")
 
 	tokenPath := filepath.Join(dir, "github-token")
@@ -5595,15 +5597,15 @@ func TestAPISharedHostCloneFetchFollowsReloadedHostToken(t *testing.T) {
 	t.Setenv("KENN_FORGE_ROTATED_TOKEN", "rotated-token")
 
 	remote := filepath.Join(dir, "remote.git")
-	runGit(t, dir, "init", "--bare", "--initial-branch=main", remote)
+	gitfixture.Run(t, dir, "init", "--bare", "--initial-branch=main", remote)
 	work := filepath.Join(dir, "work")
-	runGit(t, dir, "clone", remote, work)
-	runGit(t, work, "config", "user.email", "test@test.com")
-	runGit(t, work, "config", "user.name", "Test")
+	gitfixture.Run(t, dir, "clone", remote, work)
+	gitfixture.Run(t, work, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, work, "config", "user.name", "Test")
 	require.NoError(os.WriteFile(filepath.Join(work, "base.txt"), []byte("base\n"), 0o644))
-	runGit(t, work, "add", ".")
-	runGit(t, work, "commit", "-m", "base commit")
-	runGit(t, work, "push", "origin", "main")
+	gitfixture.Run(t, work, "add", ".")
+	gitfixture.Run(t, work, "commit", "-m", "base commit")
+	gitfixture.Run(t, work, "push", "origin", "main")
 
 	capturePath := installCredentialCapturingGit(t, dir)
 	cloneURL := gitLocalRemoteURL(remote)
@@ -6794,6 +6796,7 @@ platform_host = "ghe.example.com"
 
 func TestAPIListRepoSummariesIncludesSyncedReleaseTimeline(t *testing.T) {
 	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -6802,10 +6805,10 @@ func TestAPIListRepoSummariesIncludesSyncedReleaseTimeline(t *testing.T) {
 
 	remote := filepath.Join(dir, "remote.git")
 	work := filepath.Join(dir, "work")
-	runGit(t, dir, "init", "--bare", "--initial-branch=main", remote)
-	runGit(t, dir, "clone", remote, work)
-	runGit(t, work, "config", "user.email", "test@test.com")
-	runGit(t, work, "config", "user.name", "Test")
+	gitfixture.Run(t, dir, "init", "--bare", "--initial-branch=main", remote)
+	gitfixture.Run(t, dir, "clone", remote, work)
+	gitfixture.Run(t, work, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, work, "config", "user.name", "Test")
 
 	commitFile := func(name, message string) {
 		t.Helper()
@@ -6814,19 +6817,19 @@ func TestAPIListRepoSummariesIncludesSyncedReleaseTimeline(t *testing.T) {
 			[]byte(message+"\n"),
 			0o644,
 		))
-		runGit(t, work, "add", ".")
-		runGit(t, work, "commit", "-m", message)
+		gitfixture.Run(t, work, "add", ".")
+		gitfixture.Run(t, work, "commit", "-m", message)
 	}
 
 	commitFile("base.txt", "release v1")
-	runGit(t, work, "tag", "v1.0.0")
+	gitfixture.Run(t, work, "tag", "v1.0.0")
 	commitFile("v2.txt", "prepare v2")
-	runGit(t, work, "tag", "v2.0.0")
+	gitfixture.Run(t, work, "tag", "v2.0.0")
 	commitFile("v3.txt", "prepare v3")
-	runGit(t, work, "tag", "v3.0.0")
+	gitfixture.Run(t, work, "tag", "v3.0.0")
 	commitFile("post-1.txt", "post latest 1")
 	commitFile("post-2.txt", "post latest 2")
-	runGit(t, work, "push", "--tags", "origin", "main")
+	gitfixture.Run(t, work, "push", "--tags", "origin", "main")
 
 	clones := gitclone.New(filepath.Join(dir, "clones"), nil)
 	clonePath, err := clones.ClonePathForContext(
@@ -6835,7 +6838,7 @@ func TestAPIListRepoSummariesIncludesSyncedReleaseTimeline(t *testing.T) {
 	)
 	require.NoError(err)
 	require.NoError(os.MkdirAll(filepath.Dir(clonePath), 0o755))
-	runGit(t, dir, "clone", "--bare", remote, clonePath)
+	gitfixture.Run(t, dir, "clone", "--bare", remote, clonePath)
 
 	releaseForTag := func(tag string, publishedAt time.Time) *gh.RepositoryRelease {
 		t.Helper()
@@ -6904,10 +6907,10 @@ func TestAPIListRepoSummariesIncludesSyncedReleaseTimeline(t *testing.T) {
 	assert.Equal("post latest 1", (*widgets.CommitTimeline)[1].Message)
 	assert.Len((*widgets.CommitTimeline)[0].Sha, 40)
 
-	runGit(t, work, "tag", "-f", "v3.0.0", "HEAD")
-	runGit(t, work, "tag", "-f", "v1.0.0", "HEAD")
-	runGit(t, work, "push", "--force", "origin", "refs/tags/v3.0.0")
-	runGit(t, work, "push", "--force", "origin", "refs/tags/v1.0.0")
+	gitfixture.Run(t, work, "tag", "-f", "v3.0.0", "HEAD")
+	gitfixture.Run(t, work, "tag", "-f", "v1.0.0", "HEAD")
+	gitfixture.Run(t, work, "push", "--force", "origin", "refs/tags/v3.0.0")
+	gitfixture.Run(t, work, "push", "--force", "origin", "refs/tags/v1.0.0")
 	syncer.RunOnce(ctx)
 
 	resp, err = client.HTTP.ListRepoSummariesWithResponse(ctx)
@@ -21796,6 +21799,7 @@ func (t *lockedGitealikeTransport) ListStatuses(
 
 func TestAPIGetFilesAndDiffMarkGeneratedFilesE2E(t *testing.T) {
 	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -21813,21 +21817,21 @@ func TestAPIGetFilesAndDiffMarkGeneratedFilesE2E(t *testing.T) {
 	require.NoError(os.MkdirAll(filepath.Dir(bare), 0o755))
 
 	work := filepath.Join(dir, "work")
-	runGit(t, dir, "init", "--bare", "--initial-branch=main", bare)
-	runGit(t, dir, "clone", bare, work)
-	runGit(t, work, "config", "user.email", "test@test.com")
-	runGit(t, work, "config", "user.name", "Test")
+	gitfixture.Run(t, dir, "init", "--bare", "--initial-branch=main", bare)
+	gitfixture.Run(t, dir, "clone", bare, work)
+	gitfixture.Run(t, work, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, work, "config", "user.name", "Test")
 
 	require.NoError(os.WriteFile(
 		filepath.Join(work, "base.txt"),
 		[]byte("base\n"), 0o644,
 	))
-	runGit(t, work, "add", ".")
-	runGit(t, work, "commit", "-m", "base commit")
-	runGit(t, work, "push", "origin", "main")
-	mergeBase := testGitSHA(t, work, "HEAD")
+	gitfixture.Run(t, work, "add", ".")
+	gitfixture.Run(t, work, "commit", "-m", "base commit")
+	gitfixture.Run(t, work, "push", "origin", "main")
+	mergeBase := gitfixture.SHA(t, work, "HEAD")
 
-	runGit(t, work, "checkout", "-b", "feature")
+	gitfixture.Run(t, work, "checkout", "-b", "feature")
 	require.NoError(os.WriteFile(
 		filepath.Join(work, ".gitattributes"),
 		[]byte("dist/** linguist-generated\nbun.lock -linguist-generated\n"), 0o644,
@@ -21845,10 +21849,10 @@ func TestAPIGetFilesAndDiffMarkGeneratedFilesE2E(t *testing.T) {
 		filepath.Join(work, "src.ts"),
 		[]byte("export const source = true;\n"), 0o644,
 	))
-	runGit(t, work, "add", ".")
-	runGit(t, work, "commit", "-m", "feature commit")
-	runGit(t, work, "push", "origin", "feature")
-	headSHA := testGitSHA(t, work, "HEAD")
+	gitfixture.Run(t, work, "add", ".")
+	gitfixture.Run(t, work, "commit", "-m", "feature commit")
+	gitfixture.Run(t, work, "push", "origin", "feature")
+	headSHA := gitfixture.SHA(t, work, "HEAD")
 
 	syncer := ghclient.NewSyncer(
 		map[string]ghclient.Client{"github.com": &mockGH{}},
@@ -21876,9 +21880,9 @@ func TestAPIGetFilesAndDiffMarkGeneratedFilesE2E(t *testing.T) {
 	require.Equal(http.StatusOK, filesResp.StatusCode(), string(filesResp.Body))
 	require.NotNil(filesResp.JSON200)
 	require.NotNil(filesResp.JSON200.Files)
-	assert.True(requireWorkspaceDiffFile(t, *filesResp.JSON200.Files, "dist/api.ts").IsGenerated)
-	assert.False(requireWorkspaceDiffFile(t, *filesResp.JSON200.Files, "bun.lock").IsGenerated)
-	assert.False(requireWorkspaceDiffFile(t, *filesResp.JSON200.Files, "src.ts").IsGenerated)
+	assert.True(testutil.RequireWorkspaceDiffFile(t, *filesResp.JSON200.Files, "dist/api.ts").IsGenerated)
+	assert.False(testutil.RequireWorkspaceDiffFile(t, *filesResp.JSON200.Files, "bun.lock").IsGenerated)
+	assert.False(testutil.RequireWorkspaceDiffFile(t, *filesResp.JSON200.Files, "src.ts").IsGenerated)
 
 	diffResp, err := client.HTTP.GetPullDiffWithResponse(
 		ctx, "gh", "acme", "widget", 1,
@@ -21888,9 +21892,9 @@ func TestAPIGetFilesAndDiffMarkGeneratedFilesE2E(t *testing.T) {
 	require.Equal(http.StatusOK, diffResp.StatusCode(), string(diffResp.Body))
 	require.NotNil(diffResp.JSON200)
 	require.NotNil(diffResp.JSON200.Files)
-	assert.True(requireWorkspaceDiffFile(t, *diffResp.JSON200.Files, "dist/api.ts").IsGenerated)
-	assert.False(requireWorkspaceDiffFile(t, *diffResp.JSON200.Files, "bun.lock").IsGenerated)
-	assert.False(requireWorkspaceDiffFile(t, *diffResp.JSON200.Files, "src.ts").IsGenerated)
+	assert.True(testutil.RequireWorkspaceDiffFile(t, *diffResp.JSON200.Files, "dist/api.ts").IsGenerated)
+	assert.False(testutil.RequireWorkspaceDiffFile(t, *diffResp.JSON200.Files, "bun.lock").IsGenerated)
+	assert.False(testutil.RequireWorkspaceDiffFile(t, *diffResp.JSON200.Files, "src.ts").IsGenerated)
 }
 
 // countingTokenFileSource wraps a managed token-file source and records how
@@ -21922,6 +21926,7 @@ func (s *countingTokenFileSource) Descriptor() tokenauth.Descriptor {
 // diff views for repos that are already on disk.
 func TestAPILocalReadEndpointsServeDuringTokenRotationE2E(t *testing.T) {
 	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -21938,23 +21943,23 @@ func TestAPILocalReadEndpointsServeDuringTokenRotationE2E(t *testing.T) {
 	require.NoError(os.MkdirAll(filepath.Dir(bare), 0o755))
 
 	work := filepath.Join(dir, "work")
-	runGit(t, dir, "init", "--bare", "--initial-branch=main", bare)
-	runGit(t, dir, "clone", bare, work)
-	runGit(t, work, "config", "user.email", "test@test.com")
-	runGit(t, work, "config", "user.name", "Test")
+	gitfixture.Run(t, dir, "init", "--bare", "--initial-branch=main", bare)
+	gitfixture.Run(t, dir, "clone", bare, work)
+	gitfixture.Run(t, work, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, work, "config", "user.name", "Test")
 
 	require.NoError(os.WriteFile(filepath.Join(work, "base.txt"), []byte("base\n"), 0o644))
-	runGit(t, work, "add", ".")
-	runGit(t, work, "commit", "-m", "base commit")
-	runGit(t, work, "push", "origin", "main")
-	mergeBase := testGitSHA(t, work, "HEAD")
+	gitfixture.Run(t, work, "add", ".")
+	gitfixture.Run(t, work, "commit", "-m", "base commit")
+	gitfixture.Run(t, work, "push", "origin", "main")
+	mergeBase := gitfixture.SHA(t, work, "HEAD")
 
-	runGit(t, work, "checkout", "-b", "feature")
+	gitfixture.Run(t, work, "checkout", "-b", "feature")
 	require.NoError(os.WriteFile(filepath.Join(work, "feature.txt"), []byte("feature\n"), 0o644))
-	runGit(t, work, "add", ".")
-	runGit(t, work, "commit", "-m", "feature commit")
-	runGit(t, work, "push", "origin", "feature")
-	headSHA := testGitSHA(t, work, "HEAD")
+	gitfixture.Run(t, work, "add", ".")
+	gitfixture.Run(t, work, "commit", "-m", "feature commit")
+	gitfixture.Run(t, work, "push", "origin", "feature")
+	headSHA := gitfixture.SHA(t, work, "HEAD")
 
 	// A token-file source modeling the credential that was valid when the
 	// clone was created. Rotation empties the file before the reads below.
@@ -22970,20 +22975,6 @@ func TestAPIActivityFencesRepositoryReconciliationAcrossEventAndWorkspaceReads(t
 // The comment row carries the PR author, not the commenter, so the
 // threaded feed can attribute the item to its real author.
 
-func runGit(t *testing.T, dir string, args ...string) {
-	t.Helper()
-	runner := gitcmd.New().WithConfig("init.defaultBranch", "main")
-	out, stderr, err := runner.Run(t.Context(), dir, nil, args...)
-	require.NoError(t, err, "git %v failed: %s%s", args, out, stderr)
-}
-
-func testGitSHA(t *testing.T, dir, ref string) string {
-	t.Helper()
-	out, err := gitcmd.New().Output(t.Context(), dir, "rev-parse", ref)
-	require.NoError(t, err)
-	return strings.TrimSpace(string(out))
-}
-
 func setupTestServerWithClones(t *testing.T) (
 	client *apiclient.Client,
 	database *db.DB,
@@ -23006,6 +22997,7 @@ func setupTestServerWithClonesAndServer(t *testing.T) (
 	srv *Server,
 ) {
 	t.Helper()
+	acquireRootWorkspaceGitSlot(t)
 
 	dir := t.TempDir()
 	database = dbtest.Open(t)
@@ -23020,33 +23012,33 @@ func setupTestServerWithClonesAndServer(t *testing.T) (
 	require.NoError(t, err)
 
 	tmpWork := filepath.Join(dir, "work")
-	runGit(t, dir, "init", "--bare", "--initial-branch=main", bare)
-	runGit(t, dir, "clone", bare, tmpWork)
-	runGit(t, tmpWork, "config", "user.email", "test@test.com")
-	runGit(t, tmpWork, "config", "user.name", "Test")
+	gitfixture.Run(t, dir, "init", "--bare", "--initial-branch=main", bare)
+	gitfixture.Run(t, dir, "clone", bare, tmpWork)
+	gitfixture.Run(t, tmpWork, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, tmpWork, "config", "user.name", "Test")
 
 	require.NoError(t, os.WriteFile(filepath.Join(tmpWork, "base.txt"), []byte("base\n"), 0o644))
-	runGit(t, tmpWork, "add", ".")
-	runGit(t, tmpWork, "commit", "-m", "base commit")
-	runGit(t, tmpWork, "push", "origin", "main")
-	mergeBase = testGitSHA(t, tmpWork, "HEAD")
+	gitfixture.Run(t, tmpWork, "add", ".")
+	gitfixture.Run(t, tmpWork, "commit", "-m", "base commit")
+	gitfixture.Run(t, tmpWork, "push", "origin", "main")
+	mergeBase = gitfixture.SHA(t, tmpWork, "HEAD")
 
-	runGit(t, tmpWork, "checkout", "-b", "pr")
+	gitfixture.Run(t, tmpWork, "checkout", "-b", "pr")
 	for i := 1; i <= 5; i++ {
 		fname := fmt.Sprintf("file%d.txt", i)
 		require.NoError(t, os.WriteFile(filepath.Join(tmpWork, fname), fmt.Appendf(nil, "content %d\n", i), 0o644))
-		runGit(t, tmpWork, "add", ".")
-		runGit(t, tmpWork, "commit", "-m", fmt.Sprintf("commit %d", i))
+		gitfixture.Run(t, tmpWork, "add", ".")
+		gitfixture.Run(t, tmpWork, "commit", "-m", fmt.Sprintf("commit %d", i))
 	}
-	runGit(t, tmpWork, "push", "origin", "pr")
-	headSHA = testGitSHA(t, tmpWork, "HEAD")
+	gitfixture.Run(t, tmpWork, "push", "origin", "pr")
+	headSHA = gitfixture.SHA(t, tmpWork, "HEAD")
 
 	// Collect SHAs newest-first.
 	commitSHAs = make([]string, 5)
 	sha := headSHA
 	for i := range 5 {
 		commitSHAs[i] = sha
-		sha = testGitSHA(t, tmpWork, sha+"^1")
+		sha = gitfixture.SHA(t, tmpWork, sha+"^1")
 	}
 
 	mock := &mockGH{}
@@ -23204,6 +23196,7 @@ func TestAPIGetFilePreview_ReturnsHeadContent(t *testing.T) {
 
 func TestAPIGetFilePreview_ReturnsDeletedFileContent(t *testing.T) {
 	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -23247,6 +23240,7 @@ func TestAPIGetFilePreview_ReturnsDeletedFileContent(t *testing.T) {
 
 func TestAPIGetFilePreview_ReturnsRequestedDiffSideContent(t *testing.T) {
 	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -23370,6 +23364,7 @@ func TestAPIGetDiff_FromWithoutTo(t *testing.T) {
 
 func TestAPIGetDiff_RootCommit(t *testing.T) {
 	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
 	require := require.New(t)
 
 	dir := t.TempDir()
@@ -23384,21 +23379,21 @@ func TestAPIGetDiff_RootCommit(t *testing.T) {
 	)
 	require.NoError(err)
 	tmpWork := filepath.Join(dir, "work")
-	runGit(t, dir, "init", "--bare", "--initial-branch=main", bare)
-	runGit(t, dir, "clone", bare, tmpWork)
-	runGit(t, tmpWork, "config", "user.email", "test@test.com")
-	runGit(t, tmpWork, "config", "user.name", "Test")
+	gitfixture.Run(t, dir, "init", "--bare", "--initial-branch=main", bare)
+	gitfixture.Run(t, dir, "clone", bare, tmpWork)
+	gitfixture.Run(t, tmpWork, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, tmpWork, "config", "user.name", "Test")
 
 	require.NoError(os.WriteFile(filepath.Join(tmpWork, "root.txt"), []byte("root\n"), 0o644))
-	runGit(t, tmpWork, "add", ".")
-	runGit(t, tmpWork, "commit", "-m", "root commit")
-	rootSHA := testGitSHA(t, tmpWork, "HEAD")
+	gitfixture.Run(t, tmpWork, "add", ".")
+	gitfixture.Run(t, tmpWork, "commit", "-m", "root commit")
+	rootSHA := gitfixture.SHA(t, tmpWork, "HEAD")
 
 	require.NoError(os.WriteFile(filepath.Join(tmpWork, "second.txt"), []byte("second\n"), 0o644))
-	runGit(t, tmpWork, "add", ".")
-	runGit(t, tmpWork, "commit", "-m", "second commit")
-	runGit(t, tmpWork, "push", "origin", "main")
-	headSHA := testGitSHA(t, tmpWork, "HEAD")
+	gitfixture.Run(t, tmpWork, "add", ".")
+	gitfixture.Run(t, tmpWork, "commit", "-m", "second commit")
+	gitfixture.Run(t, tmpWork, "push", "origin", "main")
+	headSHA := gitfixture.SHA(t, tmpWork, "HEAD")
 
 	mock := &mockGH{}
 	repos := []ghclient.RepoRef{{Owner: "acme", Name: "rootrepo", PlatformHost: "github.com"}}
@@ -24702,16 +24697,17 @@ func TestAPIListActivityCapsDefaultBranchCommitMetadata(t *testing.T) {
 
 func TestAPIListActivityReflectsConfiguredDefaultBranchCommitCap(t *testing.T) {
 	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
 	dir := t.TempDir()
 	remote := filepath.Join(dir, "remote.git")
 	work := filepath.Join(dir, "work")
-	runGit(t, dir, "init", "--bare", "--initial-branch=main", remote)
-	runGit(t, dir, "clone", remote, work)
-	runGit(t, work, "config", "user.email", "alice@example.com")
-	runGit(t, work, "config", "user.name", "Alice")
+	gitfixture.Run(t, dir, "init", "--bare", "--initial-branch=main", remote)
+	gitfixture.Run(t, dir, "clone", remote, work)
+	gitfixture.Run(t, work, "config", "user.email", "alice@example.com")
+	gitfixture.Run(t, work, "config", "user.name", "Alice")
 
 	shas := map[string]string{}
 	for _, subject := range []string{"oldest", "third", "second", "newest"} {
@@ -24720,11 +24716,11 @@ func TestAPIListActivityReflectsConfiguredDefaultBranchCommitCap(t *testing.T) {
 			[]byte(subject+"\n"),
 			0o644,
 		))
-		runGit(t, work, "add", ".")
-		runGit(t, work, "commit", "-m", subject)
-		shas[subject] = testGitSHA(t, work, "HEAD")
+		gitfixture.Run(t, work, "add", ".")
+		gitfixture.Run(t, work, "commit", "-m", subject)
+		shas[subject] = gitfixture.SHA(t, work, "HEAD")
 	}
-	runGit(t, work, "push", "origin", "main")
+	gitfixture.Run(t, work, "push", "origin", "main")
 
 	database := dbtest.Open(t)
 	clones := gitclone.New(filepath.Join(dir, "clones"), nil)
@@ -26102,33 +26098,33 @@ func setupWorkspaceServerFixtureWithMockHostAndOptions(
 	remoteDir := filepath.Join(dir, "remote")
 	require.NoError(t, os.MkdirAll(remoteDir, 0o755))
 	remote := filepath.Join(remoteDir, "widget.git")
-	runGit(
+	gitfixture.Run(
 		t, dir, "init", "--bare", "--initial-branch=main", remote,
 	)
 
 	tmpWork := filepath.Join(dir, "work")
-	runGit(t, dir, "clone", remote, tmpWork)
-	runGit(t, tmpWork, "config", "user.email", "test@test.com")
-	runGit(t, tmpWork, "config", "user.name", "Test")
+	gitfixture.Run(t, dir, "clone", remote, tmpWork)
+	gitfixture.Run(t, tmpWork, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, tmpWork, "config", "user.name", "Test")
 
 	require.NoError(t, os.WriteFile(
 		filepath.Join(tmpWork, "base.txt"),
 		[]byte("base\n"), 0o644,
 	))
-	runGit(t, tmpWork, "add", ".")
-	runGit(t, tmpWork, "commit", "-m", "base commit")
-	runGit(t, tmpWork, "push", "origin", "main")
+	gitfixture.Run(t, tmpWork, "add", ".")
+	gitfixture.Run(t, tmpWork, "commit", "-m", "base commit")
+	gitfixture.Run(t, tmpWork, "push", "origin", "main")
 
-	runGit(t, tmpWork, "checkout", "-b", "feature")
+	gitfixture.Run(t, tmpWork, "checkout", "-b", "feature")
 	require.NoError(t, os.WriteFile(
 		filepath.Join(tmpWork, "new.txt"),
 		[]byte("new\n"), 0o644,
 	))
-	runGit(t, tmpWork, "add", ".")
-	runGit(t, tmpWork, "commit", "-m", "feature commit")
-	runGit(t, tmpWork, "push", "origin", "feature")
+	gitfixture.Run(t, tmpWork, "add", ".")
+	gitfixture.Run(t, tmpWork, "commit", "-m", "feature commit")
+	gitfixture.Run(t, tmpWork, "push", "origin", "feature")
 	featureSHA := gitOutput(t, tmpWork, "rev-parse", "HEAD")
-	runGit(t, remote, "update-ref", "refs/pull/1/head", featureSHA)
+	gitfixture.Run(t, remote, "update-ref", "refs/pull/1/head", featureSHA)
 
 	bareDir := filepath.Join(dir, "clones")
 	require.NoError(t, os.MkdirAll(bareDir, 0o755))
@@ -26138,8 +26134,8 @@ func setupWorkspaceServerFixtureWithMockHostAndOptions(
 		"github", platformHost, "acme", "widget",
 	)
 	require.NoError(t, err)
-	runGit(t, dir, "clone", "--bare", remote, bare)
-	runGit(t, bare, "remote", "set-url", "origin", gitLocalRemoteURL(remote))
+	gitfixture.Run(t, dir, "clone", "--bare", remote, bare)
+	gitfixture.Run(t, bare, "remote", "set-url", "origin", gitLocalRemoteURL(remote))
 
 	worktreeDir := filepath.Join(dir, "worktrees")
 	repos := []ghclient.RepoRef{
@@ -28454,22 +28450,6 @@ func TestMergeWorkspaceCleanupDeletesWorkspaceAfterConfirmedMerge(t *testing.T) 
 	assert.ErrorIs(err, os.ErrNotExist)
 }
 
-func requireWorkspaceDiffFile(
-	t *testing.T,
-	files []generated.DiffFile,
-	path string,
-) generated.DiffFile {
-	t.Helper()
-
-	for _, file := range files {
-		if file.Path == path {
-			return file
-		}
-	}
-	require.Failf(t, "workspace diff file not found", "path %q", path)
-	return generated.DiffFile{}
-}
-
 func TestWorkspaceListPrunesMissingTmuxSessionsE2E(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -29525,17 +29505,17 @@ func TestWorkspaceManualRefreshDiscoversAndSyncsAssociatedPR(t *testing.T) {
 		[]byte("feature\n"),
 		0o644,
 	))
-	runGit(t, ready.WorktreePath, "config", "user.email", "test@test.com")
-	runGit(t, ready.WorktreePath, "config", "user.name", "Test")
-	runGit(t, ready.WorktreePath, "add", ".")
-	runGit(t, ready.WorktreePath, "commit", "-m", "feature commit")
-	runGit(t, ready.WorktreePath, "push", "-u", "origin", ready.GitHeadRef)
-	runGit(
+	gitfixture.Run(t, ready.WorktreePath, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, ready.WorktreePath, "config", "user.name", "Test")
+	gitfixture.Run(t, ready.WorktreePath, "add", ".")
+	gitfixture.Run(t, ready.WorktreePath, "commit", "-m", "feature commit")
+	gitfixture.Run(t, ready.WorktreePath, "push", "-u", "origin", ready.GitHeadRef)
+	gitfixture.Run(
 		t, ready.WorktreePath,
 		"remote", "set-url", "origin", "git@github.com:acme/widget.git",
 	)
 	headRef = ready.GitHeadRef
-	headSHA = testGitSHA(t, ready.WorktreePath, "HEAD")
+	headSHA = gitfixture.SHA(t, ready.WorktreePath, "HEAD")
 
 	refreshRR := testutil.DoJSON(
 		t,
@@ -29637,23 +29617,23 @@ func TestKataWorkspaceManualRefreshDiscoversAndSyncsAssociatedPR(t *testing.T) {
 	)
 
 	worktreePath := filepath.Join(t.TempDir(), "kata-worktree")
-	runGit(t, t.TempDir(), "clone", fixture.remote, worktreePath)
-	runGit(t, worktreePath, "config", "user.email", "test@test.com")
-	runGit(t, worktreePath, "config", "user.name", "Test")
-	runGit(t, worktreePath, "checkout", "-b", headRef)
+	gitfixture.Run(t, t.TempDir(), "clone", fixture.remote, worktreePath)
+	gitfixture.Run(t, worktreePath, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, worktreePath, "config", "user.name", "Test")
+	gitfixture.Run(t, worktreePath, "checkout", "-b", headRef)
 	require.NoError(os.WriteFile(
 		filepath.Join(worktreePath, "feature.txt"),
 		[]byte("feature\n"),
 		0o644,
 	))
-	runGit(t, worktreePath, "add", ".")
-	runGit(t, worktreePath, "commit", "-m", "feature commit")
-	runGit(t, worktreePath, "push", "-u", "origin", headRef)
-	runGit(
+	gitfixture.Run(t, worktreePath, "add", ".")
+	gitfixture.Run(t, worktreePath, "commit", "-m", "feature commit")
+	gitfixture.Run(t, worktreePath, "push", "-u", "origin", headRef)
+	gitfixture.Run(
 		t, worktreePath,
 		"remote", "set-url", "origin", "git@github.com:acme/widget.git",
 	)
-	headSHA = testGitSHA(t, worktreePath, "HEAD")
+	headSHA = gitfixture.SHA(t, worktreePath, "HEAD")
 	kataMetadata := db.WorkspaceKataMetadata{
 		DaemonID:   "local",
 		ProjectUID: "project-1",
@@ -30118,14 +30098,14 @@ func TestWorkspaceCreateWithLocalBaseUsesPullRefWhenHeadBranchDeleted(
 	localRepo, remote, platformHost := setupHTTPWorktreeBaseForServerTest(
 		t, "feature",
 	)
-	wantSHA := testGitSHA(t, localRepo, "refs/remotes/origin/feature")
-	runGit(
+	wantSHA := gitfixture.SHA(t, localRepo, "refs/remotes/origin/feature")
+	gitfixture.Run(
 		t, remote, "update-ref",
 		fmt.Sprintf("refs/pull/%d/head", prNumber), wantSHA,
 	)
-	runGit(t, remote, "update-ref", "-d", "refs/heads/feature")
-	runGit(t, remote, "update-server-info")
-	runGit(t, localRepo, "fetch", "--prune", "origin")
+	gitfixture.Run(t, remote, "update-ref", "-d", "refs/heads/feature")
+	gitfixture.Run(t, remote, "update-server-info")
+	gitfixture.Run(t, localRepo, "fetch", "--prune", "origin")
 
 	cfg := &config.Config{Repos: []config.Repo{{
 		Platform:         "github",
@@ -30162,7 +30142,7 @@ func TestWorkspaceCreateWithLocalBaseUsesPullRefWhenHeadBranchDeleted(
 	require.NotNil(stored)
 	assert.Equal("ready", stored.Status)
 	assert.Equal(syntheticPRWorktreeBranchForTest(prNumber), stored.WorkspaceBranch)
-	assert.Equal(wantSHA, testGitSHA(t, ready.WorktreePath, "HEAD"))
+	assert.Equal(wantSHA, gitfixture.SHA(t, ready.WorktreePath, "HEAD"))
 	assert.Equal(
 		syntheticPRWorktreeBranchForTest(prNumber),
 		gitOutput(t, ready.WorktreePath, "branch", "--show-current"),
@@ -30183,19 +30163,19 @@ func TestWorkspaceCreateGitLabUsesSpecificMergeRequestHeadRefE2E(
 	localRepo, remote, platformHost := setupHTTPWorktreeBaseForServerTest(
 		t, "feature",
 	)
-	runGit(t, localRepo, "checkout", "-b", headBranch, "main")
+	gitfixture.Run(t, localRepo, "checkout", "-b", headBranch, "main")
 	require.NoError(os.WriteFile(
 		filepath.Join(localRepo, "gitlab-mr.txt"),
 		[]byte("gitlab mr head\n"), 0o644,
 	))
-	runGit(t, localRepo, "add", ".")
-	runGit(t, localRepo, "commit", "-m", "gitlab mr head")
-	wantSHA := testGitSHA(t, localRepo, "HEAD")
-	runGit(
+	gitfixture.Run(t, localRepo, "add", ".")
+	gitfixture.Run(t, localRepo, "commit", "-m", "gitlab mr head")
+	wantSHA := gitfixture.SHA(t, localRepo, "HEAD")
+	gitfixture.Run(
 		t, localRepo, "push", remote,
 		fmt.Sprintf("HEAD:refs/merge-requests/%d/head", mrNumber),
 	)
-	runGit(t, remote, "update-server-info")
+	gitfixture.Run(t, remote, "update-server-info")
 
 	fixture := setupWorkspaceServerFixtureWithHost(t, nil, platformHost)
 	ctx := t.Context()
@@ -30246,7 +30226,7 @@ func TestWorkspaceCreateGitLabUsesSpecificMergeRequestHeadRefE2E(
 		syntheticPRWorktreeBranchForTest(mrNumber),
 		gitOutput(t, ready.WorktreePath, "branch", "--show-current"),
 	)
-	assert.Equal(wantSHA, testGitSHA(t, ready.WorktreePath, "HEAD"))
+	assert.Equal(wantSHA, gitfixture.SHA(t, ready.WorktreePath, "HEAD"))
 }
 
 func TestWorkspaceCreateReusesExistingWorktreeThroughAPI(t *testing.T) {
@@ -30279,11 +30259,11 @@ func TestWorkspaceCreateReusesExistingWorktreeThroughAPI(t *testing.T) {
 		fixture.worktrees, "github", platformHost, "acme", "widget",
 		fmt.Sprintf("repo-%d", repoID), fmt.Sprintf("pr-%d", prNumber),
 	)
-	runGit(
+	gitfixture.Run(
 		t, localRepo,
 		"worktree", "add", worktreePath, "-b", existingBranch, "main",
 	)
-	wantSHA := testGitSHA(t, worktreePath, "HEAD")
+	wantSHA := gitfixture.SHA(t, worktreePath, "HEAD")
 	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
@@ -30306,7 +30286,7 @@ func TestWorkspaceCreateReusesExistingWorktreeThroughAPI(t *testing.T) {
 	assert.Equal(worktreePath, stored.WorktreePath)
 	assert.Equal(existingBranch, stored.WorkspaceBranch)
 	assert.Equal(worktreePath, ready.WorktreePath)
-	assert.Equal(wantSHA, testGitSHA(t, ready.WorktreePath, "HEAD"))
+	assert.Equal(wantSHA, gitfixture.SHA(t, ready.WorktreePath, "HEAD"))
 	assert.Equal(existingBranch, gitOutput(t, ready.WorktreePath, "branch", "--show-current"))
 }
 
@@ -30339,12 +30319,12 @@ func TestWorkspaceRetryReusesExistingLocalHeadBranchThroughAPI(t *testing.T) {
 		fixture.worktrees, "github", platformHost, "acme", "widget",
 		fmt.Sprintf("repo-%d", repoID), fmt.Sprintf("pr-%d", prNumber),
 	)
-	runGit(
+	gitfixture.Run(
 		t, localRepo,
 		"worktree", "add", worktreePath,
 		"-b", "feature", "refs/remotes/origin/feature",
 	)
-	wantSHA := testGitSHA(t, worktreePath, "HEAD")
+	wantSHA := gitfixture.SHA(t, worktreePath, "HEAD")
 	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
@@ -30365,7 +30345,7 @@ func TestWorkspaceRetryReusesExistingLocalHeadBranchThroughAPI(t *testing.T) {
 	assert.Equal("ready", stored.Status)
 	assert.Empty(stored.WorkspaceBranch)
 	assert.Equal("feature", gitOutput(t, ready.WorktreePath, "branch", "--show-current"))
-	assert.Equal(wantSHA, testGitSHA(t, ready.WorktreePath, "HEAD"))
+	assert.Equal(wantSHA, gitfixture.SHA(t, ready.WorktreePath, "HEAD"))
 
 	msg := "retry existing local base worktree"
 	require.NoError(fixture.database.UpdateWorkspaceStatus(
@@ -30384,7 +30364,7 @@ func TestWorkspaceRetryReusesExistingLocalHeadBranchThroughAPI(t *testing.T) {
 	assert.Empty(stored.WorkspaceBranch)
 	assert.Equal(worktreePath, stored.WorktreePath)
 	assert.Equal("feature", gitOutput(t, retried.WorktreePath, "branch", "--show-current"))
-	assert.Equal(wantSHA, testGitSHA(t, retried.WorktreePath, "HEAD"))
+	assert.Equal(wantSHA, gitfixture.SHA(t, retried.WorktreePath, "HEAD"))
 
 	force := true
 	deleteResp, err := fixture.client.HTTP.DeleteWorkspaceWithResponse(
@@ -30392,7 +30372,7 @@ func TestWorkspaceRetryReusesExistingLocalHeadBranchThroughAPI(t *testing.T) {
 	)
 	require.NoError(err)
 	require.Equal(http.StatusNoContent, deleteResp.StatusCode())
-	assert.Equal(wantSHA, testGitSHA(t, localRepo, "refs/heads/feature"))
+	assert.Equal(wantSHA, gitfixture.SHA(t, localRepo, "refs/heads/feature"))
 }
 
 func syntheticPRWorktreeBranchForTest(mrNumber int) string {
@@ -30408,7 +30388,7 @@ func setupHTTPWorktreeBaseForServerTest(
 	remote = filepath.Join(root, "acme", "widget.git")
 	repo = filepath.Join(root, "repo")
 	require.NoError(t, os.MkdirAll(filepath.Dir(remote), 0o755))
-	runGit(t, root, "init", "--bare", "--initial-branch=main", remote)
+	gitfixture.Run(t, root, "init", "--bare", "--initial-branch=main", remote)
 	server := httptest.NewServer(http.FileServer(http.Dir(root)))
 	t.Cleanup(server.Close)
 	remoteURL := server.URL + "/acme/widget.git"
@@ -30416,22 +30396,22 @@ func setupHTTPWorktreeBaseForServerTest(
 	require.NoError(t, err)
 	platformHost = parsed.Host
 
-	runGit(t, root, "init", "--initial-branch=main", repo)
-	runGit(t, repo, "config", "user.email", "test@test.com")
-	runGit(t, repo, "config", "user.name", "Test")
-	runGit(t, repo, "remote", "add", "origin", remote)
+	gitfixture.Run(t, root, "init", "--initial-branch=main", repo)
+	gitfixture.Run(t, repo, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, repo, "config", "user.name", "Test")
+	gitfixture.Run(t, repo, "remote", "add", "origin", remote)
 	require.NoError(t, os.WriteFile(
 		filepath.Join(repo, "base.txt"), []byte("base\n"), 0o644,
 	))
-	runGit(t, repo, "add", ".")
-	runGit(t, repo, "commit", "-m", "base commit")
-	runGit(t, repo, "push", "origin", "HEAD:refs/heads/main")
-	runGit(t, remote, "symbolic-ref", "HEAD", "refs/heads/main")
-	runGit(t, repo, "push", "origin", "HEAD:refs/heads/"+branch)
-	runGit(t, remote, "update-server-info")
-	runGit(t, repo, "remote", "set-url", "origin", remoteURL)
-	runGit(t, repo, "fetch", "--prune", "origin")
-	runGit(
+	gitfixture.Run(t, repo, "add", ".")
+	gitfixture.Run(t, repo, "commit", "-m", "base commit")
+	gitfixture.Run(t, repo, "push", "origin", "HEAD:refs/heads/main")
+	gitfixture.Run(t, remote, "symbolic-ref", "HEAD", "refs/heads/main")
+	gitfixture.Run(t, repo, "push", "origin", "HEAD:refs/heads/"+branch)
+	gitfixture.Run(t, remote, "update-server-info")
+	gitfixture.Run(t, repo, "remote", "set-url", "origin", remoteURL)
+	gitfixture.Run(t, repo, "fetch", "--prune", "origin")
+	gitfixture.Run(
 		t, repo, "symbolic-ref",
 		"refs/remotes/origin/HEAD", "refs/remotes/origin/main",
 	)
@@ -30450,8 +30430,8 @@ func TestWorkspaceCreatePortQualifiedHostTracksOriginBranchE2E(t *testing.T) {
 	)
 	ctx := t.Context()
 
-	headSHA := testGitSHA(t, fixture.remote, "refs/heads/feature")
-	runGit(t, fixture.remote, "update-ref", "refs/pull/1/head", headSHA)
+	headSHA := gitfixture.SHA(t, fixture.remote, "refs/heads/feature")
+	gitfixture.Run(t, fixture.remote, "update-ref", "refs/pull/1/head", headSHA)
 	_, err := fixture.database.WriteDB().ExecContext(
 		ctx,
 		`UPDATE forge_merge_requests
@@ -30502,20 +30482,20 @@ func TestWorkspaceDeleteDoesNotCleanupReplacementCloneFromStaleLocalBaseE2E(t *t
 	ctx := t.Context()
 	const branch = "kenn-forge/pr-42"
 	localRepo := filepath.Join(t.TempDir(), "local-base")
-	runGit(t, filepath.Dir(localRepo), "clone", remotePath, localRepo)
+	gitfixture.Run(t, filepath.Dir(localRepo), "clone", remotePath, localRepo)
 	replacementClone := filepath.Join(t.TempDir(), "replacement-clone")
-	runGit(
+	gitfixture.Run(
 		t, localRepo,
 		"worktree", "add", replacementClone, "-b", branch, "HEAD",
 	)
 	require.NoError(os.RemoveAll(replacementClone))
-	runGit(t, filepath.Dir(replacementClone), "clone", remotePath, replacementClone)
-	runGit(
+	gitfixture.Run(t, filepath.Dir(replacementClone), "clone", remotePath, replacementClone)
+	gitfixture.Run(
 		t, replacementClone, "remote", "set-url", "origin",
 		"https://github.com/acme/widget.git",
 	)
-	runGit(t, replacementClone, "branch", branch, "HEAD")
-	branchSHA := testGitSHA(t, replacementClone, "refs/heads/"+branch)
+	gitfixture.Run(t, replacementClone, "branch", branch, "HEAD")
+	branchSHA := gitfixture.SHA(t, replacementClone, "refs/heads/"+branch)
 
 	srv.cfgMu.Lock()
 	srv.cfg.Repos = []config.Repo{{
@@ -30551,7 +30531,7 @@ func TestWorkspaceDeleteDoesNotCleanupReplacementCloneFromStaleLocalBaseE2E(t *t
 	require.NoError(err)
 	require.Equal(http.StatusNoContent, deleteResp.StatusCode())
 	assert.DirExists(replacementClone)
-	assert.Equal(branchSHA, testGitSHA(t, replacementClone, "refs/heads/"+branch))
+	assert.Equal(branchSHA, gitfixture.SHA(t, replacementClone, "refs/heads/"+branch))
 	got, err := database.GetWorkspace(ctx, wsID)
 	require.NoError(err)
 	assert.Nil(got)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -51,7 +51,6 @@ import (
 	platformgitlab "go.kenn.io/forge/internal/platform/gitlab"
 	"go.kenn.io/forge/internal/procutil"
 	"go.kenn.io/forge/internal/ptyowner"
-	"go.kenn.io/forge/internal/ptysize"
 	"go.kenn.io/forge/internal/server/httpapi"
 	"go.kenn.io/forge/internal/server/issueapi"
 	"go.kenn.io/forge/internal/server/pullapi"
@@ -78,6 +77,7 @@ const (
 
 var (
 	privateTmuxOwner        *testtmux.Owner
+	parallelServerTestSlots = semaphore.NewWeighted(4)
 	ptyE2ESemaphore         = semaphore.NewWeighted(1)
 	serverPtyOwnerParentPID = flag.Int(
 		"server-pty-owner-parent-pid",
@@ -147,9 +147,15 @@ func isServerHelperProcess() bool {
 			args[0] == "pty-owner")
 }
 
-func runParallelPTYE2E(t *testing.T) {
+func runParallelServerTest(t *testing.T) {
 	t.Helper()
 	t.Parallel()
+	require.NoError(t, parallelServerTestSlots.Acquire(t.Context(), 1))
+	t.Cleanup(func() { parallelServerTestSlots.Release(1) })
+}
+
+func runSerialPTYE2E(t *testing.T) {
+	t.Helper()
 	releasePTYSlot := acquirePTYE2ESlot(t)
 	t.Cleanup(releasePTYSlot)
 }
@@ -1213,9 +1219,15 @@ func setupTestServerWithReposAndOptions(
 	// cleanup so LIFO ordering runs Stop first: without this, a
 	// leaked goroutine from one test's handler can outlive its DB.
 	t.Cleanup(syncer.Stop)
+	var cfg *config.Config
+	if options.WorktreeDir != "" {
+		cfg = &config.Config{Tmux: config.Tmux{
+			Command: []string{filepath.Join(t.TempDir(), "missing-tmux")},
+		}}
+	}
 	srv := New(
 		database, syncer, nil, "/",
-		nil, options,
+		cfg, options,
 	)
 	// Registered after the DB cleanup so LIFO ordering runs Shutdown
 	// first and lets background goroutines finish before DB close.
@@ -1515,6 +1527,7 @@ func seedPRWithHeadSHA(t *testing.T, database *db.DB, owner, name string, number
 }
 
 func TestAPIReplyToGitHubReviewThreadUsesProviderCommentID(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -1618,6 +1631,7 @@ func TestAPIReplyToGitHubReviewThreadUsesProviderCommentID(t *testing.T) {
 }
 
 func TestAPIMergePR405ReturnsGitHubMessage(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	mock := &mockGH{
@@ -1649,6 +1663,7 @@ func TestAPIMergePR405ReturnsGitHubMessage(t *testing.T) {
 }
 
 func TestAPIMergePR409ReturnsGitHubMessage(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	mock := &mockGH{
@@ -1680,6 +1695,7 @@ func TestAPIMergePR409ReturnsGitHubMessage(t *testing.T) {
 }
 
 func TestAPIMergePRNetworkErrorReturns502(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	mock := &mockGH{
@@ -1708,6 +1724,7 @@ func TestAPIMergePRNetworkErrorReturns502(t *testing.T) {
 }
 
 func TestAPIMergePR422ForwardsGitHubMessage(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	mock := &mockGH{
@@ -1739,6 +1756,7 @@ func TestAPIMergePR422ForwardsGitHubMessage(t *testing.T) {
 }
 
 func TestAPIMergePR403ForwardsGitHubMessage(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	mock := &mockGH{
@@ -1770,6 +1788,7 @@ func TestAPIMergePR403ForwardsGitHubMessage(t *testing.T) {
 }
 
 func TestAPIMergePR5xxReturns502WithGitHubMessage(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	mock := &mockGH{
@@ -1856,6 +1875,7 @@ func TestAPIMergePRForwardsGitHubErrorDetailsAndLogsError(t *testing.T) {
 }
 
 func TestAPIMergePRStoresUTCTimestamps(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	// The provider reports the merge in a non-UTC zone; the canonical
@@ -1896,6 +1916,7 @@ func TestAPIMergePRStoresUTCTimestamps(t *testing.T) {
 }
 
 func TestAPIGetVersionReturnsBuildMetadata(t *testing.T) {
+	runParallelServerTest(t)
 	srv, _ := setupTestServer(t)
 	srv.SetBuildInfo(BuildInfo{
 		Name:      "kenn-forge",
@@ -1919,6 +1940,7 @@ func TestAPIGetVersionReturnsBuildMetadata(t *testing.T) {
 }
 
 func TestAPIListPulls(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
 	seedPR(t, database, "acme", "widget", 1)
@@ -1934,7 +1956,7 @@ func TestAPIListPulls(t *testing.T) {
 	assert.Equal("widget", (*resp.JSON200)[0].RepoName)
 	assert.Equal("github.com", (*resp.JSON200)[0].PlatformHost)
 
-	raw := doJSON(t, srv, http.MethodGet, "/api/v1/pulls", nil)
+	raw := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/pulls", nil)
 	require.Equal(http.StatusOK, raw.Code)
 	var body []struct {
 		Repo httpapi.RepoRefResponse `json:"repo"`
@@ -1947,6 +1969,7 @@ func TestAPIListPulls(t *testing.T) {
 }
 
 func TestAPIInvolvesMeFiltersPullsIssuesAndActivity(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	mock := &mockGH{
@@ -1974,21 +1997,21 @@ func TestAPIInvolvesMeFiltersPullsIssuesAndActivity(t *testing.T) {
 	})
 	require.NoError(err)
 
-	pullsRR := doJSON(t, srv, http.MethodGet, "/api/v1/pulls?state=all&involves_me=true", nil)
+	pullsRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/pulls?state=all&involves_me=true", nil)
 	require.Equal(http.StatusOK, pullsRR.Code, pullsRR.Body.String())
 	var pulls []pullapi.MergeRequestResponse
 	require.NoError(json.Unmarshal(pullsRR.Body.Bytes(), &pulls))
 	require.Len(pulls, 1)
 	assert.Equal(1, pulls[0].Number)
 
-	issuesRR := doJSON(t, srv, http.MethodGet, "/api/v1/issues?state=all&involves_me=true", nil)
+	issuesRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/issues?state=all&involves_me=true", nil)
 	require.Equal(http.StatusOK, issuesRR.Code, issuesRR.Body.String())
 	var issues []issueapi.IssueResponse
 	require.NoError(json.Unmarshal(issuesRR.Body.Bytes(), &issues))
 	require.Len(issues, 1)
 	assert.Equal(3, issues[0].Number)
 
-	activityRR := doJSON(t, srv, http.MethodGet, "/api/v1/activity?involves_me=true", nil)
+	activityRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/activity?involves_me=true", nil)
 	require.Equal(http.StatusOK, activityRR.Code, activityRR.Body.String())
 	var activity activityResponse
 	require.NoError(json.Unmarshal(activityRR.Body.Bytes(), &activity))
@@ -2020,21 +2043,21 @@ func TestAPIUnassignedFiltersPullsIssuesAndActivity(t *testing.T) {
 	assignedIssueID := seedIssue(t, database, "acme", "widget", 4, "open")
 	require.NoError(database.UpdateIssueAssignees(ctx, repo.ID, assignedIssueID, []string{"bob"}))
 
-	pullsRR := doJSON(t, srv, http.MethodGet, "/api/v1/pulls?state=all&unassigned=true", nil)
+	pullsRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/pulls?state=all&unassigned=true", nil)
 	require.Equal(http.StatusOK, pullsRR.Code, pullsRR.Body.String())
 	var pulls []pullapi.MergeRequestResponse
 	require.NoError(json.Unmarshal(pullsRR.Body.Bytes(), &pulls))
 	require.Len(pulls, 1)
 	assert.Equal(1, pulls[0].Number)
 
-	issuesRR := doJSON(t, srv, http.MethodGet, "/api/v1/issues?state=all&unassigned=true", nil)
+	issuesRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/issues?state=all&unassigned=true", nil)
 	require.Equal(http.StatusOK, issuesRR.Code, issuesRR.Body.String())
 	var issues []issueapi.IssueResponse
 	require.NoError(json.Unmarshal(issuesRR.Body.Bytes(), &issues))
 	require.Len(issues, 1)
 	assert.Equal(3, issues[0].Number)
 
-	activityRR := doJSON(t, srv, http.MethodGet, "/api/v1/activity?unassigned=true", nil)
+	activityRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/activity?unassigned=true", nil)
 	require.Equal(http.StatusOK, activityRR.Code, activityRR.Body.String())
 	var activity activityResponse
 	require.NoError(json.Unmarshal(activityRR.Body.Bytes(), &activity))
@@ -2048,6 +2071,7 @@ func TestAPIUnassignedFiltersPullsIssuesAndActivity(t *testing.T) {
 }
 
 func TestAPIListIssuesFiltersPullRequestReferences(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
 	referencedID := seedIssue(t, database, "acme", "widget", 1, "open")
@@ -2066,7 +2090,7 @@ func TestAPIListIssuesFiltersPullRequestReferences(t *testing.T) {
 		DedupeKey: "cross-reference-42",
 	}}))
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/issues?state=all&referenced_by_pr=true", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/issues?state=all&referenced_by_pr=true", nil)
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	var issues []issueapi.IssueResponse
 	require.NoError(json.Unmarshal(rr.Body.Bytes(), &issues))
@@ -2075,6 +2099,7 @@ func TestAPIListIssuesFiltersPullRequestReferences(t *testing.T) {
 }
 
 func TestAPIPullResponsesNormalizeMissingKanbanStateToNew(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	srv, database := setupTestServer(t)
@@ -2102,21 +2127,21 @@ func TestAPIPullResponsesNormalizeMissingKanbanStateToNew(t *testing.T) {
 	require.NoError(err)
 	require.Nil(kanbanState)
 
-	rawList := doJSON(t, srv, http.MethodGet, "/api/v1/pulls", nil)
+	rawList := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/pulls", nil)
 	require.Equal(http.StatusOK, rawList.Code)
 	var list []pullapi.MergeRequestResponse
 	require.NoError(json.Unmarshal(rawList.Body.Bytes(), &list))
 	require.Len(list, 1)
 	assert.Equal(db.KanbanStatusNew, list[0].KanbanStatus)
 
-	rawNewList := doJSON(t, srv, http.MethodGet, "/api/v1/pulls?kanban=new", nil)
+	rawNewList := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/pulls?kanban=new", nil)
 	require.Equal(http.StatusOK, rawNewList.Code)
 	var newList []pullapi.MergeRequestResponse
 	require.NoError(json.Unmarshal(rawNewList.Body.Bytes(), &newList))
 	require.Len(newList, 1)
 	assert.Equal(db.KanbanStatusNew, newList[0].KanbanStatus)
 
-	rawDetail := doJSON(t, srv, http.MethodGet, "/api/v1/pulls/gh/acme/widget/7", nil)
+	rawDetail := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/pulls/gh/acme/widget/7", nil)
 	require.Equal(http.StatusOK, rawDetail.Code)
 	var detail pullapi.MergeRequestDetailResponse
 	require.NoError(json.Unmarshal(rawDetail.Body.Bytes(), &detail))
@@ -2127,6 +2152,7 @@ func TestAPIPullResponsesNormalizeMissingKanbanStateToNew(t *testing.T) {
 // TestAPIGetPullIncludesCIChecks confirms the PR-detail response decodes the
 // merge request's cached ci_checks_json into a top-level checks array.
 func TestAPIGetPullIncludesCIChecks(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	srv, database := setupTestServer(t)
@@ -2155,7 +2181,7 @@ func TestAPIGetPullIncludesCIChecks(t *testing.T) {
 	})
 	require.NoError(err)
 
-	rawDetail := doJSON(t, srv, http.MethodGet, "/api/v1/pulls/gh/acme/widget/7", nil)
+	rawDetail := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/pulls/gh/acme/widget/7", nil)
 	require.Equal(http.StatusOK, rawDetail.Code)
 	var detail pullapi.MergeRequestDetailResponse
 	require.NoError(json.Unmarshal(rawDetail.Body.Bytes(), &detail))
@@ -2171,6 +2197,7 @@ func TestAPIGetPullIncludesCIChecks(t *testing.T) {
 // TestAPIGetPullToleratesMalformedCIChecks confirms a corrupt ci_checks_json
 // cache does not fail the detail response: checks are simply omitted.
 func TestAPIGetPullToleratesMalformedCIChecks(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
 	ctx := t.Context()
@@ -2195,7 +2222,7 @@ func TestAPIGetPullToleratesMalformedCIChecks(t *testing.T) {
 	})
 	require.NoError(err)
 
-	rawDetail := doJSON(t, srv, http.MethodGet, "/api/v1/pulls/gh/acme/widget/7", nil)
+	rawDetail := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/pulls/gh/acme/widget/7", nil)
 	require.Equal(http.StatusOK, rawDetail.Code)
 	var detail pullapi.MergeRequestDetailResponse
 	require.NoError(json.Unmarshal(rawDetail.Body.Bytes(), &detail))
@@ -2203,6 +2230,7 @@ func TestAPIGetPullToleratesMalformedCIChecks(t *testing.T) {
 }
 
 func TestAPIListItemsIncludeWorkspaceRefs(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	srv, database := setupTestServer(t)
@@ -2259,6 +2287,7 @@ func TestAPIListItemsIncludeWorkspaceRefs(t *testing.T) {
 }
 
 func TestAPIListPullsOrdersByLastActivityDescending(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
 	base := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
@@ -2285,6 +2314,7 @@ func TestAPIListPullsOrdersByLastActivityDescending(t *testing.T) {
 }
 
 func TestAPIListPullsUsesProviderActivityAfterIndexSync(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -2352,6 +2382,7 @@ func TestAPIListPullsUsesProviderActivityAfterIndexSync(t *testing.T) {
 }
 
 func TestAPISyncPRUsesProviderActivityAfterForcePush(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -2425,6 +2456,7 @@ func TestAPISyncPRUsesProviderActivityAfterForcePush(t *testing.T) {
 }
 
 func TestAPIListPullsKeepsCachedCIDecorationsAfterIndexSync(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -2475,6 +2507,7 @@ func TestAPIListPullsKeepsCachedCIDecorationsAfterIndexSync(t *testing.T) {
 }
 
 func TestAPIGitHubSyncPersistsReviewThreadsThroughPullDetail(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -2576,6 +2609,7 @@ func TestAPIGitHubSyncPersistsReviewThreadsThroughPullDetail(t *testing.T) {
 }
 
 func TestAPIRepoFilterAcceptsMultipleRepos(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	srv, database := setupTestServer(t)
@@ -2589,7 +2623,7 @@ func TestAPIRepoFilterAcceptsMultipleRepos(t *testing.T) {
 
 	filter := url.QueryEscape("github|github.com/acme/widget,github|github.com/acme/worker")
 
-	rawPulls := doJSON(t, srv, http.MethodGet, "/api/v1/pulls?repo="+filter, nil)
+	rawPulls := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/pulls?repo="+filter, nil)
 	require.Equal(http.StatusOK, rawPulls.Code)
 	var pulls []pullapi.MergeRequestResponse
 	require.NoError(json.Unmarshal(rawPulls.Body.Bytes(), &pulls))
@@ -2599,7 +2633,7 @@ func TestAPIRepoFilterAcceptsMultipleRepos(t *testing.T) {
 		pulls[1].RepoName,
 	})
 
-	rawIssues := doJSON(t, srv, http.MethodGet, "/api/v1/issues?repo="+filter, nil)
+	rawIssues := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/issues?repo="+filter, nil)
 	require.Equal(http.StatusOK, rawIssues.Code)
 	var issues []issueapi.IssueResponse
 	require.NoError(json.Unmarshal(rawIssues.Body.Bytes(), &issues))
@@ -2610,7 +2644,7 @@ func TestAPIRepoFilterAcceptsMultipleRepos(t *testing.T) {
 	})
 
 	since := url.QueryEscape(time.Now().UTC().Add(-time.Hour).Format(time.RFC3339))
-	rawActivity := doJSON(t, srv, http.MethodGet, "/api/v1/activity?since="+since+"&repo="+filter, nil)
+	rawActivity := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/activity?since="+since+"&repo="+filter, nil)
 	require.Equal(http.StatusOK, rawActivity.Code)
 	var activity activityResponse
 	require.NoError(json.Unmarshal(rawActivity.Body.Bytes(), &activity))
@@ -2621,6 +2655,7 @@ func TestAPIRepoFilterAcceptsMultipleRepos(t *testing.T) {
 }
 
 func TestAPIGetPullIsDBOnly(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	mock := &mockGH{
@@ -2657,6 +2692,7 @@ func TestAPIGetPullIsDBOnly(t *testing.T) {
 }
 
 func TestAPIGetPullIncludesLifecycleTimelineEvents(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	srv, database := setupTestServer(t)
@@ -2806,6 +2842,7 @@ func TestAPIGetPullIncludesLifecycleTimelineEvents(t *testing.T) {
 }
 
 func TestAPISyncPRIncludesWorkflowApproval(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	mock := &mockGH{
@@ -2861,6 +2898,7 @@ func TestAPISyncPRIncludesWorkflowApproval(t *testing.T) {
 }
 
 func TestAPISyncPRPersistsMergeableState(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	now := time.Now().UTC().Truncate(time.Second)
@@ -2911,6 +2949,7 @@ func TestAPISyncPRPersistsMergeableState(t *testing.T) {
 }
 
 func TestAPISyncPRPersistsMergedActorInDetail(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -2973,6 +3012,7 @@ func TestAPISyncPRPersistsMergedActorInDetail(t *testing.T) {
 }
 
 func TestAPIIndexSyncPersistsMergedActorForImmediateDetail(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -3058,6 +3098,7 @@ func TestAPIIndexSyncPersistsMergedActorForImmediateDetail(t *testing.T) {
 }
 
 func TestAPIGetPullDoesNotFetchProviderForMissingMergedActor(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -3100,6 +3141,7 @@ func TestAPIGetPullDoesNotFetchProviderForMissingMergedActor(t *testing.T) {
 }
 
 func TestAPISyncPRPreservesMergeableStateWhenRefreshHasNoAnswer(t *testing.T) {
+	runParallelServerTest(t)
 	tests := []struct {
 		name  string
 		state *string
@@ -3161,6 +3203,7 @@ func TestAPISyncPRPreservesMergeableStateWhenRefreshHasNoAnswer(t *testing.T) {
 }
 
 func TestAPIEnqueuePRSyncQueuesOneRerun(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	firstStarted := make(chan struct{})
@@ -3246,6 +3289,7 @@ func TestAPIEnqueuePRSyncQueuesOneRerun(t *testing.T) {
 }
 
 func TestAPIEnqueueItemSyncRejectsRemovedUpstreamWithoutProviderCalls(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	var pullCalls atomic.Int64
 	var issueCalls atomic.Int64
@@ -3303,6 +3347,7 @@ func TestAPIEnqueueItemSyncRejectsRemovedUpstreamWithoutProviderCalls(t *testing
 }
 
 func TestAPIQueuedPRSyncRechecksRemovedUpstreamBeforeProviderCall(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	var providerCalls atomic.Int64
 	mock := &mockGH{
@@ -3366,6 +3411,7 @@ func TestAPIQueuedPRSyncRechecksRemovedUpstreamBeforeProviderCall(t *testing.T) 
 // frontend's default detail-load flow uses this path, so without
 // persistence the Approve Workflows button never appears.
 func TestAPIEnqueuePRSyncPersistsWorkflowApproval(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	mock := &mockGH{
@@ -3435,6 +3481,7 @@ func TestAPIEnqueuePRSyncPersistsWorkflowApproval(t *testing.T) {
 // onto the new head. After a sync that moves the head forward (and
 // finds no pending runs), GET must report checked=true, required=false.
 func TestAPIGetPullClearsWorkflowApprovalWhenHeadMoves(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -3509,6 +3556,7 @@ func TestAPIGetPullClearsWorkflowApprovalWhenHeadMoves(t *testing.T) {
 }
 
 func TestAPIApproveWorkflows(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	approvedRunIDs := []int64{}
@@ -3596,6 +3644,7 @@ func TestAPIApproveWorkflows(t *testing.T) {
 }
 
 func TestAPIApproveWorkflowsZeroMatchesStillSyncsPR(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	mock := &mockGH{
@@ -3644,6 +3693,7 @@ func TestAPIApproveWorkflowsZeroMatchesStillSyncsPR(t *testing.T) {
 }
 
 func TestAPIApproveWorkflowsReturnsUnderlyingApprovalErrorAfterPartialFailure(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	approvedRunIDs := []int64{}
@@ -3719,6 +3769,7 @@ func TestAPIApproveWorkflowsReturnsUnderlyingApprovalErrorAfterPartialFailure(t 
 // The sync path must still flag workflow approval as required, otherwise the
 // UI never shows the approve button for the exact case it was built for.
 func TestAPISyncPRIncludesWorkflowApprovalForForkPR(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	mock := &mockGH{
@@ -3782,6 +3833,7 @@ func TestAPISyncPRIncludesWorkflowApprovalForForkPR(t *testing.T) {
 // ApproveWorkflowRun for a fork-triggered run when the run's head repo and
 // branch match the PR.
 func TestAPIApproveWorkflowsForForkPR(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	approvedRunIDs := []int64{}
@@ -3850,6 +3902,7 @@ func TestAPIApproveWorkflowsForForkPR(t *testing.T) {
 // points at the other PR. The sync path must not flag workflow approval as
 // required for the wrong PR.
 func TestAPISyncPRIgnoresWorkflowRunsForOtherPRAtSameSHA(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	mock := &mockGH{
@@ -3906,6 +3959,7 @@ func TestAPISyncPRIgnoresWorkflowRunsForOtherPRAtSameSHA(t *testing.T) {
 // endpoint does not call ApproveWorkflowRun for runs whose pull_requests
 // association points at a different PR sharing the same head SHA.
 func TestAPIApproveWorkflowsIgnoresRunsForOtherPRAtSameSHA(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	approvedRunIDs := []int64{}
@@ -3973,6 +4027,7 @@ func TestAPIApproveWorkflowsIgnoresRunsForOtherPRAtSameSHA(t *testing.T) {
 // cross-approve. The PR's head repo is alice/widget; the run's head repo is
 // bob/widget. ApproveWorkflowRun must not be called.
 func TestAPIApproveWorkflowsRejectsRunFromDifferentForkAtSameSHA(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	approvedRunIDs := []int64{}
@@ -4040,6 +4095,7 @@ func TestAPIApproveWorkflowsRejectsRunFromDifferentForkAtSameSHA(t *testing.T) {
 // the diff is unavailable is the next getPull call. This regression
 // test pins that behavior so the warning can't silently disappear.
 func TestAPIGetPullEmitsDiffWarningWhenSHAsMissing(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -4083,6 +4139,7 @@ func TestAPIGetPullEmitsDiffWarningWhenSHAsMissing(t *testing.T) {
 // not fire when the row already carries valid diff SHAs that match the
 // latest platform head.
 func TestAPIGetPullNoDiffWarningWhenSHAsPresent(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -4132,6 +4189,7 @@ func TestAPIGetPullNoDiffWarningWhenSHAsPresent(t *testing.T) {
 // previous revision without any indication of drift. The warning must
 // fire in that case.
 func TestAPIGetPullEmitsStaleDiffWarning(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -4183,6 +4241,7 @@ func TestAPIGetPullEmitsStaleDiffWarning(t *testing.T) {
 // mirror getDiff staleness logic, which treats base drift as stale
 // for open PRs.
 func TestAPIGetPullEmitsStaleDiffWarningOnBaseDrift(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -4237,6 +4296,7 @@ func TestAPIGetPullEmitsStaleDiffWarningOnBaseDrift(t *testing.T) {
 // PR with a stale recorded diff would render outdated content with no
 // indication.
 func TestAPIGetPullEmitsStaleDiffWarningOnMergedPR(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -4290,6 +4350,7 @@ func TestAPIGetPullEmitsStaleDiffWarningOnMergedPR(t *testing.T) {
 // previous diffWarnings implementation suppressed warnings for any
 // non-open/non-merged state and the user would silently see no diff.
 func TestAPIGetPullEmitsDiffWarningWhenSHAsMissingClosed(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -4337,6 +4398,7 @@ func TestAPIGetPullEmitsDiffWarningWhenSHAsMissingClosed(t *testing.T) {
 // detail page shows a warning instead of silently rendering an old
 // diff.
 func TestAPIGetPullEmitsStaleDiffWarningOnClosedPR(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -4388,6 +4450,7 @@ func TestAPIGetPullEmitsStaleDiffWarningOnClosedPR(t *testing.T) {
 // merge. A merged PR whose head matches but base differs must NOT
 // emit a warning.
 func TestAPIGetPullNoDiffWarningOnMergedPRWithBaseDrift(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -4444,6 +4507,7 @@ func TestAPIGetPullNoDiffWarningOnMergedPRWithBaseDrift(t *testing.T) {
 // is unreadable, so EnsureClone fails and the handler must surface
 // only the sanitized warning.
 func TestAPISyncPRSanitizesDiffFailureWarning(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -4527,6 +4591,7 @@ func TestAPISyncPRSanitizesDiffFailureWarning(t *testing.T) {
 }
 
 func TestAPIRouteReuseServesOnlyCurrentRepository(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -4566,28 +4631,28 @@ func TestAPIRouteReuseServesOnlyCurrentRepository(t *testing.T) {
 		"github.com", "acme", "widget", 8, "open", "current issue",
 	)
 
-	repos := doJSON(t, srv, http.MethodGet, "/api/v1/repos", nil)
+	repos := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/repos", nil)
 	require.Equal(http.StatusOK, repos.Code, repos.Body.String())
 	var repoBody []map[string]any
 	require.NoError(json.NewDecoder(repos.Body).Decode(&repoBody))
 	require.Len(repoBody, 1)
 
-	pulls := doJSON(t, srv, http.MethodGet, "/api/v1/pulls", nil)
+	pulls := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/pulls", nil)
 	require.Equal(http.StatusOK, pulls.Code, pulls.Body.String())
 	var pullBody []pullapi.MergeRequestResponse
 	require.NoError(json.NewDecoder(pulls.Body).Decode(&pullBody))
 	require.Len(pullBody, 1)
 	assert.Equal("current pull request", pullBody[0].Title)
-	pullDetail := doJSON(
-		t, srv, http.MethodGet, "/api/v1/pulls/gh/acme/widget/7", nil,
-	)
+	pullDetail := testutil.DoJSON(
+		t, srv, http.MethodGet, "/api/v1/pulls/gh/acme/widget/7", nil)
+
 	require.Equal(http.StatusOK, pullDetail.Code, pullDetail.Body.String())
 	var pullDetailBody pullapi.MergeRequestDetailResponse
 	require.NoError(json.NewDecoder(pullDetail.Body).Decode(&pullDetailBody))
 	require.NotNil(pullDetailBody.MergeRequest)
 	assert.Equal("current pull request", pullDetailBody.MergeRequest.Title)
 
-	issues := doJSON(t, srv, http.MethodGet, "/api/v1/issues", nil)
+	issues := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/issues", nil)
 	require.Equal(http.StatusOK, issues.Code, issues.Body.String())
 	var issueBody []issueapi.IssueResponse
 	require.NoError(json.NewDecoder(issues.Body).Decode(&issueBody))
@@ -4603,6 +4668,7 @@ func TestAPIRouteReuseServesOnlyCurrentRepository(t *testing.T) {
 }
 
 func TestAPIConfiguredRepoFiltersUseProviderIdentity(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -4657,6 +4723,7 @@ func TestAPIConfiguredRepoFiltersUseProviderIdentity(t *testing.T) {
 }
 
 func TestAPIGitLabConfiguredRepoSyncThroughProviderRegistry(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -4772,6 +4839,7 @@ func TestAPIGitLabConfiguredRepoSyncThroughProviderRegistry(t *testing.T) {
 }
 
 func TestAPIGitLabClosedSyncPersistsMergedActorForImmediateDetail(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -4839,7 +4907,9 @@ func TestAPIGitLabClosedSyncPersistsMergedActorForImmediateDetail(t *testing.T) 
 		registry, database, nil, []ghclient.RepoRef{repo}, time.Minute, nil, nil,
 	)
 	t.Cleanup(syncer.Stop)
-	srv := New(database, syncer, nil, "/", nil, ServerOptions{
+	srv := New(database, syncer, nil, "/", &config.Config{Tmux: config.Tmux{
+		Command: []string{filepath.Join(t.TempDir(), "missing-tmux")},
+	}}, ServerOptions{
 		WorktreeDir:                        t.TempDir(),
 		DisableWorkspaceBackgroundMonitors: true,
 	})
@@ -4866,6 +4936,7 @@ func TestAPIGitLabClosedSyncPersistsMergedActorForImmediateDetail(t *testing.T) 
 }
 
 func TestAPIScheduledMergedActorRepairRefreshesOpenDetail(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -5013,6 +5084,7 @@ func TestAPIScheduledMergedActorRepairRefreshesOpenDetail(t *testing.T) {
 }
 
 func TestAPIGitLabDirectSyncPersistsMergedActorForImmediateDetail(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -5112,6 +5184,7 @@ func TestAPIGitLabDirectSyncPersistsMergedActorForImmediateDetail(t *testing.T) 
 }
 
 func TestAPIGitLabDirectSyncDoesNotDuplicateMergedActorAfterClosedFallback(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -5229,6 +5302,7 @@ func TestAPIGitLabDirectSyncDoesNotDuplicateMergedActorAfterClosedFallback(t *te
 }
 
 func TestAPIGitLabSyncReadsTokenFileAfterRotation(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -5322,11 +5396,11 @@ func TestAPIGitLabSyncReadsTokenFileAfterRotation(t *testing.T) {
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
 
-	firstRR := doJSON(
+	firstRR := testutil.DoJSON(
 		t, srv, http.MethodPost,
 		"/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/sync",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, firstRR.Code, firstRR.Body.String())
 	firstCallCount := len(tokens)
 	require.Positive(firstCallCount)
@@ -5335,11 +5409,11 @@ func TestAPIGitLabSyncReadsTokenFileAfterRotation(t *testing.T) {
 	}
 
 	require.NoError(os.WriteFile(tokenPath, []byte("second-token\n"), 0o600))
-	secondRR := doJSON(
+	secondRR := testutil.DoJSON(
 		t, srv, http.MethodPost,
 		"/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/sync",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, secondRR.Code, secondRR.Body.String())
 	require.Greater(len(tokens), firstCallCount)
 	for _, token := range tokens[firstCallCount:] {
@@ -5454,7 +5528,7 @@ func TestAPIGitHubSyncReadsCloneTokenFileAfterRotation(t *testing.T) {
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{Clones: clones})
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
 
-	firstRR := doJSON(t, srv, http.MethodPost, "/api/v1/pulls/gh/acme/widget/7/sync", nil)
+	firstRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/pulls/gh/acme/widget/7/sync", nil)
 	require.Equal(http.StatusOK, firstRR.Code, firstRR.Body.String())
 	firstCredentials := readCapturedCredentials(t, capturePath)
 	require.NotEmpty(firstCredentials)
@@ -5463,7 +5537,7 @@ func TestAPIGitHubSyncReadsCloneTokenFileAfterRotation(t *testing.T) {
 	}
 
 	require.NoError(os.WriteFile(tokenPath, []byte("second-token\n"), 0o600))
-	secondRR := doJSON(t, srv, http.MethodPost, "/api/v1/pulls/gh/acme/widget/7/sync", nil)
+	secondRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/pulls/gh/acme/widget/7/sync", nil)
 	require.Equal(http.StatusOK, secondRR.Code, secondRR.Body.String())
 	allCredentials := readCapturedCredentials(t, capturePath)
 	require.Greater(len(allCredentials), len(firstCredentials))
@@ -5611,7 +5685,7 @@ func TestAPISharedHostCloneFetchFollowsReloadedHostToken(t *testing.T) {
 	// fetch into the next phase's assertions.
 	identity := platform.DBRepoIdentity(giteaRef)
 	runSync := func(prevCompleted *time.Time) *time.Time {
-		rr := doJSON(t, srv, http.MethodPost, "/api/v1/sync", nil)
+		rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/sync", nil)
 		require.Equal(http.StatusAccepted, rr.Code, rr.Body.String())
 		var completed *time.Time
 		require.Eventually(func() bool {
@@ -5729,6 +5803,7 @@ func parseCapturedCredentials(raw string) []string {
 }
 
 func TestGitLabSyncCoversRepositoryItemsEventsOverviewAndCI(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -5961,6 +6036,7 @@ func TestGitLabSyncCoversRepositoryItemsEventsOverviewAndCI(t *testing.T) {
 }
 
 func TestAPICIRefreshWarnsAndPreservesCIWhenProviderFails(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -6051,6 +6127,7 @@ func TestAPICIRefreshWarnsAndPreservesCIWhenProviderFails(t *testing.T) {
 }
 
 func TestAPISyncRefreshesStaleCachedChecksWhenAggregateCIChanges(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -6168,6 +6245,7 @@ func TestAPISyncRefreshesStaleCachedChecksWhenAggregateCIChanges(t *testing.T) {
 }
 
 func TestAPISyncRefreshesCachedPendingChecksThroughDetailDrain(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -6286,6 +6364,7 @@ func TestAPISyncRefreshesCachedPendingChecksThroughDetailDrain(t *testing.T) {
 }
 
 func TestProviderRefSyncEndpointsUseGitLabNestedRepoPath(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -6509,6 +6588,7 @@ func TestProviderRefSyncEndpointsUseGitLabNestedRepoPath(t *testing.T) {
 }
 
 func TestGitLabSyncUsesTagsForRepoOverviewWhenReleasesAreAbsent(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	ctx := t.Context()
 	database := dbtest.Open(t)
@@ -6577,6 +6657,7 @@ func TestGitLabSyncUsesTagsForRepoOverviewWhenReleasesAreAbsent(t *testing.T) {
 }
 
 func TestAPIListRepoSummaries(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -6678,6 +6759,7 @@ func TestAPIListRepoSummaries(t *testing.T) {
 }
 
 func TestAPIListRepoSummariesIncludesDefaultPlatformHost(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -6700,7 +6782,7 @@ platform_host = "ghe.example.com"
 		PlatformHost: "ghe.example.com",
 	}})
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/repos/summary", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/repos/summary", nil)
 	require.Equal(http.StatusOK, rr.Code)
 
 	var summaries []repoSummaryResponse
@@ -6711,6 +6793,7 @@ platform_host = "ghe.example.com"
 }
 
 func TestAPIListRepoSummariesIncludesSyncedReleaseTimeline(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -6843,6 +6926,7 @@ func TestAPIListRepoSummariesIncludesSyncedReleaseTimeline(t *testing.T) {
 }
 
 func TestAPIListRepoSummariesUsesTagsWhenNoReleases(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -6911,6 +6995,7 @@ func TestAPIListRepoSummariesUsesTagsWhenNoReleases(t *testing.T) {
 }
 
 func TestAPIListRepoSummariesClearsStaleOverviewWhenTagFallbackFails(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -6999,6 +7084,7 @@ func TestAPIListRepoSummariesClearsStaleOverviewWhenTagFallbackFails(t *testing.
 }
 
 func TestAPICreateIssue(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -7084,6 +7170,7 @@ func TestAPICreateIssue(t *testing.T) {
 }
 
 func TestAPICreateIssueRejectsNilProviderPayload(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	mock := &mockGH{
@@ -7118,6 +7205,7 @@ func TestAPICreateIssueRejectsNilProviderPayload(t *testing.T) {
 }
 
 func TestAPICreateIssueReportsUnknownOutcomeForUnverifiedProviderFailure(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	srv := setupGitLabIssueMutatorServer(t, errors.New("provider response unavailable"))
@@ -7138,6 +7226,7 @@ func TestAPICreateIssueReportsUnknownOutcomeForUnverifiedProviderFailure(t *test
 }
 
 func TestAPICreateIssueReportsUnknownOutcomeWhenPersistenceFailsAfterProviderSuccess(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	var database *db.DB
@@ -7185,6 +7274,7 @@ func TestAPICreateIssueReportsUnknownOutcomeWhenPersistenceFailsAfterProviderSuc
 }
 
 func TestAPIEditPRContentRejectsNilProviderPayload(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -7222,6 +7312,7 @@ func TestAPIEditPRContentRejectsNilProviderPayload(t *testing.T) {
 }
 
 func TestAPIPostPRCommentRejectsNilProviderPayload(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	mock := &mockGH{
@@ -7249,6 +7340,7 @@ func TestAPIPostPRCommentRejectsNilProviderPayload(t *testing.T) {
 }
 
 func TestAPIPostIssueCommentRejectsNilProviderPayload(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	mock := &mockGH{
@@ -7276,6 +7368,7 @@ func TestAPIPostIssueCommentRejectsNilProviderPayload(t *testing.T) {
 }
 
 func TestAPIEditPRCommentRejectsNilProviderPayload(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -7315,6 +7408,7 @@ func TestAPIEditPRCommentRejectsNilProviderPayload(t *testing.T) {
 }
 
 func TestAPIEditIssueCommentRejectsNilProviderPayload(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -7354,6 +7448,7 @@ func TestAPIEditIssueCommentRejectsNilProviderPayload(t *testing.T) {
 }
 
 func TestAPIApprovePRSubmitsGitHubReview(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -7406,6 +7501,7 @@ func TestAPIApprovePRSubmitsGitHubReview(t *testing.T) {
 }
 
 func TestAPIMergePRRejectsNilProviderPayload(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -7448,6 +7544,7 @@ func TestAPIMergePRRejectsNilProviderPayload(t *testing.T) {
 }
 
 func TestAPICreateIssueUsesPlatformHost(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -7533,6 +7630,7 @@ func TestAPICreateIssueUsesPlatformHost(t *testing.T) {
 }
 
 func TestAPIPostPrCommentAllowsMixedCaseTrackedRepo(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	srv, database := setupTestServerWithRepos(
 		t,
@@ -7560,6 +7658,7 @@ func TestAPIPostPrCommentAllowsMixedCaseTrackedRepo(t *testing.T) {
 }
 
 func TestAPIEditPrCommentUpdatesGitHubAndLocalTimeline(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	commentID := int64(9876)
@@ -7615,6 +7714,7 @@ func TestAPIEditPrCommentUpdatesGitHubAndLocalTimeline(t *testing.T) {
 }
 
 func TestAPIEditPrCommentRejectsCommentFromDifferentPR(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	commentID := int64(5555)
 	var editCalls atomic.Int32
@@ -7653,6 +7753,7 @@ func TestAPIEditPrCommentRejectsCommentFromDifferentPR(t *testing.T) {
 }
 
 func TestAPIEditIssueCommentUpdatesGitHubAndLocalTimeline(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	commentID := int64(1234)
@@ -7708,6 +7809,7 @@ func TestAPIEditIssueCommentUpdatesGitHubAndLocalTimeline(t *testing.T) {
 }
 
 func TestAPIEditIssueCommentRejectsCommentFromDifferentIssue(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	commentID := int64(6666)
 	var editCalls atomic.Int32
@@ -7746,6 +7848,7 @@ func TestAPIEditIssueCommentRejectsCommentFromDifferentIssue(t *testing.T) {
 }
 
 func TestAPIDeletePrCommentLeavesLocalStateForSync(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	commentID := int64(9876)
@@ -7785,6 +7888,7 @@ func TestAPIDeletePrCommentLeavesLocalStateForSync(t *testing.T) {
 }
 
 func TestAPIDeleteIssueCommentKeepsLocalCommentWhenProviderRejects(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	commentID := int64(1234)
@@ -7818,6 +7922,7 @@ func TestAPIDeleteIssueCommentKeepsLocalCommentWhenProviderRejects(t *testing.T)
 }
 
 func TestAPIDeletePrCommentKeepsLocalCommentWhenProviderReportsNotFound(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	commentID := int64(4321)
@@ -7851,6 +7956,7 @@ func TestAPIDeletePrCommentKeepsLocalCommentWhenProviderReportsNotFound(t *testi
 }
 
 func TestAPIDeleteIssueCommentKeepsLocalCommentWhenProviderReportsNotFound(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	commentID := int64(4321)
@@ -7884,6 +7990,7 @@ func TestAPIDeleteIssueCommentKeepsLocalCommentWhenProviderReportsNotFound(t *te
 }
 
 func TestAPIDeleteIssueCommentLeavesLocalStateForSync(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	commentID := int64(5432)
@@ -7924,6 +8031,7 @@ func TestAPIDeleteIssueCommentLeavesLocalStateForSync(t *testing.T) {
 }
 
 func TestAPIDeletePrCommentRejectsAnotherParentBeforeProviderCall(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	commentID := int64(6543)
@@ -7957,6 +8065,7 @@ func TestAPIDeletePrCommentRejectsAnotherParentBeforeProviderCall(t *testing.T) 
 }
 
 func TestAPICommentAutocomplete(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -8090,6 +8199,7 @@ func TestAPICommentAutocomplete(t *testing.T) {
 }
 
 func TestAPICommentAutocompleteUsesRepoPlatformHost(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -8142,6 +8252,7 @@ func TestAPICommentAutocompleteUsesRepoPlatformHost(t *testing.T) {
 }
 
 func TestAPICommentAutocompleteReferencesScopesByProvider(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -8208,6 +8319,7 @@ func TestAPICommentAutocompleteReferencesScopesByProvider(t *testing.T) {
 }
 
 func TestAPICommentAutocompleteGitLabMergeRequestReferencesScopesByProvider(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -8278,6 +8390,7 @@ func TestAPICommentAutocompleteGitLabMergeRequestReferencesScopesByProvider(t *t
 }
 
 func TestAPISyncStatus(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	srv, _ := setupTestServer(t)
@@ -8294,6 +8407,7 @@ func TestAPISyncStatus(t *testing.T) {
 }
 
 func TestAPITriggerSyncIgnoresRequestCancellation(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	database := dbtest.Open(t)
 
@@ -8345,6 +8459,7 @@ func TestAPITriggerSyncIgnoresRequestCancellation(t *testing.T) {
 // If the route returns 202 after admission is refused, the client believes a
 // sync was retained even though no worker can execute it.
 func TestAPITriggerSyncRejectsAfterSyncerStops(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	database := dbtest.Open(t)
 	syncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
@@ -8352,11 +8467,12 @@ func TestAPITriggerSyncRejectsAfterSyncerStops(t *testing.T) {
 
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/sync", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/sync", nil)
 	require.Equal(http.StatusServiceUnavailable, rr.Code, rr.Body.String())
 }
 
 func TestAPITriggerSyncOnlyRepoRestrictsRun(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -8398,13 +8514,13 @@ func TestAPITriggerSyncOnlyRepoRestrictsRun(t *testing.T) {
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
 		"/api/v1/sync?only_repo=gh|github.com/acme/second",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusAccepted, rr.Code, rr.Body.String())
 	select {
 	case <-done:
@@ -8419,17 +8535,18 @@ func TestAPITriggerSyncOnlyRepoRestrictsRun(t *testing.T) {
 }
 
 func TestAPITriggerSyncRejectsUnknownOnlyRepo(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 
 	srv, _ := setupTestServer(t)
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
 		"/api/v1/sync?only_repo=github|github.com/acme/missing",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
 
 	var problem httpapi.ProblemError
@@ -8439,6 +8556,7 @@ func TestAPITriggerSyncRejectsUnknownOnlyRepo(t *testing.T) {
 }
 
 func TestAPITriggerSyncBypassesNextSyncAfter(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	database := dbtest.Open(t)
@@ -8499,6 +8617,7 @@ func TestAPITriggerSyncBypassesNextSyncAfter(t *testing.T) {
 }
 
 func TestAPITriggerSyncStopsDetailDrainAfterDisabledIndexResult(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -8560,7 +8679,7 @@ func TestAPITriggerSyncStopsDetailDrainAfterDisabledIndexResult(t *testing.T) {
 			}
 		}
 	})
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/sync", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/sync", nil)
 	require.Equal(http.StatusAccepted, rr.Code, rr.Body.String())
 	select {
 	case <-done:
@@ -8575,7 +8694,7 @@ func TestAPITriggerSyncStopsDetailDrainAfterDisabledIndexResult(t *testing.T) {
 }
 
 func TestAPIRepositorySyncRecoversDisabledIssueScopeThroughSQLite(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -8631,13 +8750,13 @@ func TestAPIRepositorySyncRecoversDisabledIssueScopeThroughSQLite(t *testing.T) 
 			}
 		}
 	})
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
 		"/api/v1/sync?only_repo=gh|github.com/acme/widget",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusAccepted, rr.Code, rr.Body.String())
 	select {
 	case <-done:
@@ -8656,7 +8775,7 @@ func TestAPIRepositorySyncRecoversDisabledIssueScopeThroughSQLite(t *testing.T) 
 }
 
 func TestAPIGitLabDisabledIssueCooldownPersistsThroughHTTPAndSQLite(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -8743,7 +8862,7 @@ func TestAPIGitLabDisabledIssueCooldownPersistsThroughHTTPAndSQLite(t *testing.T
 }
 
 func TestAPIGiteaDisabledIssueCooldownPersistsThroughHTTPAndSQLite(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -8834,6 +8953,7 @@ func TestAPIGiteaDisabledIssueCooldownPersistsThroughHTTPAndSQLite(t *testing.T)
 }
 
 func TestMatchPriorityRepoRequiresProviderQualifiedRepoPaths(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 
 	tracked := []ghclient.RepoRef{
@@ -8886,6 +9006,7 @@ func TestMatchPriorityRepoRequiresProviderQualifiedRepoPaths(t *testing.T) {
 }
 
 func TestAPIReadyForReview(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	database := dbtest.Open(t)
 
@@ -8963,6 +9084,7 @@ func TestAPIReadyForReview(t *testing.T) {
 }
 
 func TestAPIReadyForReviewReclassifiesWorkspaceHeadRepo(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	const forkURL = "https://github.com/contributor/widget.git"
 
@@ -9120,6 +9242,7 @@ func seedIssueForRepo(
 }
 
 func TestAPIClosePR(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -9188,6 +9311,7 @@ func TestAPIClosePR(t *testing.T) {
 }
 
 func TestAPIReopenPR(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	mock := &mockGH{
 		editPullRequestFn: func(
@@ -9225,6 +9349,7 @@ func TestAPIReopenPR(t *testing.T) {
 }
 
 func TestAPICloseIssue(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	srv, database := setupTestServer(t)
@@ -9247,6 +9372,7 @@ func TestAPICloseIssue(t *testing.T) {
 }
 
 func TestAPIReopenIssue(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
 	seedIssue(t, database, "acme", "widget", 5, "closed")
@@ -9266,6 +9392,7 @@ func TestAPIReopenIssue(t *testing.T) {
 }
 
 func TestAPISyncPRDoesNotOverwriteNewerStateChange(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -9373,6 +9500,7 @@ func TestAPISyncPRDoesNotOverwriteNewerStateChange(t *testing.T) {
 }
 
 func TestAPISyncPRPreservesCIStatusWhileRefreshingCI(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -9475,6 +9603,7 @@ func TestAPISyncPRPreservesCIStatusWhileRefreshingCI(t *testing.T) {
 }
 
 func TestAPISyncPRBypassesPullRequestETagForCIRefresh(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -9542,7 +9671,7 @@ func TestAPISyncPRBypassesPullRequestETagForCIRefresh(t *testing.T) {
 		"pull_request", 1, `"etag-v1"`,
 	))
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/pulls/gh/acme/widget/1/sync", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/pulls/gh/acme/widget/1/sync", nil)
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	stored, err := database.GetMergeRequestByRepoIDAndNumber(t.Context(), repo.ID, 1)
@@ -9559,6 +9688,7 @@ func TestAPISyncPRBypassesPullRequestETagForCIRefresh(t *testing.T) {
 // then fails, the detail must show "no CI" rather than stale checks
 // attached to a different commit.
 func TestAPISyncPRClearsCIWhenHeadSHAChanges(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -9634,6 +9764,7 @@ func TestAPISyncPRClearsCIWhenHeadSHAChanges(t *testing.T) {
 }
 
 func TestAPIEnqueuePRSyncReturnsBeforeGitHubFetchCompletes(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	syncStarted := make(chan struct{}, 1)
@@ -9694,6 +9825,7 @@ func TestAPIEnqueuePRSyncReturnsBeforeGitHubFetchCompletes(t *testing.T) {
 }
 
 func TestAPIEnqueueIssueSyncReturnsBeforeGitHubFetchCompletes(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	syncStarted := make(chan struct{}, 1)
@@ -9748,6 +9880,7 @@ func TestAPIEnqueueIssueSyncReturnsBeforeGitHubFetchCompletes(t *testing.T) {
 }
 
 func TestAPIReadyForReviewDoesNotGetRevertedByStaleSync(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -9895,6 +10028,7 @@ func TestAPIReadyForReviewDoesNotGetRevertedByStaleSync(t *testing.T) {
 }
 
 func TestAPIMarkDraftDoesNotGetRevertedByStaleSync(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -10028,6 +10162,7 @@ func TestAPIMarkDraftDoesNotGetRevertedByStaleSync(t *testing.T) {
 }
 
 func TestAPISyncIssueDoesNotOverwriteNewerStateChange(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -10119,6 +10254,7 @@ func TestAPISyncIssueDoesNotOverwriteNewerStateChange(t *testing.T) {
 // unit tests cover the same logic at the syncer layer; this test
 // covers the request path users actually hit in production.
 func TestAPISyncIssueNilUpdatedAtFallsBackToCreatedAt(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -10183,6 +10319,7 @@ func TestAPISyncIssueNilUpdatedAtFallsBackToCreatedAt(t *testing.T) {
 }
 
 func TestAPIListPullsSearchByNumber(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	srv, database := setupTestServer(t)
@@ -10248,6 +10385,7 @@ func TestAPIListPullsSearchByNumber(t *testing.T) {
 }
 
 func TestAPIListIssuesSearchByNumber(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	srv, database := setupTestServer(t)
@@ -10313,6 +10451,7 @@ func TestAPIListIssuesSearchByNumber(t *testing.T) {
 }
 
 func TestAPIListPullsReportsHistoricalMergedPRFromMergedAt(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -10364,6 +10503,7 @@ func TestAPIListPullsReportsHistoricalMergedPRFromMergedAt(t *testing.T) {
 }
 
 func TestAPIListPullsCasefoldsRepoNames(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServerWithRepos(t, &mockGH{}, []ghclient.RepoRef{
@@ -10384,6 +10524,7 @@ func TestAPIListPullsCasefoldsRepoNames(t *testing.T) {
 }
 
 func TestAPIListPullsFiltersProviderQualifiedHostedNestedRepoPath(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServerWithRepos(t, &mockGH{}, []ghclient.RepoRef{
@@ -10408,6 +10549,7 @@ func TestAPIListPullsFiltersProviderQualifiedHostedNestedRepoPath(t *testing.T) 
 }
 
 func TestAPIListPullsAcceptsProviderQualifiedRepoFilter(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -10447,6 +10589,7 @@ func TestAPIListPullsAcceptsProviderQualifiedRepoFilter(t *testing.T) {
 }
 
 func TestAPIListIssuesAcceptsProviderAndHostQualifiedRepoFilter(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -10470,6 +10613,7 @@ func TestAPIListIssuesAcceptsProviderAndHostQualifiedRepoFilter(t *testing.T) {
 }
 
 func TestAPIListIssuesFiltersProviderQualifiedHostedNestedRepoPath(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -10504,6 +10648,7 @@ func TestAPIListIssuesFiltersProviderQualifiedHostedNestedRepoPath(t *testing.T)
 }
 
 func TestAPIListIssuesAcceptsProviderQualifiedRepoFilter(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -10543,6 +10688,7 @@ func TestAPIListIssuesAcceptsProviderQualifiedRepoFilter(t *testing.T) {
 }
 
 func TestAPIGetIssueUsesPlatformHostQuery(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -10605,6 +10751,7 @@ func TestAPIGetIssueUsesPlatformHostQuery(t *testing.T) {
 }
 
 func TestAPIGetIssueWorkspaceUsesProviderScopedLookup(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -10664,7 +10811,9 @@ func TestAPIGetIssueWorkspaceUsesProviderScopedLookup(t *testing.T) {
 
 	syncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
 	t.Cleanup(syncer.Stop)
-	srv := New(database, syncer, nil, "/", nil, ServerOptions{
+	srv := New(database, syncer, nil, "/", &config.Config{Tmux: config.Tmux{
+		Command: []string{filepath.Join(t.TempDir(), "missing-tmux")},
+	}}, ServerOptions{
 		WorktreeDir:                        t.TempDir(),
 		DisableWorkspaceBackgroundMonitors: true,
 	})
@@ -10690,6 +10839,7 @@ func TestAPIGetIssueWorkspaceUsesProviderScopedLookup(t *testing.T) {
 }
 
 func TestAPIGetPRWorkspaceUsesProviderScopedLookup(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -10751,7 +10901,9 @@ func TestAPIGetPRWorkspaceUsesProviderScopedLookup(t *testing.T) {
 
 	syncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
 	t.Cleanup(syncer.Stop)
-	srv := New(database, syncer, nil, "/", nil, ServerOptions{
+	srv := New(database, syncer, nil, "/", &config.Config{Tmux: config.Tmux{
+		Command: []string{filepath.Join(t.TempDir(), "missing-tmux")},
+	}}, ServerOptions{
 		WorktreeDir:                        t.TempDir(),
 		DisableWorkspaceBackgroundMonitors: true,
 	})
@@ -10777,6 +10929,7 @@ func TestAPIGetPRWorkspaceUsesProviderScopedLookup(t *testing.T) {
 }
 
 func TestAPICreateWorkspaceRejectsEmptyProviderForAmbiguousRepo(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -10835,6 +10988,7 @@ func TestAPICreateWorkspaceRejectsEmptyProviderForAmbiguousRepo(t *testing.T) {
 }
 
 func TestAPICreateWorkspaceRejectsOmittedProviderForUnambiguousRepo(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	ctx := t.Context()
 
@@ -10883,6 +11037,7 @@ func TestAPICreateWorkspaceRejectsOmittedProviderForUnambiguousRepo(t *testing.T
 }
 
 func TestAPISyncIssueUsesPlatformHostQuery(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := context.Background()
@@ -11015,6 +11170,7 @@ func TestAPISyncIssueUsesPlatformHostQuery(t *testing.T) {
 }
 
 func TestAPISetIssueStateUsesPlatformHostBody(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := context.Background()
@@ -11134,6 +11290,7 @@ func TestAPISetIssueStateUsesPlatformHostBody(t *testing.T) {
 // path itself (GraphQL fetch → normalize → DB upsert) is tested in
 // internal/github/sync_test.go; this test covers the DB → API layer.
 func TestAPIIssueDataFromGraphQLSync(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -11213,6 +11370,7 @@ func TestAPIIssueDataFromGraphQLSync(t *testing.T) {
 // the HTTP API. Exercises: GraphQL HTTP → adapter → NormalizeIssue →
 // UpsertIssue → HTTP API handler → JSON response.
 func TestE2EGraphQLIssueSyncThroughAPI(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -11322,6 +11480,7 @@ func TestE2EGraphQLIssueSyncThroughAPI(t *testing.T) {
 }
 
 func TestE2ELargeRepoSkipsGraphQLAndUsesConditionalPRDetail(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -11489,6 +11648,7 @@ func TestE2ELargeRepoSkipsGraphQLAndUsesConditionalPRDetail(t *testing.T) {
 }
 
 func TestE2EConditionalPRDetailRefreshesInlineModerationThroughAPI(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -11638,6 +11798,7 @@ func TestE2EConditionalPRDetailRefreshesInlineModerationThroughAPI(t *testing.T)
 }
 
 func TestE2ELargeRepoSkipsGraphQLAndUsesConditionalIssueDetail(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -11806,6 +11967,7 @@ func TestE2ELargeRepoSkipsGraphQLAndUsesConditionalIssueDetail(t *testing.T) {
 // GraphQL's TotalCount, not the stale existing.CommentCount.
 // Regression test for the "preserve existing.CommentCount" overwrite.
 func TestE2EGraphQLIssueSyncTrustsTotalCount(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -11933,6 +12095,7 @@ func TestE2EGraphQLIssueSyncTrustsTotalCount(t *testing.T) {
 }
 
 func TestE2EPRDetailRefreshesEditedCommentBody(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -12066,6 +12229,7 @@ func TestE2EPRDetailRefreshesEditedCommentBody(t *testing.T) {
 }
 
 func TestE2EPRDetailRemovesDeletedCommentWhenPRListIsUnchanged(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -12196,6 +12360,7 @@ func TestE2EPRDetailRemovesDeletedCommentWhenPRListIsUnchanged(t *testing.T) {
 }
 
 func TestE2EPRDetailRemovesDeletedCommentWhenAnotherPRChanges(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -12345,6 +12510,7 @@ func TestE2EPRDetailRemovesDeletedCommentWhenAnotherPRChanges(t *testing.T) {
 }
 
 func TestE2EIssueDetailRefreshesEditedCommentBody(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -12460,6 +12626,7 @@ func TestE2EIssueDetailRefreshesEditedCommentBody(t *testing.T) {
 }
 
 func TestE2EIssueDetailRemovesDeletedCommentWhenIssueListIsUnchanged(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -12574,6 +12741,7 @@ func TestE2EIssueDetailRemovesDeletedCommentWhenIssueListIsUnchanged(t *testing.
 }
 
 func TestE2EIssueDetailRemovesDeletedCommentWhenAnotherIssueChanges(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -12714,6 +12882,7 @@ func TestE2EIssueDetailRemovesDeletedCommentWhenAnotherIssueChanges(t *testing.T
 }
 
 func TestE2EPRDetailRemovesDeletedCommentOnFullRefresh(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -12818,6 +12987,7 @@ func TestE2EPRDetailRemovesDeletedCommentOnFullRefresh(t *testing.T) {
 }
 
 func TestE2EIssueDetailRemovesDeletedCommentOnFullRefresh(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -12914,6 +13084,7 @@ func TestE2EIssueDetailRemovesDeletedCommentOnFullRefresh(t *testing.T) {
 }
 
 func TestE2EIssueDetailRemovesDeletedCommentOnGraphQLBulkSync(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -13031,6 +13202,7 @@ func TestE2EIssueDetailRemovesDeletedCommentOnGraphQLBulkSync(t *testing.T) {
 }
 
 func TestE2EIssueDetailPreservesHiddenCommentsAcrossIncompleteGraphQLRefresh(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -13224,6 +13396,7 @@ func TestE2EIssueDetailPreservesHiddenCommentsAcrossIncompleteGraphQLRefresh(t *
 }
 
 func TestE2EGraphQLBulkSyncPersistsIssueTimelineEvents(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -13369,6 +13542,7 @@ func TestE2EGraphQLBulkSyncPersistsIssueTimelineEvents(t *testing.T) {
 }
 
 func TestE2EGraphQLBulkSyncPersistsIssueLifecycleTimelineAfterReopen(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -13547,6 +13721,7 @@ func TestE2EGraphQLBulkSyncPersistsIssueLifecycleTimelineAfterReopen(t *testing.
 }
 
 func TestE2EPRDetailRemovesDeletedCommentOnGraphQLBulkSync(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -13672,6 +13847,7 @@ func TestE2EPRDetailRemovesDeletedCommentOnGraphQLBulkSync(t *testing.T) {
 }
 
 func TestE2EPRDetailPersistsCombinedGraphQLDiscussions(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -13919,6 +14095,7 @@ func TestE2EPRDetailPersistsCombinedGraphQLDiscussions(t *testing.T) {
 // over the PR's whole review history, so nested-connection truncation must not
 // gate it: the changed decision must reach the HTTP API.
 func TestE2EGraphQLBulkSyncAppliesAuthoritativeReviewDecisionOverIncompleteReviews(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -14043,6 +14220,7 @@ func TestE2EGraphQLBulkSyncAppliesAuthoritativeReviewDecisionOverIncompleteRevie
 // without ever populating workflow_approval_checked_at, leaving the
 // DB-only GET unable to surface the Approve workflows button.
 func TestE2EGraphQLBulkSyncPersistsWorkflowApproval(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -14159,6 +14337,7 @@ func TestE2EGraphQLBulkSyncPersistsWorkflowApproval(t *testing.T) {
 // removing that fallback would leave the Approve workflows button
 // hidden for every fork PR synced through bulk.
 func TestE2EGraphQLBulkSyncPersistsWorkflowApprovalForForkPR(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -14276,6 +14455,7 @@ func TestE2EGraphQLBulkSyncPersistsWorkflowApprovalForForkPR(t *testing.T) {
 }
 
 func TestE2EGraphQLBulkSyncKeepsNewestCICheckBySuiteCreatedAt(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := context.Background()
@@ -14403,6 +14583,7 @@ func make422Error() error {
 }
 
 func TestAPISetIssueGitHubStateReturns404WhenNoClientConfigured(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	repos := []ghclient.RepoRef{{Owner: "acme", Name: "widget", PlatformHost: "ghe.corp.com"}}
 	srv, database := setupTestServerWithRepos(t, &mockGH{}, repos)
@@ -14434,6 +14615,7 @@ func TestAPISetIssueGitHubStateReturns404WhenNoClientConfigured(t *testing.T) {
 }
 
 func TestAPIClosePR422NilFallbackPayloadDoesNotCorruptDB(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	mock := &mockGH{
@@ -14467,6 +14649,7 @@ func TestAPIClosePR422NilFallbackPayloadDoesNotCorruptDB(t *testing.T) {
 }
 
 func TestAPICloseIssue422NilFallbackPayloadDoesNotCorruptDB(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	mock := &mockGH{
@@ -14500,6 +14683,7 @@ func TestAPICloseIssue422NilFallbackPayloadDoesNotCorruptDB(t *testing.T) {
 }
 
 func TestAPIStateMutationDoesNotRecoverFromProviderWhenSyncDisabled(t *testing.T) {
+	runParallelServerTest(t)
 	for _, itemType := range []string{"pull request", "issue"} {
 		t.Run(itemType, func(t *testing.T) {
 			require := require.New(t)
@@ -14548,6 +14732,7 @@ func TestAPIStateMutationDoesNotRecoverFromProviderWhenSyncDisabled(t *testing.T
 }
 
 func TestAPIClosePR422AlreadyClosed(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	// EditPullRequest returns 422, but re-fetch shows PR is already closed.
 	// Should succeed since the requested state matches.
@@ -14586,6 +14771,7 @@ func TestAPIClosePR422AlreadyClosed(t *testing.T) {
 }
 
 func TestAPIMarkPRDraftPersistsDraftFlag(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	var gotOwner string
@@ -14666,6 +14852,7 @@ func TestAPIMarkPRDraftPersistsDraftFlag(t *testing.T) {
 // When MarkPullRequestReadyForReview returns (nil, nil) the handler
 // must return 502 rather than claiming success with no PR payload.
 func TestAPIReadyForReview502OnNilPR(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	mock := &mockGH{
 		markReadyForReviewFn: func(_ context.Context, _, _ string, _ int) (*gh.PullRequest, error) {
@@ -14684,6 +14871,7 @@ func TestAPIReadyForReview502OnNilPR(t *testing.T) {
 }
 
 func TestAPIReadyForReviewReturnsUnderlyingErrorDetail(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	mock := &mockGH{
 		markReadyForReviewFn: func(_ context.Context, _, _ string, _ int) (*gh.PullRequest, error) {
@@ -14708,6 +14896,7 @@ func TestAPIReadyForReviewReturnsUnderlyingErrorDetail(t *testing.T) {
 }
 
 func TestAPIReadyForReviewStaleStateRefreshesAndReturnsSuccess(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	staleErr := &staleReadyForReviewError{
@@ -14771,6 +14960,7 @@ func TestAPIReadyForReviewStaleStateRefreshesAndReturnsSuccess(t *testing.T) {
 }
 
 func TestAPIReadyForReview404RefreshesStaleDraftState(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	notFound := &gh.ErrorResponse{
 		Response: &http.Response{StatusCode: http.StatusNotFound, Status: "404 Not Found"},
@@ -14824,6 +15014,7 @@ func TestAPIReadyForReview404RefreshesStaleDraftState(t *testing.T) {
 }
 
 func TestAPIClosePR422Merged(t *testing.T) {
+	runParallelServerTest(t)
 	// EditPullRequest returns 422, re-fetch shows PR is merged.
 	// Should return 409.
 	merged := "closed"
@@ -14858,6 +15049,7 @@ func TestAPIClosePR422Merged(t *testing.T) {
 }
 
 func TestResolveItem_PR(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	repos := []ghclient.RepoRef{{Owner: "acme", Name: "widget"}}
 	srv, database := setupTestServerWithRepos(t, &mockGH{}, repos)
@@ -14876,6 +15068,7 @@ func TestResolveItem_PR(t *testing.T) {
 }
 
 func TestResolveItem_Issue(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	repos := []ghclient.RepoRef{{Owner: "acme", Name: "widget"}}
 	srv, database := setupTestServerWithRepos(t, &mockGH{}, repos)
@@ -14894,6 +15087,7 @@ func TestResolveItem_Issue(t *testing.T) {
 }
 
 func TestResolveItem_UsesItemTypeHintForGitLab(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	repos := []ghclient.RepoRef{{
 		Platform:     platform.KindGitLab,
@@ -14954,6 +15148,7 @@ func TestResolveItem_UsesItemTypeHintForGitLab(t *testing.T) {
 }
 
 func TestResolveItem_NotFoundOnGitHub(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	mock := &mockGH{
 		getIssueFn: func(_ context.Context, _, _ string, _ int) (*gh.Issue, error) {
@@ -14977,6 +15172,7 @@ func TestResolveItem_NotFoundOnGitHub(t *testing.T) {
 }
 
 func TestResolveItem_GitHubServerError(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	mock := &mockGH{
 		getIssueFn: func(_ context.Context, _, _ string, _ int) (*gh.Issue, error) {
@@ -15000,6 +15196,7 @@ func TestResolveItem_GitHubServerError(t *testing.T) {
 }
 
 func TestAPICloseIssue422AlreadyClosed(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	state := "closed"
 	mock := &mockGH{
@@ -15034,6 +15231,7 @@ func TestAPICloseIssue422AlreadyClosed(t *testing.T) {
 }
 
 func TestMRListIncludesWorktreeLinks(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
 	prID := seedPR(t, database, "acme", "widget", 1)
@@ -15065,6 +15263,7 @@ func TestMRListIncludesWorktreeLinks(t *testing.T) {
 }
 
 func TestMRDetailIncludesWorktreeLinks(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
 	prID := seedPR(t, database, "acme", "widget", 1)
@@ -15094,6 +15293,7 @@ func TestMRDetailIncludesWorktreeLinks(t *testing.T) {
 }
 
 func TestProviderPullRouteResolvesEscapedGitLabRepoPath(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	srv, database := setupTestServer(t)
@@ -15128,7 +15328,7 @@ func TestProviderPullRouteResolvesEscapedGitLabRepoPath(t *testing.T) {
 
 	path := "/api/v1/host/gitlab.example.com:8443/pulls/gl/" +
 		"Group%2FSubGroup%2FSubGroup%202/My_Project.v2/12"
-	rr := doJSON(t, srv, http.MethodGet, path, nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, path, nil)
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	var body generated.MergeRequestDetailResponse
@@ -15142,12 +15342,13 @@ func TestProviderPullRouteResolvesEscapedGitLabRepoPath(t *testing.T) {
 }
 
 func TestAPIGitLabProviderCapabilitiesExposeOnResponses(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	srv, database := setupGitLabCapabilityServer(t)
 	ctx := t.Context()
 
-	rawPulls := doJSON(t, srv, http.MethodGet, "/api/v1/pulls", nil)
+	rawPulls := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/pulls", nil)
 	require.Equal(http.StatusOK, rawPulls.Code, rawPulls.Body.String())
 	var pulls []map[string]any
 	require.NoError(json.NewDecoder(rawPulls.Body).Decode(&pulls))
@@ -15169,13 +15370,13 @@ func TestAPIGitLabProviderCapabilitiesExposeOnResponses(t *testing.T) {
 	assert.Equal(false, pullCaps["native_multiline_ranges"])
 	assert.Empty(pullCaps["supported_review_actions"])
 
-	rawDetail := doJSON(
+	rawDetail := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodGet,
 		"/api/v1/host/gitlab.example.com/pulls/gl/group/project/7",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, rawDetail.Code, rawDetail.Body.String())
 	var detail map[string]any
 	require.NoError(json.NewDecoder(rawDetail.Body).Decode(&detail))
@@ -15185,7 +15386,7 @@ func TestAPIGitLabProviderCapabilitiesExposeOnResponses(t *testing.T) {
 	assert.Equal(false, detailCaps["merge_mutation"])
 	assert.Equal(false, detailCaps["review_draft_mutation"])
 
-	rawSummaries := doJSON(t, srv, http.MethodGet, "/api/v1/repos/summary", nil)
+	rawSummaries := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/repos/summary", nil)
 	require.Equal(http.StatusOK, rawSummaries.Code, rawSummaries.Body.String())
 	var summaries []map[string]any
 	require.NoError(json.NewDecoder(rawSummaries.Body).Decode(&summaries))
@@ -15196,7 +15397,7 @@ func TestAPIGitLabProviderCapabilitiesExposeOnResponses(t *testing.T) {
 	assert.Equal(false, summaryCaps["issue_mutation"])
 	assert.Equal(false, summaryCaps["read_review_threads"])
 
-	rawRepos := doJSON(t, srv, http.MethodGet, "/api/v1/repos", nil)
+	rawRepos := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/repos", nil)
 	require.Equal(http.StatusOK, rawRepos.Code, rawRepos.Body.String())
 	var repos []map[string]any
 	require.NoError(json.NewDecoder(rawRepos.Body).Decode(&repos))
@@ -15227,7 +15428,7 @@ func TestAPIGitLabProviderCapabilitiesExposeOnResponses(t *testing.T) {
 	}))
 
 	since := time.Now().UTC().AddDate(0, 0, -7).Format(time.RFC3339)
-	rawActivity := doJSON(t, srv, http.MethodGet, "/api/v1/activity?since="+since, nil)
+	rawActivity := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/activity?since="+since, nil)
 	require.Equal(http.StatusOK, rawActivity.Code, rawActivity.Body.String())
 	var activity map[string]any
 	require.NoError(json.NewDecoder(rawActivity.Body).Decode(&activity))
@@ -15252,7 +15453,7 @@ func TestAPIGitLabProviderCapabilitiesExposeOnResponses(t *testing.T) {
 		TmuxSession:  "kenn-forge-gitlabcap0000001",
 		Status:       "creating",
 	}))
-	rawWorkspaces := doJSON(t, srv, http.MethodGet, "/api/v1/workspaces", nil)
+	rawWorkspaces := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/workspaces", nil)
 	require.Equal(http.StatusOK, rawWorkspaces.Code, rawWorkspaces.Body.String())
 	var workspaces map[string]any
 	require.NoError(json.NewDecoder(rawWorkspaces.Body).Decode(&workspaces))
@@ -15266,6 +15467,7 @@ func TestAPIGitLabProviderCapabilitiesExposeOnResponses(t *testing.T) {
 }
 
 func TestAPIGitLabUnsupportedMutationsReturnCodedCapabilityErrors(t *testing.T) {
+	runParallelServerTest(t)
 	srv, _ := setupGitLabCapabilityServer(t)
 
 	tests := []struct {
@@ -15392,7 +15594,7 @@ func TestAPIGitLabUnsupportedMutationsReturnCodedCapabilityErrors(t *testing.T) 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			rr := doJSON(t, srv, tt.method, tt.path, tt.body)
+			rr := testutil.DoJSON(t, srv, tt.method, tt.path, tt.body)
 			require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
 			assertUnsupportedCapabilityProblem(
 				t, rr.Body, "gitlab", "gitlab.example.com", tt.capability,
@@ -15406,17 +15608,18 @@ func TestAPIGitLabUnsupportedMutationsReturnCodedCapabilityErrors(t *testing.T) 
 // `code = "unsupportedCapability"` and `details.capability` carrying the
 // capability the route required. Frontend callers branch on `code`.
 func TestAPIUnsupportedCapabilityEnvelope(t *testing.T) {
+	runParallelServerTest(t)
 	srv, _ := setupGitLabCapabilityServer(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
 		"/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/approve-workflows",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
 
 	var problem rawProblemDetail
@@ -15429,6 +15632,7 @@ func TestAPIUnsupportedCapabilityEnvelope(t *testing.T) {
 }
 
 func TestAPICapabilityGatedRouteReturnsLookupProblemBeforeCapabilityProblem(t *testing.T) {
+	runParallelServerTest(t)
 	srv, _ := setupTestServer(t)
 
 	tests := []struct {
@@ -15456,13 +15660,13 @@ func TestAPICapabilityGatedRouteReturnsLookupProblemBeforeCapabilityProblem(t *t
 			require := require.New(t)
 			assert := assert.New(t)
 
-			rr := doJSON(
+			rr := testutil.DoJSON(
 				t,
 				srv,
 				http.MethodPatch,
 				tt.path,
-				map[string]string{"title": "Updated title"},
-			)
+				map[string]string{"title": "Updated title"})
+
 			require.Equal(tt.wantCode, rr.Code, rr.Body.String())
 
 			var problem rawProblemDetail
@@ -15473,6 +15677,7 @@ func TestAPICapabilityGatedRouteReturnsLookupProblemBeforeCapabilityProblem(t *t
 }
 
 func TestAPICapabilityGatedMutationsHandleMissingSyncer(t *testing.T) {
+	runParallelServerTest(t)
 	database := dbtest.Open(t)
 	srv := New(database, nil, nil, "/", nil, ServerOptions{})
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
@@ -15580,7 +15785,7 @@ func TestAPICapabilityGatedMutationsHandleMissingSyncer(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 
-			rr := doJSON(t, srv, tt.method, tt.path, tt.body)
+			rr := testutil.DoJSON(t, srv, tt.method, tt.path, tt.body)
 			require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
 			assertUnsupportedCapabilityProblem(
 				t, rr.Body, "github", "github.com", tt.capability,
@@ -15595,6 +15800,7 @@ func TestAPICapabilityGatedMutationsHandleMissingSyncer(t *testing.T) {
 // providerCallProblem / mapPlatformError, which builds the rateLimited
 // problem with details.retryAfter populated as an RFC 3339 string.
 func TestAPIRateLimitedEnvelope(t *testing.T) {
+	runParallelServerTest(t)
 	reset := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
 	srv := setupGitLabIssueMutatorServer(t, &platform.Error{
 		Code:         platform.ErrCodeRateLimited,
@@ -15628,7 +15834,7 @@ func TestAPIRateLimitedEnvelope(t *testing.T) {
 			require := require.New(t)
 			assert := assert.New(t)
 
-			rr := doJSON(t, srv, tt.method, tt.path, tt.body)
+			rr := testutil.DoJSON(t, srv, tt.method, tt.path, tt.body)
 			require.Equal(http.StatusTooManyRequests, rr.Code, rr.Body.String())
 
 			var problem rawProblemDetail
@@ -15654,6 +15860,7 @@ func TestAPIRateLimitedEnvelope(t *testing.T) {
 // expects the typed validationError envelope with details.field and
 // details.allowed.
 func TestAPIValidationErrorEnvelope(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -15683,13 +15890,13 @@ func TestAPIValidationErrorEnvelope(t *testing.T) {
 	})
 	require.NoError(err)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPut,
 		"/api/v1/pulls/gh/acme/widget/42/state",
-		map[string]string{"status": "frobnicated"},
-	)
+		map[string]string{"status": "frobnicated"})
+
 	require.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
 
 	var problem rawProblemDetail
@@ -15820,6 +16027,7 @@ func (p *issueMutatorGitLabProvider) EditMergeRequestContent(
 // must carry the classified outcome — not a raw upstream failure or a 500 —
 // and the moved outcome must include the destination extension members.
 func TestAPIResolveItemMapsLookupOutcomes(t *testing.T) {
+	runParallelServerTest(t)
 	const movedRepoAPIURL = "https://api.github.com/repos/newowner/newname"
 
 	statusErr := func(status int) error {
@@ -15878,7 +16086,7 @@ func TestAPIResolveItemMapsLookupOutcomes(t *testing.T) {
 			)
 			require.NoError(err)
 
-			rr := doJSON(t, srv, http.MethodPost, "/api/v1/repo/gh/acme/widget/resolve/5", nil)
+			rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/repo/gh/acme/widget/resolve/5", nil)
 			require.Equal(tc.wantStatus, rr.Code, rr.Body.String())
 
 			var problem rawProblemDetail
@@ -15926,6 +16134,7 @@ func (p *movedLookupGitLabProvider) GetMergeRequest(
 // problem body must carry the full provider-aware destination identity as
 // stable extension members so clients can retarget the reference.
 func TestAPIMovedLookupProblemCarriesDestination(t *testing.T) {
+	runParallelServerTest(t)
 	ctx := t.Context()
 	now := time.Now().UTC().Truncate(time.Second)
 
@@ -16028,7 +16237,7 @@ func TestAPIMovedLookupProblemCarriesDestination(t *testing.T) {
 			require := require.New(t)
 			assert := assert.New(t)
 
-			rr := doJSON(t, srv, http.MethodPost, tt.path, nil)
+			rr := testutil.DoJSON(t, srv, http.MethodPost, tt.path, nil)
 			require.Equal(http.StatusNotFound, rr.Code, rr.Body.String())
 
 			var problem rawProblemDetail
@@ -16048,6 +16257,7 @@ func TestAPIMovedLookupProblemCarriesDestination(t *testing.T) {
 }
 
 func TestAPIDiffReviewDraftCRUDUsesLocalStorage(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	caps := platform.Capabilities{
@@ -16073,7 +16283,7 @@ func TestAPIDiffReviewDraftCRUDUsesLocalStorage(t *testing.T) {
 	require.NotNil(mr)
 
 	basePath := "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-draft"
-	getRR := doJSON(t, srv, http.MethodGet, basePath, nil)
+	getRR := testutil.DoJSON(t, srv, http.MethodGet, basePath, nil)
 	require.Equal(http.StatusOK, getRR.Code, getRR.Body.String())
 	var draft map[string]any
 	require.NoError(json.NewDecoder(getRR.Body).Decode(&draft))
@@ -16082,7 +16292,7 @@ func TestAPIDiffReviewDraftCRUDUsesLocalStorage(t *testing.T) {
 	assert.Equal([]any{"comment"}, draft["supported_actions"])
 	assert.Equal(false, draft["native_multiline_ranges"])
 
-	createRR := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
+	createRR := testutil.DoJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
 		"body": "Please tighten this assertion.",
 		"range": map[string]any{
 			"path":          "internal/server/api_test.go",
@@ -16094,6 +16304,7 @@ func TestAPIDiffReviewDraftCRUDUsesLocalStorage(t *testing.T) {
 			"commit_sha":    "abc123",
 		},
 	})
+
 	require.Equal(http.StatusCreated, createRR.Code, createRR.Body.String())
 	var created map[string]any
 	require.NoError(json.NewDecoder(createRR.Body).Decode(&created))
@@ -16104,13 +16315,13 @@ func TestAPIDiffReviewDraftCRUDUsesLocalStorage(t *testing.T) {
 	assert.Equal("right", created["side"])
 	assert.InDelta(42, created["line"], 0)
 
-	getRR = doJSON(t, srv, http.MethodGet, basePath, nil)
+	getRR = testutil.DoJSON(t, srv, http.MethodGet, basePath, nil)
 	require.Equal(http.StatusOK, getRR.Code, getRR.Body.String())
 	require.NoError(json.NewDecoder(getRR.Body).Decode(&draft))
 	assert.NotEmpty(draft["draft_id"])
 	require.Len(draft["comments"], 1)
 
-	editRR := doJSON(
+	editRR := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPatch,
@@ -16126,27 +16337,27 @@ func TestAPIDiffReviewDraftCRUDUsesLocalStorage(t *testing.T) {
 				"diff_head_sha": "abc123",
 				"commit_sha":    "abc123",
 			},
-		},
-	)
+		})
+
 	require.Equal(http.StatusOK, editRR.Code, editRR.Body.String())
 	var edited map[string]any
 	require.NoError(json.NewDecoder(editRR.Body).Decode(&edited))
 	assert.Equal("Updated draft body.", edited["body"])
 	assert.InDelta(43, edited["line"], 0)
 
-	deleteRR := doJSON(
+	deleteRR := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodDelete,
 		basePath+"/comments/"+commentID,
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, deleteRR.Code, deleteRR.Body.String())
 	comments, err := database.ListMRReviewDraftComments(ctx, draftIDFromResponse(t, draft))
 	require.NoError(err)
 	assert.Empty(comments)
 
-	discardRR := doJSON(t, srv, http.MethodDelete, basePath, nil)
+	discardRR := testutil.DoJSON(t, srv, http.MethodDelete, basePath, nil)
 	require.Equal(http.StatusOK, discardRR.Code, discardRR.Body.String())
 	storedDraft, err := database.GetMRReviewDraft(ctx, mr.ID)
 	require.NoError(err)
@@ -16154,6 +16365,7 @@ func TestAPIDiffReviewDraftCRUDUsesLocalStorage(t *testing.T) {
 }
 
 func TestAPIDiffReviewDraftRejectsInvalidLineCoordinates(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	caps := platform.Capabilities{
@@ -16222,10 +16434,11 @@ func TestAPIDiffReviewDraftRejectsInvalidLineCoordinates(t *testing.T) {
 		},
 	}
 	for _, lineRange := range invalidRanges {
-		rr := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
+		rr := testutil.DoJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
 			"body":  "Invalid range.",
 			"range": lineRange,
 		})
+
 		require.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
 	}
 
@@ -16243,17 +16456,18 @@ func TestAPIDiffReviewDraftRejectsInvalidLineCoordinates(t *testing.T) {
 	require.NoError(err)
 	assert.Nil(storedDraft)
 
-	createRR := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
+	createRR := testutil.DoJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
 		"body":  "Valid draft.",
 		"range": validRange,
 	})
+
 	require.Equal(http.StatusCreated, createRR.Code, createRR.Body.String())
 	var created map[string]any
 	require.NoError(json.NewDecoder(createRR.Body).Decode(&created))
 	commentID, ok := created["id"].(string)
 	require.True(ok)
 
-	patchRR := doJSON(t, srv, http.MethodPatch, basePath+"/comments/"+commentID, map[string]any{
+	patchRR := testutil.DoJSON(t, srv, http.MethodPatch, basePath+"/comments/"+commentID, map[string]any{
 		"body": "Invalid patch.",
 		"range": map[string]any{
 			"path":          "internal/server/api_test.go",
@@ -16265,6 +16479,7 @@ func TestAPIDiffReviewDraftRejectsInvalidLineCoordinates(t *testing.T) {
 			"diff_head_sha": "abc123",
 		},
 	})
+
 	require.Equal(http.StatusBadRequest, patchRR.Code, patchRR.Body.String())
 	storedDraft, err = database.GetMRReviewDraft(ctx, mr.ID)
 	require.NoError(err)
@@ -16276,6 +16491,7 @@ func TestAPIDiffReviewDraftRejectsInvalidLineCoordinates(t *testing.T) {
 }
 
 func TestAPIGitHubPublishReviewDraftSendsCommentsThroughServer(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -16322,7 +16538,7 @@ func TestAPIGitHubPublishReviewDraftSendsCommentsThroughServer(t *testing.T) {
 	require.NoError(database.UpdateDiffSHAs(ctx, mr.RepoID, 42, "github-head", "base", "merge-base"))
 
 	basePath := "/api/v1/pulls/gh/acme/widget/42/review-draft"
-	createRR := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
+	createRR := testutil.DoJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
 		"body": "Please tighten this line.",
 		"range": map[string]any{
 			"path":          "src/main.go",
@@ -16336,12 +16552,14 @@ func TestAPIGitHubPublishReviewDraftSendsCommentsThroughServer(t *testing.T) {
 			"commit_sha":    "github-commit",
 		},
 	})
+
 	require.Equal(http.StatusCreated, createRR.Code, createRR.Body.String())
 
-	publishRR := doJSON(t, srv, http.MethodPost, basePath+"/publish", map[string]string{
+	publishRR := testutil.DoJSON(t, srv, http.MethodPost, basePath+"/publish", map[string]string{
 		"action": "request_changes",
 		"body":   " Needs changes. ",
 	})
+
 	require.Equal(http.StatusOK, publishRR.Code, publishRR.Body.String())
 	var publishStatus pullapi.ActionStatusBody
 	require.NoError(json.NewDecoder(publishRR.Body).Decode(&publishStatus))
@@ -16368,6 +16586,7 @@ func TestAPIGitHubPublishReviewDraftSendsCommentsThroughServer(t *testing.T) {
 }
 
 func TestAPIGitHubRequestChangesDoesNotPublishSavedDraftComments(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -16405,19 +16624,21 @@ func TestAPIGitHubRequestChangesDoesNotPublishSavedDraftComments(t *testing.T) {
 	require.NoError(database.UpdateDiffSHAs(ctx, mr.RepoID, 42, "reviewed-head", "base", "merge-base"))
 
 	basePath := "/api/v1/pulls/gh/acme/widget/42/review-draft"
-	createRR := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
+	createRR := testutil.DoJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
 		"body": "Saved for the later inline review.",
 		"range": map[string]any{
 			"path": "src/main.go", "side": "right", "line": 42,
 			"new_line": 42, "line_type": "add", "diff_head_sha": "reviewed-head",
 		},
 	})
+
 	require.Equal(http.StatusCreated, createRR.Code, createRR.Body.String())
 
-	requestRR := doJSON(t, srv, http.MethodPost, "/api/v1/pulls/gh/acme/widget/42/request-changes", map[string]string{
+	requestRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/pulls/gh/acme/widget/42/request-changes", map[string]string{
 		"body":              " Please cover the empty state. ",
 		"expected_head_sha": "provider-head",
 	})
+
 	require.Equal(http.StatusOK, requestRR.Code, requestRR.Body.String())
 	assert.Equal("Please cover the empty state.", captured.Body)
 	assert.Equal(platform.ReviewActionRequestChanges, captured.Action)
@@ -16433,6 +16654,7 @@ func TestAPIGitHubRequestChangesDoesNotPublishSavedDraftComments(t *testing.T) {
 }
 
 func TestAPIGitHubPublishReviewDraftRejectsSelfApprovalBeforeProvider(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -16462,7 +16684,7 @@ func TestAPIGitHubPublishReviewDraftRejectsSelfApprovalBeforeProvider(t *testing
 	require.NoError(database.UpdateDiffSHAs(ctx, mr.RepoID, 42, "github-head", "base", "merge-base"))
 
 	basePath := "/api/v1/pulls/gh/acme/widget/42/review-draft"
-	createRR := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
+	createRR := testutil.DoJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
 		"body": "Please tighten this line.",
 		"range": map[string]any{
 			"path":          "src/main.go",
@@ -16474,12 +16696,14 @@ func TestAPIGitHubPublishReviewDraftRejectsSelfApprovalBeforeProvider(t *testing
 			"commit_sha":    "github-head",
 		},
 	})
+
 	require.Equal(http.StatusCreated, createRR.Code, createRR.Body.String())
 
-	publishRR := doJSON(t, srv, http.MethodPost, basePath+"/publish", map[string]string{
+	publishRR := testutil.DoJSON(t, srv, http.MethodPost, basePath+"/publish", map[string]string{
 		"action": "approve",
 		"body":   "looks good",
 	})
+
 	require.Equal(http.StatusForbidden, publishRR.Code, publishRR.Body.String())
 	var problem rawProblemDetail
 	require.NoError(json.NewDecoder(publishRR.Body).Decode(&problem))
@@ -16494,6 +16718,7 @@ func TestAPIGitHubPublishReviewDraftRejectsSelfApprovalBeforeProvider(t *testing
 }
 
 func TestAPIGitHubReviewDraftHidesApproveForSelfAuthoredPR(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	mock := &mockGH{
@@ -16505,7 +16730,7 @@ func TestAPIGitHubReviewDraftHidesApproveForSelfAuthoredPR(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 42, withSeedPRAuthor("marius"))
 	seedPR(t, database, "acme", "widget", 43, withSeedPRAuthor("someone-else"))
 
-	selfRR := doJSON(t, srv, http.MethodGet, "/api/v1/pulls/gh/acme/widget/42/review-draft", nil)
+	selfRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/pulls/gh/acme/widget/42/review-draft", nil)
 	require.Equal(http.StatusOK, selfRR.Code, selfRR.Body.String())
 	var selfDraft map[string]any
 	require.NoError(json.NewDecoder(selfRR.Body).Decode(&selfDraft))
@@ -16515,7 +16740,7 @@ func TestAPIGitHubReviewDraftHidesApproveForSelfAuthoredPR(t *testing.T) {
 		"self-authored PR draft must not advertise approve",
 	)
 
-	otherRR := doJSON(t, srv, http.MethodGet, "/api/v1/pulls/gh/acme/widget/43/review-draft", nil)
+	otherRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/pulls/gh/acme/widget/43/review-draft", nil)
 	require.Equal(http.StatusOK, otherRR.Code, otherRR.Body.String())
 	var otherDraft map[string]any
 	require.NoError(json.NewDecoder(otherRR.Body).Decode(&otherDraft))
@@ -16527,6 +16752,7 @@ func TestAPIGitHubReviewDraftHidesApproveForSelfAuthoredPR(t *testing.T) {
 }
 
 func TestAPIGitHubApprovePullRejectsSelfApprovalBeforeProvider(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	var providerCalled atomic.Bool
@@ -16548,11 +16774,11 @@ func TestAPIGitHubApprovePullRejectsSelfApprovalBeforeProvider(t *testing.T) {
 	srv, database := setupTestServerWithMock(t, mock)
 	seedPR(t, database, "acme", "widget", 42, withSeedPRAuthor("marius"))
 
-	approveRR := doJSON(
+	approveRR := testutil.DoJSON(
 		t, srv, http.MethodPost,
 		"/api/v1/pulls/gh/acme/widget/42/approve",
-		map[string]any{"body": ""},
-	)
+		map[string]any{"body": ""})
+
 	require.Equal(http.StatusForbidden, approveRR.Code, approveRR.Body.String())
 	var problem rawProblemDetail
 	require.NoError(json.NewDecoder(approveRR.Body).Decode(&problem))
@@ -16563,6 +16789,7 @@ func TestAPIGitHubApprovePullRejectsSelfApprovalBeforeProvider(t *testing.T) {
 }
 
 func TestAPIPublishReviewDraftRejectsStoredCommentWithoutDiffHeadSHA(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	caps := platform.Capabilities{
 		ReadRepositories:       true,
@@ -16603,17 +16830,18 @@ func TestAPIPublishReviewDraftRejectsStoredCommentWithoutDiffHeadSHA(t *testing.
 	})
 	require.NoError(err)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
 		"/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-draft/publish",
-		map[string]string{"action": "comment"},
-	)
+		map[string]string{"action": "comment"})
+
 	require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
 }
 
 func TestAPIPublishReviewDraftUsesPlatformHeadSHAWhenDiffHeadIsUnavailable(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	caps := platform.Capabilities{
@@ -16653,13 +16881,12 @@ func TestAPIPublishReviewDraftUsesPlatformHeadSHAWhenDiffHeadIsUnavailable(t *te
 	})
 	require.NoError(err)
 
-	publishRR := doJSON(
+	publishRR := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
 		"/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-draft/publish",
-		map[string]string{"action": "approve", "body": "looks good"},
-	)
+		map[string]string{"action": "approve", "body": "looks good"})
 
 	require.Equal(http.StatusOK, publishRR.Code, publishRR.Body.String())
 	require.Len(provider.publishedReviews, 1)
@@ -16667,6 +16894,7 @@ func TestAPIPublishReviewDraftUsesPlatformHeadSHAWhenDiffHeadIsUnavailable(t *te
 }
 
 func TestAPIPublishReviewDraftMapsStaleProviderErrorToConflict(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	caps := platform.Capabilities{
@@ -16717,13 +16945,12 @@ func TestAPIPublishReviewDraftMapsStaleProviderErrorToConflict(t *testing.T) {
 	})
 	require.NoError(err)
 
-	publishRR := doJSON(
+	publishRR := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
 		"/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-draft/publish",
-		map[string]string{"action": "approve", "body": "looks good"},
-	)
+		map[string]string{"action": "approve", "body": "looks good"})
 
 	require.Equal(http.StatusConflict, publishRR.Code, publishRR.Body.String())
 	var problem rawProblemDetail
@@ -16752,6 +16979,7 @@ func TestAPIPublishReviewDraftMapsStaleProviderErrorToConflict(t *testing.T) {
 }
 
 func TestAPIPublishReviewDraftMapsPartialStaleProviderErrorToConflict(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	caps := platform.Capabilities{
@@ -16804,13 +17032,12 @@ func TestAPIPublishReviewDraftMapsPartialStaleProviderErrorToConflict(t *testing
 	})
 	require.NoError(err)
 
-	publishRR := doJSON(
+	publishRR := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
 		"/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-draft/publish",
-		map[string]string{"action": "approve", "body": "looks good"},
-	)
+		map[string]string{"action": "approve", "body": "looks good"})
 
 	require.Equal(http.StatusConflict, publishRR.Code, publishRR.Body.String())
 	var problem rawProblemDetail
@@ -16837,6 +17064,7 @@ func TestAPIPublishReviewDraftMapsPartialStaleProviderErrorToConflict(t *testing
 }
 
 func TestAPIPublishReviewDraftRejectsMultilineRangeWithoutCapability(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	caps := platform.Capabilities{
 		ReadRepositories:       true,
@@ -16860,7 +17088,7 @@ func TestAPIPublishReviewDraftRejectsMultilineRangeWithoutCapability(t *testing.
 	require.NoError(database.UpdateDiffSHAs(ctx, repo.ID, 7, "current-head", "base", "merge"))
 
 	basePath := "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-draft"
-	createRR := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
+	createRR := testutil.DoJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
 		"body": "Please fix this range.",
 		"range": map[string]any{
 			"path":          "internal/server/api_test.go",
@@ -16873,20 +17101,22 @@ func TestAPIPublishReviewDraftRejectsMultilineRangeWithoutCapability(t *testing.
 			"diff_head_sha": "current-head",
 		},
 	})
+
 	require.Equal(http.StatusCreated, createRR.Code, createRR.Body.String())
 
-	publishRR := doJSON(
+	publishRR := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
 		basePath+"/publish",
-		map[string]string{"action": "comment"},
-	)
+		map[string]string{"action": "comment"})
+
 	require.Equal(http.StatusBadRequest, publishRR.Code, publishRR.Body.String())
 	require.Empty(provider.publishedReviews)
 }
 
 func TestAPIGitLabPublishReviewDraftApprovesWithDiffPositionSHAs(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	caps := platform.Capabilities{
@@ -16914,14 +17144,14 @@ func TestAPIGitLabPublishReviewDraftApprovesWithDiffPositionSHAs(t *testing.T) {
 	require.NoError(database.UpdateDiffSHAs(ctx, repo.ID, 7, "gitlab-head", "gitlab-base", "gitlab-merge-base"))
 
 	basePath := "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-draft"
-	getRR := doJSON(t, srv, http.MethodGet, basePath, nil)
+	getRR := testutil.DoJSON(t, srv, http.MethodGet, basePath, nil)
 	require.Equal(http.StatusOK, getRR.Code, getRR.Body.String())
 	var draft map[string]any
 	require.NoError(json.NewDecoder(getRR.Body).Decode(&draft))
 	assert.Equal([]any{"comment", "approve"}, draft["supported_actions"])
 	assert.Equal(false, draft["native_multiline_ranges"])
 
-	createRR := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
+	createRR := testutil.DoJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
 		"body": "Please tighten this line.",
 		"range": map[string]any{
 			"path":          "internal/server/api_test.go",
@@ -16933,28 +17163,29 @@ func TestAPIGitLabPublishReviewDraftApprovesWithDiffPositionSHAs(t *testing.T) {
 			"commit_sha":    "gitlab-head",
 		},
 	})
+
 	require.Equal(http.StatusCreated, createRR.Code, createRR.Body.String())
 
-	rejectRR := doJSON(
+	rejectRR := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
 		basePath+"/publish",
-		map[string]string{"action": "request_changes"},
-	)
+		map[string]string{"action": "request_changes"})
+
 	require.Equal(http.StatusConflict, rejectRR.Code, rejectRR.Body.String())
 	assertUnsupportedCapabilityProblem(
 		t, rejectRR.Body, "gitlab", "gitlab.example.com", "review_action_request_changes",
 	)
 	require.Empty(provider.publishedReviews)
 
-	publishRR := doJSON(
+	publishRR := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
 		basePath+"/publish",
-		map[string]string{"action": "approve", "body": "approved"},
-	)
+		map[string]string{"action": "approve", "body": "approved"})
+
 	require.Equal(http.StatusOK, publishRR.Code, publishRR.Body.String())
 	require.Len(provider.publishedReviews, 1)
 	published := provider.publishedReviews[0]
@@ -16970,6 +17201,7 @@ func TestAPIGitLabPublishReviewDraftApprovesWithDiffPositionSHAs(t *testing.T) {
 }
 
 func TestAPIPublishReviewDraftPreservesDraftWhenPartialStatusIsUnknown(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	caps := platform.Capabilities{
 		ReadRepositories:       true,
@@ -16998,7 +17230,7 @@ func TestAPIPublishReviewDraftPreservesDraftWhenPartialStatusIsUnknown(t *testin
 	require.NoError(database.UpdateDiffSHAs(ctx, repo.ID, 7, "gitlab-head", "gitlab-base", "gitlab-merge-base"))
 
 	basePath := "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-draft"
-	createRR := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
+	createRR := testutil.DoJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
 		"body": "Please tighten this line.",
 		"range": map[string]any{
 			"path":          "internal/server/api_test.go",
@@ -17010,15 +17242,16 @@ func TestAPIPublishReviewDraftPreservesDraftWhenPartialStatusIsUnknown(t *testin
 			"commit_sha":    "gitlab-head",
 		},
 	})
+
 	require.Equal(http.StatusCreated, createRR.Code, createRR.Body.String())
 
-	publishRR := doJSON(
+	publishRR := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
 		basePath+"/publish",
-		map[string]string{"action": "comment"},
-	)
+		map[string]string{"action": "comment"})
+
 	require.Equal(http.StatusOK, publishRR.Code, publishRR.Body.String())
 	var publishStatus pullapi.ActionStatusBody
 	require.NoError(json.NewDecoder(publishRR.Body).Decode(&publishStatus))
@@ -17034,6 +17267,7 @@ func TestAPIPublishReviewDraftPreservesDraftWhenPartialStatusIsUnknown(t *testin
 }
 
 func TestAPIGitLabPublishReviewDraftSurfacesCleanupFailureAsPartial(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -17182,7 +17416,7 @@ func TestAPIGitLabPublishReviewDraftSurfacesCleanupFailureAsPartial(t *testing.T
 
 	basePath := "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-draft"
 	for _, line := range []int{41, 42} {
-		createRR := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
+		createRR := testutil.DoJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
 			"body": fmt.Sprintf("line %d", line),
 			"range": map[string]any{
 				"path":          "src/main.go",
@@ -17193,12 +17427,14 @@ func TestAPIGitLabPublishReviewDraftSurfacesCleanupFailureAsPartial(t *testing.T
 				"diff_head_sha": "gitlab-head",
 			},
 		})
+
 		require.Equal(http.StatusCreated, createRR.Code, createRR.Body.String())
 	}
 
-	publishRR := doJSON(t, srv, http.MethodPost, basePath+"/publish", map[string]string{
+	publishRR := testutil.DoJSON(t, srv, http.MethodPost, basePath+"/publish", map[string]string{
 		"action": "comment",
 	})
+
 	require.Equal(http.StatusOK, publishRR.Code, publishRR.Body.String())
 	var publishStatus pullapi.ActionStatusBody
 	require.NoError(json.NewDecoder(publishRR.Body).Decode(&publishStatus))
@@ -17231,6 +17467,7 @@ func TestAPIGitLabPublishReviewDraftSurfacesCleanupFailureAsPartial(t *testing.T
 }
 
 func TestAPIGitLabPublishReviewDraftSendsSummaryThroughServer(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -17307,7 +17544,7 @@ func TestAPIGitLabPublishReviewDraftSendsSummaryThroughServer(t *testing.T) {
 	require.NoError(database.UpdateDiffSHAs(ctx, repoID, 7, "gitlab-head", "base", "merge-base"))
 
 	basePath := "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-draft"
-	createRR := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
+	createRR := testutil.DoJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
 		"body": "inline note",
 		"range": map[string]any{
 			"path":          "src/main.go",
@@ -17318,12 +17555,14 @@ func TestAPIGitLabPublishReviewDraftSendsSummaryThroughServer(t *testing.T) {
 			"diff_head_sha": "gitlab-head",
 		},
 	})
+
 	require.Equal(http.StatusCreated, createRR.Code, createRR.Body.String())
 
-	publishRR := doJSON(t, srv, http.MethodPost, basePath+"/publish", map[string]string{
+	publishRR := testutil.DoJSON(t, srv, http.MethodPost, basePath+"/publish", map[string]string{
 		"action": "approve",
 		"body":   " review summary from ui ",
 	})
+
 	require.Equal(http.StatusOK, publishRR.Code, publishRR.Body.String())
 	var publishStatus pullapi.ActionStatusBody
 	require.NoError(json.NewDecoder(publishRR.Body).Decode(&publishStatus))
@@ -17428,6 +17667,7 @@ func writeRawJSONForTest(w http.ResponseWriter, body string) {
 }
 
 func TestAPIPublishReviewDraftPersistsProviderReviewThreads(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	caps := platform.Capabilities{
@@ -17524,7 +17764,7 @@ func TestAPIPublishReviewDraftPersistsProviderReviewThreads(t *testing.T) {
 		},
 	}
 	basePath := "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-draft"
-	createRR := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
+	createRR := testutil.DoJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
 		"body": "Please fix this.",
 		"range": map[string]any{
 			"path":          "internal/server/api_test.go",
@@ -17535,15 +17775,16 @@ func TestAPIPublishReviewDraftPersistsProviderReviewThreads(t *testing.T) {
 			"diff_head_sha": "current-head",
 		},
 	})
+
 	require.Equal(http.StatusCreated, createRR.Code, createRR.Body.String())
 
-	publishRR := doJSON(
+	publishRR := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
 		basePath+"/publish",
-		map[string]string{"action": "comment", "body": "review summary"},
-	)
+		map[string]string{"action": "comment", "body": "review summary"})
+
 	require.Equal(http.StatusOK, publishRR.Code, publishRR.Body.String())
 	require.Len(provider.publishedReviews, 1)
 	assert.Equal(platform.ReviewActionComment, provider.publishedReviews[0].Action)
@@ -17586,6 +17827,7 @@ func TestAPIPublishReviewDraftPersistsProviderReviewThreads(t *testing.T) {
 }
 
 func TestAPIForgejoPublishReviewDraftIngestsTimelineThread(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	caps := platform.Capabilities{
@@ -17633,7 +17875,7 @@ func TestAPIForgejoPublishReviewDraftIngestsTimelineThread(t *testing.T) {
 	}}
 
 	basePath := "/api/v1/pulls/forgejo/acme/widgets/42/review-draft"
-	createRR := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
+	createRR := testutil.DoJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
 		"body": "Forgejo inline note",
 		"range": map[string]any{
 			"path":          "src/main.go",
@@ -17645,15 +17887,17 @@ func TestAPIForgejoPublishReviewDraftIngestsTimelineThread(t *testing.T) {
 			"commit_sha":    "forgejo-head",
 		},
 	})
+
 	require.Equal(http.StatusCreated, createRR.Code, createRR.Body.String())
 
-	publishRR := doJSON(t, srv, http.MethodPost, basePath+"/publish", map[string]string{
+	publishRR := testutil.DoJSON(t, srv, http.MethodPost, basePath+"/publish", map[string]string{
 		"action": "comment",
 	})
+
 	require.Equal(http.StatusOK, publishRR.Code, publishRR.Body.String())
 	require.Len(provider.publishedReviews, 1)
 
-	detailRR := doJSON(t, srv, http.MethodGet, "/api/v1/pulls/forgejo/acme/widgets/42", nil)
+	detailRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/pulls/forgejo/acme/widgets/42", nil)
 	require.Equal(http.StatusOK, detailRR.Code, detailRR.Body.String())
 	var detail pullapi.MergeRequestDetailResponse
 	require.NoError(json.NewDecoder(detailRR.Body).Decode(&detail))
@@ -17665,6 +17909,7 @@ func TestAPIForgejoPublishReviewDraftIngestsTimelineThread(t *testing.T) {
 }
 
 func TestAPIForgejoSyncPersistsCompleteLargeReviewDatasetBeforeSuccess(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	caps := platform.Capabilities{
@@ -17711,13 +17956,13 @@ func TestAPIForgejoSyncPersistsCompleteLargeReviewDatasetBeforeSuccess(t *testin
 		}
 	}
 
-	syncRR := doJSON(t, srv, http.MethodPost, "/api/v1/pulls/forgejo/acme/widgets/42/sync", nil)
+	syncRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/pulls/forgejo/acme/widgets/42/sync", nil)
 	require.Equal(http.StatusOK, syncRR.Code, syncRR.Body.String())
 	threads, err := database.ListMRReviewThreads(ctx, mr.ID)
 	require.NoError(err)
 	require.Len(threads, 101)
 
-	detailRR := doJSON(t, srv, http.MethodGet, "/api/v1/pulls/forgejo/acme/widgets/42", nil)
+	detailRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/pulls/forgejo/acme/widgets/42", nil)
 	require.Equal(http.StatusOK, detailRR.Code, detailRR.Body.String())
 	var detail pullapi.MergeRequestDetailResponse
 	require.NoError(json.NewDecoder(detailRR.Body).Decode(&detail))
@@ -17730,6 +17975,7 @@ func TestAPIForgejoSyncPersistsCompleteLargeReviewDatasetBeforeSuccess(t *testin
 }
 
 func TestAPIGitLabSyncKeepsCanonicalReviewThreadWhenProviderReturnsReplies(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	caps := platform.Capabilities{
@@ -17791,7 +18037,7 @@ func TestAPIGitLabSyncKeepsCanonicalReviewThreadWhenProviderReturnsReplies(t *te
 		},
 	}
 
-	syncRR := doJSON(t, srv, http.MethodPost, "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/sync", nil)
+	syncRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/sync", nil)
 	require.Equal(http.StatusOK, syncRR.Code, syncRR.Body.String())
 
 	threads, err := database.ListMRReviewThreads(ctx, mr.ID)
@@ -17803,7 +18049,7 @@ func TestAPIGitLabSyncKeepsCanonicalReviewThreadWhenProviderReturnsReplies(t *te
 	assert.Equal("reviewer", threads[0].AuthorLogin)
 	assert.Equal(originalLine, threads[0].Range.Line)
 
-	detailRR := doJSON(t, srv, http.MethodGet, "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7", nil)
+	detailRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7", nil)
 	require.Equal(http.StatusOK, detailRR.Code, detailRR.Body.String())
 	var detail pullapi.MergeRequestDetailResponse
 	require.NoError(json.NewDecoder(detailRR.Body).Decode(&detail))
@@ -17825,6 +18071,7 @@ func TestAPIGitLabSyncKeepsCanonicalReviewThreadWhenProviderReturnsReplies(t *te
 }
 
 func TestAPIGitLabSyncRemovesMissingReviewThreadTimelineEvents(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	caps := platform.Capabilities{
 		ReadRepositories:  true,
@@ -17885,13 +18132,13 @@ func TestAPIGitLabSyncRemovesMissingReviewThreadTimelineEvents(t *testing.T) {
 	provider.mergeRequests[0].LastActivityAt = providerUpdatedAt
 	provider.reviewThreads = nil
 
-	syncRR := doJSON(t, srv, http.MethodPost, "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/sync", nil)
+	syncRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/sync", nil)
 	require.Equal(http.StatusOK, syncRR.Code, syncRR.Body.String())
 
 	threads, err := database.ListMRReviewThreads(ctx, mr.ID)
 	require.NoError(err)
 	require.Empty(threads)
-	detailRR := doJSON(t, srv, http.MethodGet, "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7", nil)
+	detailRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7", nil)
 	require.Equal(http.StatusOK, detailRR.Code, detailRR.Body.String())
 	var detail pullapi.MergeRequestDetailResponse
 	require.NoError(json.NewDecoder(detailRR.Body).Decode(&detail))
@@ -17900,6 +18147,7 @@ func TestAPIGitLabSyncRemovesMissingReviewThreadTimelineEvents(t *testing.T) {
 }
 
 func TestAPIGitLabSyncPrunesLegacyPositionedNoteCommentEvents(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	caps := platform.Capabilities{
@@ -17951,10 +18199,10 @@ func TestAPIGitLabSyncPrunesLegacyPositionedNoteCommentEvents(t *testing.T) {
 		UpdatedAt: now,
 	}}
 
-	syncRR := doJSON(t, srv, http.MethodPost, "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/sync", nil)
+	syncRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/sync", nil)
 	require.Equal(http.StatusOK, syncRR.Code, syncRR.Body.String())
 
-	detailRR := doJSON(t, srv, http.MethodGet, "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7", nil)
+	detailRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7", nil)
 	require.Equal(http.StatusOK, detailRR.Code, detailRR.Body.String())
 	var detail pullapi.MergeRequestDetailResponse
 	require.NoError(json.NewDecoder(detailRR.Body).Decode(&detail))
@@ -17971,6 +18219,7 @@ func TestAPIGitLabSyncPrunesLegacyPositionedNoteCommentEvents(t *testing.T) {
 }
 
 func TestAPIPublishReviewDraftReconcilesAfterTransientThreadIngestFailure(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	caps := platform.Capabilities{
@@ -18030,7 +18279,7 @@ func TestAPIPublishReviewDraftReconcilesAfterTransientThreadIngestFailure(t *tes
 	}
 
 	basePath := "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-draft"
-	createRR := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
+	createRR := testutil.DoJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
 		"body": "Please fix this.",
 		"range": map[string]any{
 			"path":          "internal/server/api_test.go",
@@ -18041,15 +18290,16 @@ func TestAPIPublishReviewDraftReconcilesAfterTransientThreadIngestFailure(t *tes
 			"diff_head_sha": "current-head",
 		},
 	})
+
 	require.Equal(http.StatusCreated, createRR.Code, createRR.Body.String())
 
-	publishRR := doJSON(
+	publishRR := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
 		basePath+"/publish",
-		map[string]string{"action": "comment"},
-	)
+		map[string]string{"action": "comment"})
+
 	require.Equal(http.StatusOK, publishRR.Code, publishRR.Body.String())
 	var publishStatus pullapi.ActionStatusBody
 	require.NoError(json.NewDecoder(publishRR.Body).Decode(&publishStatus))
@@ -18069,7 +18319,7 @@ func TestAPIPublishReviewDraftReconcilesAfterTransientThreadIngestFailure(t *tes
 		}
 	}, 10*time.Second, 10*time.Millisecond, "background refresh did not reach the provider")
 	require.Eventually(func() bool {
-		detailRR := doJSON(t, srv, http.MethodGet, detailPath, nil)
+		detailRR := testutil.DoJSON(t, srv, http.MethodGet, detailPath, nil)
 		if detailRR.Code != http.StatusOK {
 			return false
 		}
@@ -18098,6 +18348,7 @@ func TestAPIPublishReviewDraftReconcilesAfterTransientThreadIngestFailure(t *tes
 }
 
 func TestAPIResolveReviewThreadPersistsProviderState(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	caps := platform.Capabilities{
@@ -18141,13 +18392,13 @@ func TestAPIResolveReviewThreadPersistsProviderState(t *testing.T) {
 	require.Len(threads, 1)
 	threadID := strconv.FormatInt(threads[0].ID, 10)
 
-	resolveRR := doJSON(
+	resolveRR := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
 		"/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-threads/"+threadID+"/resolve",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, resolveRR.Code, resolveRR.Body.String())
 	assert.Equal([]string{"thread-7"}, provider.resolvedThreads)
 	thread, err := database.GetMRReviewThread(ctx, mr.ID, threads[0].ID)
@@ -18155,13 +18406,13 @@ func TestAPIResolveReviewThreadPersistsProviderState(t *testing.T) {
 	require.NotNil(thread)
 	assert.True(thread.Resolved)
 
-	unresolveRR := doJSON(
+	unresolveRR := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
 		"/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-threads/"+threadID+"/unresolve",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, unresolveRR.Code, unresolveRR.Body.String())
 	assert.Equal([]string{"thread-7"}, provider.unresolvedThreads)
 	thread, err = database.GetMRReviewThread(ctx, mr.ID, threads[0].ID)
@@ -18171,6 +18422,7 @@ func TestAPIResolveReviewThreadPersistsProviderState(t *testing.T) {
 }
 
 func TestAPIResolveReviewThreadReturnsServerErrorForCorruptStoredThread(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	caps := platform.Capabilities{
 		ReadRepositories:       true,
@@ -18223,18 +18475,19 @@ func TestAPIResolveReviewThreadReturnsServerErrorForCorruptStoredThread(t *testi
 	)
 	require.NoError(err)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
 		"/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-threads/"+
 			strconv.FormatInt(threads[0].ID, 10)+"/resolve",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusInternalServerError, rr.Code, rr.Body.String())
 }
 
 func TestAPIPullDetailAttachesReviewThreadMetadata(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	srv, database := setupGitLabCapabilityServer(t)
@@ -18277,13 +18530,13 @@ func TestAPIPullDetailAttachesReviewThreadMetadata(t *testing.T) {
 		UpdatedAt: time.Now().UTC(),
 	}}))
 
-	rawDetail := doJSON(
+	rawDetail := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodGet,
 		"/api/v1/host/gitlab.example.com/pulls/gl/group/project/7",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, rawDetail.Code, rawDetail.Body.String())
 	var detail map[string]any
 	require.NoError(json.NewDecoder(rawDetail.Body).Decode(&detail))
@@ -18324,6 +18577,7 @@ func seedApplySuggestionReviewThread(t *testing.T, database *db.DB, mrID int64) 
 }
 
 func TestAPIApplyReviewSuggestionPassesStoredThreadRangeToProvider(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	caps := platform.Capabilities{
@@ -18373,7 +18627,7 @@ func TestAPIApplyReviewSuggestionPassesStoredThreadRangeToProvider(t *testing.T)
 	require.NoError(err)
 	require.Len(threads, 1)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
@@ -18384,8 +18638,8 @@ func TestAPIApplyReviewSuggestionPassesStoredThreadRangeToProvider(t *testing.T)
 				"thread_id":   strconv.FormatInt(threads[0].ID, 10),
 				"replacement": "return client.publishThreads();",
 			}},
-		},
-	)
+		})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	var response pullapi.ApplyReviewSuggestionResponse
 	require.NoError(json.NewDecoder(rr.Body).Decode(&response))
@@ -18404,6 +18658,7 @@ func TestAPIApplyReviewSuggestionPassesStoredThreadRangeToProvider(t *testing.T)
 }
 
 func TestAPIApplyReviewSuggestionRejectsNonOpenPullRequest(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	caps := platform.Capabilities{
@@ -18432,7 +18687,7 @@ func TestAPIApplyReviewSuggestionRejectsNonOpenPullRequest(t *testing.T) {
 	require.NotNil(mr)
 	thread := seedApplySuggestionReviewThread(t, database, mr.ID)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
@@ -18443,8 +18698,7 @@ func TestAPIApplyReviewSuggestionRejectsNonOpenPullRequest(t *testing.T) {
 				"thread_id":   strconv.FormatInt(thread.ID, 10),
 				"replacement": "return client.publishThreads();",
 			}},
-		},
-	)
+		})
 
 	require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
 	var problem rawProblemDetail
@@ -18457,6 +18711,7 @@ func TestAPIApplyReviewSuggestionRejectsNonOpenPullRequest(t *testing.T) {
 }
 
 func TestAPIApplyReviewSuggestionRejectsUnknownHeadRepoOnGitHub(t *testing.T) {
+	runParallelServerTest(t)
 	tests := []struct {
 		name             string
 		headRepoCloneURL string
@@ -18479,7 +18734,7 @@ func TestAPIApplyReviewSuggestionRejectsUnknownHeadRepoOnGitHub(t *testing.T) {
 			}
 			srv, _, provider := setupGitHubCapabilityServerWithProvider(t, &caps, tt.headRepoCloneURL)
 
-			rr := doJSON(
+			rr := testutil.DoJSON(
 				t,
 				srv,
 				http.MethodPost,
@@ -18490,8 +18745,7 @@ func TestAPIApplyReviewSuggestionRejectsUnknownHeadRepoOnGitHub(t *testing.T) {
 						"thread_id":   "1",
 						"replacement": "return client.publishThreads();",
 					}},
-				},
-			)
+				})
 
 			require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
 			var problem rawProblemDetail
@@ -18506,6 +18760,7 @@ func TestAPIApplyReviewSuggestionRejectsUnknownHeadRepoOnGitHub(t *testing.T) {
 }
 
 func TestAPIApplyReviewSuggestionPassesHeadRepoToGitHubProvider(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	caps := platform.Capabilities{
@@ -18534,7 +18789,7 @@ func TestAPIApplyReviewSuggestionPassesHeadRepoToGitHubProvider(t *testing.T) {
 	require.NotNil(mr)
 	thread := seedApplySuggestionReviewThread(t, database, mr.ID)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
@@ -18545,8 +18800,7 @@ func TestAPIApplyReviewSuggestionPassesHeadRepoToGitHubProvider(t *testing.T) {
 				"thread_id":   strconv.FormatInt(thread.ID, 10),
 				"replacement": "return client.publishThreads();",
 			}},
-		},
-	)
+		})
 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	require.Len(provider.appliedSuggestions, 1)
@@ -18557,6 +18811,7 @@ func TestAPIApplyReviewSuggestionPassesHeadRepoToGitHubProvider(t *testing.T) {
 }
 
 func TestAPIApplyReviewSuggestionMapsProviderConflictReason(t *testing.T) {
+	runParallelServerTest(t)
 	tests := []struct {
 		name   string
 		reason string
@@ -18601,7 +18856,7 @@ func TestAPIApplyReviewSuggestionMapsProviderConflictReason(t *testing.T) {
 			require.NotNil(mr)
 			thread := seedApplySuggestionReviewThread(t, database, mr.ID)
 
-			rr := doJSON(
+			rr := testutil.DoJSON(
 				t,
 				srv,
 				http.MethodPost,
@@ -18612,8 +18867,7 @@ func TestAPIApplyReviewSuggestionMapsProviderConflictReason(t *testing.T) {
 						"thread_id":   strconv.FormatInt(thread.ID, 10),
 						"replacement": "return client.publishThreads();",
 					}},
-				},
-			)
+				})
 
 			require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
 			var problem rawProblemDetail
@@ -18626,6 +18880,7 @@ func TestAPIApplyReviewSuggestionMapsProviderConflictReason(t *testing.T) {
 }
 
 func TestAPIApplyReviewSuggestionMapsProviderStaleStateAndRefreshesDetail(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	caps := platform.Capabilities{
@@ -18661,7 +18916,7 @@ func TestAPIApplyReviewSuggestionMapsProviderStaleStateAndRefreshesDetail(t *tes
 	thread := seedApplySuggestionReviewThread(t, database, mr.ID)
 	ch, _ := srv.Hub().Subscribe(ctx, false)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
@@ -18672,8 +18927,7 @@ func TestAPIApplyReviewSuggestionMapsProviderStaleStateAndRefreshesDetail(t *tes
 				"thread_id":   strconv.FormatInt(thread.ID, 10),
 				"replacement": "return client.publishThreads();",
 			}},
-		},
-	)
+		})
 
 	require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
 	var problem rawProblemDetail
@@ -18690,6 +18944,7 @@ func TestAPIApplyReviewSuggestionMapsProviderStaleStateAndRefreshesDetail(t *tes
 }
 
 func TestAPIApplyReviewSuggestionReturnsAppliedWithoutCommitMetadata(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	caps := platform.Capabilities{
@@ -18717,7 +18972,7 @@ func TestAPIApplyReviewSuggestionReturnsAppliedWithoutCommitMetadata(t *testing.
 	require.NotNil(mr)
 	thread := seedApplySuggestionReviewThread(t, database, mr.ID)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
@@ -18728,8 +18983,7 @@ func TestAPIApplyReviewSuggestionReturnsAppliedWithoutCommitMetadata(t *testing.
 				"thread_id":   strconv.FormatInt(thread.ID, 10),
 				"replacement": "return client.publishThreads();",
 			}},
-		},
-	)
+		})
 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	var response pullapi.ApplyReviewSuggestionResponse
@@ -18740,6 +18994,7 @@ func TestAPIApplyReviewSuggestionReturnsAppliedWithoutCommitMetadata(t *testing.
 }
 
 func TestAPIApplyReviewSuggestionReturnsAppliedForNilProviderResult(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	caps := platform.Capabilities{
@@ -18767,7 +19022,7 @@ func TestAPIApplyReviewSuggestionReturnsAppliedForNilProviderResult(t *testing.T
 	require.NotNil(mr)
 	thread := seedApplySuggestionReviewThread(t, database, mr.ID)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
@@ -18778,8 +19033,7 @@ func TestAPIApplyReviewSuggestionReturnsAppliedForNilProviderResult(t *testing.T
 				"thread_id":   strconv.FormatInt(thread.ID, 10),
 				"replacement": "return client.publishThreads();",
 			}},
-		},
-	)
+		})
 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	var response pullapi.ApplyReviewSuggestionResponse
@@ -18790,6 +19044,7 @@ func TestAPIApplyReviewSuggestionReturnsAppliedForNilProviderResult(t *testing.T
 }
 
 func TestAPIApplyReviewSuggestionProviderErrorQueuesDetailSync(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	caps := platform.Capabilities{
@@ -18818,7 +19073,7 @@ func TestAPIApplyReviewSuggestionProviderErrorQueuesDetailSync(t *testing.T) {
 	thread := seedApplySuggestionReviewThread(t, database, mr.ID)
 	ch, _ := srv.Hub().Subscribe(ctx, false)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
@@ -18829,8 +19084,7 @@ func TestAPIApplyReviewSuggestionProviderErrorQueuesDetailSync(t *testing.T) {
 				"thread_id":   strconv.FormatInt(thread.ID, 10),
 				"replacement": "return client.publishThreads();",
 			}},
-		},
-	)
+		})
 
 	require.Equal(http.StatusBadGateway, rr.Code, rr.Body.String())
 	changed := readEventMatching(t, ch, func(ev Event) bool {
@@ -18840,6 +19094,7 @@ func TestAPIApplyReviewSuggestionProviderErrorQueuesDetailSync(t *testing.T) {
 }
 
 func TestAPIApplyReviewSuggestionBroadcastsAfterDetailSync(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	caps := platform.Capabilities{
 		ReadRepositories:            true,
@@ -18866,7 +19121,7 @@ func TestAPIApplyReviewSuggestionBroadcastsAfterDetailSync(t *testing.T) {
 	thread := seedApplySuggestionReviewThread(t, database, mr.ID)
 	ch, _ := srv.Hub().Subscribe(ctx, false)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
@@ -18877,8 +19132,7 @@ func TestAPIApplyReviewSuggestionBroadcastsAfterDetailSync(t *testing.T) {
 				"thread_id":   strconv.FormatInt(thread.ID, 10),
 				"replacement": "return client.publishThreads();",
 			}},
-		},
-	)
+		})
 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	changed := readEventMatching(t, ch, func(ev Event) bool {
@@ -18888,6 +19142,7 @@ func TestAPIApplyReviewSuggestionBroadcastsAfterDetailSync(t *testing.T) {
 }
 
 func TestAPIApplyReviewSuggestionRejectsReplacementOutsideStoredSuggestion(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	caps := platform.Capabilities{
@@ -18933,7 +19188,7 @@ func TestAPIApplyReviewSuggestionRejectsReplacementOutsideStoredSuggestion(t *te
 	require.NoError(err)
 	require.Len(threads, 1)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
@@ -18944,14 +19199,15 @@ func TestAPIApplyReviewSuggestionRejectsReplacementOutsideStoredSuggestion(t *te
 				"thread_id":   strconv.FormatInt(threads[0].ID, 10),
 				"replacement": "return maliciousRewrite();",
 			}},
-		},
-	)
+		})
+
 	require.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
 	assert.Contains(rr.Body.String(), "body.suggestions[0].replacement")
 	assert.Empty(provider.appliedSuggestions)
 }
 
 func TestAPIApplyReviewSuggestionRejectsReplacementInsideIndentedExampleFence(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	caps := platform.Capabilities{
@@ -19009,7 +19265,7 @@ func TestAPIApplyReviewSuggestionRejectsReplacementInsideIndentedExampleFence(t 
 	require.NoError(err)
 	require.Len(threads, 1)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
@@ -19020,12 +19276,12 @@ func TestAPIApplyReviewSuggestionRejectsReplacementInsideIndentedExampleFence(t 
 				"thread_id":   strconv.FormatInt(threads[0].ID, 10),
 				"replacement": "return client.publishThreads();",
 			}},
-		},
-	)
+		})
+
 	require.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
 	assert.Empty(provider.appliedSuggestions)
 
-	rr = doJSON(
+	rr = testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
@@ -19036,14 +19292,15 @@ func TestAPIApplyReviewSuggestionRejectsReplacementInsideIndentedExampleFence(t 
 				"thread_id":   strconv.FormatInt(threads[0].ID, 10),
 				"replacement": "return actualSuggestion();",
 			}},
-		},
-	)
+		})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	require.Len(provider.appliedSuggestions, 1)
 	assert.Equal("return actualSuggestion();", provider.appliedSuggestions[0].Suggestions[0].Replacement)
 }
 
 func TestAPIApplyReviewSuggestionRejectsRateLimitedOperationBeforeProviderCall(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	caps := platform.Capabilities{
@@ -19099,7 +19356,7 @@ func TestAPIApplyReviewSuggestionRejectsRateLimitedOperationBeforeProviderCall(t
 	require.NoError(err)
 	require.Len(threads, 1)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
@@ -19110,8 +19367,8 @@ func TestAPIApplyReviewSuggestionRejectsRateLimitedOperationBeforeProviderCall(t
 				"thread_id":   strconv.FormatInt(threads[0].ID, 10),
 				"replacement": "return client.publishThreads();",
 			}},
-		},
-	)
+		})
+
 	require.Equal(http.StatusTooManyRequests, rr.Code, rr.Body.String())
 	var problem rawProblemDetail
 	require.NoError(json.NewDecoder(rr.Body).Decode(&problem))
@@ -19120,6 +19377,7 @@ func TestAPIApplyReviewSuggestionRejectsRateLimitedOperationBeforeProviderCall(t
 }
 
 func TestAPIApplyReviewSuggestionPreProviderValidationFailureDoesNotQueueDetailSync(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	caps := platform.Capabilities{
 		ReadRepositories:            true,
@@ -19147,7 +19405,7 @@ func TestAPIApplyReviewSuggestionPreProviderValidationFailureDoesNotQueueDetailS
 	provider.blockNextMRFetch.Store(true)
 	provider.mrFetchStarted = make(chan struct{}, 1)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
@@ -19158,8 +19416,7 @@ func TestAPIApplyReviewSuggestionPreProviderValidationFailureDoesNotQueueDetailS
 				"thread_id":   strconv.FormatInt(thread.ID, 10),
 				"replacement": "return client.publishThreads();",
 			}},
-		},
-	)
+		})
 
 	require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
 	require.Empty(provider.appliedSuggestions)
@@ -19171,6 +19428,7 @@ func TestAPIApplyReviewSuggestionPreProviderValidationFailureDoesNotQueueDetailS
 }
 
 func TestAPIApplyReviewSuggestionRejectsStaleHead(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	caps := platform.Capabilities{
 		ReadRepositories:            true,
@@ -19212,7 +19470,7 @@ func TestAPIApplyReviewSuggestionRejectsStaleHead(t *testing.T) {
 	require.NoError(err)
 	require.Len(threads, 1)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodPost,
@@ -19223,8 +19481,8 @@ func TestAPIApplyReviewSuggestionRejectsStaleHead(t *testing.T) {
 				"thread_id":   strconv.FormatInt(threads[0].ID, 10),
 				"replacement": "return client.publishThreads();",
 			}},
-		},
-	)
+		})
+
 	require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
 }
 
@@ -19238,6 +19496,7 @@ func draftIDFromResponse(t *testing.T, draft map[string]any) int64 {
 }
 
 func TestAPIGitealikeReadSyncPersistsThroughServer(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -19374,6 +19633,7 @@ func TestAPIGitealikeReadSyncPersistsThroughServer(t *testing.T) {
 }
 
 func TestAPIGitealikeHTTPMergeabilityPersistsThroughServer(t *testing.T) {
+	runParallelServerTest(t)
 	tests := []struct {
 		name      string
 		kind      platform.Kind
@@ -19517,6 +19777,7 @@ func TestAPIGitealikeHTTPMergeabilityPersistsThroughServer(t *testing.T) {
 }
 
 func TestAPIGitealikeMutationsPersistThroughServer(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -19882,6 +20143,7 @@ func setupGitealikeCloneFixture(t *testing.T) (cloneURL, baseSHA, headSHA string
 // sync path that never writes it would leave every head-bound action
 // permanently rejected with 409 head_unknown.
 func TestAPIGitealikeNormalSyncEnablesHeadBoundMutations(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -19964,6 +20226,7 @@ func TestAPIGitealikeNormalSyncEnablesHeadBoundMutations(t *testing.T) {
 }
 
 func TestAPIGitealikePinnedMergeHeadMismatchIsStale(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	transport := &apiTestGitealikeTransport{
@@ -19996,6 +20259,7 @@ func TestAPIGitealikePinnedMergeHeadMismatchIsStale(t *testing.T) {
 }
 
 func TestAPIGitealikePinnedMergeGenericConflictStaysConflict(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	transport := &apiTestGitealikeTransport{
@@ -20026,6 +20290,7 @@ func TestAPIGitealikePinnedMergeGenericConflictStaysConflict(t *testing.T) {
 }
 
 func TestAPIGitealikeApproveSubmitsReview(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	transport := &apiTestGitealikeTransport{}
@@ -20045,6 +20310,7 @@ func TestAPIGitealikeApproveSubmitsReview(t *testing.T) {
 }
 
 func TestAPIGitealikeApproveRefreshesAfterMutation(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	transport := &apiTestGitealikeTransport{}
@@ -20066,6 +20332,7 @@ func TestAPIGitealikeApproveRefreshesAfterMutation(t *testing.T) {
 }
 
 func TestAPIGiteaActionsSyncPersistsThroughServer(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -20247,6 +20514,7 @@ func requireIssue(t *testing.T, database *db.DB, repoID int64, number int) *db.I
 }
 
 func TestAPIGitealikeMergeConflictReturnsConflict(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -20420,6 +20688,7 @@ func newAPIGitealikeHeadPinTransport(t *testing.T) *apiTestGitealikeTransport {
 }
 
 func TestAPIGitealikeMergePassesReviewedHeadPinToProvider(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -20451,6 +20720,7 @@ func TestAPIGitealikeMergePassesReviewedHeadPinToProvider(t *testing.T) {
 }
 
 func TestAPIGitealikeMergeHeadMismatchMapsToStaleState(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -20482,6 +20752,7 @@ func TestAPIGitealikeMergeHeadMismatchMapsToStaleState(t *testing.T) {
 }
 
 func TestAPIGitealikeApproveBeforeHeadRace(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -20503,6 +20774,7 @@ func TestAPIGitealikeApproveBeforeHeadRace(t *testing.T) {
 }
 
 func TestAPIGitealikeRequestChangesPassesReviewedHeadPinToProvider(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -21009,7 +21281,9 @@ func setupGitLabCapabilityServerWithProvider(
 		registry, database, nil, []ghclient.RepoRef{repo}, time.Minute, nil, nil,
 	)
 	t.Cleanup(syncer.Stop)
-	srv := New(database, syncer, nil, "/", nil, ServerOptions{
+	srv := New(database, syncer, nil, "/", &config.Config{Tmux: config.Tmux{
+		Command: []string{filepath.Join(t.TempDir(), "missing-tmux")},
+	}}, ServerOptions{
 		WorktreeDir:                        t.TempDir(),
 		DisableWorkspaceBackgroundMonitors: true,
 	})
@@ -21190,6 +21464,7 @@ func assertUnsupportedCapabilityProblem(
 }
 
 func TestAPIGitealikeLockedPRPersistsThroughServer(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -21274,6 +21549,7 @@ func TestAPIGitealikeLockedPRPersistsThroughServer(t *testing.T) {
 }
 
 func TestAPIGitealikeDraftPRFieldsPersistThroughServer(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -21519,6 +21795,7 @@ func (t *lockedGitealikeTransport) ListStatuses(
 // Should contain an empty array, not null.
 
 func TestAPIGetFilesAndDiffMarkGeneratedFilesE2E(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -21644,6 +21921,7 @@ func (s *countingTokenFileSource) Descriptor() tokenauth.Descriptor {
 // briefly empty file would surface a missing-token error and break commit and
 // diff views for repos that are already on disk.
 func TestAPILocalReadEndpointsServeDuringTokenRotationE2E(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -21752,6 +22030,7 @@ func TestAPILocalReadEndpointsServeDuringTokenRotationE2E(t *testing.T) {
 }
 
 func TestAPIRateLimits(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 
 	database := dbtest.Open(t)
@@ -21796,6 +22075,7 @@ func TestAPIRateLimits(t *testing.T) {
 }
 
 func TestAPIRateLimitsSeparatesCredentialPoolsFromLocalCeilings(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	database := dbtest.Open(t)
@@ -21859,6 +22139,7 @@ func TestAPIRateLimitsSeparatesCredentialPoolsFromLocalCeilings(t *testing.T) {
 }
 
 func TestAPIRateLimitsMarksExpiredProviderQuotaUnknown(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	database := dbtest.Open(t)
@@ -21894,6 +22175,7 @@ func TestAPIRateLimitsMarksExpiredProviderQuotaUnknown(t *testing.T) {
 }
 
 func TestAPIRateLimitsRollsExpiredTrackerBeforeResponse(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	database := dbtest.Open(t)
@@ -21923,6 +22205,7 @@ func TestAPIRateLimitsRollsExpiredTrackerBeforeResponse(t *testing.T) {
 }
 
 func TestAPISyncPRIncrementsRequestCount(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -21982,6 +22265,7 @@ func TestAPISyncPRIncrementsRequestCount(t *testing.T) {
 }
 
 func TestAPIRateLimitsWithBudget(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 
 	database := dbtest.Open(t)
@@ -22026,6 +22310,7 @@ func TestAPIRateLimitsWithBudget(t *testing.T) {
 }
 
 func TestAPIRateLimitsResetExpiredBudgetWindow(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 
 	database := dbtest.Open(t)
@@ -22075,6 +22360,7 @@ func TestAPIRateLimitsResetExpiredBudgetWindow(t *testing.T) {
 }
 
 func TestAPIRateLimitsUsesSafeIdentityKeyAndResolvedPrincipalLabel(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	database := dbtest.Open(t)
@@ -22119,6 +22405,7 @@ func TestAPIRateLimitsUsesSafeIdentityKeyAndResolvedPrincipalLabel(t *testing.T)
 }
 
 func TestAPIRateLimitsIncludesWriteOnlyGraphQLState(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	database := dbtest.Open(t)
@@ -22147,6 +22434,7 @@ func TestAPIRateLimitsIncludesWriteOnlyGraphQLState(t *testing.T) {
 }
 
 func TestAPIRateLimitsWithGQL(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 
 	database := dbtest.Open(t)
@@ -22204,6 +22492,7 @@ func TestAPIRateLimitsWithGQL(t *testing.T) {
 }
 
 func TestAPIRateLimitsReadsLocalStateWithoutRefreshingGitHubRateLimit(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 
 	database := dbtest.Open(t)
@@ -22292,6 +22581,7 @@ func TestAPIRateLimitsReadsLocalStateWithoutRefreshingGitHubRateLimit(t *testing
 }
 
 func TestAPIRateLimitsGQLDefaultsUnknown(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 
 	database := dbtest.Open(t)
@@ -22331,6 +22621,7 @@ func TestAPIRateLimitsGQLDefaultsUnknown(t *testing.T) {
 }
 
 func TestAPIRateLimitsMultiHostMixed(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 
 	database := dbtest.Open(t)
@@ -22398,6 +22689,7 @@ func TestAPIRateLimitsMultiHostMixed(t *testing.T) {
 }
 
 func TestAPIRateLimitsScopesSameHostByProvider(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 
 	database := dbtest.Open(t)
@@ -22452,6 +22744,7 @@ func TestAPIRateLimitsScopesSameHostByProvider(t *testing.T) {
 }
 
 func TestAPIGetPullDetailLoaded(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -22537,6 +22830,7 @@ func TestAPIGetPullDetailIncludesAssociatedWorkspace(t *testing.T) {
 }
 
 func TestAPIActivityReturnsUTCCreatedAt(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -22582,6 +22876,7 @@ func TestAPIActivityReturnsUTCCreatedAt(t *testing.T) {
 }
 
 func TestAPIActivityFencesRepositoryReconciliationAcrossEventAndWorkspaceReads(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	srv, database := setupTestServer(t)
@@ -22771,6 +23066,7 @@ func setupTestServerWithClonesAndServer(t *testing.T) (
 }
 
 func TestAPIGetCommits(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -22788,6 +23084,7 @@ func TestAPIGetCommits(t *testing.T) {
 }
 
 func TestAPIGetCommits_NotFound(t *testing.T) {
+	runParallelServerTest(t)
 	client, _, _, _, _ := setupTestServerWithClones(t)
 
 	resp, err := client.HTTP.GetPullCommitsWithResponse(
@@ -22798,6 +23095,7 @@ func TestAPIGetCommits_NotFound(t *testing.T) {
 }
 
 func TestAPIGetDiff_SingleCommit(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	client, _, _, _, commitSHAs := setupTestServerWithClones(t)
@@ -22812,6 +23110,7 @@ func TestAPIGetDiff_SingleCommit(t *testing.T) {
 }
 
 func TestAPIGetDiffReportsSyncedDiffHeadSHA(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -22827,6 +23126,7 @@ func TestAPIGetDiffReportsSyncedDiffHeadSHA(t *testing.T) {
 }
 
 func TestAPIGetRepoCommitDiff(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -22854,6 +23154,7 @@ func TestAPIGetRepoCommitDiff(t *testing.T) {
 }
 
 func TestAPIGetRepoCommitDiffRejectsOptionLikeSHA(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	_, _, _, _, _, srv := setupTestServerWithClonesAndServer(t)
@@ -22881,6 +23182,7 @@ func TestAPIGetRepoCommitDiffRejectsOptionLikeSHA(t *testing.T) {
 }
 
 func TestAPIGetFilePreview_ReturnsHeadContent(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -22901,6 +23203,7 @@ func TestAPIGetFilePreview_ReturnsHeadContent(t *testing.T) {
 }
 
 func TestAPIGetFilePreview_ReturnsDeletedFileContent(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -22943,6 +23246,7 @@ func TestAPIGetFilePreview_ReturnsDeletedFileContent(t *testing.T) {
 }
 
 func TestAPIGetFilePreview_ReturnsRequestedDiffSideContent(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -22999,6 +23303,7 @@ func TestAPIGetFilePreview_ReturnsRequestedDiffSideContent(t *testing.T) {
 }
 
 func TestAPIGetDiff_Range(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	client, _, _, _, commitSHAs := setupTestServerWithClones(t)
@@ -23015,6 +23320,7 @@ func TestAPIGetDiff_Range(t *testing.T) {
 }
 
 func TestAPIGetDiff_InvalidScope(t *testing.T) {
+	runParallelServerTest(t)
 	client, _, _, _, commitSHAs := setupTestServerWithClones(t)
 	from := commitSHAs[0]
 	resp, err := client.HTTP.GetPullDiffWithResponse(
@@ -23026,6 +23332,7 @@ func TestAPIGetDiff_InvalidScope(t *testing.T) {
 }
 
 func TestAPIGetDiff_UnknownSHA(t *testing.T) {
+	runParallelServerTest(t)
 	client, _, _, _, _ := setupTestServerWithClones(t)
 	bogus := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	resp, err := client.HTTP.GetPullDiffWithResponse(
@@ -23037,6 +23344,7 @@ func TestAPIGetDiff_UnknownSHA(t *testing.T) {
 }
 
 func TestAPIGetDiff_ReversedRange(t *testing.T) {
+	runParallelServerTest(t)
 	client, _, _, _, commitSHAs := setupTestServerWithClones(t)
 	from := commitSHAs[0] // newest
 	to := commitSHAs[4]   // oldest
@@ -23049,6 +23357,7 @@ func TestAPIGetDiff_ReversedRange(t *testing.T) {
 }
 
 func TestAPIGetDiff_FromWithoutTo(t *testing.T) {
+	runParallelServerTest(t)
 	client, _, _, _, commitSHAs := setupTestServerWithClones(t)
 	from := commitSHAs[0]
 	resp, err := client.HTTP.GetPullDiffWithResponse(
@@ -23060,6 +23369,7 @@ func TestAPIGetDiff_FromWithoutTo(t *testing.T) {
 }
 
 func TestAPIGetDiff_RootCommit(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	dir := t.TempDir()
@@ -23113,6 +23423,7 @@ func TestAPIGetDiff_RootCommit(t *testing.T) {
 }
 
 func TestAPIListActivity(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -23148,7 +23459,7 @@ func TestAPIListActivity(t *testing.T) {
 		"activity feed should contain PR and comment items")
 	assert.Equal("github.com", (*resp.JSON200.Items)[0].PlatformHost)
 
-	collapsed := doJSON(
+	collapsed := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodGet,
@@ -23168,14 +23479,14 @@ func TestAPIListActivity(t *testing.T) {
 		"collapsed parents must identify the exact child ledger snapshot")
 	assert.NotEmpty(collapsedBody.EventCursor, "cursor must cover omitted child events")
 
-	delta := doJSON(
+	delta := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodGet,
 		"/api/v1/activity?since="+url.QueryEscape(since)+"&projection=events&after="+
 			url.QueryEscape(collapsedBody.EventCursor),
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, delta.Code)
 	var deltaBody struct {
 		Items        []activityItemResponse    `json:"items"`
@@ -23187,15 +23498,15 @@ func TestAPIListActivity(t *testing.T) {
 	assert.Empty(deltaBody.ItemActivity, "event deltas must not resend parent summaries")
 	assert.Equal(collapsedBody.EventCursor, deltaBody.EventCursor)
 
-	thread := doJSON(
+	thread := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodGet,
 		"/api/v1/activity/thread-events?provider=github&platform_host=github.com"+
 			"&platform_repo_id=repo-acme-widget&item_type=pr&item_number=1&since="+
 			url.QueryEscape(since),
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, thread.Code)
 	var threadBody activityResponse
 	require.NoError(json.NewDecoder(thread.Body).Decode(&threadBody))
@@ -23203,7 +23514,7 @@ func TestAPIListActivity(t *testing.T) {
 	assert.Empty(threadBody.ItemActivity)
 
 	require.NoError(database.UpdateMergeRequestAssignees(ctx, repo.ID, prID, []string{"alice"}))
-	assignedThread := doJSON(
+	assignedThread := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodGet,
@@ -23217,15 +23528,15 @@ func TestAPIListActivity(t *testing.T) {
 	require.NoError(json.NewDecoder(assignedThread.Body).Decode(&assignedThreadBody))
 	assert.Empty(assignedThreadBody.Items)
 
-	filteredThread := doJSON(
+	filteredThread := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodGet,
 		"/api/v1/activity/thread-events?provider=github&platform_host=github.com"+
 			"&platform_repo_id=repo-acme-widget&item_type=pr&item_number=1&since="+
 			url.QueryEscape(since)+"&types=comment&search="+url.QueryEscape("Looks good"),
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, filteredThread.Code)
 	var filteredThreadBody activityResponse
 	require.NoError(json.NewDecoder(filteredThread.Body).Decode(&filteredThreadBody))
@@ -23269,6 +23580,7 @@ func TestAPIListActivity(t *testing.T) {
 }
 
 func TestAPIListCollapsedActivityHonorsLimit(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -23282,13 +23594,13 @@ func TestAPIListCollapsedActivityHonorsLimit(t *testing.T) {
 	}
 
 	since := url.QueryEscape(now.Add(-7 * 24 * time.Hour).Format(time.RFC3339))
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodGet,
 		"/api/v1/activity?since="+since+"&projection=collapsed&limit=10",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, rr.Code)
 	var body activityResponse
 	require.NoError(json.NewDecoder(rr.Body).Decode(&body))
@@ -23298,6 +23610,7 @@ func TestAPIListCollapsedActivityHonorsLimit(t *testing.T) {
 }
 
 func TestAPIListCollapsedActivitySearchLimitCountsDistinctParents(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -23336,13 +23649,13 @@ func TestAPIListCollapsedActivitySearchLimitCountsDistinctParents(t *testing.T) 
 	require.NoError(database.UpsertMREvents(ctx, newerEvents))
 
 	since := url.QueryEscape(base.Add(-time.Minute).Format(time.RFC3339))
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodGet,
 		"/api/v1/activity?since="+since+"&projection=collapsed&limit=30&search=needle",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, rr.Code)
 	var body activityResponse
 	require.NoError(json.NewDecoder(rr.Body).Decode(&body))
@@ -23352,6 +23665,7 @@ func TestAPIListCollapsedActivitySearchLimitCountsDistinctParents(t *testing.T) 
 }
 
 func TestAPIListCollapsedActivityIncludesParentRecentOnlyByNotification(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupNotificationsEnabledTestServer(t)
@@ -23377,13 +23691,13 @@ func TestAPIListCollapsedActivityIncludesParentRecentOnlyByNotification(t *testi
 	}}))
 
 	since := url.QueryEscape(now.Add(-7 * 24 * time.Hour).Format(time.RFC3339))
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodGet,
 		"/api/v1/activity?since="+since+"&projection=collapsed",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, rr.Code)
 	var body struct {
 		Items        []activityItemResponse    `json:"items"`
@@ -23395,13 +23709,13 @@ func TestAPIListCollapsedActivityIncludesParentRecentOnlyByNotification(t *testi
 	assert.Equal(71, body.ItemActivity[0].ItemNumber)
 	assert.Equal(formatUTCRFC3339(notificationAt), body.ItemActivity[0].ActivityAt)
 
-	filtered := doJSON(
+	filtered := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodGet,
 		"/api/v1/activity?since="+since+"&projection=collapsed&types=comment",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, filtered.Code)
 	var filteredBody struct {
 		Items        []activityItemResponse    `json:"items"`
@@ -23414,6 +23728,7 @@ func TestAPIListCollapsedActivityIncludesParentRecentOnlyByNotification(t *testi
 }
 
 func TestAPIListCollapsedActivityRetainsVisibleEventsForBotParents(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -23435,13 +23750,13 @@ func TestAPIListCollapsedActivityRetainsVisibleEventsForBotParents(t *testing.T)
 	}}))
 
 	since := url.QueryEscape(now.Add(-7 * 24 * time.Hour).Format(time.RFC3339))
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodGet,
 		"/api/v1/activity?since="+since+"&projection=collapsed&hide_bots=true",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, rr.Code)
 	var body struct {
 		Items        []activityItemResponse    `json:"items"`
@@ -23456,6 +23771,7 @@ func TestAPIListCollapsedActivityRetainsVisibleEventsForBotParents(t *testing.T)
 }
 
 func TestAPIListActivityReturnsRecentParentWhenItsVisibleEventsAreFiltered(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -23483,13 +23799,13 @@ func TestAPIListActivityReturnsRecentParentWhenItsVisibleEventsAreFiltered(t *te
 	}}))
 
 	since := url.QueryEscape(now.Add(-7 * 24 * time.Hour).Format(time.RFC3339))
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodGet,
 		"/api/v1/activity?since="+since+"&types=commit&item_types=pr,repo",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, rr.Code)
 	var body struct {
 		Items        []activityItemResponse    `json:"items"`
@@ -23507,6 +23823,7 @@ func TestAPIListActivityReturnsRecentParentWhenItsVisibleEventsAreFiltered(t *te
 }
 
 func TestAPIListActivityIncrementalSearchReturnsParentsMatchedByProviderEvents(t *testing.T) {
+	runParallelServerTest(t)
 	req := require.New(t)
 	srv, database := setupTestServer(t)
 	ctx := t.Context()
@@ -23554,13 +23871,13 @@ func TestAPIListActivityIncrementalSearchReturnsParentsMatchedByProviderEvents(t
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
-			rr := doJSON(
+			rr := testutil.DoJSON(
 				t,
 				srv,
 				http.MethodGet,
 				"/api/v1/activity?since="+since+"&after="+after+"&search="+url.QueryEscape(tc.search),
-				nil,
-			)
+				nil)
+
 			require.Equal(http.StatusOK, rr.Code)
 			var body struct {
 				Items        []activityItemResponse    `json:"items"`
@@ -23575,6 +23892,7 @@ func TestAPIListActivityIncrementalSearchReturnsParentsMatchedByProviderEvents(t
 }
 
 func TestAPIListActivitySeparatesEventAndParentSnapshotCaps(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	srv, database := setupTestServer(t)
@@ -23607,13 +23925,13 @@ func TestAPIListActivitySeparatesEventAndParentSnapshotCaps(t *testing.T) {
 	require.NoError(err)
 
 	since := url.QueryEscape(now.Add(-time.Minute).Format(time.RFC3339))
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodGet,
 		"/api/v1/activity?since="+since+"&types=commit&item_types=pr,repo",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, rr.Code)
 	var body struct {
 		Items              []activityItemResponse    `json:"items"`
@@ -23629,6 +23947,7 @@ func TestAPIListActivitySeparatesEventAndParentSnapshotCaps(t *testing.T) {
 }
 
 func TestWorkspaceActivitySearchKeepsSubjectsWithMatchingProviderEvents(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
@@ -23683,6 +24002,7 @@ func TestWorkspaceActivitySearchKeepsSubjectsWithMatchingProviderEvents(t *testi
 }
 
 func TestWorkspaceActivityAuthorMatchesTheSubjectInsteadOfProviderEventActors(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
@@ -23750,6 +24070,7 @@ func TestWorkspaceActivityAuthorMatchesTheSubjectInsteadOfProviderEventActors(t 
 }
 
 func TestMergeWorkspaceActivityAuthorsDeduplicatesCaseInsensitively(t *testing.T) {
+	runParallelServerTest(t)
 	now := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
 	since := now.Add(-time.Hour)
 	activityAt := func(offset time.Duration) *time.Time {
@@ -23798,6 +24119,7 @@ func TestMergeWorkspaceActivityAuthorsDeduplicatesCaseInsensitively(t *testing.T
 }
 
 func TestWorkspaceActivityProjectionUsesHubPolicy(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	now := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
 	key := db.WorkspaceSubjectKey{
@@ -23839,6 +24161,7 @@ func TestWorkspaceActivityProjectionUsesHubPolicy(t *testing.T) {
 }
 
 func TestAPIListActivityFiltersByAuthorAndListsScopedCandidates(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -23873,13 +24196,13 @@ func TestAPIListActivityFiltersByAuthorAndListsScopedCandidates(t *testing.T) {
 	)
 
 	since := base.Add(-time.Minute).Format(time.RFC3339)
-	feed := doJSON(
+	feed := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodGet,
 		"/api/v1/activity?since="+url.QueryEscape(since)+"&author=ITEM%20OWNER",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, feed.Code)
 	var feedBody activityResponse
 	require.NoError(json.Unmarshal(feed.Body.Bytes(), &feedBody))
@@ -23888,25 +24211,25 @@ func TestAPIListActivityFiltersByAuthorAndListsScopedCandidates(t *testing.T) {
 		assert.Equal("Item Owner", item.ItemAuthor)
 	}
 
-	commenterFeed := doJSON(
+	commenterFeed := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodGet,
 		"/api/v1/activity?since="+url.QueryEscape(since)+"&author=REVIEWER",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, commenterFeed.Code)
 	var commenterFeedBody activityResponse
 	require.NoError(json.Unmarshal(commenterFeed.Body.Bytes(), &commenterFeedBody))
 	assert.Empty(commenterFeedBody.Items)
 
-	candidates := doJSON(
+	candidates := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodGet,
 		"/api/v1/activity/authors?since="+url.QueryEscape(since),
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, candidates.Code)
 	var candidateBody struct {
 		Authors []string `json:"authors"`
@@ -23917,6 +24240,7 @@ func TestAPIListActivityFiltersByAuthorAndListsScopedCandidates(t *testing.T) {
 }
 
 func TestAPIListActivityReturnsParentRecencyWhenCommitEventsAreFiltered(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
 	ctx := t.Context()
@@ -23947,13 +24271,13 @@ func TestAPIListActivityReturnsParentRecencyWhenCommitEventsAreFiltered(t *testi
 	}))
 
 	since := base.Add(-time.Minute).Format(time.RFC3339)
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodGet,
 		"/api/v1/activity?since="+url.QueryEscape(since)+"&types=comment",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, rr.Code)
 	var body activityResponse
 	require.NoError(json.Unmarshal(rr.Body.Bytes(), &body))
@@ -23963,6 +24287,7 @@ func TestAPIListActivityReturnsParentRecencyWhenCommitEventsAreFiltered(t *testi
 }
 
 func TestAPIActivityScopesFollowTrackedRepositoryIDAcrossRename(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	srv, database := setupTestServer(t)
@@ -23996,10 +24321,10 @@ func TestAPIActivityScopesFollowTrackedRepositoryIDAcrossRename(t *testing.T) {
 	require.True(applied)
 
 	since := now.Add(-time.Minute).Format(time.RFC3339)
-	feed := doJSON(
+	feed := testutil.DoJSON(
 		t, srv, http.MethodGet,
-		"/api/v1/activity?since="+url.QueryEscape(since), nil,
-	)
+		"/api/v1/activity?since="+url.QueryEscape(since), nil)
+
 	require.Equal(http.StatusOK, feed.Code)
 	var feedBody activityResponse
 	require.NoError(json.Unmarshal(feed.Body.Bytes(), &feedBody))
@@ -24009,10 +24334,10 @@ func TestAPIActivityScopesFollowTrackedRepositoryIDAcrossRename(t *testing.T) {
 	require.Len(feedBody.ItemActivity, 1)
 	assert.Equal(repo.PlatformRepoID, feedBody.ItemActivity[0].Repo.PlatformRepoID)
 
-	candidates := doJSON(
+	candidates := testutil.DoJSON(
 		t, srv, http.MethodGet,
-		"/api/v1/activity/authors?since="+url.QueryEscape(since), nil,
-	)
+		"/api/v1/activity/authors?since="+url.QueryEscape(since), nil)
+
 	require.Equal(http.StatusOK, candidates.Code)
 	var candidateBody struct {
 		Authors []string `json:"authors"`
@@ -24022,6 +24347,7 @@ func TestAPIActivityScopesFollowTrackedRepositoryIDAcrossRename(t *testing.T) {
 }
 
 func TestAPIListActivityAppliesTrackedRepoScopeBeforeAuthorLimit(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	srv, database := setupNotificationsEnabledTestServer(t)
@@ -24059,13 +24385,13 @@ func TestAPIListActivityAppliesTrackedRepoScopeBeforeAuthorLimit(t *testing.T) {
 	require.NoError(database.UpsertMREvents(ctx, untrackedEvents))
 
 	since := base.Add(-time.Minute).Format(time.RFC3339)
-	feed := doJSON(
+	feed := testutil.DoJSON(
 		t,
 		srv,
 		http.MethodGet,
 		"/api/v1/activity?since="+url.QueryEscape(since)+"&author=ITEM%20OWNER",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, feed.Code)
 	var feedBody activityResponse
 	require.NoError(json.Unmarshal(feed.Body.Bytes(), &feedBody))
@@ -24079,6 +24405,7 @@ func TestAPIListActivityAppliesTrackedRepoScopeBeforeAuthorLimit(t *testing.T) {
 }
 
 func TestAPIListActivitySearchReportsParentTruncationWhenMatchesOverflowEventCap(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	srv, database := setupTestServer(t)
@@ -24120,7 +24447,7 @@ func TestAPIListActivitySearchReportsParentTruncationWhenMatchesOverflowEventCap
 	require.NoError(database.UpsertMREvents(ctx, noisyEvents))
 
 	since := url.QueryEscape(base.Add(-time.Minute).Format(time.RFC3339))
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/activity?since="+since+"&search=needle", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/activity?since="+since+"&search=needle", nil)
 	require.Equal(http.StatusOK, rr.Code)
 	var body struct {
 		Items              []activityItemResponse    `json:"items"`
@@ -24138,6 +24465,7 @@ func TestAPIListActivitySearchReportsParentTruncationWhenMatchesOverflowEventCap
 }
 
 func TestAPIListActivityIncludesNotificationSyncedBeforeRepo(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupNotificationsEnabledTestServer(t)
@@ -24188,6 +24516,7 @@ func TestAPIListActivityIncludesNotificationSyncedBeforeRepo(t *testing.T) {
 }
 
 func TestAPIListActivityScopesNotificationsToTrackedRepos(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupNotificationsEnabledTestServer(t)
@@ -24258,6 +24587,7 @@ func TestAPIListActivityScopesNotificationsToTrackedRepos(t *testing.T) {
 }
 
 func TestAPIListActivityReturnsDefaultBranchActivity(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -24289,7 +24619,7 @@ func TestAPIListActivityReturnsDefaultBranchActivity(t *testing.T) {
 	}))
 
 	since := url.QueryEscape(base.Format(time.RFC3339))
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/activity?since="+since, nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/activity?since="+since, nil)
 	require.Equal(http.StatusOK, rr.Code)
 	var body struct {
 		Items []map[string]any `json:"items"`
@@ -24321,6 +24651,7 @@ func TestAPIListActivityReturnsDefaultBranchActivity(t *testing.T) {
 }
 
 func TestAPIListActivityCapsDefaultBranchCommitMetadata(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -24351,7 +24682,7 @@ func TestAPIListActivityCapsDefaultBranchCommitMetadata(t *testing.T) {
 	require.NoError(err)
 
 	since := url.QueryEscape(base.Format(time.RFC3339))
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/activity?since="+since, nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/activity?since="+since, nil)
 	require.Equal(http.StatusOK, rr.Code)
 	var body struct {
 		Items []map[string]any `json:"items"`
@@ -24370,6 +24701,7 @@ func TestAPIListActivityCapsDefaultBranchCommitMetadata(t *testing.T) {
 }
 
 func TestAPIListActivityReflectsConfiguredDefaultBranchCommitCap(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -24464,6 +24796,7 @@ func TestAPIListActivityReflectsConfiguredDefaultBranchCommitCap(t *testing.T) {
 }
 
 func TestAPIListActivityReturnsProviderCompareURLsForDefaultBranchForcePushes(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -24530,7 +24863,7 @@ func TestAPIListActivityReturnsProviderCompareURLsForDefaultBranchForcePushes(t 
 	}
 
 	since := url.QueryEscape(base.Add(-time.Minute).Format(time.RFC3339))
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/activity?since="+since, nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/activity?since="+since, nil)
 	require.Equal(http.StatusOK, rr.Code)
 	var body struct {
 		Items []map[string]any `json:"items"`
@@ -24560,6 +24893,7 @@ func TestAPIListActivityReturnsProviderCompareURLsForDefaultBranchForcePushes(t 
 }
 
 func TestAPIListActivityCanHideDefaultBranchActivity(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -24604,6 +24938,7 @@ func TestAPIListActivityCanHideDefaultBranchActivity(t *testing.T) {
 }
 
 func TestAPIListActivityAcceptsProviderQualifiedRepoFilter(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -24648,6 +24983,7 @@ func TestAPIListActivityAcceptsProviderQualifiedRepoFilter(t *testing.T) {
 }
 
 func TestAPIListActivityKeepsProviderNamedHostsProviderQualified(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -24684,6 +25020,7 @@ func TestAPIListActivityKeepsProviderNamedHostsProviderQualified(t *testing.T) {
 }
 
 func TestAPIListActivityFiltersConfiguredReposByHost(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database, _ := setupTestServerWithConfig(t)
@@ -24692,7 +25029,7 @@ func TestAPIListActivityFiltersConfiguredReposByHost(t *testing.T) {
 	seedPROnHost(t, database, "ghe.example.com", "acme", "widget", 2)
 
 	since := time.Now().UTC().AddDate(0, 0, -7).Format(time.RFC3339)
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/activity?since="+since, nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/activity?since="+since, nil)
 	require.Equal(http.StatusOK, rr.Code)
 	var body activityResponse
 	require.NoError(json.NewDecoder(rr.Body).Decode(&body))
@@ -24782,6 +25119,7 @@ func runStackDetection(t *testing.T, database *db.DB, owner, name string) {
 }
 
 func TestAPIListStacks(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -24806,6 +25144,7 @@ func TestAPIListStacks(t *testing.T) {
 }
 
 func TestAPIListStacks_RepoFilter(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	repos := []ghclient.RepoRef{
@@ -24847,6 +25186,7 @@ func TestAPIListStacks_RepoFilter(t *testing.T) {
 }
 
 func TestAPIGetStackForPR(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -24873,6 +25213,7 @@ func TestAPIGetStackForPR(t *testing.T) {
 }
 
 func TestAPIGetPullDetailIncludesStackContext(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -24904,6 +25245,7 @@ func TestAPIGetPullDetailIncludesStackContext(t *testing.T) {
 }
 
 func TestAPIStackBaseConflictMarksDownstreamPRsDirty(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -24950,6 +25292,7 @@ func TestAPIStackBaseConflictMarksDownstreamPRsDirty(t *testing.T) {
 }
 
 func TestAPIGetStackForPR_DraftNotBaseReady(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	srv, database := setupTestServer(t)
 	client := setupTestClient(t, srv)
@@ -24968,6 +25311,7 @@ func TestAPIGetStackForPR_DraftNotBaseReady(t *testing.T) {
 }
 
 func TestAPIListStacks_DraftNotAllGreen(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -24995,6 +25339,7 @@ func TestAPIListStacks_DraftNotAllGreen(t *testing.T) {
 // GET /stacks and GET /repos/{owner}/{name}/pulls/{number}/stack return
 // data produced entirely by the sync-completion callback path.
 func TestAPIStacks_DetectionViaSyncHook(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -25069,6 +25414,7 @@ func TestAPIStacks_DetectionViaSyncHook(t *testing.T) {
 }
 
 func TestAPIStacks_DetectionViaSyncHookPrefersGitHubNativeOrder(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -25144,6 +25490,7 @@ func TestAPIStacks_DetectionViaSyncHookPrefersGitHubNativeOrder(t *testing.T) {
 }
 
 func TestAPIStacks_DetectionViaSyncHookIgnoresForkHeadBranchCollision(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -25217,6 +25564,7 @@ func TestAPIStacks_DetectionViaSyncHookIgnoresForkHeadBranchCollision(t *testing
 }
 
 func TestAPIStacks_GitLabUnknownForkHeadSyncsButSkipsStackEdges(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -25327,6 +25675,7 @@ func TestAPIStacks_GitLabUnknownForkHeadSyncsButSkipsStackEdges(t *testing.T) {
 }
 
 func TestAPIStacks_DetectionViaSyncHookIgnoresSameRepoSelfEdge(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -25407,6 +25756,7 @@ func stackMemberNumbers(members []generated.StackMemberResponse) []int64 {
 }
 
 func TestAPIGetStackForPR_SingleFailingIsInProgress(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	srv, database := setupTestServer(t)
 	client := setupTestClient(t, srv)
@@ -25426,6 +25776,7 @@ func TestAPIGetStackForPR_SingleFailingIsInProgress(t *testing.T) {
 }
 
 func TestAPIGetStackForPR_BaseBranchNotMain(t *testing.T) {
+	runParallelServerTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -25453,6 +25804,7 @@ func TestAPIGetStackForPR_BaseBranchNotMain(t *testing.T) {
 // AuthorDisplayName after each pass, and that GetUser is only
 // called during the first sync.
 func TestDisplayNameCacheE2E(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	now := time.Now().UTC().Truncate(time.Second)
@@ -25496,7 +25848,7 @@ func TestDisplayNameCacheE2E(t *testing.T) {
 	firstCalls := getUserCalls
 
 	// GET /api/v1/pulls — display name must appear.
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/pulls", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/pulls", nil)
 	require.Equal(http.StatusOK, rr.Code)
 	require.Contains(rr.Body.String(), `"AuthorDisplayName":"Alice Smith"`)
 
@@ -25506,12 +25858,13 @@ func TestDisplayNameCacheE2E(t *testing.T) {
 		"second sync must not re-fetch cached display names")
 
 	// GET /api/v1/pulls — display name still present.
-	rr2 := doJSON(t, srv, http.MethodGet, "/api/v1/pulls", nil)
+	rr2 := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/pulls", nil)
 	require.Equal(http.StatusOK, rr2.Code)
 	require.Contains(rr2.Body.String(), `"AuthorDisplayName":"Alice Smith"`)
 }
 
 func TestCICheckDedupLatestRunWinsE2E(t *testing.T) {
+	runParallelServerTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -26205,78 +26558,6 @@ func TestListWorkspacesIncludesItemLastActivityAt(t *testing.T) {
 	assert.Nil(byID["ws-unsynced-activity"].ItemLastActivityAt)
 }
 
-func TestListWorkspacesIncludesKataMetadata(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	client, database, _, _ := setupTestServerWithWorkspaces(t)
-	ctx := t.Context()
-
-	repo, err := database.GetRepoByIdentity(ctx, verifiedGitHubRepoIdentity("github.com", "acme", "widget"))
-	require.NoError(err)
-	require.NotNil(repo)
-
-	metadata := db.WorkspaceKataMetadata{
-		DaemonID:    "desktop",
-		ProjectUID:  "project-kata",
-		ProjectName: "Widget",
-		IssueUID:    "issue-kata-1",
-		ShortID:     "task-123",
-		QualifiedID: "Kata#task-123",
-		Title:       "Wire kata workspace sidebar",
-	}
-	itemKey := db.KataWorkspaceItemKey(metadata)
-	require.NotEmpty(itemKey)
-	require.NoError(database.InsertWorkspace(ctx, &db.Workspace{
-		ID:           "ws-kata-list",
-		Platform:     "github",
-		PlatformHost: "github.com",
-		RepoOwner:    "acme",
-		RepoName:     "widget",
-		ItemType:     db.WorkspaceItemTypeKataTask,
-		ItemKey:      itemKey,
-		GitHeadRef:   "kenn-forge/kata/task-123-abcd1234",
-		WorktreePath: filepath.Join(t.TempDir(), "ws-kata-list"),
-		TmuxSession:  "kenn-forge-ws-kata-list",
-		Status:       "creating",
-		CreatedAt:    time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC),
-		KataMetadata: &metadata,
-	}))
-
-	// The workspace list UI reloads from GET /workspaces, so the kata owner
-	// metadata it renders must survive the DB summary hydration on that path,
-	// not just the create response.
-	resp, err := client.HTTP.ListWorkspacesWithResponse(ctx)
-	require.NoError(err)
-	require.Equal(http.StatusOK, resp.StatusCode())
-	require.NotNil(resp.JSON200)
-	require.NotNil(resp.JSON200.Workspaces)
-
-	var kata *generated.WorkspaceResponse
-	for i := range *resp.JSON200.Workspaces {
-		if (*resp.JSON200.Workspaces)[i].Id == "ws-kata-list" {
-			kata = &(*resp.JSON200.Workspaces)[i]
-			break
-		}
-	}
-	require.NotNil(kata)
-	assert.Equal(db.WorkspaceItemTypeKataTask, kata.ItemType)
-	assert.Equal(itemKey, kata.ItemKey)
-	// item_number is always emitted and is 0 (ignored) for Kata workspaces.
-	assert.Equal(int64(0), kata.ItemNumber)
-	require.NotNil(kata.Kata)
-	assert.Equal("desktop", kata.Kata.DaemonId)
-	assert.Equal("issue-kata-1", kata.Kata.IssueUid)
-	assert.Equal("project-kata", kata.Kata.ProjectUid)
-	require.NotNil(kata.Kata.ProjectName)
-	assert.Equal("Widget", *kata.Kata.ProjectName)
-	require.NotNil(kata.Kata.ShortId)
-	assert.Equal("task-123", *kata.Kata.ShortId)
-	require.NotNil(kata.Kata.QualifiedId)
-	assert.Equal("Kata#task-123", *kata.Kata.QualifiedId)
-	require.NotNil(kata.Kata.Title)
-	assert.Equal("Wire kata workspace sidebar", *kata.Kata.Title)
-}
-
 func TestWorkspaceServerFixtureCleansUpTmuxSessions(t *testing.T) {
 	require := require.New(t)
 	if testing.Short() {
@@ -26515,7 +26796,7 @@ func TestServerTestCleanupDoesNotInvokeDefaultTmux(t *testing.T) {
 }
 
 func TestWorkspaceRuntimeTargetsRefreshAfterSettingsUpdateE2E(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 	acquireRootWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -26553,10 +26834,10 @@ func TestWorkspaceRuntimeTargetsRefreshAfterSettingsUpdateE2E(t *testing.T) {
 		Label:   "Custom Codex",
 		Command: []string{agentPath, "--full-auto"},
 	}}
-	updateResp := doJSON(
+	updateResp := testutil.DoJSON(
 		t, srv, http.MethodPut, "/api/v1/settings",
-		updateSettingsRequest{Agents: &agents},
-	)
+		updateSettingsRequest{Agents: &agents})
+
 	require.Equal(http.StatusOK, updateResp.Code, updateResp.Body.String())
 
 	reloaded, err := config.Load(cfgPath)
@@ -26584,7 +26865,7 @@ func TestWorkspaceRuntimeTargetsRefreshAfterSettingsUpdateE2E(t *testing.T) {
 }
 
 func TestWorkspaceCreatesPtyOwnerSessionWhenTmuxUnavailableE2E(t *testing.T) {
-	runParallelPTYE2E(t)
+	runSerialPTYE2E(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -26668,106 +26949,11 @@ func TestWorkspaceCreatesPtyOwnerSessionWhenTmuxUnavailableE2E(t *testing.T) {
 	assert.True(os.IsNotExist(err))
 }
 
-func TestWorkspacePtyOwnerTitleMarksWorkspaceWorkingE2E(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("workspace clone fixture uses Unix-style local remotes")
-	}
-	runParallelPTYE2E(t)
-
-	require := require.New(t)
-	assert := assert.New(t)
-
-	fixture, _, ptyOwnerDir := setupPtyOwnerWorkspaceFixture(t, true)
-	ctx := context.Background()
-	ws := createReadyWorkspace(t, ctx, fixture.client)
-	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, ws.TmuxSession)
-
-	ts := httptest.NewServer(fixture.server)
-	t.Cleanup(ts.Close)
-
-	conn, _, err := workspaceTerminalDial(ctx, ts.URL, ws.Id)
-	require.NoError(err)
-	defer conn.Close(websocket.StatusNormalClosure, "done")
-	workspaceTerminalConnWriteRead(
-		t, ctx, conn, "stty -echo\rprintf '%s\\n' $((40+2))\r", "42",
-	)
-	// The spinner glyph is sent as printf octal escapes (\342\240\264
-	// is "⠴") so the typed line stays pure ASCII. Raw multibyte bytes
-	// written to an interactive shell are interpreted by readline as
-	// meta editing commands when the host has no UTF-8 locale set,
-	// scrambling the command before it runs. The session still emits
-	// the real multibyte title for the pty owner to track.
-	workspaceTerminalConnWriteRead(
-		t, ctx, conn,
-		"printf 'title-sent\\n'; "+
-			"printf '\\033]0;\\342\\240\\264 t3code-b5014b03\\007'\r",
-		"t3code-b5014b03",
-	)
-
-	var got *generated.WorkspaceResponse
-	require.Eventually(func() bool {
-		resp, err := fixture.client.HTTP.GetWorkspaceWithResponse(ctx, ws.Id)
-		if err != nil || resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
-			return false
-		}
-		got = resp.JSON200
-		return got.TmuxWorking &&
-			got.TmuxActivitySource == workspaceapi.TmuxActivitySourceTitle &&
-			got.TmuxPaneTitle != nil
-	}, 6*time.Second, 50*time.Millisecond)
-	require.NotNil(got)
-	assert.True(got.TmuxWorking)
-	assert.Equal(workspaceapi.TmuxActivitySourceTitle, got.TmuxActivitySource)
-	require.NotNil(got.TmuxPaneTitle)
-	assert.Equal("⠴ t3code-b5014b03", *got.TmuxPaneTitle)
-}
-
-func TestWorkspaceRuntimePlainShellUsesPtyOwnerWhenTmuxUnavailableE2E(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test fixture uses /bin/sh")
-	}
-	runParallelPTYE2E(t)
-
-	require := require.New(t)
-	assert := assert.New(t)
-
-	fixture, _, ptyOwnerDir := setupPtyOwnerWorkspaceFixture(t)
-	ctx := context.Background()
-	ws := createReadyWorkspace(t, ctx, fixture.client)
-
-	session := launchPlainShellRuntimeSession(t, ctx, fixture.client, ws.Id)
-	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, session.Key)
-	assert.Equal(string(localruntime.LaunchTargetPlainShell), session.TargetKey)
-	assert.Equal(string(localruntime.SessionStatusRunning), session.Status)
-
-	paths, err := ptyowner.NewSessionPaths(ptyOwnerDir, session.Key)
-	require.NoError(err)
-	_, err = os.Stat(paths.StatePath)
-	require.NoError(err)
-
-	storedTmux, err := fixture.database.ListWorkspaceRuntimeTmuxSessions(ctx, ws.Id)
-	require.NoError(err)
-	assert.Empty(storedTmux)
-
-	ts := httptest.NewServer(fixture.server)
-	t.Cleanup(ts.Close)
-	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
-		"/ws/v1/workspaces/" + ws.Id +
-		"/runtime/sessions/" + session.Key + "/terminal?cols=80&rows=24"
-	conn, _, err := websocket.Dial(ctx, wsURL, nil)
-	require.NoError(err)
-	defer conn.Close(websocket.StatusNormalClosure, "done")
-
-	workspaceTerminalConnWriteRead(
-		t, ctx, conn, "printf 'pty-owner-shell\\n'\r", "pty-owner-shell",
-	)
-}
-
 func TestWorkspaceRuntimePtyOwnerPersistenceFailureRollsBackSessionE2E(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test fixture uses /bin/sh")
 	}
-	runParallelPTYE2E(t)
+	runSerialPTYE2E(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -26823,7 +27009,7 @@ func TestWorkspaceRuntimePtyOwnerShellReattachesAfterServerRestartE2E(t *testing
 	if runtime.GOOS == "windows" {
 		t.Skip("test fixture uses /bin/sh")
 	}
-	runParallelPTYE2E(t)
+	runSerialPTYE2E(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -26936,7 +27122,7 @@ func TestWorkspaceRuntimeUnavailablePtyOwnerSessionStaysUntilUserStopE2E(t *test
 	if runtime.GOOS == "windows" {
 		t.Skip("test fixture uses /bin/sh")
 	}
-	runParallelPTYE2E(t)
+	runSerialPTYE2E(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -27032,7 +27218,7 @@ func TestWorkspaceDeleteStopsPtyOwnerAgentAfterServerRestartE2E(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test fixture uses /bin/sh")
 	}
-	runParallelPTYE2E(t)
+	runSerialPTYE2E(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -27088,192 +27274,6 @@ func TestWorkspaceDeleteStopsPtyOwnerAgentAfterServerRestartE2E(t *testing.T) {
 	assert.True(os.IsNotExist(err))
 }
 
-func TestRustPtyManagerRejectsConcurrentAttachmentsE2E(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("concurrent attach coverage is exercised by the Rust owner tests on Windows")
-	}
-	requirePTYAvailable(t)
-	runParallelPTYE2E(t)
-
-	require := require.New(t)
-	assert := assert.New(t)
-
-	managerPath := buildRustPtyManagerForTest(t)
-	ptyOwnerDir := longRustPtyOwnerDirForTest(t)
-	session := "kenn-forge-rust-concurrent"
-	command := []string{
-		"sh", "-c",
-		"printf ready; while IFS= read -r line; do echo got:$line; done",
-	}
-	readyNeedle := "ready"
-	firstNeedle := "got:before-second"
-	thirdNeedle := "got:after-close"
-	if runtime.GOOS == "windows" {
-		command = serverRuntimeHelperCommand("echo")
-		readyNeedle = ""
-		firstNeedle = "echo:before-second"
-		thirdNeedle = "echo:after-close"
-	}
-	client := ptyowner.Client{
-		Root:        ptyOwnerDir,
-		ManagerPath: managerPath,
-		Command:     command,
-	}
-	require.NoError(client.Ensure(t.Context(), session, t.TempDir()))
-	t.Cleanup(func() {
-		_ = client.Stop(context.Background(), session)
-	})
-
-	first, err := client.Attach(
-		context.Background(), session,
-		ptysize.Geometry{Cols: 120, Rows: 30},
-	)
-	require.NoError(err)
-	defer first.Close()
-	if readyNeedle != "" {
-		require.Contains(
-			readPtyOwnerOutputUntil(t, first.Output, readyNeedle),
-			readyNeedle,
-		)
-	}
-	require.NoError(first.Write([]byte("before-second\r")))
-	require.Contains(
-		readPtyOwnerOutputUntil(t, first.Output, firstNeedle),
-		firstNeedle,
-	)
-
-	second, err := client.Attach(
-		context.Background(), session,
-		ptysize.Geometry{Cols: 100, Rows: 20},
-	)
-	if second != nil {
-		second.Close()
-	}
-	require.Error(err)
-	assert.Contains(err.Error(), "already has an active attachment")
-
-	first.Close()
-	var third *ptyowner.Attachment
-	require.Eventually(func() bool {
-		var attachErr error
-		third, attachErr = client.Attach(
-			context.Background(), session,
-			ptysize.Geometry{Cols: 80, Rows: 24},
-		)
-		return attachErr == nil
-	}, 2*time.Second, 20*time.Millisecond)
-	defer third.Close()
-	require.NoError(third.Write([]byte("after-close\n")))
-	require.Contains(
-		readPtyOwnerOutputUntil(t, third.Output, thirdNeedle),
-		thirdNeedle,
-	)
-}
-
-func readPtyOwnerOutputUntil(
-	t *testing.T,
-	output <-chan []byte,
-	needle string,
-) string {
-	t.Helper()
-
-	deadline := time.After(2 * time.Second)
-	var builder strings.Builder
-	for {
-		select {
-		case chunk, ok := <-output:
-			if !ok {
-				return builder.String()
-			}
-			builder.Write(chunk)
-			if strings.Contains(builder.String(), needle) {
-				return builder.String()
-			}
-		case <-deadline:
-			require.New(t).Failf(
-				"timed out waiting for output",
-				"wanted %q in %q", needle, builder.String(),
-			)
-		}
-	}
-}
-
-func TestWorkspacePtyOwnerTerminalRejectsConcurrentAttachmentsE2E(t *testing.T) {
-	runParallelPTYE2E(t)
-
-	require := require.New(t)
-	assert := assert.New(t)
-
-	fixture, _, ptyOwnerDir := setupPtyOwnerWorkspaceFixture(t)
-	ctx := context.Background()
-	ws := createReadyWorkspace(t, ctx, fixture.client)
-	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, ws.TmuxSession)
-
-	ts := httptest.NewServer(fixture.server)
-	t.Cleanup(ts.Close)
-
-	first, _, err := workspaceTerminalDial(ctx, ts.URL, ws.Id)
-	require.NoError(err)
-	defer first.Close(websocket.StatusNormalClosure, "done")
-
-	second, resp, err := workspaceTerminalDial(ctx, ts.URL, ws.Id)
-	require.Error(err)
-	if second != nil {
-		second.Close(websocket.StatusNormalClosure, "done")
-	}
-	require.NotNil(resp)
-	assert.Equal(http.StatusConflict, resp.StatusCode)
-	if resp.Body != nil {
-		resp.Body.Close()
-	}
-
-	require.NoError(first.Close(websocket.StatusNormalClosure, "done"))
-	third := workspaceTerminalDialEventually(t, ctx, ts.URL, ws.Id)
-	defer third.Close(websocket.StatusNormalClosure, "done")
-	workspaceTerminalConnWriteRead(
-		t, ctx, third, "printf 'owner-after-close\n'\n", "owner-after-close",
-	)
-}
-
-func TestWorkspacePtyOwnerTerminalFlushesFinalOutputOnExitE2E(t *testing.T) {
-	runParallelPTYE2E(t)
-
-	require := require.New(t)
-
-	fixture, _, ptyOwnerDir := setupPtyOwnerWorkspaceFixture(t)
-	ctx := context.Background()
-	ws := createReadyWorkspace(t, ctx, fixture.client)
-	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, ws.TmuxSession)
-
-	ts := httptest.NewServer(fixture.server)
-	t.Cleanup(ts.Close)
-
-	conn, _, err := workspaceTerminalDial(ctx, ts.URL, ws.Id)
-	require.NoError(err)
-	defer conn.Close(websocket.StatusNormalClosure, "done")
-
-	require.NoError(conn.Write(
-		ctx, websocket.MessageBinary,
-		[]byte("printf 'final-owner-output\n'; exit\n"),
-	))
-	readCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
-	var got strings.Builder
-	for {
-		typ, data, readErr := conn.Read(readCtx)
-		if readErr != nil {
-			break
-		}
-		if typ == websocket.MessageBinary {
-			got.WriteString(string(data))
-		}
-		if strings.Contains(got.String(), "final-owner-output") {
-			return
-		}
-	}
-	require.Contains(got.String(), "final-owner-output")
-}
-
 func setupPtyOwnerWorkspaceFixture(
 	t *testing.T,
 	enableEnrichment ...bool,
@@ -27318,46 +27318,6 @@ func gitLocalRemoteURL(path string) string {
 	return (&url.URL{Scheme: "file", Path: slashPath}).String()
 }
 
-func buildRustPtyManagerForTest(t *testing.T) string {
-	t.Helper()
-
-	cargo, err := exec.LookPath("cargo")
-	if err != nil {
-		t.Skip("cargo not available")
-	}
-	if err := procutil.Command(cargo, "--version").Run(); err != nil {
-		t.Skipf("cargo not usable: %v", err)
-	}
-	root := repoRootForTest(t)
-	cmd := procutil.Command(cargo, "build", "-p", "kenn-forge-pty-manager")
-	cmd.Dir = root
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, string(out))
-	exe := filepath.Join(root, "target", "debug", "kenn-forge-pty-manager")
-	if runtime.GOOS == "windows" {
-		exe += ".exe"
-	}
-	return exe
-}
-
-func repoRootForTest(t *testing.T) string {
-	t.Helper()
-
-	root, err := filepath.Abs(filepath.Join("..", ".."))
-	require.NoError(t, err)
-	_, err = os.Stat(filepath.Join(root, "Cargo.toml"))
-	require.NoError(t, err)
-	return root
-}
-
-func longRustPtyOwnerDirForTest(t *testing.T) string {
-	t.Helper()
-
-	dir := filepath.Join(t.TempDir(), strings.Repeat("long-owner-root-", 8))
-	require.NoError(t, os.MkdirAll(dir, 0o755))
-	return dir
-}
-
 func cleanupPtyOwnerWorkspace(
 	t *testing.T,
 	ptyOwnerDir string,
@@ -27372,7 +27332,7 @@ func cleanupPtyOwnerWorkspace(
 }
 
 func TestWorkspaceRuntimeExistingSessionsAvailableWhenWorkspaceErroredE2E(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 	acquireRootWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -27419,243 +27379,6 @@ func TestWorkspaceRuntimeExistingSessionsAvailableWhenWorkspaceErroredE2E(t *tes
 	)
 	require.NoError(err)
 	require.Equal(http.StatusConflict, relaunchResp.StatusCode())
-}
-
-func TestWorkspaceRuntimeLaunchMultipleAndStopOneE2E(t *testing.T) {
-	runParallelPTYE2E(t)
-
-	require := require.New(t)
-	assert := assert.New(t)
-	disableTmuxAgentSessions := false
-	cfg := &config.Config{Agents: []config.Agent{{
-		Key:     "helper",
-		Label:   "Helper",
-		Command: serverRuntimeHelperCommand("sleep"),
-	}}, Tmux: config.Tmux{AgentSessions: &disableTmuxAgentSessions}}
-	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, cfg)
-	ctx := context.Background()
-	ws := createReadyWorkspace(t, ctx, client)
-
-	firstResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
-		ctx, ws.Id,
-		generated.LaunchWorkspaceRuntimeSessionInputBody{
-			TargetKey: "helper",
-		},
-	)
-	require.NoError(err)
-	require.Equal(http.StatusOK, firstResp.StatusCode())
-	require.NotNil(firstResp.JSON200)
-	first := firstResp.JSON200
-
-	secondResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
-		ctx, ws.Id,
-		generated.LaunchWorkspaceRuntimeSessionInputBody{
-			TargetKey: "helper",
-		},
-	)
-	require.NoError(err)
-	require.Equal(http.StatusOK, secondResp.StatusCode())
-	require.NotNil(secondResp.JSON200)
-	second := secondResp.JSON200
-	assert.NotEqual(first.Key, second.Key)
-	assert.True(isRuntimeSessionKeyForWorkspace(ws.Id, first.Key))
-	assert.True(isRuntimeSessionKeyForWorkspace(ws.Id, second.Key))
-	assert.Equal("Helper", first.Label)
-	assert.Equal("Helper 2", second.Label)
-	assert.Equal(string(localruntime.SessionStatusRunning), first.Status)
-
-	renameRR := doJSON(
-		t,
-		srv,
-		http.MethodPatch,
-		"/api/v1/workspaces/"+ws.Id+"/runtime/sessions/"+url.PathEscape(second.Key),
-		map[string]string{"label": "Review helper"},
-	)
-	require.Equal(http.StatusOK, renameRR.Code, renameRR.Body.String())
-	var renamed generated.SessionInfo
-	require.NoError(json.NewDecoder(renameRR.Body).Decode(&renamed))
-	assert.Equal(second.Key, renamed.Key)
-	assert.Equal("Review helper", renamed.Label)
-
-	listResp, err := client.HTTP.GetWorkspaceRuntimeWithResponse(
-		ctx, ws.Id,
-	)
-	require.NoError(err)
-	require.Equal(http.StatusOK, listResp.StatusCode())
-	require.NotNil(listResp.JSON200)
-	require.NotNil(listResp.JSON200.Sessions)
-	require.Len(*listResp.JSON200.Sessions, 2)
-	assert.Equal(first.Key, (*listResp.JSON200.Sessions)[0].Key)
-	assert.Equal("Helper", (*listResp.JSON200.Sessions)[0].Label)
-	assert.Equal("Review helper", (*listResp.JSON200.Sessions)[1].Label)
-
-	stopResp, err := client.HTTP.StopWorkspaceRuntimeSessionWithResponse(
-		ctx, ws.Id, first.Key,
-	)
-	require.NoError(err)
-	require.Equal(http.StatusNoContent, stopResp.StatusCode())
-
-	afterStopResp, err := client.HTTP.GetWorkspaceRuntimeWithResponse(
-		ctx, ws.Id,
-	)
-	require.NoError(err)
-	require.Equal(http.StatusOK, afterStopResp.StatusCode())
-	require.NotNil(afterStopResp.JSON200)
-	require.NotNil(afterStopResp.JSON200.Sessions)
-	require.Len(*afterStopResp.JSON200.Sessions, 1)
-	assert.Equal(second.Key, (*afterStopResp.JSON200.Sessions)[0].Key)
-}
-
-func TestWorkspaceRuntimeNaturalAgentExitRemovesSessionE2E(t *testing.T) {
-	runParallelPTYE2E(t)
-
-	require := require.New(t)
-	assert := assert.New(t)
-	disableTmuxAgentSessions := false
-	cfg := &config.Config{Agents: []config.Agent{{
-		Key:     "helper",
-		Label:   "Helper",
-		Command: serverRuntimeHelperCommand("exit"),
-	}}, Tmux: config.Tmux{AgentSessions: &disableTmuxAgentSessions}}
-	client, database, _, _, _ := setupTestServerWithWorkspacesServer(t, cfg)
-	ctx := context.Background()
-	ws := createReadyWorkspace(t, ctx, client)
-
-	launchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
-		ctx, ws.Id,
-		generated.LaunchWorkspaceRuntimeSessionInputBody{
-			TargetKey: "helper",
-		},
-	)
-	require.NoError(err)
-	require.Equal(http.StatusOK, launchResp.StatusCode(), string(launchResp.Body))
-	require.NotNil(launchResp.JSON200)
-
-	require.Eventually(func() bool {
-		runtimeResp, runtimeErr := client.HTTP.GetWorkspaceRuntimeWithResponse(
-			ctx, ws.Id,
-		)
-		if runtimeErr != nil ||
-			runtimeResp.StatusCode() != http.StatusOK ||
-			runtimeResp.JSON200 == nil ||
-			runtimeResp.JSON200.Sessions == nil {
-			return false
-		}
-		return len(*runtimeResp.JSON200.Sessions) == 0
-	}, 2*time.Second, 20*time.Millisecond)
-	stored, err := database.ListWorkspaceRuntimeSessions(ctx, ws.Id)
-	require.NoError(err)
-	assert.Empty(stored)
-	assert.NotEmpty(launchResp.JSON200.Key)
-}
-
-func TestWorkspaceRuntimePtyOwnerQuickExitLaunchSucceedsE2E(t *testing.T) {
-	runParallelPTYE2E(t)
-
-	require := require.New(t)
-	assert := assert.New(t)
-	disableTmuxAgentSessions := false
-	cfg := &config.Config{Agents: []config.Agent{{
-		Key:     "helper",
-		Label:   "Helper",
-		Command: serverRuntimeHelperCommand("print-exit"),
-	}}, Tmux: config.Tmux{AgentSessions: &disableTmuxAgentSessions}}
-	client, database, _, _, _ := setupTestServerWithWorkspacesServer(t, cfg)
-	ctx := context.Background()
-	ws := createReadyWorkspace(t, ctx, client)
-
-	launchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
-		ctx, ws.Id,
-		generated.LaunchWorkspaceRuntimeSessionInputBody{
-			TargetKey: "helper",
-		},
-	)
-	require.NoError(err)
-	require.Equal(http.StatusOK, launchResp.StatusCode(), string(launchResp.Body))
-	require.NotNil(launchResp.JSON200)
-	assert.NotEmpty(launchResp.JSON200.Key)
-
-	require.Eventually(func() bool {
-		runtimeResp, runtimeErr := client.HTTP.GetWorkspaceRuntimeWithResponse(
-			ctx, ws.Id,
-		)
-		if runtimeErr != nil ||
-			runtimeResp.StatusCode() != http.StatusOK ||
-			runtimeResp.JSON200 == nil ||
-			runtimeResp.JSON200.Sessions == nil {
-			return false
-		}
-		return len(*runtimeResp.JSON200.Sessions) == 0
-	}, 2*time.Second, 20*time.Millisecond)
-	stored, err := database.ListWorkspaceRuntimeSessions(ctx, ws.Id)
-	require.NoError(err)
-	assert.Empty(stored)
-}
-
-func TestWorkspaceRuntimeNaturalTmuxAgentExitForgetsStoredSessionE2E(
-	t *testing.T,
-) {
-	require := require.New(t)
-	assert := assert.New(t)
-	dir := t.TempDir()
-	record := filepath.Join(dir, "tmux-record")
-	tmuxPath := filepath.Join(dir, "fake-tmux")
-	require.NoError(os.WriteFile(tmuxPath, []byte("#!/bin/sh\n"+
-		"TMUX_RECORD="+shellquote.Join(record)+"\n"+
-		`printf '%s\0' "$@" >> "$TMUX_RECORD"
-if [ "$1" = "-u" ]; then shift; fi
-case "$1" in
-  has-session)
-    echo "can't find session: $3" >&2
-    exit 1
-    ;;
-  new-session|set-option|attach-session)
-    exit 0
-    ;;
-esac
-exit 0
-`), 0o755))
-
-	cfg := &config.Config{
-		Agents: []config.Agent{{
-			Key:     "helper",
-			Label:   "Helper",
-			Command: []string{"/bin/sh", "-lc", "exit 0"},
-		}},
-		Tmux: config.Tmux{Command: []string{tmuxPath}},
-	}
-	client, database, _, _, _ := setupTestServerWithWorkspacesServer(t, cfg)
-	ctx := context.Background()
-	ws := createReadyWorkspace(t, ctx, client)
-
-	launchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
-		ctx, ws.Id,
-		generated.LaunchWorkspaceRuntimeSessionInputBody{
-			TargetKey: "helper",
-		},
-	)
-	require.NoError(err)
-	require.Equal(http.StatusOK, launchResp.StatusCode())
-	require.NotNil(launchResp.JSON200)
-
-	require.Eventually(func() bool {
-		runtimeResp, runtimeErr := client.HTTP.GetWorkspaceRuntimeWithResponse(
-			ctx, ws.Id,
-		)
-		if runtimeErr != nil ||
-			runtimeResp.StatusCode() != http.StatusOK ||
-			runtimeResp.JSON200 == nil ||
-			runtimeResp.JSON200.Sessions == nil {
-			return false
-		}
-		return len(*runtimeResp.JSON200.Sessions) == 0
-	}, 2*time.Second, 20*time.Millisecond)
-
-	require.Eventually(func() bool {
-		stored, storedErr := database.ListWorkspaceRuntimeTmuxSessions(ctx, ws.Id)
-		return storedErr == nil && len(stored) == 0
-	}, 2*time.Second, 20*time.Millisecond)
-	assert.NotEmpty(launchResp.JSON200.Key)
 }
 
 func TestWorkspaceRuntimeIncludesStoredRuntimeSessionsAfterReloadE2E(t *testing.T) {
@@ -28288,15 +28011,6 @@ func tmuxNewSessionPaneCommand(argv []string) string {
 	return command
 }
 
-func isRuntimeSessionKeyForWorkspace(workspaceID string, key string) bool {
-	suffix := strings.TrimPrefix(key, workspaceID+"_")
-	return suffix != key &&
-		len(suffix) == 16 &&
-		strings.IndexFunc(suffix, func(r rune) bool {
-			return !strings.ContainsRune("0123456789abcdef", r)
-		}) == -1
-}
-
 func TestWorkspaceRuntimeTmuxSessionsHashUnsafeTargetKeysE2E(
 	t *testing.T,
 ) {
@@ -28523,87 +28237,8 @@ exit 0
 	)
 }
 
-func TestWorkspaceResponseUsesStoredRuntimeTmuxSessionsAfterRestartE2E(
-	t *testing.T,
-) {
-	require := require.New(t)
-	assert := assert.New(t)
-	dir := t.TempDir()
-	tmuxPath := filepath.Join(dir, "fake-tmux")
-	liveSessionsFile := filepath.Join(dir, "live-sessions")
-	require.NoError(os.WriteFile(tmuxPath, []byte("#!/bin/sh\n"+
-		"TMUX_LIVE_SESSIONS_FILE="+shellquote.Join(liveSessionsFile)+"\n"+
-		`target=""
-mode=""
-prev=""
-for a in "$@"; do
-  if [ "$prev" = "-t" ]; then target="$a"; fi
-  if [ "$a" = "display-message" ]; then mode="display-message"; fi
-  if [ "$a" = "capture-pane" ]; then mode="capture-pane"; fi
-  if [ "$a" = "list-sessions" ]; then
-    [ -f "$TMUX_LIVE_SESSIONS_FILE" ] && cat "$TMUX_LIVE_SESSIONS_FILE"
-    exit 0
-  fi
-  prev="$a"
-done
-if [ "$mode" = "display-message" ]; then
-  case "$target" in
-    *-claude) printf '⠴ claude-activity\n' ;;
-    *) printf 'idle\n' ;;
-  esac
-  exit 0
-fi
-if [ "$mode" = "capture-pane" ]; then
-  printf 'stable\n'
-  exit 0
-fi
-exit 0
-`), 0o755))
-	cfg := &config.Config{Tmux: config.Tmux{Command: []string{tmuxPath}}}
-	client, database, _, _, _ := setupTestServerWithWorkspacesServerAndEnrichment(t, cfg)
-	ctx := context.Background()
-	ws := createReadyWorkspace(t, ctx, client)
-	require.NotEmpty(ws.TmuxSession)
-	require.NoError(os.WriteFile(liveSessionsFile, []byte(strings.Join([]string{
-		ws.TmuxSession,
-		ws.TmuxSession + "-codex",
-		ws.TmuxSession + "-claude",
-	}, "\n")+"\n"), 0o644))
-	recordRuntimeTmuxSessionForServerTest(
-		t, database, ws.Id, "", "codex", ws.TmuxSession+"-codex", time.Time{},
-	)
-	recordRuntimeTmuxSessionForServerTest(
-		t, database, ws.Id, "", "claude", ws.TmuxSession+"-claude", time.Time{},
-	)
-
-	var listed *generated.WorkspaceResponse
-	require.Eventually(func() bool {
-		listResp, err := client.HTTP.ListWorkspacesWithResponse(ctx)
-		require.NoError(err)
-		if listResp.StatusCode() != http.StatusOK ||
-			listResp.JSON200 == nil || listResp.JSON200.Workspaces == nil {
-			return false
-		}
-		listed = nil
-		for i := range *listResp.JSON200.Workspaces {
-			if (*listResp.JSON200.Workspaces)[i].Id == ws.Id {
-				listed = &(*listResp.JSON200.Workspaces)[i]
-				break
-			}
-		}
-		return listed != nil && listed.TmuxWorking &&
-			listed.TmuxActivitySource == workspaceapi.TmuxActivitySourceTitle &&
-			listed.TmuxPaneTitle != nil
-	}, 6*time.Second, 10*time.Millisecond)
-	require.NotNil(listed)
-	assert.True(listed.TmuxWorking)
-	assert.Equal(workspaceapi.TmuxActivitySourceTitle, listed.TmuxActivitySource)
-	require.NotNil(listed.TmuxPaneTitle)
-	assert.Equal("⠴ claude-activity", *listed.TmuxPaneTitle)
-}
-
 func TestWorkspaceDeletionRecoversAcrossServerRestartE2E(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 	acquireRootWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -28667,7 +28302,7 @@ func TestWorkspaceDeletionRecoversAcrossServerRestartE2E(t *testing.T) {
 }
 
 func TestWorkspaceDeleteStopsRuntimeSessionsE2E(t *testing.T) {
-	runParallelPTYE2E(t)
+	runSerialPTYE2E(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -28707,7 +28342,7 @@ func TestWorkspaceDeleteStopsRuntimeSessionsE2E(t *testing.T) {
 }
 
 func TestWorkspaceDeleteDirtyKeepsRuntimeSessionsE2E(t *testing.T) {
-	runParallelPTYE2E(t)
+	runSerialPTYE2E(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -28793,7 +28428,7 @@ func TestMergeWorkspaceCleanupDeletesWorkspaceAfterConfirmedMerge(t *testing.T) 
 	ws := createReadyWorkspace(t, ctx, client)
 	headSHA := pinWorkspaceMergeRequestForReview(t, ctx, database, ws)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/pulls/github/acme/widget/1/merge", map[string]any{
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/pulls/github/acme/widget/1/merge", map[string]any{
 		"commit_title":        "merge title",
 		"commit_message":      "merge body",
 		"method":              "squash",
@@ -28817,79 +28452,6 @@ func TestMergeWorkspaceCleanupDeletesWorkspaceAfterConfirmedMerge(t *testing.T) 
 	}, 5*time.Second, 10*time.Millisecond)
 	_, err := os.Stat(ws.WorktreePath)
 	assert.ErrorIs(err, os.ErrNotExist)
-}
-
-func TestWorkspaceDiffCacheHitReturnsWhileGitCapacityIsHeldE2E(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-	restoreLimiter := procutil.SetDefaultLimiterForTest(
-		procutil.NewLimiterWithAcquireTimeout(1, 500*time.Millisecond),
-	)
-	t.Cleanup(restoreLimiter)
-
-	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
-	ws := createReadyWorkspace(t, context.Background(), client)
-	initial := requestWorkspaceDiff(t, srv, ws.Id, "head")
-	assert.False(initial.Stale)
-
-	releaseHeld, err := procutil.TryAcquire(
-		context.Background(), "test-held workspace diff capacity",
-	)
-	require.NoError(err)
-	defer releaseHeld()
-
-	started := time.Now()
-	cached := requestWorkspaceDiff(t, srv, ws.Id, "head")
-	elapsed := time.Since(started)
-	releaseHeld()
-
-	assert.False(cached.Stale)
-	assert.Less(elapsed, 200*time.Millisecond)
-}
-
-func requestWorkspaceDiff(
-	t *testing.T,
-	srv *Server,
-	workspaceID string,
-	base string,
-	whitespace ...string,
-) generated.DiffResponse {
-	t.Helper()
-
-	query := "/api/v1/workspaces/" + workspaceID + "/diff?base=" + base
-	if len(whitespace) > 0 {
-		query += "&whitespace=" + whitespace[0]
-	}
-	return requestWorkspaceDiffPath(t, srv, query)
-}
-
-func requestWorkspaceDiffPath(
-	t *testing.T,
-	srv *Server,
-	query string,
-) generated.DiffResponse {
-	t.Helper()
-
-	req := newWorkspaceFixtureRequest(http.MethodGet, query, nil)
-	rr := httptest.NewRecorder()
-	srv.ServeHTTP(rr, req)
-	resp := rr.Result()
-	defer resp.Body.Close()
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-
-	var body generated.DiffResponse
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
-	return body
-}
-
-func newWorkspaceFixtureRequest(
-	method string,
-	target string,
-	body io.Reader,
-) *http.Request {
-	req := httptest.NewRequest(method, target, body)
-	req.Host = "forge.test"
-	return req
 }
 
 func requireWorkspaceDiffFile(
@@ -29251,326 +28813,11 @@ func TestWorkspaceRuntimeRestoreKeepsStoredTmuxShellWithDifferentOwnerMarkerE2E(
 	assert.Equal(string(localruntime.SessionStatusRunning), (*runtimeResp.JSON200.Sessions)[0].Status)
 }
 
-// TestWorkspaceRuntimePlainShellTerminalWebSocketE2E exercises the runtime
-// session websocket path end-to-end with a custom Shell.Command. Hardened
-// deployments (e.g. systemd services with SystemCallFilter=~@privileged) need
-// the override so that zsh's startup setresuid is not SIGSYS'd by the parent's
-// seccomp filter; this test guards both the websocket route and the
-// config.Shell.Command -> manager.Options.ShellCommand wiring.
-func TestWorkspaceRuntimePlainShellTerminalWebSocketE2E(t *testing.T) {
-	runParallelPTYE2E(t)
-
-	require := require.New(t)
-	tmuxCommand := isolatedRealTmuxCommandIfAvailable(t)
-	cfg := &config.Config{
-		Tmux: config.Tmux{Command: tmuxCommand},
-		Shell: config.Shell{
-			Command: serverRuntimeHelperCommand("echo"),
-		},
-	}
-	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, cfg)
-	ctx := context.Background()
-	ws := createReadyWorkspace(t, ctx, client)
-
-	shell := launchPlainShellRuntimeSession(t, ctx, client, ws.Id)
-
-	ts := httptest.NewServer(srv)
-	t.Cleanup(ts.Close)
-	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
-		"/ws/v1/workspaces/" + ws.Id +
-		"/runtime/sessions/" + shell.Key + "/terminal?cols=80&rows=24"
-	conn, _, err := websocket.Dial(ctx, wsURL, nil)
-	require.NoError(err)
-	defer conn.Close(websocket.StatusNormalClosure, "done")
-
-	require.NoError(conn.Write(
-		ctx, websocket.MessageBinary, []byte("ping\n"),
-	))
-	readCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
-	var got strings.Builder
-	for {
-		typ, data, readErr := conn.Read(readCtx)
-		if readErr != nil {
-			break
-		}
-		if typ != websocket.MessageBinary {
-			continue
-		}
-		got.WriteString(string(data))
-		if strings.Contains(got.String(), "echo:ping") {
-			return
-		}
-	}
-	require.Contains(got.String(), "echo:ping")
-}
-
-// TestWorkspaceRuntimePlainShellTerminalDeliversActualExitCodeE2E pins the
-// websocket "exited" text frame contract through the real runtime stack. The
-// helper closes its PTY shortly before exiting so this exercises the window
-// where PTY EOF can arrive before process wait publishes the exit code.
-func TestWorkspaceRuntimePlainShellTerminalDeliversActualExitCodeE2E(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test fixture uses /bin/sh")
-	}
-	runParallelPTYE2E(t)
-
-	require := require.New(t)
-	dir := t.TempDir()
-	ptyOwnerDir := filepath.Join(dir, "pty-owner")
-	cfg := &config.Config{
-		Tmux: config.Tmux{
-			Command: []string{filepath.Join(dir, "missing-tmux")},
-		},
-		Shell: config.Shell{
-			Command: serverRuntimeHelperCommand("pty-close-on-input-then-exit"),
-		},
-	}
-	fixture := setupWorkspaceServerFixtureWithOptions(
-		t, cfg, ptyOwnerServerOptions(ptyOwnerDir),
-	)
-	client := fixture.client
-	srv := fixture.server
-	ctx := context.Background()
-	ws := createReadyWorkspace(t, ctx, client)
-
-	shell := launchPlainShellRuntimeSession(t, ctx, client, ws.Id)
-	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, shell.Key)
-	stored, err := fixture.database.ListWorkspaceRuntimeSessions(ctx, ws.Id)
-	require.NoError(err)
-	require.Len(stored, 1)
-	require.Equal(shell.Key, stored[0].SessionKey)
-	require.Empty(stored[0].TmuxSession)
-
-	ts := httptest.NewServer(srv)
-	t.Cleanup(ts.Close)
-	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
-		"/ws/v1/workspaces/" + ws.Id +
-		"/runtime/sessions/" + shell.Key + "/terminal?cols=80&rows=24"
-	conn := dialWebSocketForTest(t, ctx, wsURL, "shell")
-	defer conn.Close(websocket.StatusNormalClosure, "done")
-
-	// Trigger after attach so the session cannot exit before the websocket
-	// connects. The helper's short delay makes PTY EOF reliably precede process
-	// exit while remaining inside the owner's bounded exit-code grace period.
-	require.NoError(conn.Write(ctx, websocket.MessageBinary, []byte("close\n")))
-	readCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	for {
-		typ, data, readErr := conn.Read(readCtx)
-		if readErr != nil {
-			require.Failf(
-				"never received exit frame",
-				"read err before exit frame: %v", readErr,
-			)
-		}
-		if typ != websocket.MessageText {
-			continue
-		}
-		var msg struct {
-			Type string `json:"type"`
-			Code int    `json:"code"`
-		}
-		require.NoError(json.Unmarshal(data, &msg))
-		require.Equal("exited", msg.Type)
-		require.Equal(7, msg.Code)
-		break
-	}
-
-	require.Eventually(func() bool {
-		runtimeResp, runtimeErr := client.HTTP.GetWorkspaceRuntimeWithResponse(
-			ctx, ws.Id,
-		)
-		if runtimeErr != nil || runtimeResp.StatusCode() != http.StatusOK ||
-			runtimeResp.JSON200 == nil {
-			return false
-		}
-		if runtimeResp.JSON200.Sessions != nil {
-			for _, session := range *runtimeResp.JSON200.Sessions {
-				if session.Key == shell.Key {
-					return false
-				}
-			}
-		}
-		rows, rowsErr := fixture.database.ListWorkspaceRuntimeSessions(ctx, ws.Id)
-		return rowsErr == nil && len(rows) == 0
-	}, 5*time.Second, 20*time.Millisecond)
-}
-
-func TestWorkspaceRuntimePtyOwnerQuickExitReportsExactStatusE2E(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test fixture uses Unix PTY exit semantics")
-	}
-	runParallelPTYE2E(t)
-
-	require := require.New(t)
-	dir := t.TempDir()
-	ptyOwnerDir := filepath.Join(dir, "pty-owner")
-	disableTmuxAgentSessions := false
-	cfg := &config.Config{
-		Agents: []config.Agent{{
-			Key:   "helper",
-			Label: "Helper",
-			// Keep the PTY open briefly after the shell exits so the owner can
-			// publish the exact status before output EOF reaches the bridge.
-			// Without this ordering, a loaded race runner can legitimately hit
-			// the owner's bounded unknown-status fallback instead.
-			Command: []string{
-				"sh", "-c", "IFS= read -r line; sleep 1 & exit 9",
-			},
-		}},
-		Tmux: config.Tmux{
-			Command:       []string{filepath.Join(dir, "missing-tmux")},
-			AgentSessions: &disableTmuxAgentSessions,
-		},
-	}
-	fixture := setupWorkspaceServerFixtureWithOptions(
-		t, cfg, ptyOwnerServerOptions(ptyOwnerDir),
-	)
-	ctx := context.Background()
-	ws := createReadyWorkspace(t, ctx, fixture.client)
-
-	launchResp, err := fixture.client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
-		ctx, ws.Id,
-		generated.LaunchWorkspaceRuntimeSessionInputBody{TargetKey: "helper"},
-	)
-	require.NoError(err)
-	require.Equal(http.StatusOK, launchResp.StatusCode(), string(launchResp.Body))
-	require.NotNil(launchResp.JSON200)
-	session := launchResp.JSON200
-	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, session.Key)
-
-	stored, err := fixture.database.ListWorkspaceRuntimeSessions(ctx, ws.Id)
-	require.NoError(err)
-	require.Len(stored, 1)
-	require.Equal(session.Key, stored[0].SessionKey)
-
-	ts := httptest.NewServer(fixture.server)
-	t.Cleanup(ts.Close)
-	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
-		"/ws/v1/workspaces/" + ws.Id +
-		"/runtime/sessions/" + session.Key + "/terminal?cols=80&rows=24"
-	conn := dialWebSocketForTest(t, ctx, wsURL, "quick-exit helper")
-	defer conn.Close(websocket.StatusNormalClosure, "done")
-	require.NoError(conn.Write(ctx, websocket.MessageBinary, []byte("exit\n")))
-
-	readCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	for {
-		typ, data, readErr := conn.Read(readCtx)
-		if readErr != nil {
-			require.Failf(
-				"never received exact exit frame",
-				"read err before exit frame: %v", readErr,
-			)
-		}
-		if typ != websocket.MessageText {
-			continue
-		}
-		var msg struct {
-			Type string `json:"type"`
-			Code int    `json:"code"`
-		}
-		require.NoError(json.Unmarshal(data, &msg))
-		require.Equal("exited", msg.Type)
-		require.Equal(9, msg.Code)
-		break
-	}
-
-	require.Eventually(func() bool {
-		runtimeResp, runtimeErr := fixture.client.HTTP.GetWorkspaceRuntimeWithResponse(
-			ctx, ws.Id,
-		)
-		if runtimeErr != nil || runtimeResp.StatusCode() != http.StatusOK ||
-			runtimeResp.JSON200 == nil || runtimeResp.JSON200.Sessions == nil ||
-			len(*runtimeResp.JSON200.Sessions) != 0 {
-			return false
-		}
-		stored, storedErr := fixture.database.ListWorkspaceRuntimeSessions(ctx, ws.Id)
-		return storedErr == nil && len(stored) == 0
-	}, 2*time.Second, 20*time.Millisecond)
-}
-
 // TestBridgeRuntimeAttachmentOutputClosedEmitsExitFrameBeforeDone pins the
 // bridge branch for wrappers where PTY EOF reaches the subscriber before
 // cmd.Wait marks the session done. That is the race the real ShellDrawer cares
 // about, but it is cleaner to drive it with controlled channels than to depend
 // on backend-specific PTY behavior in an e2e helper.
-
-// TestWorkspaceRuntimePlainShellAfterExitStartsFreshE2E pins the user-visible
-// no-tmux behavior that launching a shell after the terminal has reported exit
-// returns a fresh ptyowner-backed session, never the dead shell record the
-// frontend just auto-closed.
-func TestWorkspaceRuntimePlainShellAfterExitStartsFreshE2E(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("test fixture uses /bin/sh")
-	}
-	runParallelPTYE2E(t)
-
-	require := require.New(t)
-	assert := assert.New(t)
-	cfg := &config.Config{
-		Tmux: config.Tmux{
-			Command: []string{filepath.Join(t.TempDir(), "missing-tmux")},
-		},
-		Shell: config.Shell{
-			Command: serverRuntimeHelperCommand("pty-close-on-input-then-sleep"),
-		},
-	}
-	ptyOwnerDir := filepath.Join(t.TempDir(), "pty-owner")
-	fixture := setupWorkspaceServerFixtureWithOptions(
-		t, cfg, ptyOwnerServerOptions(ptyOwnerDir),
-	)
-	client := fixture.client
-	srv := fixture.server
-	ctx := context.Background()
-	ws := createReadyWorkspace(t, ctx, client)
-
-	first := launchPlainShellRuntimeSession(t, ctx, client, ws.Id)
-	firstCreatedAt := first.CreatedAt
-	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, first.Key)
-
-	// Attach + drain to drive the helper through exit, then ensure
-	// the next shell open does not reuse the session that just
-	// reported an exit frame to the frontend.
-	ts := httptest.NewServer(srv)
-	t.Cleanup(ts.Close)
-	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
-		"/ws/v1/workspaces/" + ws.Id +
-		"/runtime/sessions/" + first.Key + "/terminal?cols=80&rows=24"
-	conn := dialWebSocketForTest(t, ctx, wsURL, "plain shell after exit")
-	require.NoError(conn.Write(ctx, websocket.MessageBinary, []byte("exit\n")))
-	readCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	for {
-		typ, data, readErr := conn.Read(readCtx)
-		if readErr != nil {
-			require.Failf(
-				"never received exit frame",
-				"read err before exit frame: %v", readErr,
-			)
-		}
-		if typ != websocket.MessageText {
-			continue
-		}
-		var msg struct {
-			Type string `json:"type"`
-		}
-		require.NoError(json.Unmarshal(data, &msg))
-		require.Equal("exited", msg.Type)
-		break
-	}
-	conn.Close(websocket.StatusNormalClosure, "done")
-
-	// Inside the zombie window: helper still sleeping, so cmd.Wait
-	// hasn't returned and watchSession hasn't run.
-	second := launchPlainShellRuntimeSession(t, ctx, client, ws.Id)
-	assert.NotEqual(
-		firstCreatedAt, second.CreatedAt,
-		"second shell launch must return a fresh session, not the zombie",
-	)
-	assert.Equal(string(localruntime.SessionStatusRunning), second.Status)
-}
 
 // TestBridgeRuntimeAttachmentSubscriberDropDoesNotEmitExitFrame
 // pins the bridge's branch that distinguishes a subscriber drop from
@@ -29590,122 +28837,6 @@ func TestWorkspaceRuntimePlainShellAfterExitStartsFreshE2E(t *testing.T) {
 
 // Read until close. With the bug present (always-emit on
 // outputDone), we'd see a MessageText "exited" frame here.
-
-func TestWorkspaceRuntimeSessionTerminalWebSocketE2E(t *testing.T) {
-	runParallelPTYE2E(t)
-
-	require := require.New(t)
-	disableTmuxAgentSessions := false
-	cfg := &config.Config{Agents: []config.Agent{{
-		Key:     "helper",
-		Label:   "Helper",
-		Command: serverRuntimeHelperCommand("echo"),
-	}}, Tmux: config.Tmux{AgentSessions: &disableTmuxAgentSessions}}
-	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, cfg)
-	ctx := context.Background()
-	ws := createReadyWorkspace(t, ctx, client)
-
-	launchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
-		ctx, ws.Id,
-		generated.LaunchWorkspaceRuntimeSessionInputBody{
-			TargetKey: "helper",
-		},
-	)
-	require.NoError(err)
-	require.Equal(http.StatusOK, launchResp.StatusCode())
-	require.NotNil(launchResp.JSON200)
-	session := launchResp.JSON200
-
-	ts := httptest.NewServer(srv)
-	t.Cleanup(ts.Close)
-	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
-		"/ws/v1/workspaces/" + ws.Id +
-		"/runtime/sessions/" + session.Key + "/terminal"
-	conn, _, err := websocket.Dial(ctx, wsURL, nil)
-	require.NoError(err)
-	defer conn.Close(websocket.StatusNormalClosure, "done")
-
-	require.NoError(conn.Write(
-		ctx, websocket.MessageBinary, []byte("ping\n"),
-	))
-	readCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
-	var got strings.Builder
-	for {
-		typ, data, readErr := conn.Read(readCtx)
-		if readErr != nil {
-			break
-		}
-		if typ != websocket.MessageBinary {
-			continue
-		}
-		got.WriteString(string(data))
-		if strings.Contains(got.String(), "echo:ping") {
-			return
-		}
-	}
-	require.Contains(got.String(), "echo:ping")
-}
-
-func TestWorkspaceRuntimeSessionTerminalWebSocketBasePathE2E(t *testing.T) {
-	runParallelPTYE2E(t)
-
-	require := require.New(t)
-	disableTmuxAgentSessions := false
-	cfg := &config.Config{
-		BasePath: "/kenn-forge/",
-		Agents: []config.Agent{{
-			Key:     "helper",
-			Label:   "Helper",
-			Command: serverRuntimeHelperCommand("echo"),
-		}},
-		Tmux: config.Tmux{AgentSessions: &disableTmuxAgentSessions},
-	}
-	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, cfg)
-	ctx := context.Background()
-	ws := createReadyWorkspace(t, ctx, client)
-
-	launchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
-		ctx, ws.Id,
-		generated.LaunchWorkspaceRuntimeSessionInputBody{
-			TargetKey: "helper",
-		},
-	)
-	require.NoError(err)
-	require.Equal(http.StatusOK, launchResp.StatusCode())
-	require.NotNil(launchResp.JSON200)
-	session := launchResp.JSON200
-
-	ts := httptest.NewServer(srv)
-	t.Cleanup(ts.Close)
-	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
-		"/kenn-forge/ws/v1/workspaces/" + ws.Id +
-		"/runtime/sessions/" + session.Key + "/terminal"
-	conn, _, err := websocket.Dial(ctx, wsURL, nil)
-	require.NoError(err)
-	defer conn.Close(websocket.StatusNormalClosure, "done")
-
-	require.NoError(conn.Write(
-		ctx, websocket.MessageBinary, []byte("ping\n"),
-	))
-	readCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
-	var got strings.Builder
-	for {
-		typ, data, readErr := conn.Read(readCtx)
-		if readErr != nil {
-			break
-		}
-		if typ != websocket.MessageBinary {
-			continue
-		}
-		got.WriteString(string(data))
-		if strings.Contains(got.String(), "echo:ping") {
-			return
-		}
-	}
-	require.Contains(got.String(), "echo:ping")
-}
 
 func workspaceTerminalWriteRead(
 	t *testing.T,
@@ -29760,30 +28891,6 @@ func workspaceTerminalConnWriteRead(
 	require.Contains(t, got.String(), needle)
 }
 
-func workspaceTerminalDialEventually(
-	t *testing.T,
-	ctx context.Context,
-	serverURL string,
-	workspaceID string,
-) *websocket.Conn {
-	t.Helper()
-
-	var conn *websocket.Conn
-	require.Eventually(t, func() bool {
-		var resp *http.Response
-		var err error
-		conn, resp, err = workspaceTerminalDial(ctx, serverURL, workspaceID)
-		if err != nil && conn != nil {
-			conn.Close(websocket.StatusNormalClosure, "done")
-		}
-		if resp != nil && resp.Body != nil {
-			resp.Body.Close()
-		}
-		return err == nil
-	}, 2*time.Second, 20*time.Millisecond)
-	return conn
-}
-
 func workspaceTerminalDial(
 	ctx context.Context,
 	serverURL string,
@@ -29804,159 +28911,6 @@ func workspaceTerminalDialWithQuery(
 		wsURL += "?" + query
 	}
 	return websocket.Dial(ctx, wsURL, nil)
-}
-
-func TestWorkspaceRuntimeSessionTerminalSkipsAltScreenReplayE2E(t *testing.T) {
-	runParallelPTYE2E(t)
-
-	require := require.New(t)
-	assert := assert.New(t)
-	disableTmuxAgentSessions := false
-	cfg := &config.Config{Agents: []config.Agent{{
-		Key:     "helper",
-		Label:   "Helper",
-		Command: serverRuntimeHelperCommand("altscreen"),
-	}}, Tmux: config.Tmux{AgentSessions: &disableTmuxAgentSessions}}
-	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, cfg)
-	ctx := context.Background()
-	ws := createReadyWorkspace(t, ctx, client)
-
-	launchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
-		ctx, ws.Id,
-		generated.LaunchWorkspaceRuntimeSessionInputBody{
-			TargetKey: "helper",
-		},
-	)
-	require.NoError(err)
-	require.Equal(http.StatusOK, launchResp.StatusCode())
-	require.NotNil(launchResp.JSON200)
-	session := launchResp.JSON200
-
-	ts := httptest.NewServer(srv)
-	t.Cleanup(ts.Close)
-	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
-		"/ws/v1/workspaces/" + ws.Id +
-		"/runtime/sessions/" + session.Key + "/terminal"
-
-	primingConn := dialWebSocketForTest(t, ctx, wsURL, "priming")
-	require.NoError(primingConn.Write(
-		ctx, websocket.MessageBinary, []byte("prime\n"),
-	))
-	readWebSocketBinaryUntil(t, ctx, primingConn, 2*time.Second, "codex screen")
-	require.NoError(primingConn.Close(websocket.StatusNormalClosure, "primed"))
-
-	conn := dialWebSocketForTest(t, ctx, wsURL, "late")
-	defer conn.Close(websocket.StatusNormalClosure, "done")
-
-	type terminalRead struct {
-		typ  websocket.MessageType
-		data []byte
-		err  error
-	}
-	reads := make(chan terminalRead, 1)
-	readOnce := func() {
-		go func() {
-			typ, data, readErr := conn.Read(context.Background())
-			reads <- terminalRead{typ: typ, data: data, err: readErr}
-		}()
-	}
-	readOnce()
-	select {
-	case read := <-reads:
-		require.NoError(read.err)
-		require.Empty(
-			string(read.data),
-			"late attach must not replay stale alternate-screen output",
-		)
-	case <-time.After(100 * time.Millisecond):
-	}
-
-	require.NoError(conn.Write(
-		ctx, websocket.MessageBinary, []byte("paint\n"),
-	))
-	var got strings.Builder
-	deadline := time.After(5 * time.Second)
-	for {
-		select {
-		case read := <-reads:
-			require.NoError(read.err)
-			if read.typ == websocket.MessageBinary {
-				got.WriteString(string(read.data))
-			}
-			if strings.Contains(got.String(), "live:paint") {
-				break
-			}
-			readOnce()
-			continue
-		case <-deadline:
-			require.Contains(got.String(), "live:paint")
-		}
-		break
-	}
-	assert.NotContains(got.String(), "codex screen")
-	require.Contains(got.String(), "live:paint")
-}
-
-func TestWorkspaceRuntimeSessionTerminalAppliesInitialSizeE2E(t *testing.T) {
-	runParallelPTYE2E(t)
-
-	require := require.New(t)
-	// This intentionally goes through the generated HTTP client, the real
-	// httptest server, and the terminal websocket rather than attaching to
-	// localruntime directly. The helper exits quickly after printing the
-	// observed PTY size, so receiving size:41:177 exercises the full path
-	// that must preserve final terminal output before the exit frame wins.
-	disableTmuxAgentSessions := false
-	cfg := &config.Config{Agents: []config.Agent{{
-		Key:     "helper",
-		Label:   "Helper",
-		Command: serverRuntimeHelperCommand("size"),
-	}}, Tmux: config.Tmux{AgentSessions: &disableTmuxAgentSessions}}
-	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, cfg)
-	ctx := context.Background()
-	ws := createReadyWorkspace(t, ctx, client)
-
-	launchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
-		ctx, ws.Id,
-		generated.LaunchWorkspaceRuntimeSessionInputBody{
-			TargetKey: "helper",
-		},
-	)
-	require.NoError(err)
-	require.Equal(http.StatusOK, launchResp.StatusCode())
-	require.NotNil(launchResp.JSON200)
-	session := launchResp.JSON200
-
-	ts := httptest.NewServer(srv)
-	t.Cleanup(ts.Close)
-	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
-		"/ws/v1/workspaces/" + ws.Id +
-		"/runtime/sessions/" + session.Key +
-		"/terminal?cols=177&rows=41"
-	conn, _, err := websocket.Dial(ctx, wsURL, nil)
-	require.NoError(err)
-	defer conn.Close(websocket.StatusNormalClosure, "done")
-
-	require.NoError(conn.Write(
-		ctx, websocket.MessageBinary, []byte("size\n"),
-	))
-	readCtx, cancel := context.WithTimeout(ctx, 4*time.Second)
-	defer cancel()
-	var got strings.Builder
-	for {
-		typ, data, readErr := conn.Read(readCtx)
-		if readErr != nil {
-			break
-		}
-		if typ != websocket.MessageBinary {
-			continue
-		}
-		got.WriteString(string(data))
-		if strings.Contains(got.String(), "size:41:177") {
-			return
-		}
-	}
-	require.Contains(got.String(), "size:41:177")
 }
 
 func TestWorkspaceRuntimeSessionTerminalTmuxBackedWebSocketE2E(
@@ -30325,27 +29279,6 @@ func TestServerRuntimeHelperProcess(t *testing.T) {
 			fmt.Print("echo:" + line)
 		}
 		blockServerRuntimeHelper()
-	case "altscreen":
-		reader := bufio.NewReader(os.Stdin)
-		_, err := reader.ReadString('\n')
-		if err != nil {
-			blockServerRuntimeHelper()
-		}
-		fmt.Print("\x1b[?1049h\x1b[Hcodex screen")
-		line, err := reader.ReadString('\n')
-		if err == nil {
-			fmt.Print("\x1b[Hlive:" + line)
-		}
-		blockServerRuntimeHelper()
-	case "size":
-		line, err := bufio.NewReader(os.Stdin).ReadString('\n')
-		if err == nil {
-			rows, cols, sizeErr := pty.Getsize(os.Stdin)
-			if sizeErr == nil {
-				fmt.Printf("size:%d:%d:%s", rows, cols, line)
-			}
-		}
-		return
 	case "size-live":
 		reader := bufio.NewReader(os.Stdin)
 		for {
@@ -30358,11 +29291,6 @@ func TestServerRuntimeHelperProcess(t *testing.T) {
 				fmt.Printf("size:%d:%d:%s", rows, cols, line)
 			}
 		}
-	case "exit":
-		os.Exit(3)
-	case "print-exit":
-		fmt.Print("quick-api-output")
-		os.Exit(7)
 	case "pty-close-then-sleep":
 		// Simulate the systemd-run-wrapper window the bridge has to
 		// survive: PTY EOF observed (drainOutput exits) well before
@@ -30380,28 +29308,6 @@ func TestServerRuntimeHelperProcess(t *testing.T) {
 		_ = os.Stdout.Close()
 		_ = os.Stderr.Close()
 		time.Sleep(2 * time.Second)
-		os.Exit(7)
-	case "pty-close-on-input-then-sleep":
-		_, err := bufio.NewReader(os.Stdin).ReadString('\n')
-		if err != nil {
-			os.Exit(2)
-		}
-		signal.Ignore(syscall.SIGHUP, syscall.SIGTERM, syscall.SIGINT)
-		_ = os.Stdin.Close()
-		_ = os.Stdout.Close()
-		_ = os.Stderr.Close()
-		time.Sleep(2 * time.Second)
-		os.Exit(7)
-	case "pty-close-on-input-then-exit":
-		_, err := bufio.NewReader(os.Stdin).ReadString('\n')
-		if err != nil {
-			os.Exit(2)
-		}
-		signal.Ignore(syscall.SIGHUP, syscall.SIGTERM, syscall.SIGINT)
-		_ = os.Stdin.Close()
-		_ = os.Stdout.Close()
-		_ = os.Stderr.Close()
-		time.Sleep(50 * time.Millisecond)
 		os.Exit(7)
 	default:
 		os.Exit(2)
@@ -30515,7 +29421,7 @@ type rawProblemDetail struct {
 }
 
 func TestWorkspaceManualRefreshDiscoversAndSyncsAssociatedPR(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 	acquireRootWorkspaceGitSlot(t)
 
 	assert := assert.New(t)
@@ -30602,13 +29508,13 @@ func TestWorkspaceManualRefreshDiscoversAndSyncsAssociatedPR(t *testing.T) {
 	)
 
 	seedIssue(t, fixture.database, "acme", "widget", 7, "open")
-	createRR := doJSON(
+	createRR := testutil.DoJSON(
 		t,
 		fixture.server,
 		http.MethodPost,
 		"/api/v1/issues/gh/acme/widget/7/workspace",
-		map[string]string{},
-	)
+		map[string]string{})
+
 	require.Equal(http.StatusAccepted, createRR.Code, createRR.Body.String())
 
 	var created rawWorkspaceStatusResponse
@@ -30631,13 +29537,13 @@ func TestWorkspaceManualRefreshDiscoversAndSyncsAssociatedPR(t *testing.T) {
 	headRef = ready.GitHeadRef
 	headSHA = testGitSHA(t, ready.WorktreePath, "HEAD")
 
-	refreshRR := doJSON(
+	refreshRR := testutil.DoJSON(
 		t,
 		fixture.server,
 		http.MethodPost,
 		"/api/v1/workspaces/"+created.ID+"/refresh",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, refreshRR.Code, refreshRR.Body.String())
 
 	var refreshed rawWorkspaceStatusResponse
@@ -30662,7 +29568,7 @@ func TestWorkspaceManualRefreshDiscoversAndSyncsAssociatedPR(t *testing.T) {
 }
 
 func TestKataWorkspaceManualRefreshDiscoversAndSyncsAssociatedPR(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 	acquireRootWorkspaceGitSlot(t)
 
 	assert := assert.New(t)
@@ -30772,13 +29678,13 @@ func TestKataWorkspaceManualRefreshDiscoversAndSyncsAssociatedPR(t *testing.T) {
 		KataMetadata:    &kataMetadata,
 	}))
 
-	refreshRR := doJSON(
+	refreshRR := testutil.DoJSON(
 		t,
 		fixture.server,
 		http.MethodPost,
 		"/api/v1/workspaces/ws-kata-refresh/refresh",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, refreshRR.Code, refreshRR.Body.String())
 
 	var refreshed rawWorkspaceStatusResponse
@@ -30813,7 +29719,7 @@ func TestKataWorkspaceManualRefreshDiscoversAndSyncsAssociatedPR(t *testing.T) {
 }
 
 func TestWorkspaceManualRefreshSkipsRemovedIssueProviderDetail(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 	acquireRootWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -30866,10 +29772,10 @@ func TestWorkspaceManualRefreshSkipsRemovedIssueProviderDetail(t *testing.T) {
 	)
 	seedIssue(t, fixture.database, "acme", "widget", issueNumber, "open")
 
-	createRR := doJSON(
+	createRR := testutil.DoJSON(
 		t, fixture.server, http.MethodPost,
-		"/api/v1/issues/gh/acme/widget/7/workspace", map[string]string{},
-	)
+		"/api/v1/issues/gh/acme/widget/7/workspace", map[string]string{})
+
 	require.Equal(http.StatusAccepted, createRR.Code, createRR.Body.String())
 	var created rawWorkspaceStatusResponse
 	require.NoError(json.NewDecoder(createRR.Body).Decode(&created))
@@ -30885,10 +29791,10 @@ func TestWorkspaceManualRefreshSkipsRemovedIssueProviderDetail(t *testing.T) {
 	)
 	before := issueDetailCalls.Load()
 
-	refreshRR := doJSON(
+	refreshRR := testutil.DoJSON(
 		t, fixture.server, http.MethodPost,
-		"/api/v1/workspaces/"+created.ID+"/refresh", nil,
-	)
+		"/api/v1/workspaces/"+created.ID+"/refresh", nil)
+
 	require.Equal(http.StatusOK, refreshRR.Code, refreshRR.Body.String())
 	require.Equal(before, issueDetailCalls.Load(),
 		"manual refresh must not fetch a tombstoned issue")
@@ -30901,7 +29807,7 @@ func TestWorkspaceManualRefreshSkipsRemovedIssueProviderDetail(t *testing.T) {
 // association discovery proceeds, the targeted PR-detail update still runs,
 // and the tolerated partial failure stays recorded in repo sync health.
 func TestWorkspaceRefreshProceedsThroughIssueScopePartialSyncFailure(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 	acquireRootWorkspaceGitSlot(t)
 
 	assert := assert.New(t)
@@ -30953,13 +29859,13 @@ func TestWorkspaceRefreshProceedsThroughIssueScopePartialSyncFailure(t *testing.
 	ws := createReadyWorkspace(t, ctx, fixture.client)
 	before := detailCalls.Load()
 
-	refreshRR := doJSON(
+	refreshRR := testutil.DoJSON(
 		t,
 		fixture.server,
 		http.MethodPost,
 		"/api/v1/workspaces/"+ws.Id+"/refresh",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusOK, refreshRR.Code, refreshRR.Body.String())
 
 	var refreshed rawWorkspaceStatusResponse
@@ -30993,7 +29899,7 @@ func TestWorkspaceRefreshProceedsThroughIssueScopePartialSyncFailure(t *testing.
 // association/PR-detail refresh must not continue — while sync health still
 // records the failure.
 func TestWorkspaceRefreshAbortsOnMergeRequestScopePartialSyncFailure(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 	acquireRootWorkspaceGitSlot(t)
 
 	assert := assert.New(t)
@@ -31054,13 +29960,13 @@ func TestWorkspaceRefreshAbortsOnMergeRequestScopePartialSyncFailure(t *testing.
 	require.NotNil(before)
 	detailCallsBefore := pr1DetailCalls.Load()
 
-	refreshRR := doJSON(
+	refreshRR := testutil.DoJSON(
 		t,
 		fixture.server,
 		http.MethodPost,
 		"/api/v1/workspaces/"+ws.Id+"/refresh",
-		nil,
-	)
+		nil)
+
 	require.Equal(http.StatusBadGateway, refreshRR.Code, refreshRR.Body.String())
 
 	var problem rawProblemDetail
@@ -31087,7 +29993,7 @@ func TestWorkspaceRefreshAbortsOnMergeRequestScopePartialSyncFailure(t *testing.
 }
 
 func TestWorkspaceManualRefreshReturnsAssociationInspectionError(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 	acquireRootWorkspaceGitSlot(t)
 
 	assert := assert.New(t)
@@ -31149,13 +30055,13 @@ func TestWorkspaceManualRefreshReturnsAssociationInspectionError(t *testing.T) {
 	)
 
 	seedIssue(t, fixture.database, "acme", "widget", 7, "open")
-	createRR := doJSON(
+	createRR := testutil.DoJSON(
 		t,
 		fixture.server,
 		http.MethodPost,
 		"/api/v1/issues/gh/acme/widget/7/workspace",
-		map[string]string{},
-	)
+		map[string]string{})
+
 	require.Equal(http.StatusAccepted, createRR.Code, createRR.Body.String())
 
 	var created rawWorkspaceStatusResponse
@@ -31163,13 +30069,13 @@ func TestWorkspaceManualRefreshReturnsAssociationInspectionError(t *testing.T) {
 	ready := waitForWorkspaceReady(t, ctx, fixture.client, created.ID)
 	require.NoError(os.RemoveAll(ready.WorktreePath))
 
-	refreshRR := doJSON(
+	refreshRR := testutil.DoJSON(
 		t,
 		fixture.server,
 		http.MethodPost,
 		"/api/v1/workspaces/"+created.ID+"/refresh",
-		nil,
-	)
+		nil)
+
 	require.Equal(
 		http.StatusInternalServerError, refreshRR.Code, refreshRR.Body.String(),
 	)
@@ -31202,7 +30108,7 @@ func readEventMatching(
 func TestWorkspaceCreateWithLocalBaseUsesPullRefWhenHeadBranchDeleted(
 	t *testing.T,
 ) {
-	t.Parallel()
+	runParallelServerTest(t)
 	acquireRootWorkspaceGitSlot(t)
 
 	assert := assert.New(t)
@@ -31266,7 +30172,7 @@ func TestWorkspaceCreateWithLocalBaseUsesPullRefWhenHeadBranchDeleted(
 func TestWorkspaceCreateGitLabUsesSpecificMergeRequestHeadRefE2E(
 	t *testing.T,
 ) {
-	t.Parallel()
+	runParallelServerTest(t)
 	acquireRootWorkspaceGitSlot(t)
 
 	assert := assert.New(t)
@@ -31344,7 +30250,7 @@ func TestWorkspaceCreateGitLabUsesSpecificMergeRequestHeadRefE2E(
 }
 
 func TestWorkspaceCreateReusesExistingWorktreeThroughAPI(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 	acquireRootWorkspaceGitSlot(t)
 
 	assert := assert.New(t)
@@ -31405,7 +30311,7 @@ func TestWorkspaceCreateReusesExistingWorktreeThroughAPI(t *testing.T) {
 }
 
 func TestWorkspaceRetryReusesExistingLocalHeadBranchThroughAPI(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 	acquireRootWorkspaceGitSlot(t)
 
 	assert := assert.New(t)
@@ -31533,7 +30439,7 @@ func setupHTTPWorktreeBaseForServerTest(
 }
 
 func TestWorkspaceCreatePortQualifiedHostTracksOriginBranchE2E(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 	acquireRootWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -31585,7 +30491,7 @@ func TestWorkspaceCreatePortQualifiedHostTracksOriginBranchE2E(t *testing.T) {
 }
 
 func TestWorkspaceDeleteDoesNotCleanupReplacementCloneFromStaleLocalBaseE2E(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 	acquireRootWorkspaceGitSlot(t)
 
 	assert := assert.New(t)
@@ -31775,9 +30681,10 @@ func TestAPIEditPRTitleAndBody(t *testing.T) {
 	srv, database := setupTestServer(t)
 	seedPR(t, database, "acme", "widget", 1)
 
-	rr := doJSON(t, srv, http.MethodPatch,
+	rr := testutil.DoJSON(t, srv, http.MethodPatch,
 		"/api/v1/pulls/gh/acme/widget/1",
 		map[string]string{"title": "updated title", "body": "updated body"})
+
 	require.Equal(http.StatusOK, rr.Code)
 
 	mr, err := database.GetMergeRequest(
@@ -31793,9 +30700,10 @@ func TestAPIEditPRTitleOnly(t *testing.T) {
 	srv, database := setupTestServer(t)
 	seedPR(t, database, "acme", "widget", 1)
 
-	rr := doJSON(t, srv, http.MethodPatch,
+	rr := testutil.DoJSON(t, srv, http.MethodPatch,
 		"/api/v1/pulls/gh/acme/widget/1",
 		map[string]string{"title": "new title"})
+
 	require.Equal(http.StatusOK, rr.Code)
 
 	mr, err := database.GetMergeRequest(
@@ -31811,9 +30719,10 @@ func TestAPIEditPRBodyOnly(t *testing.T) {
 	srv, database := setupTestServer(t)
 	seedPR(t, database, "acme", "widget", 1)
 
-	rr := doJSON(t, srv, http.MethodPatch,
+	rr := testutil.DoJSON(t, srv, http.MethodPatch,
 		"/api/v1/pulls/gh/acme/widget/1",
 		map[string]string{"body": "new body"})
+
 	require.Equal(http.StatusOK, rr.Code)
 
 	mr, err := database.GetMergeRequest(
@@ -31829,9 +30738,10 @@ func TestAPIEditPRClearBody(t *testing.T) {
 	srv, database := setupTestServer(t)
 	seedPR(t, database, "acme", "widget", 1)
 
-	rr := doJSON(t, srv, http.MethodPatch,
+	rr := testutil.DoJSON(t, srv, http.MethodPatch,
 		"/api/v1/pulls/gh/acme/widget/1",
 		map[string]string{"body": ""})
+
 	require.Equal(http.StatusOK, rr.Code)
 
 	mr, err := database.GetMergeRequest(
@@ -31847,9 +30757,10 @@ func TestAPIEditPRNoFields400(t *testing.T) {
 	srv, database := setupTestServer(t)
 	seedPR(t, database, "acme", "widget", 1)
 
-	rr := doJSON(t, srv, http.MethodPatch,
+	rr := testutil.DoJSON(t, srv, http.MethodPatch,
 		"/api/v1/pulls/gh/acme/widget/1",
 		map[string]any{})
+
 	require.Equal(http.StatusBadRequest, rr.Code)
 }
 
@@ -31858,9 +30769,10 @@ func TestAPIEditPRBlankTitle400(t *testing.T) {
 	srv, database := setupTestServer(t)
 	seedPR(t, database, "acme", "widget", 1)
 
-	rr := doJSON(t, srv, http.MethodPatch,
+	rr := testutil.DoJSON(t, srv, http.MethodPatch,
 		"/api/v1/pulls/gh/acme/widget/1",
 		map[string]string{"title": "   "})
+
 	require.Equal(http.StatusBadRequest, rr.Code)
 }
 
@@ -31880,9 +30792,10 @@ func TestAPIEditPRPreservesDerivedFields(t *testing.T) {
 	}))
 	require.NoError(database.UpdateMRCIStatus(ctx, repo.ID, 1, "success", "[]"))
 
-	rr := doJSON(t, srv, http.MethodPatch,
+	rr := testutil.DoJSON(t, srv, http.MethodPatch,
 		"/api/v1/pulls/gh/acme/widget/1",
 		map[string]string{"title": "changed title"})
+
 	require.Equal(http.StatusOK, rr.Code)
 
 	after, err := database.GetMergeRequest(ctx, "github", "github.com", "acme", "widget", 1)
@@ -31901,9 +30814,10 @@ func TestAPIEditIssueBodyOnly(t *testing.T) {
 	srv, database := setupTestServer(t)
 	seedIssue(t, database, "acme", "widget", 5, "open")
 
-	rr := doJSON(t, srv, http.MethodPatch,
+	rr := testutil.DoJSON(t, srv, http.MethodPatch,
 		"/api/v1/issues/gh/acme/widget/5",
 		map[string]string{"body": "- [x] task done"})
+
 	require.Equal(http.StatusOK, rr.Code)
 
 	issue, err := database.GetIssue(t.Context(), "github", "github.com", "acme", "widget", 5)
@@ -31918,9 +30832,10 @@ func TestAPIEditIssueTitleAndBody(t *testing.T) {
 	srv, database := setupTestServer(t)
 	seedIssue(t, database, "acme", "widget", 5, "open")
 
-	rr := doJSON(t, srv, http.MethodPatch,
+	rr := testutil.DoJSON(t, srv, http.MethodPatch,
 		"/api/v1/issues/gh/acme/widget/5",
 		map[string]string{"title": "new title", "body": "new body"})
+
 	require.Equal(http.StatusOK, rr.Code)
 
 	issue, err := database.GetIssue(t.Context(), "github", "github.com", "acme", "widget", 5)
@@ -31935,9 +30850,10 @@ func TestAPIEditIssueNoFields400(t *testing.T) {
 	srv, database := setupTestServer(t)
 	seedIssue(t, database, "acme", "widget", 5, "open")
 
-	rr := doJSON(t, srv, http.MethodPatch,
+	rr := testutil.DoJSON(t, srv, http.MethodPatch,
 		"/api/v1/issues/gh/acme/widget/5",
 		map[string]any{})
+
 	require.Equal(http.StatusBadRequest, rr.Code)
 }
 
@@ -31946,9 +30862,10 @@ func TestAPIEditIssueBlankTitle400(t *testing.T) {
 	srv, database := setupTestServer(t)
 	seedIssue(t, database, "acme", "widget", 5, "open")
 
-	rr := doJSON(t, srv, http.MethodPatch,
+	rr := testutil.DoJSON(t, srv, http.MethodPatch,
 		"/api/v1/issues/gh/acme/widget/5",
 		map[string]string{"title": "   "})
+
 	require.Equal(http.StatusBadRequest, rr.Code)
 }
 
@@ -31962,9 +30879,10 @@ func TestAPIEditIssueMissing404(t *testing.T) {
 	)
 	require.NoError(err)
 
-	rr := doJSON(t, srv, http.MethodPatch,
+	rr := testutil.DoJSON(t, srv, http.MethodPatch,
 		"/api/v1/issues/gh/acme/widget/999",
 		map[string]string{"body": "anything"})
+
 	require.Equal(http.StatusNotFound, rr.Code)
 }
 

--- a/internal/server/archive_routes_schema_test.go
+++ b/internal/server/archive_routes_schema_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestArchiveReportResponseTransformSchemaNamesReportSchema(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 
 	property := &huma.Schema{}
 	schema := &huma.Schema{

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -20,12 +20,14 @@ import (
 	gh "github.com/google/go-github/v89/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/apiclient/generated"
 	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/db"
 	ghclient "go.kenn.io/forge/internal/github"
 	"go.kenn.io/forge/internal/platform"
 	ptyownerruntime "go.kenn.io/forge/internal/ptyowner/runtime"
 	"go.kenn.io/forge/internal/ptysize"
+	"go.kenn.io/forge/internal/testutil"
 	"go.kenn.io/forge/internal/testutil/dbtest"
 	"go.kenn.io/forge/internal/tokenauth"
 	"go.kenn.io/forge/internal/workspace/localruntime"
@@ -654,24 +656,31 @@ func TestConfigReload_UpdatesDocFoldersAndRegistry(t *testing.T) {
 	wantRegistryRoot, err := filepath.EvalSymlinks(updatedRoot)
 	require.NoError(err)
 	assert.Equal(wantRegistryRoot, gotRegistryFolders[0].Path)
-	listRR := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/folders", nil)
-	require.Equal(http.StatusOK, listRR.Code, listRR.Body.String())
-	var listBody docsFolderListWire
-	require.NoError(json.NewDecoder(listRR.Body).Decode(&listBody))
-	require.Len(listBody.Folders, 1)
-	assert.Equal("handbook", listBody.Folders[0].ID)
-	assert.Equal("Handbook", listBody.Folders[0].Name)
+	httpServer := httptest.NewServer(srv)
+	t.Cleanup(httpServer.Close)
+	listResponse, err := httpServer.Client().Get(httpServer.URL + "/api/v1/docs/folders")
+	require.NoError(err)
+	t.Cleanup(func() { listResponse.Body.Close() })
+	require.Equal(http.StatusOK, listResponse.StatusCode)
+	var listBody generated.ListDocsFoldersOutputBody
+	require.NoError(json.NewDecoder(listResponse.Body).Decode(&listBody))
+	require.NotNil(listBody.Folders)
+	require.Len(*listBody.Folders, 1)
+	assert.Equal("handbook", (*listBody.Folders)[0].Id)
+	assert.Equal("Handbook", (*listBody.Folders)[0].Name)
 
-	updatedReadRR := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/handbook/file?path=guide.md", nil)
-	require.Equal(http.StatusOK, updatedReadRR.Code, updatedReadRR.Body.String())
-	var readBody struct {
-		Content string `json:"content"`
-	}
-	require.NoError(json.NewDecoder(updatedReadRR.Body).Decode(&readBody))
+	updatedReadResponse, err := httpServer.Client().Get(httpServer.URL + "/api/v1/docs/folders/handbook/file?path=guide.md")
+	require.NoError(err)
+	t.Cleanup(func() { updatedReadResponse.Body.Close() })
+	require.Equal(http.StatusOK, updatedReadResponse.StatusCode)
+	var readBody generated.DocsReadFileOutputBody
+	require.NoError(json.NewDecoder(updatedReadResponse.Body).Decode(&readBody))
 	assert.Equal("# Guide\n", readBody.Content)
 
-	oldReadRR := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/notes/file?path=old.md", nil)
-	assert.Equal(http.StatusNotFound, oldReadRR.Code, oldReadRR.Body.String())
+	oldReadResponse, err := httpServer.Client().Get(httpServer.URL + "/api/v1/docs/folders/notes/file?path=old.md")
+	require.NoError(err)
+	t.Cleanup(func() { oldReadResponse.Body.Close() })
+	assert.Equal(http.StatusNotFound, oldReadResponse.StatusCode)
 }
 
 func TestConfigReloadSerializesDocsFolderMutation(t *testing.T) {
@@ -883,19 +892,16 @@ command = ["sh"]
 	event := srv.applyConfigChange(t.Context())
 	require.True(event.Valid, event.Error)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodGet,
-		"/api/v1/projects/"+project.ID+"/launch-targets", nil,
-	)
+		"/api/v1/projects/"+project.ID+"/launch-targets", nil)
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-	var body struct {
-		LaunchTargets []struct {
-			Key string `json:"key"`
-		} `json:"launch_targets"`
-	}
+	var body generated.ListLaunchTargetsOutputBody
 	require.NoError(json.NewDecoder(rr.Body).Decode(&body))
-	keys := make([]string, 0, len(body.LaunchTargets))
-	for _, target := range body.LaunchTargets {
+	require.NotNil(body.LaunchTargets)
+	keys := make([]string, 0, len(*body.LaunchTargets))
+	for _, target := range *body.LaunchTargets {
 		keys = append(keys, target.Key)
 	}
 	assert.Contains(keys, "after")
@@ -2107,10 +2113,10 @@ func TestConfigReload_RouteReuseRefreshThenFailedReloadTracksRenamedRepoOnce(t *
 	defer stream.Close()
 
 	renamed.Store(true)
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodPost,
-		"/api/v1/repo/gh/acme/*/refresh", nil,
-	)
+		"/api/v1/repo/gh/acme/*/refresh", nil)
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	writeConfigToml(t, cfgPath, validReloadConfigExactPlusGlobChangedActivity)
@@ -2711,12 +2717,13 @@ func TestConfigReload_SettingsSavePreservesRestartRequiredFields(t *testing.T) {
 	require.True(ev.Valid, "reload error: %s", ev.Error)
 	require.True(ev.RestartRequired)
 
-	rr := doJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
+	rr := testutil.DoJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
 		Activity: &config.Activity{
 			ViewMode:  "flat",
 			TimeRange: "30d",
 		},
 	})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	reloaded, err := config.Load(cfgPath)

--- a/internal/server/docstest/git_routes_test.go
+++ b/internal/server/docstest/git_routes_test.go
@@ -1,12 +1,12 @@
-package server
+package docstest
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -14,75 +14,41 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/apiclient/generated"
 	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/docs"
+	"go.kenn.io/forge/internal/server"
 	"go.kenn.io/forge/internal/server/httpapi"
+	"go.kenn.io/forge/internal/testutil"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 	"go.kenn.io/forge/internal/testutil/gitsafe"
-	gitcmd "go.kenn.io/kit/git/cmd"
+	"go.kenn.io/forge/internal/testutil/servertest"
 )
 
-type docsGitRepo struct {
-	dir    string
-	remote string
-}
-
-func newDocsGitRepo(t *testing.T, upstream bool) docsGitRepo {
-	t.Helper()
-	if _, err := gitcmd.New().Output(t.Context(), "", "--version"); err != nil {
-		t.Skip("git binary unavailable")
-	}
-	dir := t.TempDir()
-	remote := t.TempDir()
-	runDocsGit(t, dir, "init", "-b", "main")
-	runDocsGit(t, dir, "config", "user.email", "kenn-forge-fixture@example.invalid")
-	runDocsGit(t, dir, "config", "user.name", "Kenn Forge Fixture")
-	runDocsGit(t, dir, "config", "commit.gpgsign", "false")
-	runDocsGit(t, dir, "config", "tag.gpgsign", "false")
-	runDocsGit(t, dir, "config", "core.hooksPath", ".git/hooks")
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "seed.md"), []byte("seed\n"), 0o644))
-	runDocsGit(t, dir, "add", "seed.md")
-	runDocsGit(t, dir, "commit", "-m", "seed")
-	if upstream {
-		runDocsGit(t, remote, "init", "--bare")
-		runDocsGit(t, dir, "remote", "add", "origin", remote)
-		runDocsGit(t, dir, "push", "-u", "origin", "main")
-	}
-	return docsGitRepo{dir: dir, remote: remote}
-}
-
-func runDocsGit(t *testing.T, dir string, args ...string) string {
-	t.Helper()
-	out, stderr, err := gitcmd.New().Run(t.Context(), dir, nil, args...)
-	require.NoError(t, err, "git %v: %s", args, string(stderr))
-	return string(out)
-}
-
-func (g docsGitRepo) write(t *testing.T, rel, body string) {
-	t.Helper()
-	full := filepath.Join(g.dir, filepath.FromSlash(rel))
-	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
-	require.NoError(t, os.WriteFile(full, []byte(body), 0o644))
-}
-
-func setupDocsGitRouteServer(t *testing.T, root string) *Server {
+func setupDocsGitRouteServer(t *testing.T, root string) *server.Server {
 	t.Helper()
 	cfg := &config.Config{
+		Host:       "127.0.0.1",
+		Port:       8091,
 		DocFolders: []config.DocFolder{{ID: "f", Name: "F", Path: root}},
 	}
 	registry := docs.NewRegistry(cfg.DocFolders, docs.WithGitRunner(gitsafe.Runner()))
-	srv := New(openTestDB(t), nil, nil, "/", cfg, ServerOptions{DocsRegistry: registry})
-	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	srv := servertest.New(t, dbtest.Open(t), nil, nil, "/", cfg, server.ServerOptions{
+		DocsRegistry:                  registry,
+		HostCheckAllowLoopbackAnyPort: true,
+	})
 	return srv
 }
 
 func TestDocsGitStatusEndpointReturnsEntries(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	repo := newDocsGitRepo(t, true)
-	repo.write(t, "new.md", "# new\n")
-	srv := setupDocsGitRouteServer(t, repo.dir)
+	repo := gitfixture.NewRepository(t, true)
+	repo.Write(t, "new.md", "# new\n")
+	srv := setupDocsGitRouteServer(t, repo.Dir)
 
-	rr := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/f/git", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/f/git", nil)
 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	var body docs.GitStatusResponse
@@ -96,11 +62,11 @@ func TestDocsGitStatusEndpointReturnsEntries(t *testing.T) {
 func TestDocsGitChangesEndpointReturnsPreview(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	repo := newDocsGitRepo(t, true)
-	repo.write(t, "new.md", "# new\n")
-	srv := setupDocsGitRouteServer(t, repo.dir)
+	repo := gitfixture.NewRepository(t, true)
+	repo.Write(t, "new.md", "# new\n")
+	srv := setupDocsGitRouteServer(t, repo.Dir)
 
-	rr := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/f/git/changes", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/f/git/changes", nil)
 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	var body docs.GitChangesResponse
@@ -118,21 +84,21 @@ func TestDocsGitChangesEndpointNotARepoAndUnknownFolder(t *testing.T) {
 	require := require.New(t)
 	srv := setupDocsGitRouteServer(t, t.TempDir())
 
-	notRepoRR := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/f/git/changes", nil)
+	notRepoRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/f/git/changes", nil)
 	require.Equal(http.StatusOK, notRepoRR.Code, notRepoRR.Body.String())
 	var notRepo docs.GitChangesResponse
 	require.NoError(json.NewDecoder(notRepoRR.Body).Decode(&notRepo))
 	assert.False(notRepo.IsRepo)
 	assert.NotNil(notRepo.Changes)
 
-	missingRR := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/missing/git/changes", nil)
+	missingRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/missing/git/changes", nil)
 	assert.Equal(http.StatusNotFound, missingRR.Code, missingRR.Body.String())
 }
 
 func TestDocsGitStatusAndChangesEndpointsRejectUnsafeAttributes(t *testing.T) {
-	repo := newDocsGitRepo(t, true)
-	repo.write(t, ".gitattributes", "*.md filter=evil\n")
-	srv := setupDocsGitRouteServer(t, repo.dir)
+	repo := gitfixture.NewRepository(t, true)
+	repo.Write(t, ".gitattributes", "*.md filter=evil\n")
+	srv := setupDocsGitRouteServer(t, repo.Dir)
 
 	for _, path := range []string{
 		"/api/v1/docs/folders/f/git",
@@ -142,7 +108,7 @@ func TestDocsGitStatusAndChangesEndpointsRejectUnsafeAttributes(t *testing.T) {
 			assert := assert.New(t)
 			require := require.New(t)
 
-			rr := doDocsJSON(t, srv, http.MethodGet, path, nil)
+			rr := testutil.DoJSON(t, srv, http.MethodGet, path, nil)
 
 			require.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
 			var problem httpapi.ProblemError
@@ -156,15 +122,15 @@ func TestDocsGitStatusAndChangesEndpointsRejectUnsafeAttributes(t *testing.T) {
 func TestDocsGitChangesEndpointRejectsUnsafeLocalConfig(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	repo := newDocsGitRepo(t, true)
-	repo.write(t, "new.md", "# new\n")
+	repo := gitfixture.NewRepository(t, true)
+	repo.Write(t, "new.md", "# new\n")
 	// Command-bearing local config does not execute during the status
 	// read, but the preview must still refuse it so the UI's publish
 	// signal matches publish-time behavior.
-	runDocsGit(t, repo.dir, "config", "gpg.program", "/tmp/evil")
-	srv := setupDocsGitRouteServer(t, repo.dir)
+	gitfixture.Run(t, repo.Dir, "config", "gpg.program", "/tmp/evil")
+	srv := setupDocsGitRouteServer(t, repo.Dir)
 
-	rr := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/f/git/changes", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/f/git/changes", nil)
 
 	require.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
 	var problem httpapi.ProblemError
@@ -176,13 +142,14 @@ func TestDocsGitChangesEndpointRejectsUnsafeLocalConfig(t *testing.T) {
 func TestDocsGitReadEndpointsRejectNonLoopback(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	repo := newDocsGitRepo(t, true)
-	srv := setupDocsGitRouteServer(t, repo.dir)
+	repo := gitfixture.NewRepository(t, true)
+	srv := setupDocsGitRouteServer(t, repo.Dir)
 	for _, path := range []string{
 		"/api/v1/docs/folders/f/git",
 		"/api/v1/docs/folders/f/git/changes",
 	} {
 		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.Host = "127.0.0.1"
 		req.RemoteAddr = "203.0.113.7:54321"
 		rr := httptest.NewRecorder()
 
@@ -199,12 +166,12 @@ func TestDocsGitReadEndpointsRejectNonLoopback(t *testing.T) {
 func TestDocsGitPublishEndpointHappyPath(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	repo := newDocsGitRepo(t, true)
-	repo.write(t, "new.md", "# new\n")
-	srv := setupDocsGitRouteServer(t, repo.dir)
+	repo := gitfixture.NewRepository(t, true)
+	repo.Write(t, "new.md", "# new\n")
+	srv := setupDocsGitRouteServer(t, repo.Dir)
 
-	rr := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/publish", map[string]string{
-		"message": "docs: update new.md\n\n- new.md\n",
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/publish", generated.PublishDocsGitJSONRequestBody{
+		Message: new("docs: update new.md\n\n- new.md\n"),
 	})
 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
@@ -222,37 +189,37 @@ func TestDocsGitPublishEndpointHappyPath(t *testing.T) {
 func TestDocsGitPublishEndpointAcceptsLargeMessageBelowRouteLimit(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	repo := newDocsGitRepo(t, true)
-	repo.write(t, "new.md", "# new\n")
-	srv := setupDocsGitRouteServer(t, repo.dir)
+	repo := gitfixture.NewRepository(t, true)
+	repo.Write(t, "new.md", "# new\n")
+	srv := setupDocsGitRouteServer(t, repo.Dir)
 
-	rr := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/publish", map[string]string{
-		"message": "docs: " + strings.Repeat("large ", 2<<18),
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/publish", generated.PublishDocsGitJSONRequestBody{
+		Message: new("docs: " + strings.Repeat("large ", 2<<18)),
 	})
 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	var body docs.PublishResponse
 	require.NoError(json.NewDecoder(rr.Body).Decode(&body))
 	assert.NotEmpty(body.Commit)
-	assert.Equal(body.Commit, strings.TrimSpace(runDocsGit(t, repo.remote, "rev-parse", "main")))
+	assert.Equal(body.Commit, strings.TrimSpace(string(gitfixture.Run(t, repo.Remote, "rev-parse", "main"))))
 }
 
 func TestDocsGitPublishEndpointPushesConfiguredUpstreamDespitePushDefaults(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	repo := newDocsGitRepo(t, true)
+	repo := gitfixture.NewRepository(t, true)
 	backup := t.TempDir()
-	runDocsGit(t, backup, "init", "--bare")
-	runDocsGit(t, repo.dir, "remote", "add", "backup", backup)
-	runDocsGit(t, repo.dir, "push", "backup", "main:main")
-	backupInitial := strings.TrimSpace(runDocsGit(t, backup, "rev-parse", "main"))
-	runDocsGit(t, repo.dir, "config", "remote.pushDefault", "backup")
-	runDocsGit(t, repo.dir, "config", "push.default", "current")
-	repo.write(t, "new.md", "# new\n")
-	srv := setupDocsGitRouteServer(t, repo.dir)
+	gitfixture.Run(t, backup, "init", "--bare")
+	gitfixture.Run(t, repo.Dir, "remote", "add", "backup", backup)
+	gitfixture.Run(t, repo.Dir, "push", "backup", "main:main")
+	backupInitial := strings.TrimSpace(string(gitfixture.Run(t, backup, "rev-parse", "main")))
+	gitfixture.Run(t, repo.Dir, "config", "remote.pushDefault", "backup")
+	gitfixture.Run(t, repo.Dir, "config", "push.default", "current")
+	repo.Write(t, "new.md", "# new\n")
+	srv := setupDocsGitRouteServer(t, repo.Dir)
 
-	rr := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/publish", map[string]string{
-		"message": "docs: explicit upstream",
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/publish", generated.PublishDocsGitJSONRequestBody{
+		Message: new("docs: explicit upstream"),
 	})
 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
@@ -260,16 +227,19 @@ func TestDocsGitPublishEndpointPushesConfiguredUpstreamDespitePushDefaults(t *te
 	require.NoError(json.NewDecoder(rr.Body).Decode(&body))
 	assert.Equal("origin/main", body.Upstream)
 	assert.True(body.Pushed)
-	assert.Equal(body.Commit, strings.TrimSpace(runDocsGit(t, repo.remote, "rev-parse", "main")))
-	assert.Equal(backupInitial, strings.TrimSpace(runDocsGit(t, backup, "rev-parse", "main")))
+	assert.Equal(body.Commit, strings.TrimSpace(string(gitfixture.Run(t, repo.Remote, "rev-parse", "main"))))
+	assert.Equal(backupInitial, strings.TrimSpace(string(gitfixture.Run(t, backup, "rev-parse", "main"))))
 }
 
 func TestDocsGitPublishEndpointRejectsNonLoopback(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	repo := newDocsGitRepo(t, true)
-	srv := setupDocsGitRouteServer(t, repo.dir)
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/docs/folders/f/git/publish", strings.NewReader(`{"message":"docs: x"}`))
+	repo := gitfixture.NewRepository(t, true)
+	srv := setupDocsGitRouteServer(t, repo.Dir)
+	body, err := json.Marshal(generated.PublishDocsGitJSONRequestBody{Message: new("docs: x")})
+	require.NoError(err)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/docs/folders/f/git/publish", bytes.NewReader(body))
+	req.Host = "127.0.0.1"
 	req.RemoteAddr = "203.0.113.7:54321"
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
@@ -288,6 +258,7 @@ func TestDocsGitPublishEndpointRejectsNonJSONContentType(t *testing.T) {
 	require := require.New(t)
 	srv := setupDocsGitRouteServer(t, t.TempDir())
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/docs/folders/f/git/publish", strings.NewReader("docs: x"))
+	req.Host = "127.0.0.1"
 	req.RemoteAddr = "127.0.0.1:12345"
 	req.Header.Set("Content-Type", "text/plain")
 	rr := httptest.NewRecorder()
@@ -309,34 +280,37 @@ func TestDocsGitPublishEndpointRejectsNonJSONContentType(t *testing.T) {
 func TestDocsGitPublishEndpointErrors(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	repo := newDocsGitRepo(t, true)
-	repo.write(t, "new.md", "# new\n")
-	srv := setupDocsGitRouteServer(t, repo.dir)
+	repo := gitfixture.NewRepository(t, true)
+	repo.Write(t, "new.md", "# new\n")
+	srv := setupDocsGitRouteServer(t, repo.Dir)
 
-	emptyRR := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/publish", map[string]string{
-		"message": "   \n\t",
+	emptyRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/publish", generated.PublishDocsGitJSONRequestBody{
+		Message: new("   \n\t"),
 	})
+
 	require.Equal(http.StatusBadRequest, emptyRR.Code, emptyRR.Body.String())
 	var empty httpapi.ProblemError
 	require.NoError(json.NewDecoder(emptyRR.Body).Decode(&empty))
 	assert.Equal("emptyMessage", empty.Details["reason"])
 
-	missingRR := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/missing/git/publish", map[string]string{
-		"message": "docs: x",
+	missingRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/missing/git/publish", generated.PublishDocsGitJSONRequestBody{
+		Message: new("docs: x"),
 	})
+
 	assert.Equal(http.StatusNotFound, missingRR.Code, missingRR.Body.String())
 }
 
 func TestDocsGitPublishEndpointNoUpstreamAndCommitFailure(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	noUpstream := newDocsGitRepo(t, false)
-	noUpstream.write(t, "new.md", "# new\n")
-	noUpstreamSrv := setupDocsGitRouteServer(t, noUpstream.dir)
+	noUpstream := gitfixture.NewRepository(t, false)
+	noUpstream.Write(t, "new.md", "# new\n")
+	noUpstreamSrv := setupDocsGitRouteServer(t, noUpstream.Dir)
 
-	noUpstreamRR := doDocsJSON(t, noUpstreamSrv, http.MethodPost, "/api/v1/docs/folders/f/git/publish", map[string]string{
-		"message": "docs: x",
+	noUpstreamRR := testutil.DoJSON(t, noUpstreamSrv, http.MethodPost, "/api/v1/docs/folders/f/git/publish", generated.PublishDocsGitJSONRequestBody{
+		Message: new("docs: x"),
 	})
+
 	require.Equal(http.StatusBadRequest, noUpstreamRR.Code, noUpstreamRR.Body.String())
 	var noUpstreamProblem httpapi.ProblemError
 	require.NoError(json.NewDecoder(noUpstreamRR.Body).Decode(&noUpstreamProblem))
@@ -347,15 +321,16 @@ func TestDocsGitPublishEndpointNoUpstreamAndCommitFailure(t *testing.T) {
 	// command-bearing signer (which the publish safety gate would reject):
 	// staging the markdown succeeds, then the commit cannot lock the branch
 	// ref. This keeps coverage for git stderr passing through to the detail.
-	repo := newDocsGitRepo(t, true)
-	repo.write(t, "new.md", "# new\n")
-	lockPath := filepath.Join(repo.dir, ".git", "refs", "heads", "main.lock")
+	repo := gitfixture.NewRepository(t, true)
+	repo.Write(t, "new.md", "# new\n")
+	lockPath := filepath.Join(repo.Dir, ".git", "refs", "heads", "main.lock")
 	require.NoError(os.WriteFile(lockPath, nil, 0o644))
-	commitFailSrv := setupDocsGitRouteServer(t, repo.dir)
+	commitFailSrv := setupDocsGitRouteServer(t, repo.Dir)
 
-	commitFailRR := doDocsJSON(t, commitFailSrv, http.MethodPost, "/api/v1/docs/folders/f/git/publish", map[string]string{
-		"message": "docs: x",
+	commitFailRR := testutil.DoJSON(t, commitFailSrv, http.MethodPost, "/api/v1/docs/folders/f/git/publish", generated.PublishDocsGitJSONRequestBody{
+		Message: new("docs: x"),
 	})
+
 	require.Equal(http.StatusInternalServerError, commitFailRR.Code, commitFailRR.Body.String())
 	var commitFailProblem httpapi.ProblemError
 	require.NoError(json.NewDecoder(commitFailRR.Body).Decode(&commitFailProblem))
@@ -367,13 +342,13 @@ func TestDocsGitPublishEndpointNoUpstreamAndCommitFailure(t *testing.T) {
 func TestDocsGitPublishEndpointRejectsUnsafeGitConfig(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	repo := newDocsGitRepo(t, true)
-	repo.write(t, "new.md", "# new\n")
-	runDocsGit(t, repo.dir, "config", "filter.evil.clean", "/bin/sh -c evil")
-	srv := setupDocsGitRouteServer(t, repo.dir)
+	repo := gitfixture.NewRepository(t, true)
+	repo.Write(t, "new.md", "# new\n")
+	gitfixture.Run(t, repo.Dir, "config", "filter.evil.clean", "/bin/sh -c evil")
+	srv := setupDocsGitRouteServer(t, repo.Dir)
 
-	rr := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/publish", map[string]string{
-		"message": "docs: x",
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/publish", generated.PublishDocsGitJSONRequestBody{
+		Message: new("docs: x"),
 	})
 
 	require.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
@@ -385,17 +360,17 @@ func TestDocsGitPublishEndpointRejectsUnsafeGitConfig(t *testing.T) {
 func TestDocsGitPublishEndpointIgnoresDocsRepoHooks(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	repo := newDocsGitRepo(t, true)
-	repo.write(t, "new.md", "# new\n")
+	repo := gitfixture.NewRepository(t, true)
+	repo.Write(t, "new.md", "# new\n")
 	marker := filepath.Join(t.TempDir(), "hook-ran")
-	hookDir := filepath.Join(repo.dir, ".git", "hooks")
+	hookDir := filepath.Join(repo.Dir, ".git", "hooks")
 	require.NoError(os.MkdirAll(hookDir, 0o755))
 	hook := "#!/bin/sh\necho hooked > \"" + marker + "\"\nexit 1\n"
 	require.NoError(os.WriteFile(filepath.Join(hookDir, "pre-commit"), []byte(hook), 0o755))
-	srv := setupDocsGitRouteServer(t, repo.dir)
+	srv := setupDocsGitRouteServer(t, repo.Dir)
 
-	rr := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/publish", map[string]string{
-		"message": "docs: x",
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/publish", generated.PublishDocsGitJSONRequestBody{
+		Message: new("docs: x"),
 	})
 
 	assert.Equal(http.StatusOK, rr.Code, rr.Body.String())
@@ -405,23 +380,23 @@ func TestDocsGitPublishEndpointIgnoresDocsRepoHooks(t *testing.T) {
 func TestDocsGitPublishEndpointProblemMappings(t *testing.T) {
 	cases := []struct {
 		name       string
-		setup      func(t *testing.T) *Server
+		setup      func(t *testing.T) *server.Server
 		wantStatus int
 		wantReason string
 	}{
 		{
 			name: "no markdown changes",
-			setup: func(t *testing.T) *Server {
-				repo := newDocsGitRepo(t, true)
-				repo.write(t, "code.go", "package x\n")
-				return setupDocsGitRouteServer(t, repo.dir)
+			setup: func(t *testing.T) *server.Server {
+				repo := gitfixture.NewRepository(t, true)
+				repo.Write(t, "code.go", "package x\n")
+				return setupDocsGitRouteServer(t, repo.Dir)
 			},
 			wantStatus: http.StatusBadRequest,
 			wantReason: "noMarkdownChanges",
 		},
 		{
 			name: "not a git repo",
-			setup: func(t *testing.T) *Server {
+			setup: func(t *testing.T) *server.Server {
 				return setupDocsGitRouteServer(t, t.TempDir())
 			},
 			wantStatus: http.StatusBadRequest,
@@ -429,54 +404,54 @@ func TestDocsGitPublishEndpointProblemMappings(t *testing.T) {
 		},
 		{
 			name: "index not clean",
-			setup: func(t *testing.T) *Server {
-				repo := newDocsGitRepo(t, true)
-				repo.write(t, "new.md", "# new\n")
-				repo.write(t, "code.go", "package x\n")
-				runDocsGit(t, repo.dir, "add", "code.go")
-				return setupDocsGitRouteServer(t, repo.dir)
+			setup: func(t *testing.T) *server.Server {
+				repo := gitfixture.NewRepository(t, true)
+				repo.Write(t, "new.md", "# new\n")
+				repo.Write(t, "code.go", "package x\n")
+				gitfixture.Run(t, repo.Dir, "add", "code.go")
+				return setupDocsGitRouteServer(t, repo.Dir)
 			},
 			wantStatus: http.StatusConflict,
 			wantReason: "indexNotClean",
 		},
 		{
 			name: "conflict",
-			setup: func(t *testing.T) *Server {
-				repo := newDocsGitRepo(t, true)
-				runDocsGit(t, repo.dir, "checkout", "-b", "side")
-				repo.write(t, "seed.md", "side version\n")
-				runDocsGit(t, repo.dir, "commit", "-am", "side")
-				runDocsGit(t, repo.dir, "checkout", "main")
-				repo.write(t, "seed.md", "main version\n")
-				runDocsGit(t, repo.dir, "commit", "-am", "main")
-				out, _, mergeErr := gitcmd.New().Run(
-					t.Context(), repo.dir, nil, "merge", "side",
+			setup: func(t *testing.T) *server.Server {
+				repo := gitfixture.NewRepository(t, true)
+				gitfixture.Run(t, repo.Dir, "checkout", "-b", "side")
+				repo.Write(t, "seed.md", "side version\n")
+				gitfixture.Run(t, repo.Dir, "commit", "-am", "side")
+				gitfixture.Run(t, repo.Dir, "checkout", "main")
+				repo.Write(t, "seed.md", "main version\n")
+				gitfixture.Run(t, repo.Dir, "commit", "-am", "main")
+				out, _, mergeErr := gitsafe.Runner().Run(
+					t.Context(), repo.Dir, nil, "merge", "side",
 				)
 				require.Error(t, mergeErr, "expected merge conflict, got clean merge: %s", out)
-				return setupDocsGitRouteServer(t, repo.dir)
+				return setupDocsGitRouteServer(t, repo.Dir)
 			},
 			wantStatus: http.StatusConflict,
 			wantReason: "conflict",
 		},
 		{
 			name: "push target inside docs folder",
-			setup: func(t *testing.T) *Server {
-				repo := newDocsGitRepo(t, true)
-				repo.write(t, "new.md", "# new\n")
-				runDocsGit(t, repo.dir, "init", "--bare", "evil.git")
-				runDocsGit(t, repo.dir, "remote", "set-url", "origin", "./evil.git")
-				return setupDocsGitRouteServer(t, repo.dir)
+			setup: func(t *testing.T) *server.Server {
+				repo := gitfixture.NewRepository(t, true)
+				repo.Write(t, "new.md", "# new\n")
+				gitfixture.Run(t, repo.Dir, "init", "--bare", "evil.git")
+				gitfixture.Run(t, repo.Dir, "remote", "set-url", "origin", "./evil.git")
+				return setupDocsGitRouteServer(t, repo.Dir)
 			},
 			wantStatus: http.StatusBadRequest,
 			wantReason: "unsafeGitConfig",
 		},
 		{
 			name: "push failed after commit",
-			setup: func(t *testing.T) *Server {
-				repo := newDocsGitRepo(t, true)
-				repo.write(t, "new.md", "# new\n")
-				runDocsGit(t, repo.dir, "remote", "set-url", "origin", filepath.Join(t.TempDir(), "missing-origin"))
-				return setupDocsGitRouteServer(t, repo.dir)
+			setup: func(t *testing.T) *server.Server {
+				repo := gitfixture.NewRepository(t, true)
+				repo.Write(t, "new.md", "# new\n")
+				gitfixture.Run(t, repo.Dir, "remote", "set-url", "origin", filepath.Join(t.TempDir(), "missing-origin"))
+				return setupDocsGitRouteServer(t, repo.Dir)
 			},
 			wantStatus: http.StatusBadGateway,
 			wantReason: "pushFailedAfterCommit",
@@ -488,8 +463,8 @@ func TestDocsGitPublishEndpointProblemMappings(t *testing.T) {
 			require := require.New(t)
 			srv := tc.setup(t)
 
-			rr := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/publish", map[string]string{
-				"message": "docs: x",
+			rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/publish", generated.PublishDocsGitJSONRequestBody{
+				Message: new("docs: x"),
 			})
 
 			require.Equal(tc.wantStatus, rr.Code, rr.Body.String())
@@ -507,17 +482,21 @@ func TestDocsGitPublishEndpointProblemMappings(t *testing.T) {
 func TestDocsGitPublishEndpointRejectsConcurrentInFlightPublish(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	repo := newDocsGitRepo(t, true)
-	repo.write(t, "blocked.md", "# blocked\n")
+	repo := gitfixture.NewRepository(t, true)
+	repo.Write(t, "blocked.md", "# blocked\n")
 	cfg := &config.Config{
+		Host: "127.0.0.1",
+		Port: 8091,
 		DocFolders: []config.DocFolder{
-			{ID: "f", Name: "F", Path: repo.dir},
-			{ID: "alias", Name: "Alias", Path: repo.dir},
+			{ID: "f", Name: "F", Path: repo.Dir},
+			{ID: "alias", Name: "Alias", Path: repo.Dir},
 		},
 	}
 	registry := docs.NewRegistry(cfg.DocFolders, docs.WithGitRunner(gitsafe.Runner()))
-	srv := New(openTestDB(t), nil, nil, "/", cfg, ServerOptions{DocsRegistry: registry})
-	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	srv := servertest.New(t, dbtest.Open(t), nil, nil, "/", cfg, server.ServerOptions{
+		DocsRegistry:                  registry,
+		HostCheckAllowLoopbackAnyPort: true,
+	})
 
 	// The publish safety gate forbids command-bearing config, so hold the
 	// publish in-flight by hanging its push: point origin at an HTTP server
@@ -537,16 +516,19 @@ func TestDocsGitPublishEndpointRejectsConcurrentInFlightPublish(t *testing.T) {
 	}))
 	defer hung.Close()
 	defer doRelease()
-	runDocsGit(t, repo.dir, "remote", "set-url", "origin", hung.URL+"/repo.git")
+	gitfixture.Run(t, repo.Dir, "remote", "set-url", "origin", hung.URL+"/repo.git")
 
 	publishAsync := func(message string) <-chan *httptest.ResponseRecorder {
+		body, err := json.Marshal(generated.PublishDocsGitJSONRequestBody{Message: new(message)})
+		require.NoError(err)
 		done := make(chan *httptest.ResponseRecorder, 1)
 		go func() {
 			req := httptest.NewRequest(
 				http.MethodPost,
 				"/api/v1/docs/folders/f/git/publish",
-				strings.NewReader(`{"message":`+strconv.Quote(message)+`}`),
+				bytes.NewReader(body),
 			)
+			req.Host = "127.0.0.1"
 			req.RemoteAddr = "127.0.0.1:12345"
 			req.Header.Set("Content-Type", "application/json")
 			rr := httptest.NewRecorder()
@@ -589,7 +571,7 @@ func TestDocsGitPublishEndpointRejectsConcurrentInFlightPublish(t *testing.T) {
 	assert.Equal(httpapi.CodeConflict, problem.Code)
 	assert.Equal("publishInProgress", problem.Details["reason"])
 
-	aliasPull := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/alias/git/pull", nil)
+	aliasPull := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/alias/git/pull", nil)
 	require.Equal(http.StatusConflict, aliasPull.Code, aliasPull.Body.String())
 	var aliasProblem httpapi.ProblemError
 	require.NoError(json.NewDecoder(aliasPull.Body).Decode(&aliasProblem))
@@ -611,41 +593,23 @@ func TestDocsGitPublishEndpointRejectsConcurrentInFlightPublish(t *testing.T) {
 	assert.Equal("pushFailedAfterCommit", firstProblem.Details["reason"])
 
 	// With the lock released and a working remote, a fresh publish succeeds.
-	runDocsGit(t, repo.dir, "remote", "set-url", "origin", repo.remote)
-	repo.write(t, "after.md", "# after\n")
-	afterRR := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/publish", map[string]string{
-		"message": "docs: after",
+	gitfixture.Run(t, repo.Dir, "remote", "set-url", "origin", repo.Remote)
+	repo.Write(t, "after.md", "# after\n")
+	afterRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/publish", generated.PublishDocsGitJSONRequestBody{
+		Message: new("docs: after"),
 	})
-	assert.Equal(http.StatusOK, afterRR.Code, afterRR.Body.String())
-}
 
-// remoteAdvance advances the bare fixture remote by one commit created in a
-// scratch clone, returning the new remote head SHA. The explicit checkout
-// matters: under the stripped git env the bare remote's default HEAD is
-// master, so a fresh clone would otherwise sit on an unborn branch.
-func (g docsGitRepo) remoteAdvance(t *testing.T, rel, body string) string {
-	t.Helper()
-	clone := t.TempDir()
-	runDocsGit(t, g.dir, "clone", g.remote, clone)
-	runDocsGit(t, clone, "checkout", "main")
-	runDocsGit(t, clone, "config", "user.email", "kenn-forge-fixture@example.invalid")
-	runDocsGit(t, clone, "config", "user.name", "Kenn Forge Fixture")
-	runDocsGit(t, clone, "config", "commit.gpgsign", "false")
-	require.NoError(t, os.WriteFile(filepath.Join(clone, filepath.FromSlash(rel)), []byte(body), 0o644))
-	runDocsGit(t, clone, "add", "--", rel)
-	runDocsGit(t, clone, "commit", "-m", "remote update")
-	runDocsGit(t, clone, "push", "origin", "main")
-	return strings.TrimSpace(runDocsGit(t, clone, "rev-parse", "HEAD"))
+	assert.Equal(http.StatusOK, afterRR.Code, afterRR.Body.String())
 }
 
 func TestDocsGitPullEndpointFastForwards(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	repo := newDocsGitRepo(t, true)
-	want := repo.remoteAdvance(t, "remote.md", "# remote\n")
-	srv := setupDocsGitRouteServer(t, repo.dir)
+	repo := gitfixture.NewRepository(t, true)
+	want := repo.RemoteCommit(t, "remote.md", "# remote\n")
+	srv := setupDocsGitRouteServer(t, repo.Dir)
 
-	rr := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/pull", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/pull", nil)
 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	var body docs.PullResponse
@@ -654,17 +618,17 @@ func TestDocsGitPullEndpointFastForwards(t *testing.T) {
 	assert.Equal(want, body.Commit)
 	assert.Equal("main", body.Branch)
 	assert.Equal("origin/main", body.Upstream)
-	_, statErr := os.Stat(filepath.Join(repo.dir, "remote.md"))
+	_, statErr := os.Stat(filepath.Join(repo.Dir, "remote.md"))
 	assert.NoError(statErr)
 }
 
 func TestDocsGitPullEndpointUpToDate(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	repo := newDocsGitRepo(t, true)
-	srv := setupDocsGitRouteServer(t, repo.dir)
+	repo := gitfixture.NewRepository(t, true)
+	srv := setupDocsGitRouteServer(t, repo.Dir)
 
-	rr := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/pull", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/pull", nil)
 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	var body docs.PullResponse
@@ -676,14 +640,14 @@ func TestDocsGitPullEndpointUpToDate(t *testing.T) {
 func TestDocsGitPullEndpointDivergedIs409(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	repo := newDocsGitRepo(t, true)
-	repo.remoteAdvance(t, "remote.md", "remote\n")
-	repo.write(t, "local.md", "local\n")
-	runDocsGit(t, repo.dir, "add", "--", "local.md")
-	runDocsGit(t, repo.dir, "commit", "-m", "local update")
-	srv := setupDocsGitRouteServer(t, repo.dir)
+	repo := gitfixture.NewRepository(t, true)
+	repo.RemoteCommit(t, "remote.md", "remote\n")
+	repo.Write(t, "local.md", "local\n")
+	gitfixture.Run(t, repo.Dir, "add", "--", "local.md")
+	gitfixture.Run(t, repo.Dir, "commit", "-m", "local update")
+	srv := setupDocsGitRouteServer(t, repo.Dir)
 
-	rr := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/pull", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/pull", nil)
 
 	require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
 	var problem httpapi.ProblemError
@@ -694,10 +658,10 @@ func TestDocsGitPullEndpointDivergedIs409(t *testing.T) {
 func TestDocsGitPullEndpointNoUpstreamIs400(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	repo := newDocsGitRepo(t, false)
-	srv := setupDocsGitRouteServer(t, repo.dir)
+	repo := gitfixture.NewRepository(t, false)
+	srv := setupDocsGitRouteServer(t, repo.Dir)
 
-	rr := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/pull", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/f/git/pull", nil)
 
 	require.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
 	var problem httpapi.ProblemError

--- a/internal/server/docstest/routes_test.go
+++ b/internal/server/docstest/routes_test.go
@@ -1,4 +1,4 @@
-package server
+package docstest
 
 import (
 	"bytes"
@@ -12,22 +12,17 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/apiclient/generated"
 	"go.kenn.io/forge/internal/config"
+	"go.kenn.io/forge/internal/docs"
+	"go.kenn.io/forge/internal/server"
 	"go.kenn.io/forge/internal/server/httpapi"
+	"go.kenn.io/forge/internal/testutil"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/testutil/servertest"
 )
 
-type docsFolderWire struct {
-	ID     string `json:"id"`
-	Name   string `json:"name"`
-	Path   string `json:"path"`
-	Daemon string `json:"daemon,omitempty"`
-}
-
-type docsFolderListWire struct {
-	Folders []docsFolderWire `json:"folders"`
-}
-
-func setupDocsRouteServer(t *testing.T) (*Server, string) {
+func setupDocsRouteServer(t *testing.T) (*server.Server, string) {
 	t.Helper()
 	root := t.TempDir()
 	mustWrite := func(rel, body string) {
@@ -42,16 +37,19 @@ func setupDocsRouteServer(t *testing.T) (*Server, string) {
 	mustWrite("notes/image.png", string([]byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}))
 
 	cfg := &config.Config{
+		Host: "127.0.0.1",
+		Port: 8091,
 		DocFolders: []config.DocFolder{
 			{ID: "notes", Name: "Notes", Path: root, Daemon: "work"},
 		},
 	}
-	srv := New(openTestDB(t), nil, nil, "/", cfg, ServerOptions{})
-	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	srv := servertest.New(t, dbtest.Open(t), nil, nil, "/", cfg, server.ServerOptions{
+		HostCheckAllowLoopbackAnyPort: true,
+	})
 	return srv, root
 }
 
-func setupPersistentDocsRouteServer(t *testing.T) (*Server, string, string) {
+func setupPersistentDocsRouteServer(t *testing.T) (*server.Server, string, string) {
 	t.Helper()
 	root := t.TempDir()
 	cfg := &config.Config{
@@ -66,35 +64,10 @@ func setupPersistentDocsRouteServer(t *testing.T) (*Server, string, string) {
 	require.NoError(t, cfg.Save(cfgPath))
 	loaded, err := config.Load(cfgPath)
 	require.NoError(t, err)
-	srv := NewWithConfig(openTestDB(t), nil, nil, nil, loaded, cfgPath, ServerOptions{})
-	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	srv := servertest.NewWithConfig(t, dbtest.Open(t), nil, nil, nil, loaded, cfgPath, server.ServerOptions{
+		HostCheckAllowLoopbackAnyPort: true,
+	})
 	return srv, root, cfgPath
-}
-
-func doDocsJSON(t *testing.T, srv *Server, method, path string, body any) *httptest.ResponseRecorder {
-	t.Helper()
-	var buf bytes.Buffer
-	if body != nil {
-		require.NoError(t, json.NewEncoder(&buf).Encode(body))
-	}
-	req := httptest.NewRequest(method, path, &buf)
-	setAcceptedHostForServerTest(req, srv)
-	req.RemoteAddr = "127.0.0.1:12345"
-	if method != http.MethodGet {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	rr := httptest.NewRecorder()
-	srv.ServeHTTP(rr, req)
-	return rr
-}
-
-func decodeDocsFolder(t *testing.T, rr *httptest.ResponseRecorder) docsFolderWire {
-	t.Helper()
-	var body struct {
-		Folder docsFolderWire `json:"folder"`
-	}
-	require.NoError(t, json.NewDecoder(rr.Body).Decode(&body))
-	return body.Folder
 }
 
 func TestDocsFoldersEndpointListsConfiguredFolders(t *testing.T) {
@@ -102,18 +75,21 @@ func TestDocsFoldersEndpointListsConfiguredFolders(t *testing.T) {
 	require := require.New(t)
 	srv, root := setupDocsRouteServer(t)
 
-	rr := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/folders", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/folders", nil)
 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-	var body docsFolderListWire
+	var body generated.ListDocsFoldersOutputBody
 	require.NoError(json.NewDecoder(rr.Body).Decode(&body))
-	require.Len(body.Folders, 1)
+	require.NotNil(body.Folders)
+	require.Len(*body.Folders, 1)
 	canonicalRoot, err := filepath.EvalSymlinks(root)
 	require.NoError(err)
-	assert.Equal("notes", body.Folders[0].ID)
-	assert.Equal("Notes", body.Folders[0].Name)
-	assert.Equal(canonicalRoot, body.Folders[0].Path)
-	assert.Equal("work", body.Folders[0].Daemon)
+	folder := (*body.Folders)[0]
+	assert.Equal("notes", folder.Id)
+	assert.Equal("Notes", folder.Name)
+	assert.Equal(canonicalRoot, folder.Path)
+	require.NotNil(folder.Daemon)
+	assert.Equal("work", *folder.Daemon)
 }
 
 func TestDocsFolderConfigEndpointsAddRenameRemoveAndPersist(t *testing.T) {
@@ -122,38 +98,46 @@ func TestDocsFolderConfigEndpointsAddRenameRemoveAndPersist(t *testing.T) {
 	srv, _, cfgPath := setupPersistentDocsRouteServer(t)
 	extraRoot := t.TempDir()
 
-	addRR := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders", map[string]string{
-		"id":     "extra",
-		"path":   extraRoot,
-		"daemon": "work",
+	addRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders", generated.CreateDocsFolderJSONRequestBody{
+		Id:     new("extra"),
+		Path:   new(extraRoot),
+		Daemon: new("work"),
 	})
+
 	require.Equal(http.StatusCreated, addRR.Code, addRR.Body.String())
-	added := decodeDocsFolder(t, addRR)
-	assert.Equal("extra", added.ID)
+	var addedBody generated.DocsFolderOutputBody
+	require.NoError(json.NewDecoder(addRR.Body).Decode(&addedBody))
+	added := addedBody.Folder
+	assert.Equal("extra", added.Id)
 	assert.Equal(filepath.Base(extraRoot), added.Name)
-	assert.Equal("work", added.Daemon)
+	require.NotNil(added.Daemon)
+	assert.Equal("work", *added.Daemon)
 	wantExtraRoot, err := filepath.EvalSymlinks(extraRoot)
 	require.NoError(err)
 	assert.Equal(wantExtraRoot, added.Path)
 
-	renameRR := doDocsJSON(t, srv, http.MethodPatch, "/api/v1/docs/folders/extra", map[string]string{
-		"name": "Reference",
+	renameRR := testutil.DoJSON(t, srv, http.MethodPatch, "/api/v1/docs/folders/extra", generated.UpdateDocsFolderJSONRequestBody{
+		Name: new("Reference"),
 	})
+
 	require.Equal(http.StatusOK, renameRR.Code, renameRR.Body.String())
-	renamed := decodeDocsFolder(t, renameRR)
-	assert.Equal("extra", renamed.ID)
+	var renamedBody generated.DocsFolderOutputBody
+	require.NoError(json.NewDecoder(renameRR.Body).Decode(&renamedBody))
+	renamed := renamedBody.Folder
+	assert.Equal("extra", renamed.Id)
 	assert.Equal("Reference", renamed.Name)
 
-	deleteRR := doDocsJSON(t, srv, http.MethodDelete, "/api/v1/docs/folders/notes", nil)
+	deleteRR := testutil.DoJSON(t, srv, http.MethodDelete, "/api/v1/docs/folders/notes", nil)
 	require.Equal(http.StatusNoContent, deleteRR.Code, deleteRR.Body.String())
 
-	listRR := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/folders", nil)
+	listRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/folders", nil)
 	require.Equal(http.StatusOK, listRR.Code, listRR.Body.String())
-	var listBody docsFolderListWire
+	var listBody generated.ListDocsFoldersOutputBody
 	require.NoError(json.NewDecoder(listRR.Body).Decode(&listBody))
-	require.Len(listBody.Folders, 1)
-	assert.Equal("extra", listBody.Folders[0].ID)
-	assert.Equal("Reference", listBody.Folders[0].Name)
+	require.NotNil(listBody.Folders)
+	require.Len(*listBody.Folders, 1)
+	assert.Equal("extra", (*listBody.Folders)[0].Id)
+	assert.Equal("Reference", (*listBody.Folders)[0].Name)
 
 	reloaded, err := config.Load(cfgPath)
 	require.NoError(err)
@@ -166,8 +150,10 @@ func TestDocsFolderAddRejectsNonLoopback(t *testing.T) {
 	require := require.New(t)
 	srv, _, _ := setupPersistentDocsRouteServer(t)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/docs/folders", bytes.NewReader([]byte(`{"path":"/tmp/whatever"}`)))
-	setAcceptedHostForServerTest(req, srv)
+	body, err := json.Marshal(generated.CreateDocsFolderJSONRequestBody{Path: new("/tmp/whatever")})
+	require.NoError(err)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/docs/folders", bytes.NewReader(body))
+	req.Host = "127.0.0.1"
 	req.RemoteAddr = "203.0.113.7:54321"
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Sec-Fetch-Site", "same-origin")
@@ -189,72 +175,87 @@ func TestDocsFolderAddDerivesIDAndRejectsInvalidRequests(t *testing.T) {
 	extraRoot := filepath.Join(t.TempDir(), "Research Papers!")
 	require.NoError(os.Mkdir(extraRoot, 0o755))
 
-	addRR := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders", map[string]string{
-		"path": extraRoot,
+	addRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders", generated.CreateDocsFolderJSONRequestBody{
+		Path: new(extraRoot),
 	})
+
 	require.Equal(http.StatusCreated, addRR.Code, addRR.Body.String())
-	added := decodeDocsFolder(t, addRR)
-	assert.Equal("research-papers", added.ID)
+	var addedBody generated.DocsFolderOutputBody
+	require.NoError(json.NewDecoder(addRR.Body).Decode(&addedBody))
+	added := addedBody.Folder
+	assert.Equal("research-papers", added.Id)
 
 	collidingRoot := filepath.Join(t.TempDir(), "Notes")
 	require.NoError(os.Mkdir(collidingRoot, 0o755))
-	collisionRR := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders", map[string]string{
-		"path": collidingRoot,
+	collisionRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders", generated.CreateDocsFolderJSONRequestBody{
+		Path: new(collidingRoot),
 	})
+
 	require.Equal(http.StatusCreated, collisionRR.Code, collisionRR.Body.String())
-	collision := decodeDocsFolder(t, collisionRR)
-	assert.Equal("notes-2", collision.ID)
+	var collisionBody generated.DocsFolderOutputBody
+	require.NoError(json.NewDecoder(collisionRR.Body).Decode(&collisionBody))
+	collision := collisionBody.Folder
+	assert.Equal("notes-2", collision.Id)
 	assert.Equal("Notes", collision.Name)
 
 	spacedRoot := t.TempDir()
 	wantSpacedRoot, err := filepath.EvalSymlinks(spacedRoot)
 	require.NoError(err)
-	spacedRR := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders", map[string]string{
-		"id":   " spaced ",
-		"name": " Spaced ",
-		"path": " " + spacedRoot + " ",
+	spacedRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders", generated.CreateDocsFolderJSONRequestBody{
+		Id:   new(" spaced "),
+		Name: new(" Spaced "),
+		Path: new(" " + spacedRoot + " "),
 	})
+
 	require.Equal(http.StatusCreated, spacedRR.Code, spacedRR.Body.String())
-	spaced := decodeDocsFolder(t, spacedRR)
-	assert.Equal("spaced", spaced.ID)
+	var spacedBody generated.DocsFolderOutputBody
+	require.NoError(json.NewDecoder(spacedRR.Body).Decode(&spacedBody))
+	spaced := spacedBody.Folder
+	assert.Equal("spaced", spaced.Id)
 	assert.Equal("Spaced", spaced.Name)
 	assert.Equal(wantSpacedRoot, spaced.Path)
 
-	duplicateRR := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders", map[string]string{
-		"id":   "notes",
-		"path": filepath.Join(t.TempDir(), "missing"),
+	duplicateRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders", generated.CreateDocsFolderJSONRequestBody{
+		Id:   new("notes"),
+		Path: new(filepath.Join(t.TempDir(), "missing")),
 	})
+
 	assert.Equal(http.StatusConflict, duplicateRR.Code, duplicateRR.Body.String())
 
-	missingRR := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders", map[string]string{
-		"id":   "ghost",
-		"path": filepath.Join(t.TempDir(), "missing"),
+	missingRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders", generated.CreateDocsFolderJSONRequestBody{
+		Id:   new("ghost"),
+		Path: new(filepath.Join(t.TempDir(), "missing")),
 	})
+
 	assert.Equal(http.StatusNotFound, missingRR.Code, missingRR.Body.String())
 
-	trimmedDuplicateRR := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders", map[string]string{
-		"id":   " notes ",
-		"path": t.TempDir(),
+	trimmedDuplicateRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders", generated.CreateDocsFolderJSONRequestBody{
+		Id:   new(" notes "),
+		Path: new(t.TempDir()),
 	})
+
 	assert.Equal(http.StatusConflict, trimmedDuplicateRR.Code, trimmedDuplicateRR.Body.String())
 
-	blankPathRR := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders", map[string]string{
-		"id":   "blank",
-		"path": " \t",
+	blankPathRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders", generated.CreateDocsFolderJSONRequestBody{
+		Id:   new("blank"),
+		Path: new(" \t"),
 	})
+
 	assert.Equal(http.StatusBadRequest, blankPathRR.Code, blankPathRR.Body.String())
 
-	blankNameRR := doDocsJSON(t, srv, http.MethodPatch, "/api/v1/docs/folders/notes", map[string]string{
-		"name": " \t",
+	blankNameRR := testutil.DoJSON(t, srv, http.MethodPatch, "/api/v1/docs/folders/notes", generated.UpdateDocsFolderJSONRequestBody{
+		Name: new(" \t"),
 	})
+
 	assert.Equal(http.StatusBadRequest, blankNameRR.Code, blankNameRR.Body.String())
 
 	// An explicit id that cannot be addressed as a single path segment is
 	// rejected up front instead of persisting an unreachable folder.
-	slashIDRR := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders", map[string]string{
-		"id":   "team/docs",
-		"path": t.TempDir(),
+	slashIDRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders", generated.CreateDocsFolderJSONRequestBody{
+		Id:   new("team/docs"),
+		Path: new(t.TempDir()),
 	})
+
 	require.Equal(http.StatusBadRequest, slashIDRR.Code, slashIDRR.Body.String())
 	var slashIDProblem httpapi.ProblemError
 	require.NoError(json.NewDecoder(slashIDRR.Body).Decode(&slashIDProblem))
@@ -266,10 +267,11 @@ func TestDocsFolderMutationsRequireConfigPersistenceAndRollbackOnSaveFailure(t *
 	require := require.New(t)
 	srv, _ := setupDocsRouteServer(t)
 
-	unavailableRR := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders", map[string]string{
-		"id":   "extra",
-		"path": t.TempDir(),
+	unavailableRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders", generated.CreateDocsFolderJSONRequestBody{
+		Id:   new("extra"),
+		Path: new(t.TempDir()),
 	})
+
 	require.Equal(http.StatusNotFound, unavailableRR.Code, unavailableRR.Body.String())
 	var unavailable httpapi.ProblemError
 	require.NoError(json.NewDecoder(unavailableRR.Body).Decode(&unavailable))
@@ -284,20 +286,26 @@ func TestDocsFolderMutationsRequireConfigPersistenceAndRollbackOnSaveFailure(t *
 		DocFolders:   []config.DocFolder{{ID: "notes", Name: "Notes", Path: root}},
 	}
 	badPath := filepath.Join(t.TempDir(), "config.toml")
-	failSrv := NewWithConfig(openTestDB(t), nil, nil, nil, cfg, badPath, ServerOptions{})
-	t.Cleanup(func() { gracefulShutdown(t, failSrv) })
-
-	rollbackRR := doDocsJSON(t, failSrv, http.MethodPost, "/api/v1/docs/folders", map[string]string{
-		"id":   "rollback",
-		"path": t.TempDir(),
+	failSrv := servertest.NewWithConfig(t, dbtest.Open(t), nil, nil, nil, cfg, badPath, server.ServerOptions{
+		HostCheck: server.HostCheckOptions{
+			Bind: config.HostKey{Host: "127.0.0.1", Port: "8091"},
+		},
+		HostCheckAllowLoopbackAnyPort: true,
 	})
+
+	rollbackRR := testutil.DoJSON(t, failSrv, http.MethodPost, "/api/v1/docs/folders", generated.CreateDocsFolderJSONRequestBody{
+		Id:   new("rollback"),
+		Path: new(t.TempDir()),
+	})
+
 	require.Equal(http.StatusInternalServerError, rollbackRR.Code, rollbackRR.Body.String())
-	listRR := doDocsJSON(t, failSrv, http.MethodGet, "/api/v1/docs/folders", nil)
+	listRR := testutil.DoJSON(t, failSrv, http.MethodGet, "/api/v1/docs/folders", nil)
 	require.Equal(http.StatusOK, listRR.Code, listRR.Body.String())
-	var listBody docsFolderListWire
+	var listBody generated.ListDocsFoldersOutputBody
 	require.NoError(json.NewDecoder(listRR.Body).Decode(&listBody))
-	require.Len(listBody.Folders, 1)
-	assert.Equal("notes", listBody.Folders[0].ID)
+	require.NotNil(listBody.Folders)
+	require.Len(*listBody.Folders, 1)
+	assert.Equal("notes", (*listBody.Folders)[0].Id)
 }
 
 func TestDocsBrowseEndpointListsDirectoriesOnly(t *testing.T) {
@@ -309,21 +317,15 @@ func TestDocsBrowseEndpointListsDirectoriesOnly(t *testing.T) {
 	require.NoError(os.MkdirAll(filepath.Join(root, ".hidden"), 0o755))
 	require.NoError(os.WriteFile(filepath.Join(root, "skipme.md"), []byte("hi"), 0o644))
 
-	rr := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/browse?path="+root, nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/browse?path="+root, nil)
 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-	var body struct {
-		Path    string `json:"path"`
-		Entries []struct {
-			Name   string `json:"name"`
-			Path   string `json:"path"`
-			Hidden bool   `json:"hidden"`
-		} `json:"entries"`
-	}
+	var body generated.DocsBrowseOutputBody
 	require.NoError(json.NewDecoder(rr.Body).Decode(&body))
 	assert.Equal(root, body.Path)
-	byName := make(map[string]bool, len(body.Entries))
-	for _, entry := range body.Entries {
+	require.NotNil(body.Entries)
+	byName := make(map[string]bool, len(*body.Entries))
+	for _, entry := range *body.Entries {
 		byName[entry.Name] = entry.Hidden
 		assert.True(filepath.IsAbs(entry.Path))
 	}
@@ -343,12 +345,10 @@ func TestDocsBrowseEndpointExpandsHomeShortcut(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	rr := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/browse?path=~", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/browse?path=~", nil)
 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-	var body struct {
-		Path string `json:"path"`
-	}
+	var body generated.DocsBrowseOutputBody
 	require.NoError(json.NewDecoder(rr.Body).Decode(&body))
 	assert.Equal(home, body.Path)
 }
@@ -358,7 +358,7 @@ func TestDocsBrowseEndpointRejectsNonLoopback(t *testing.T) {
 	require := require.New(t)
 	srv, _ := setupDocsRouteServer(t)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/docs/browse?path="+t.TempDir(), nil)
-	setAcceptedHostForServerTest(req, srv)
+	req.Host = "127.0.0.1"
 	req.RemoteAddr = "203.0.113.7:54321"
 	rr := httptest.NewRecorder()
 
@@ -376,23 +376,11 @@ func TestDocsTreeEndpointListsMarkdownOnly(t *testing.T) {
 	require := require.New(t)
 	srv, _ := setupDocsRouteServer(t)
 
-	rr := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/notes/tree", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/notes/tree", nil)
 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	raw := rr.Body.String()
-	var body struct {
-		Name     string `json:"name"`
-		Children []struct {
-			Name     string `json:"name"`
-			RelPath  string `json:"rel_path"`
-			IsDir    bool   `json:"is_dir"`
-			Children []struct {
-				Name    string `json:"name"`
-				RelPath string `json:"rel_path"`
-				IsDir   bool   `json:"is_dir"`
-			} `json:"children"`
-		} `json:"children"`
-	}
+	var body docs.Node
 	require.NoError(json.NewDecoder(rr.Body).Decode(&body))
 	assert.Equal("Notes", body.Name)
 	assert.Contains(raw, `"rel_path":"README.md"`)
@@ -405,27 +393,22 @@ func TestDocsFileEndpointReadsAndWritesMarkdown(t *testing.T) {
 	require := require.New(t)
 	srv, root := setupDocsRouteServer(t)
 
-	readRR := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/notes/file?path=notes/ideas.md", nil)
+	readRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/notes/file?path=notes/ideas.md", nil)
 	require.Equal(http.StatusOK, readRR.Code, readRR.Body.String())
-	var readBody struct {
-		RelPath string `json:"rel_path"`
-		Content string `json:"content"`
-	}
+	var readBody generated.DocsReadFileOutputBody
 	require.NoError(json.NewDecoder(readRR.Body).Decode(&readBody))
 	assert.Equal("notes/ideas.md", readBody.RelPath)
 	assert.Equal("# Ideas\n", readBody.Content)
 
-	writeRR := doDocsJSON(t, srv, http.MethodPut, "/api/v1/docs/folders/notes/file?path=notes/ideas.md", map[string]string{
-		"content": "# Updated\n",
+	writeRR := testutil.DoJSON(t, srv, http.MethodPut, "/api/v1/docs/folders/notes/file?path=notes/ideas.md", generated.WriteDocsFileJSONRequestBody{
+		Content: new("# Updated\n"),
 	})
+
 	require.Equal(http.StatusOK, writeRR.Code, writeRR.Body.String())
-	var writeBody struct {
-		RelPath string `json:"rel_path"`
-		Size    int    `json:"size"`
-	}
+	var writeBody generated.DocsFileWriteBody
 	require.NoError(json.NewDecoder(writeRR.Body).Decode(&writeBody))
 	assert.Equal("notes/ideas.md", writeBody.RelPath)
-	assert.Equal(len("# Updated\n"), writeBody.Size)
+	assert.Equal(int64(len("# Updated\n")), writeBody.Size)
 	got, err := os.ReadFile(filepath.Join(root, "notes/ideas.md"))
 	require.NoError(err)
 	assert.Equal("# Updated\n", string(got))
@@ -436,29 +419,21 @@ func TestDocsSearchEndpointsReturnArrays(t *testing.T) {
 	require := require.New(t)
 	srv, _ := setupDocsRouteServer(t)
 
-	folderRR := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/notes/search?q=daily&limit=10", nil)
+	folderRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/notes/search?q=daily&limit=10", nil)
 	require.Equal(http.StatusOK, folderRR.Code, folderRR.Body.String())
-	var folderBody struct {
-		Query string            `json:"query"`
-		Hits  []json.RawMessage `json:"hits"`
-	}
+	var folderBody generated.DocsSearchOutputBody
 	require.NoError(json.NewDecoder(folderRR.Body).Decode(&folderBody))
 	assert.Equal("daily", folderBody.Query)
-	assert.NotNil(folderBody.Hits)
-	assert.NotEmpty(folderBody.Hits)
+	require.NotNil(folderBody.Hits)
+	assert.NotEmpty(*folderBody.Hits)
 
-	globalRR := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/search?q=budget&limit=10", nil)
+	globalRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/search?q=budget&limit=10", nil)
 	require.Equal(http.StatusOK, globalRR.Code, globalRR.Body.String())
-	var globalBody struct {
-		Query     string            `json:"query"`
-		Hits      []json.RawMessage `json:"hits"`
-		Warnings  []string          `json:"warnings,omitempty"`
-		Truncated bool              `json:"truncated"`
-	}
+	var globalBody generated.DocsSearchAllOutputBody
 	require.NoError(json.NewDecoder(globalRR.Body).Decode(&globalBody))
 	assert.Equal("budget", globalBody.Query)
-	assert.NotNil(globalBody.Hits)
-	assert.NotEmpty(globalBody.Hits)
+	require.NotNil(globalBody.Hits)
+	assert.NotEmpty(*globalBody.Hits)
 	assert.False(globalBody.Truncated)
 }
 
@@ -467,72 +442,65 @@ func TestDocsFileCreateDeleteRenameAndBlob(t *testing.T) {
 	require := require.New(t)
 	srv, root := setupDocsRouteServer(t)
 
-	createRR := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/notes/file?path=notes/new.md", map[string]string{
-		"content": "# New\n",
+	createRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/notes/file?path=notes/new.md", generated.CreateDocsFileJSONRequestBody{
+		Content: new("# New\n"),
 	})
+
 	require.Equal(http.StatusCreated, createRR.Code, createRR.Body.String())
-	var createBody struct {
-		RelPath string `json:"rel_path"`
-		Size    int    `json:"size"`
-	}
+	var createBody generated.DocsFileWriteBody
 	require.NoError(json.NewDecoder(createRR.Body).Decode(&createBody))
 	assert.Equal("notes/new.md", createBody.RelPath)
-	assert.Equal(len("# New\n"), createBody.Size)
+	assert.Equal(int64(len("# New\n")), createBody.Size)
 
-	duplicateRR := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/notes/file?path=notes/new.md", map[string]string{
-		"content": "# New\n",
+	duplicateRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/notes/file?path=notes/new.md", generated.CreateDocsFileJSONRequestBody{
+		Content: new("# New\n"),
 	})
+
 	assert.Equal(http.StatusConflict, duplicateRR.Code, duplicateRR.Body.String())
 
-	emptyRR := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/notes/file?path=notes/empty.md", map[string]string{})
+	emptyRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/notes/file?path=notes/empty.md", generated.CreateDocsFileJSONRequestBody{})
 	require.Equal(http.StatusCreated, emptyRR.Code, emptyRR.Body.String())
-	emptyReadRR := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/notes/file?path=notes/empty.md", nil)
+	emptyReadRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/notes/file?path=notes/empty.md", nil)
 	require.Equal(http.StatusOK, emptyReadRR.Code, emptyReadRR.Body.String())
-	var emptyReadBody struct {
-		Content string `json:"content"`
-	}
+	var emptyReadBody generated.DocsReadFileOutputBody
 	require.NoError(json.NewDecoder(emptyReadRR.Body).Decode(&emptyReadBody))
 	assert.Empty(emptyReadBody.Content)
 
-	renameRR := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/notes/file/actions/rename", map[string]string{
-		"from": "notes/new.md",
-		"to":   "notes/renamed.md",
+	renameRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/notes/file/actions/rename", generated.RenameDocsFileJSONRequestBody{
+		From: new("notes/new.md"),
+		To:   new("notes/renamed.md"),
 	})
+
 	require.Equal(http.StatusOK, renameRR.Code, renameRR.Body.String())
-	var renameBody struct {
-		From string `json:"from"`
-		To   string `json:"to"`
-	}
+	var renameBody generated.DocsRenameFileOutputBody
 	require.NoError(json.NewDecoder(renameRR.Body).Decode(&renameBody))
 	assert.Equal("notes/new.md", renameBody.From)
 	assert.Equal("notes/renamed.md", renameBody.To)
 
-	renamedReadRR := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/notes/file?path=notes/renamed.md", nil)
+	renamedReadRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/notes/file?path=notes/renamed.md", nil)
 	require.Equal(http.StatusOK, renamedReadRR.Code, renamedReadRR.Body.String())
-	var renamedReadBody struct {
-		Content string `json:"content"`
-	}
+	var renamedReadBody generated.DocsReadFileOutputBody
 	require.NoError(json.NewDecoder(renamedReadRR.Body).Decode(&renamedReadBody))
 	assert.Equal("# New\n", renamedReadBody.Content)
 
-	blobRR := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/notes/blob?path=notes/image.png", nil)
+	blobRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/notes/blob?path=notes/image.png", nil)
 	require.Equal(http.StatusOK, blobRR.Code, blobRR.Body.String())
 	assert.Equal("image/png", blobRR.Header().Get("Content-Type"))
 	assert.Equal("private, max-age=60", blobRR.Header().Get("Cache-Control"))
 	assert.NotEmpty(blobRR.Body.Bytes())
 
-	deleteRR := doDocsJSON(t, srv, http.MethodDelete, "/api/v1/docs/folders/notes/file?path=notes/renamed.md", nil)
+	deleteRR := testutil.DoJSON(t, srv, http.MethodDelete, "/api/v1/docs/folders/notes/file?path=notes/renamed.md", nil)
 	require.Equal(http.StatusNoContent, deleteRR.Code, deleteRR.Body.String())
 	_, err := os.Stat(filepath.Join(root, "notes/renamed.md"))
 	require.ErrorIs(err, os.ErrNotExist)
-	deletedReadRR := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/notes/file?path=notes/renamed.md", nil)
+	deletedReadRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/notes/file?path=notes/renamed.md", nil)
 	assert.Equal(http.StatusNotFound, deletedReadRR.Code, deletedReadRR.Body.String())
 }
 
 func TestDocsBlobOpenAPIResponseIsBinary(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	doc := NewOpenAPI()
+	doc := server.NewOpenAPI()
 	item := doc.Paths["/docs/folders/{id}/blob"]
 	require.NotNil(item)
 	require.NotNil(item.Get)
@@ -551,21 +519,22 @@ func TestDocsFileEndpointRejectsInvalidPathsAndTypes(t *testing.T) {
 	assert := assert.New(t)
 	srv, _ := setupDocsRouteServer(t)
 
-	unknownRR := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/missing/tree", nil)
+	unknownRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/missing/tree", nil)
 	assert.Equal(http.StatusNotFound, unknownRR.Code, unknownRR.Body.String())
 
-	traversalRR := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/notes/file?path=../../escape", nil)
+	traversalRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/notes/file?path=../../escape", nil)
 	assert.Equal(http.StatusForbidden, traversalRR.Code, traversalRR.Body.String())
 
-	createTextRR := doDocsJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/notes/file?path=notes/bad.txt", map[string]string{
-		"content": "x",
+	createTextRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/docs/folders/notes/file?path=notes/bad.txt", generated.CreateDocsFileJSONRequestBody{
+		Content: new("x"),
 	})
+
 	assert.Equal(http.StatusUnsupportedMediaType, createTextRR.Code, createTextRR.Body.String())
 
-	deleteTextRR := doDocsJSON(t, srv, http.MethodDelete, "/api/v1/docs/folders/notes/file?path=notes/bad.txt", nil)
+	deleteTextRR := testutil.DoJSON(t, srv, http.MethodDelete, "/api/v1/docs/folders/notes/file?path=notes/bad.txt", nil)
 	assert.Equal(http.StatusUnsupportedMediaType, deleteTextRR.Code, deleteTextRR.Body.String())
 
-	blobMarkdownRR := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/notes/blob?path=README.md", nil)
+	blobMarkdownRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/folders/notes/blob?path=README.md", nil)
 	assert.Equal(http.StatusUnsupportedMediaType, blobMarkdownRR.Code, blobMarkdownRR.Body.String())
 }
 
@@ -574,15 +543,13 @@ func TestDocsSearchEndpointEmptyQueryReturnsEmptyArray(t *testing.T) {
 	require := require.New(t)
 	srv, _ := setupDocsRouteServer(t)
 
-	rr := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/search?q=&limit=10", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/search?q=&limit=10", nil)
 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-	var body struct {
-		Hits []json.RawMessage `json:"hits"`
-	}
+	var body generated.DocsSearchAllOutputBody
 	require.NoError(json.NewDecoder(rr.Body).Decode(&body))
-	assert.NotNil(body.Hits)
-	assert.Empty(body.Hits)
+	require.NotNil(body.Hits)
+	assert.Empty(*body.Hits)
 }
 
 func TestDocsSearchEndpointTruncationAndFailure(t *testing.T) {
@@ -590,26 +557,25 @@ func TestDocsSearchEndpointTruncationAndFailure(t *testing.T) {
 	require := require.New(t)
 	srv, _ := setupDocsRouteServer(t)
 
-	truncatedRR := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/search?q=budget&limit=1", nil)
+	truncatedRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/search?q=budget&limit=1", nil)
 	require.Equal(http.StatusOK, truncatedRR.Code, truncatedRR.Body.String())
-	var truncatedBody struct {
-		Hits      []json.RawMessage `json:"hits"`
-		Truncated bool              `json:"truncated"`
-	}
+	var truncatedBody generated.DocsSearchAllOutputBody
 	require.NoError(json.NewDecoder(truncatedRR.Body).Decode(&truncatedBody))
-	assert.Len(truncatedBody.Hits, 1)
+	require.NotNil(truncatedBody.Hits)
+	assert.Len(*truncatedBody.Hits, 1)
 	assert.True(truncatedBody.Truncated)
 
 	missingA := filepath.Join(t.TempDir(), "missing-a")
 	missingB := filepath.Join(t.TempDir(), "missing-b")
-	failSrv := New(openTestDB(t), nil, nil, "/", &config.Config{
+	failSrv := servertest.New(t, dbtest.Open(t), nil, nil, "/", &config.Config{
+		Host: "127.0.0.1",
+		Port: 8091,
 		DocFolders: []config.DocFolder{
 			{ID: "a", Name: "A", Path: missingA},
 			{ID: "b", Name: "B", Path: missingB},
 		},
-	}, ServerOptions{})
-	t.Cleanup(func() { gracefulShutdown(t, failSrv) })
-	failRR := doDocsJSON(t, failSrv, http.MethodGet, "/api/v1/docs/search?q=budget&limit=10", nil)
+	}, server.ServerOptions{HostCheckAllowLoopbackAnyPort: true})
+	failRR := testutil.DoJSON(t, failSrv, http.MethodGet, "/api/v1/docs/search?q=budget&limit=10", nil)
 	assert.Equal(http.StatusInternalServerError, failRR.Code, failRR.Body.String())
 }
 
@@ -619,28 +585,25 @@ func TestDocsSearchEndpointSerializesPartialWarnings(t *testing.T) {
 	goodRoot := t.TempDir()
 	require.NoError(os.WriteFile(filepath.Join(goodRoot, "hit.md"), []byte("budget partial\n"), 0o644))
 	missingRoot := filepath.Join(t.TempDir(), "missing")
-	srv := New(openTestDB(t), nil, nil, "/", &config.Config{
+	srv := servertest.New(t, dbtest.Open(t), nil, nil, "/", &config.Config{
+		Host: "127.0.0.1",
+		Port: 8091,
 		DocFolders: []config.DocFolder{
 			{ID: "good", Name: "Good", Path: goodRoot},
 			{ID: "missing", Name: "Missing", Path: missingRoot},
 		},
-	}, ServerOptions{})
-	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	}, server.ServerOptions{HostCheckAllowLoopbackAnyPort: true})
 
-	rr := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/search?q=budget&limit=10", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/search?q=budget&limit=10", nil)
 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-	var body struct {
-		Hits []struct {
-			Folder string `json:"folder"`
-		} `json:"hits"`
-		Warnings  []string `json:"warnings"`
-		Truncated bool     `json:"truncated"`
-	}
+	var body generated.DocsSearchAllOutputBody
 	require.NoError(json.NewDecoder(rr.Body).Decode(&body))
-	require.Len(body.Hits, 1)
-	assert.Equal("good", body.Hits[0].Folder)
-	assert.NotEmpty(body.Warnings)
+	require.NotNil(body.Hits)
+	require.Len(*body.Hits, 1)
+	assert.Equal("good", (*body.Hits)[0].Folder)
+	require.NotNil(body.Warnings)
+	assert.NotEmpty(*body.Warnings)
 	assert.False(body.Truncated)
 }
 
@@ -651,26 +614,23 @@ func TestDocsSearchEndpointFindsHitsAcrossFolders(t *testing.T) {
 	rootB := t.TempDir()
 	require.NoError(os.WriteFile(filepath.Join(rootA, "a.md"), []byte("budget alpha\n"), 0o644))
 	require.NoError(os.WriteFile(filepath.Join(rootB, "b.md"), []byte("budget beta\n"), 0o644))
-	srv := New(openTestDB(t), nil, nil, "/", &config.Config{
+	srv := servertest.New(t, dbtest.Open(t), nil, nil, "/", &config.Config{
+		Host: "127.0.0.1",
+		Port: 8091,
 		DocFolders: []config.DocFolder{
 			{ID: "a", Name: "A", Path: rootA},
 			{ID: "b", Name: "B", Path: rootB},
 		},
-	}, ServerOptions{})
-	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	}, server.ServerOptions{HostCheckAllowLoopbackAnyPort: true})
 
-	rr := doDocsJSON(t, srv, http.MethodGet, "/api/v1/docs/search?q=budget&limit=10", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/docs/search?q=budget&limit=10", nil)
 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-	var body struct {
-		Hits []struct {
-			Folder string `json:"folder"`
-		} `json:"hits"`
-		Truncated bool `json:"truncated"`
-	}
+	var body generated.DocsSearchAllOutputBody
 	require.NoError(json.NewDecoder(rr.Body).Decode(&body))
-	require.Len(body.Hits, 2)
-	ids := []string{body.Hits[0].Folder, body.Hits[1].Folder}
+	require.NotNil(body.Hits)
+	require.Len(*body.Hits, 2)
+	ids := []string{(*body.Hits)[0].Folder, (*body.Hits)[1].Folder}
 	assert.ElementsMatch([]string{"a", "b"}, ids)
 	assert.False(body.Truncated)
 }
@@ -690,13 +650,13 @@ func TestDocsFileMutationsRejectNonLoopback(t *testing.T) {
 			name:   "write",
 			method: http.MethodPut,
 			path:   "/api/v1/docs/folders/notes/file?path=notes/ideas.md",
-			body:   map[string]string{"content": "blocked"},
+			body:   generated.WriteDocsFileJSONRequestBody{Content: new("blocked")},
 		},
 		{
 			name:   "create",
 			method: http.MethodPost,
 			path:   "/api/v1/docs/folders/notes/file?path=notes/blocked.md",
-			body:   map[string]string{"content": "blocked"},
+			body:   generated.CreateDocsFileJSONRequestBody{Content: new("blocked")},
 		},
 		{
 			name:   "delete",
@@ -707,7 +667,10 @@ func TestDocsFileMutationsRejectNonLoopback(t *testing.T) {
 			name:   "rename",
 			method: http.MethodPost,
 			path:   "/api/v1/docs/folders/notes/file/actions/rename",
-			body:   map[string]string{"from": "notes/ideas.md", "to": "notes/blocked.md"},
+			body: generated.RenameDocsFileJSONRequestBody{
+				From: new("notes/ideas.md"),
+				To:   new("notes/blocked.md"),
+			},
 		},
 	}
 	for _, tc := range cases {
@@ -717,7 +680,7 @@ func TestDocsFileMutationsRejectNonLoopback(t *testing.T) {
 				require.NoError(json.NewEncoder(&buf).Encode(tc.body))
 			}
 			req := httptest.NewRequest(tc.method, tc.path, &buf)
-			setAcceptedHostForServerTest(req, srv)
+			req.Host = "127.0.0.1"
 			req.RemoteAddr = "203.0.113.7:54321"
 			req.Header.Set("Content-Type", "application/json")
 			rr := httptest.NewRecorder()
@@ -742,49 +705,54 @@ func TestDocsMutationsRejectBodyTooLarge(t *testing.T) {
 		name   string
 		method string
 		path   string
-		body   string
+		body   any
 	}{
 		{
 			name:   "create folder",
 			method: http.MethodPost,
 			path:   "/api/v1/docs/folders",
-			body:   `{"path":"` + huge + `"}`,
+			body:   generated.CreateDocsFolderJSONRequestBody{Path: new(huge)},
 		},
 		{
 			name:   "update folder",
 			method: http.MethodPatch,
 			path:   "/api/v1/docs/folders/notes",
-			body:   `{"name":"` + huge + `"}`,
+			body:   generated.UpdateDocsFolderJSONRequestBody{Name: new(huge)},
 		},
 		{
 			name:   "write file",
 			method: http.MethodPut,
 			path:   "/api/v1/docs/folders/notes/file?path=notes/ideas.md",
-			body:   `{"content":"` + huge + `"}`,
+			body:   generated.WriteDocsFileJSONRequestBody{Content: new(huge)},
 		},
 		{
 			name:   "create file",
 			method: http.MethodPost,
 			path:   "/api/v1/docs/folders/notes/file?path=notes/large.md",
-			body:   `{"content":"` + huge + `"}`,
+			body:   generated.CreateDocsFileJSONRequestBody{Content: new(huge)},
 		},
 		{
 			name:   "rename file",
 			method: http.MethodPost,
 			path:   "/api/v1/docs/folders/notes/file/actions/rename",
-			body:   `{"from":"notes/ideas.md","to":"` + huge + `"}`,
+			body: generated.RenameDocsFileJSONRequestBody{
+				From: new("notes/ideas.md"),
+				To:   new(huge),
+			},
 		},
 		{
 			name:   "publish git",
 			method: http.MethodPost,
 			path:   "/api/v1/docs/folders/notes/git/publish",
-			body:   `{"message":"` + huge + `"}`,
+			body:   generated.PublishDocsGitJSONRequestBody{Message: new(huge)},
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest(tc.method, tc.path, strings.NewReader(tc.body))
-			setAcceptedHostForServerTest(req, srv)
+			var body bytes.Buffer
+			require.NoError(json.NewEncoder(&body).Encode(tc.body))
+			req := httptest.NewRequest(tc.method, tc.path, &body)
+			req.Host = "127.0.0.1"
 			req.RemoteAddr = "127.0.0.1:12345"
 			req.Header.Set("Content-Type", "application/json")
 			rr := httptest.NewRecorder()
@@ -803,26 +771,23 @@ func TestDocsFileWriteAllowsBodyBelowEditorLimit(t *testing.T) {
 	require := require.New(t)
 	srv, _ := setupDocsRouteServer(t)
 	content := strings.Repeat("a", 2<<20)
-	body, err := json.Marshal(map[string]string{"content": content})
+	body, err := json.Marshal(generated.WriteDocsFileJSONRequestBody{Content: new(content)})
 	require.NoError(err)
 
 	req := httptest.NewRequest(http.MethodPut,
 		"/api/v1/docs/folders/notes/file?path=notes/ideas.md",
 		bytes.NewReader(body))
-	setAcceptedHostForServerTest(req, srv)
+	req.Host = "127.0.0.1"
 	req.RemoteAddr = "127.0.0.1:12345"
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	srv.ServeHTTP(rr, req)
 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-	var parsed struct {
-		RelPath string `json:"rel_path"`
-		Size    int    `json:"size"`
-	}
+	var parsed generated.DocsFileWriteBody
 	require.NoError(json.NewDecoder(rr.Body).Decode(&parsed))
 	assert.Equal("notes/ideas.md", parsed.RelPath)
-	assert.Equal(len(content), parsed.Size)
+	assert.Equal(int64(len(content)), parsed.Size)
 }
 
 func TestDocsReadEndpointsRejectNonLoopback(t *testing.T) {
@@ -844,7 +809,7 @@ func TestDocsReadEndpointsRejectNonLoopback(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
-			setAcceptedHostForServerTest(req, srv)
+			req.Host = "127.0.0.1"
 			req.RemoteAddr = "203.0.113.7:54321"
 			rr := httptest.NewRecorder()
 

--- a/internal/server/docstest/testmain_test.go
+++ b/internal/server/docstest/testmain_test.go
@@ -1,0 +1,12 @@
+package docstest
+
+import (
+	"os"
+	"testing"
+
+	"go.kenn.io/forge/internal/testutil/gitsafe"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(gitsafe.RunIsolatedMain(m))
+}

--- a/internal/server/filesystem_handlers_test.go
+++ b/internal/server/filesystem_handlers_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 )
 
 // TestFilesystemComplete covers GET /api/v1/filesystem/complete: directory
@@ -76,10 +77,10 @@ func TestFilesystemValidateRepo(t *testing.T) {
 
 	repo := filepath.Join(t.TempDir(), "repo")
 	require.NoError(os.MkdirAll(repo, 0o755))
-	runGit(t, repo, "init", "--initial-branch=main")
-	runGit(t, repo, "config", "user.email", "test@example.com")
-	runGit(t, repo, "config", "user.name", "Test User")
-	runGit(t, repo, "commit", "--allow-empty", "-m", "initial")
+	gitfixture.Run(t, repo, "init", "--initial-branch=main")
+	gitfixture.Run(t, repo, "config", "user.email", "test@example.com")
+	gitfixture.Run(t, repo, "config", "user.name", "Test User")
+	gitfixture.Run(t, repo, "commit", "--allow-empty", "-m", "initial")
 	require.NoError(os.MkdirAll(filepath.Join(repo, "subdir"), 0o755))
 
 	decode := func(path string) (bool, string, string) {

--- a/internal/server/gitlab_container_e2e_test.go
+++ b/internal/server/gitlab_container_e2e_test.go
@@ -25,6 +25,7 @@ import (
 	"go.kenn.io/forge/internal/platform"
 	platformgitlab "go.kenn.io/forge/internal/platform/gitlab"
 	"go.kenn.io/forge/internal/procutil"
+	"go.kenn.io/forge/internal/testutil"
 	"go.kenn.io/forge/internal/testutil/dbtest"
 )
 
@@ -256,9 +257,10 @@ func TestGitLabContainerE2E(t *testing.T) {
 	runID := time.Now().UnixNano()
 
 	// Comment post and edit on the seeded MR.
-	commentRR := doJSON(t, srv, http.MethodPost, seededMR+"/comments", map[string]string{
+	commentRR := testutil.DoJSON(t, srv, http.MethodPost, seededMR+"/comments", map[string]string{
 		"body": fmt.Sprintf("Write parity comment %d", runID),
 	})
+
 	require.Equal(http.StatusCreated, commentRR.Code, commentRR.Body.String())
 	var commentEvent struct {
 		PlatformID *int64
@@ -270,11 +272,11 @@ func TestGitLabContainerE2E(t *testing.T) {
 	assert.Equal("root", commentEvent.Author)
 
 	editedBody := fmt.Sprintf("Write parity comment %d (edited)", runID)
-	editRR := doJSON(
+	editRR := testutil.DoJSON(
 		t, srv, http.MethodPatch,
 		fmt.Sprintf("%s/comments/%d", seededMR, *commentEvent.PlatformID),
-		map[string]string{"body": editedBody},
-	)
+		map[string]string{"body": editedBody})
+
 	require.Equal(http.StatusOK, editRR.Code, editRR.Body.String())
 	editedNote := gitlabContainerAPI(
 		t, ctx, manifest, http.MethodGet,
@@ -286,9 +288,10 @@ func TestGitLabContainerE2E(t *testing.T) {
 
 	// MR description edit (title is left alone so bootstrap stays idempotent).
 	editedDescription := fmt.Sprintf("Description updated by write parity e2e %d", runID)
-	mrEditRR := doJSON(t, srv, http.MethodPatch, seededMR, map[string]string{
+	mrEditRR := testutil.DoJSON(t, srv, http.MethodPatch, seededMR, map[string]string{
 		"body": editedDescription,
 	})
+
 	require.Equal(http.StatusOK, mrEditRR.Code, mrEditRR.Body.String())
 	editedMR := gitlabContainerAPI(t, ctx, manifest, http.MethodGet,
 		fmt.Sprintf("/projects/%d/merge_requests/%d", manifest.ProjectID, manifest.MergeRequestIID),
@@ -297,19 +300,20 @@ func TestGitLabContainerE2E(t *testing.T) {
 	assert.Equal(editedDescription, editedMR["description"])
 
 	// Close and reopen the seeded MR.
-	closeRR := doJSON(t, srv, http.MethodPost, seededMR+"/github-state", map[string]string{"state": "closed"})
+	closeRR := testutil.DoJSON(t, srv, http.MethodPost, seededMR+"/github-state", map[string]string{"state": "closed"})
 	require.Equal(http.StatusOK, closeRR.Code, closeRR.Body.String())
 	assert.Equal("closed", gitlabContainerMRState(t, ctx, manifest, manifest.MergeRequestIID))
-	reopenRR := doJSON(t, srv, http.MethodPost, seededMR+"/github-state", map[string]string{"state": "open"})
+	reopenRR := testutil.DoJSON(t, srv, http.MethodPost, seededMR+"/github-state", map[string]string{"state": "open"})
 	require.Equal(http.StatusOK, reopenRR.Code, reopenRR.Body.String())
 	assert.Equal("opened", gitlabContainerMRState(t, ctx, manifest, manifest.MergeRequestIID))
 
 	// Issue comment, close, and reopen on the seeded issue, each verified
 	// against GitLab's own API.
 	issueCommentBody := fmt.Sprintf("Issue write parity comment %d", runID)
-	issueCommentRR := doJSON(t, srv, http.MethodPost, seededIssue+"/comments", map[string]string{
+	issueCommentRR := testutil.DoJSON(t, srv, http.MethodPost, seededIssue+"/comments", map[string]string{
 		"body": issueCommentBody,
 	})
+
 	require.Equal(http.StatusCreated, issueCommentRR.Code, issueCommentRR.Body.String())
 	var issueCommentEvent struct {
 		PlatformID *int64
@@ -323,19 +327,20 @@ func TestGitLabContainerE2E(t *testing.T) {
 	)
 	assert.Equal(issueCommentBody, issueNote["body"])
 
-	issueCloseRR := doJSON(t, srv, http.MethodPost, seededIssue+"/github-state", map[string]string{"state": "closed"})
+	issueCloseRR := testutil.DoJSON(t, srv, http.MethodPost, seededIssue+"/github-state", map[string]string{"state": "closed"})
 	require.Equal(http.StatusOK, issueCloseRR.Code, issueCloseRR.Body.String())
 	assert.Equal("closed", gitlabContainerIssueState(t, ctx, manifest, manifest.IssueIID))
-	issueReopenRR := doJSON(t, srv, http.MethodPost, seededIssue+"/github-state", map[string]string{"state": "open"})
+	issueReopenRR := testutil.DoJSON(t, srv, http.MethodPost, seededIssue+"/github-state", map[string]string{"state": "open"})
 	require.Equal(http.StatusOK, issueReopenRR.Code, issueReopenRR.Body.String())
 	assert.Equal("opened", gitlabContainerIssueState(t, ctx, manifest, manifest.IssueIID))
 
 	// Issue create plus title/body edit, verified upstream.
 	createdIssueTitle := fmt.Sprintf("Write parity issue %d", runID)
-	createIssueRR := doJSON(t, srv, http.MethodPost, issueBase, map[string]string{
+	createIssueRR := testutil.DoJSON(t, srv, http.MethodPost, issueBase, map[string]string{
 		"title": createdIssueTitle,
 		"body":  "Issue created through kenn-forge against the GitLab container.",
 	})
+
 	require.Equal(http.StatusCreated, createIssueRR.Code, createIssueRR.Body.String())
 	var createdIssue struct {
 		Number int
@@ -351,11 +356,11 @@ func TestGitLabContainerE2E(t *testing.T) {
 	)
 
 	editedIssueTitle := fmt.Sprintf("Write parity issue %d (edited)", runID)
-	issueEditRR := doJSON(
+	issueEditRR := testutil.DoJSON(
 		t, srv, http.MethodPatch,
 		fmt.Sprintf("%s/%d", issueBase, createdIssue.Number),
-		map[string]string{"title": editedIssueTitle},
-	)
+		map[string]string{"title": editedIssueTitle})
+
 	require.Equal(http.StatusOK, issueEditRR.Code, issueEditRR.Body.String())
 	upstreamIssue = gitlabContainerAPI(t, ctx, manifest, http.MethodGet,
 		fmt.Sprintf("/projects/%d/issues/%d", manifest.ProjectID, createdIssue.Number), nil)
@@ -363,9 +368,10 @@ func TestGitLabContainerE2E(t *testing.T) {
 
 	// request_changes has no GitLab equivalent and must fail with the typed
 	// capability envelope.
-	rejectRR := doJSON(t, srv, http.MethodPost, seededMR+"/review-draft/publish", map[string]string{
+	rejectRR := testutil.DoJSON(t, srv, http.MethodPost, seededMR+"/review-draft/publish", map[string]string{
 		"action": "request_changes", "body": "needs work",
 	})
+
 	require.Equal(http.StatusConflict, rejectRR.Code, rejectRR.Body.String())
 	var rejectProblem struct {
 		Code    string         `json:"code"`
@@ -414,10 +420,11 @@ func TestGitLabContainerE2E(t *testing.T) {
 	require.NotEmpty(parityHeadSHA)
 
 	// Approve through the approvals API (body becomes a regular note).
-	approveRR := doJSON(t, srv, http.MethodPost, parityMR+"/approve", map[string]string{
+	approveRR := testutil.DoJSON(t, srv, http.MethodPost, parityMR+"/approve", map[string]string{
 		"body":              "Approving from kenn-forge write parity e2e",
 		"expected_head_sha": parityHeadSHA,
 	})
+
 	require.Equal(http.StatusOK, approveRR.Code, approveRR.Body.String())
 	approvalState := gitlabContainerAPI(t, ctx, manifest, http.MethodGet,
 		fmt.Sprintf("/projects/%d/merge_requests/%d/approvals", manifest.ProjectID, mergeIID),
@@ -434,10 +441,10 @@ func TestGitLabContainerE2E(t *testing.T) {
 	discussionID, _ := discussion["id"].(string)
 	require.NotEmpty(discussionID)
 
-	replyRR := doJSON(t, srv, http.MethodPost,
+	replyRR := testutil.DoJSON(t, srv, http.MethodPost,
 		fmt.Sprintf("%s/discussions/%s/reply", parityMR, discussionID),
-		map[string]string{"body": "Reply sent through kenn-forge"},
-	)
+		map[string]string{"body": "Reply sent through kenn-forge"})
+
 	require.Equal(http.StatusCreated, replyRR.Code, replyRR.Body.String())
 	repliedDiscussion := gitlabContainerAPI(t, ctx, manifest, http.MethodGet,
 		fmt.Sprintf("/projects/%d/merge_requests/%d/discussions/%s",
@@ -449,26 +456,27 @@ func TestGitLabContainerE2E(t *testing.T) {
 	lastNote, _ := replyNotes[1].(map[string]any)
 	assert.Equal("Reply sent through kenn-forge", lastNote["body"])
 
-	resolveRR := doJSON(t, srv, http.MethodPost,
+	resolveRR := testutil.DoJSON(t, srv, http.MethodPost,
 		fmt.Sprintf("%s/discussions/%s/resolve", parityMR, discussionID),
-		map[string]bool{"resolved": true},
-	)
+		map[string]bool{"resolved": true})
+
 	require.Equal(http.StatusOK, resolveRR.Code, resolveRR.Body.String())
 	assert.True(gitlabContainerDiscussionResolved(t, ctx, manifest, mergeIID, discussionID))
 
-	unresolveRR := doJSON(t, srv, http.MethodPost,
+	unresolveRR := testutil.DoJSON(t, srv, http.MethodPost,
 		fmt.Sprintf("%s/discussions/%s/resolve", parityMR, discussionID),
-		map[string]bool{"resolved": false},
-	)
+		map[string]bool{"resolved": false})
+
 	require.Equal(http.StatusOK, unresolveRR.Code, unresolveRR.Body.String())
 	assert.False(gitlabContainerDiscussionResolved(t, ctx, manifest, mergeIID, discussionID))
 
 	// Rebase cannot be honored per merge on GitLab and must fail typed,
 	// without merging anything.
-	rebaseRR := doJSON(t, srv, http.MethodPost, parityMR+"/merge", map[string]string{
+	rebaseRR := testutil.DoJSON(t, srv, http.MethodPost, parityMR+"/merge", map[string]string{
 		"method": "rebase", "commit_title": "t", "commit_message": "m",
 		"expected_head_sha": parityHeadSHA,
 	})
+
 	require.Equal(http.StatusConflict, rebaseRR.Code, rebaseRR.Body.String())
 	var rebaseProblem struct {
 		Code    string         `json:"code"`
@@ -482,12 +490,13 @@ func TestGitLabContainerE2E(t *testing.T) {
 
 	// Squash merge once GitLab finishes its async mergeability check.
 	waitForGitLabMergeable(t, ctx, manifest, mergeIID)
-	mergeRR := doJSON(t, srv, http.MethodPost, parityMR+"/merge", map[string]string{
+	mergeRR := testutil.DoJSON(t, srv, http.MethodPost, parityMR+"/merge", map[string]string{
 		"method":            "squash",
 		"commit_title":      fmt.Sprintf("Write parity squash merge %d", runID),
 		"commit_message":    "Squash merged through kenn-forge against the GitLab container",
 		"expected_head_sha": parityHeadSHA,
 	})
+
 	require.Equal(http.StatusOK, mergeRR.Code, mergeRR.Body.String())
 	var mergeResult struct {
 		Merged bool   `json:"merged"`

--- a/internal/server/host_check_test.go
+++ b/internal/server/host_check_test.go
@@ -152,6 +152,8 @@ func TestDirectDaemonBearerClassificationWithoutGeneralAPIAuth(t *testing.T) {
 //
 // Bind for every case is 127.0.0.1:8091.
 func TestHostCheckBackendHost(t *testing.T) {
+	runParallelServerTest(t)
+
 	cases := []struct {
 		name    string
 		allowed []config.HostKey
@@ -212,6 +214,8 @@ func TestHostCheckBackendHost(t *testing.T) {
 // Always also exercises that DNS-rebinding rejections from Step 2
 // run before any forwarded header is read.
 func TestHostCheckForwardedHost(t *testing.T) {
+	runParallelServerTest(t)
+
 	cases := []struct {
 		name              string
 		allowed           []config.HostKey

--- a/internal/server/kata_client_test.go
+++ b/internal/server/kata_client_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestKataAPIClientExposesSnapshotEnrichmentMethods(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 
 	_ = kataAPIClient.ShowIssueByUIDWithResponse
 	_ = kataAPIClient.PollEventsWithResponse
@@ -24,7 +24,7 @@ func TestKataAPIClientExposesSnapshotEnrichmentMethods(t *testing.T) {
 }
 
 func TestNewKataAPIClientUsesResolvedTargetAuth(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	var authorization string
@@ -50,7 +50,7 @@ func TestNewKataAPIClientUsesResolvedTargetAuth(t *testing.T) {
 }
 
 func TestKataAPIClientStreamEventsRawDoesNotBuffer(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	requestHeaders := make(chan http.Header, 1)
@@ -97,7 +97,7 @@ func TestKataAPIClientStreamEventsRawDoesNotBuffer(t *testing.T) {
 }
 
 func TestKataGeneratedHTTPDoerRejectsResponseBeyondEndpointBudget(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -126,7 +126,7 @@ func TestKataGeneratedHTTPDoerRejectsResponseBeyondEndpointBudget(t *testing.T) 
 }
 
 func TestKataGeneratedResponseLimitLeavesRoomForCompleteAuthorities(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 	require := require.New(t)
 
 	require.Equal(int64(128<<20), kataGeneratedResponseLimit("/api/v1/issues"))

--- a/internal/server/operation_availability_test.go
+++ b/internal/server/operation_availability_test.go
@@ -17,6 +17,7 @@ import (
 	"go.kenn.io/forge/internal/ratelimit"
 	"go.kenn.io/forge/internal/server/httpapi"
 	"go.kenn.io/forge/internal/server/pullapi"
+	"go.kenn.io/forge/internal/testutil"
 	"go.kenn.io/forge/internal/testutil/dbtest"
 	"go.kenn.io/forge/internal/tokenauth"
 )
@@ -359,7 +360,7 @@ func TestAPIRepoResponseIncludesOperationsHealthy(t *testing.T) {
 	// Keep merge available so this fixture isolates the healthy path.
 	require.NoError(database.UpdateRepoViewerCanMerge(t.Context(), repoID, true))
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
 	require.Equal(http.StatusOK, rr.Code)
 
 	var resp repoResponse
@@ -386,7 +387,7 @@ func TestAPIRepoResponseIncludesOperationsRateLimited(t *testing.T) {
 	resetAt := time.Now().UTC().Add(30 * time.Minute)
 	rt.UpdateFromRate(ratelimit.Rate{Limit: 5000, Remaining: 0, Reset: resetAt})
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
 	require.Equal(http.StatusOK, rr.Code)
 
 	var resp repoResponse
@@ -439,7 +440,7 @@ func TestAPIRepoResponseIncludesOperationsGraphQLPauseDoesNotBlockREST(t *testin
 	resetAt := time.Now().UTC().Add(30 * time.Minute)
 	gqlRT.UpdateFromRate(ratelimit.Rate{Limit: 5000, Remaining: 0, Reset: resetAt})
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
 	require.Equal(http.StatusOK, rr.Code)
 
 	var resp repoResponse
@@ -482,7 +483,7 @@ func TestAPIRepoResponseApplySuggestionRateBucketsFollowProvider(t *testing.T) {
 		require.NoError(err)
 		gqlRT.UpdateFromRate(ratelimit.Rate{Limit: 5000, Remaining: 0, Reset: resetAt})
 
-		rr := doJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
+		rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
 		require.Equal(http.StatusOK, rr.Code)
 		var resp repoResponse
 		require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
@@ -544,10 +545,10 @@ func TestAPIRepoResponseApplySuggestionRateBucketsFollowProvider(t *testing.T) {
 		require.NoError(err)
 		gqlRT.UpdateFromRate(ratelimit.Rate{Limit: 5000, Remaining: 0, Reset: resetAt})
 
-		rr := doJSON(
+		rr := testutil.DoJSON(
 			t, srv, http.MethodGet,
-			"/api/v1/host/gitlab.example.com/repo/gitlab/group/project", nil,
-		)
+			"/api/v1/host/gitlab.example.com/repo/gitlab/group/project", nil)
+
 		require.Equal(http.StatusOK, rr.Code)
 		var resp repoResponse
 		require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
@@ -608,10 +609,10 @@ func TestAPIRepoResponseApplySuggestionRateBucketsFollowProvider(t *testing.T) {
 		})
 		require.NoError(err)
 
-		rr := doJSON(
+		rr := testutil.DoJSON(
 			t, srv, http.MethodGet,
-			"/api/v1/host/gitlab.example.com/repo/gitlab/group/project", nil,
-		)
+			"/api/v1/host/gitlab.example.com/repo/gitlab/group/project", nil)
+
 		require.Equal(http.StatusOK, rr.Code)
 		var resp repoResponse
 		require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
@@ -669,7 +670,7 @@ func TestAPIRepoResponseOperationsGateOnWriteTrackerWhenSplit(t *testing.T) {
 	resetAt := time.Now().UTC().Add(30 * time.Minute)
 	restRT.UpdateFromRate(ratelimit.Rate{Limit: 5000, Remaining: 0, Reset: resetAt})
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
 	require.Equal(http.StatusOK, rr.Code)
 	var resp repoResponse
 	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
@@ -680,7 +681,7 @@ func TestAPIRepoResponseOperationsGateOnWriteTrackerWhenSplit(t *testing.T) {
 	// mutation (ready-for-review) follows its own write bucket.
 	writeRT.UpdateFromRate(ratelimit.Rate{Limit: 5000, Remaining: 0, Reset: resetAt})
 
-	rr = doJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
+	rr = testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
 	require.Equal(http.StatusOK, rr.Code)
 	resp = repoResponse{}
 	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
@@ -696,7 +697,7 @@ func TestAPIRepoResponseOperationsGateOnWriteTrackerWhenSplit(t *testing.T) {
 	writeRT.UpdateFromRate(ratelimit.Rate{Limit: 5000, Remaining: 4000, Reset: resetAt})
 	writeGQLRT.UpdateFromRate(ratelimit.Rate{Limit: 5000, Remaining: 0, Reset: resetAt})
 
-	rr = doJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
+	rr = testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
 	require.Equal(http.StatusOK, rr.Code)
 	resp = repoResponse{}
 	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
@@ -735,7 +736,7 @@ func TestAPIRepoResponseOperationsRequireWriteCredentialWhenSplit(t *testing.T) 
 	require.NoError(err)
 	srv.syncer.SetGitHubRouters(map[string]*ghclient.HostRouter{"github.com": router})
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
 	require.Equal(http.StatusOK, rr.Code)
 	var resp repoResponse
 	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
@@ -753,7 +754,7 @@ func TestAPIRepoResponseOperationsRequireWriteCredentialWhenSplit(t *testing.T) 
 	set.Upsert(splitTestDescriptor(tokenauth.Candidate{
 		Kind: tokenauth.SourceKindEnv, EnvName: "SPLIT_WRITE_CRED_PAT_NEW",
 	}))
-	rr = doJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
+	rr = testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
 	require.Equal(http.StatusOK, rr.Code)
 	resp = repoResponse{}
 	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
@@ -774,7 +775,7 @@ func TestAPIRepoResponseOperationsDistinguishWriteCredentialErrors(t *testing.T)
 		FilePath: filepath.Join(t.TempDir(), "does-not-exist.token"),
 	})
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
 	require.Equal(http.StatusOK, rr.Code)
 	var resp repoResponse
 	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
@@ -823,7 +824,7 @@ func TestAPIRepoResponseProbesRestartBoundWriteCredential(t *testing.T) {
 	)
 	require.NoError(err)
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
 	require.Equal(http.StatusOK, rr.Code)
 	var resp repoResponse
 	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
@@ -832,7 +833,7 @@ func TestAPIRepoResponseProbesRestartBoundWriteCredential(t *testing.T) {
 	assert.Equal(availabilityCodeWriteCredentialError, merge.Code)
 	assert.Contains(merge.UnavailableReason, "restart")
 
-	rr = doJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
+	rr = testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
 	require.Equal(http.StatusOK, rr.Code)
 	assert.Equal(1, client.calls, "routed write credential probes must use the TTL cache")
 }
@@ -862,7 +863,7 @@ func TestAPIRepoResponseDisablesWritesWhenConfiguredRouterHasNoRoute(t *testing.
 	)
 	require.NoError(err)
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/repo/github/other/widget", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/repo/github/other/widget", nil)
 	require.Equal(http.StatusOK, rr.Code)
 	var resp repoResponse
 	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
@@ -939,7 +940,7 @@ func TestAPIRepoResponseIncludesOperationsViewerCannotMerge(t *testing.T) {
 	// merge gate (not the capability gate) decides this case.
 	require.NoError(database.UpdateRepoViewerCanMerge(t.Context(), repoID, false))
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
 	require.Equal(http.StatusOK, rr.Code)
 
 	var resp repoResponse
@@ -974,7 +975,7 @@ func TestAPIPullDetailOperationsDisableSelfApproval(t *testing.T) {
 	// Keep merge available so this fixture isolates the self-approval gate.
 	require.NoError(database.UpdateRepoViewerCanMerge(t.Context(), repo.ID, true))
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/pulls/github/acme/widget/1", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/pulls/github/acme/widget/1", nil)
 	require.Equal(http.StatusOK, rr.Code)
 
 	var resp pullapi.MergeRequestDetailResponse
@@ -987,7 +988,7 @@ func TestAPIPullDetailOperationsDisableSelfApproval(t *testing.T) {
 	assert.Equal("You cannot approve your own pull request", submitReview.UnavailableReason)
 	assert.True(resp.Repo.Operations.MergePR.Available)
 
-	rr = doJSON(t, srv, http.MethodGet, "/api/v1/pulls/github/acme/widget/1", nil)
+	rr = testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/pulls/github/acme/widget/1", nil)
 	require.Equal(http.StatusOK, rr.Code)
 	assert.Equal(1, mock.authenticatedViewerCalls,
 		"provider should cache the authenticated viewer login")
@@ -1004,7 +1005,7 @@ func TestAPIPullDetailOperationsSkipViewerLookupWhenSubmitReviewUnavailable(t *t
 	}, mock)
 	seedPR(t, srv.db, "acme", "widget", 1, withSeedPRAuthor("marius"))
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/pulls/github/acme/widget/1", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/pulls/github/acme/widget/1", nil)
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	var resp pullapi.MergeRequestDetailResponse

--- a/internal/server/provider_descriptors_test.go
+++ b/internal/server/provider_descriptors_test.go
@@ -26,6 +26,7 @@ import (
 	"go.kenn.io/forge/internal/server/pullapi"
 	"go.kenn.io/forge/internal/testutil"
 	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 	"go.kenn.io/forge/internal/tokenauth"
 	gitcmd "go.kenn.io/kit/git/cmd"
 )
@@ -101,16 +102,16 @@ func TestNodeGitLabCloneReadsFetchMergeRequestHead(t *testing.T) {
 	const mrNumber = 7
 
 	work, remote, platformHost := setupHTTPWorktreeBaseForServerTest(t, "base-copy")
-	baseSHA := testGitSHA(t, work, "main")
-	runGit(t, work, "checkout", "-b", "contributor/fork", "main")
+	baseSHA := gitfixture.SHA(t, work, "main")
+	gitfixture.Run(t, work, "checkout", "-b", "contributor/fork", "main")
 	require.NoError(os.WriteFile(
 		filepath.Join(work, "gitlab-mr.txt"), []byte("merge request head\n"), 0o644,
 	))
-	runGit(t, work, "add", ".")
-	runGit(t, work, "commit", "-m", "gitlab merge request head")
-	headSHA := testGitSHA(t, work, "HEAD")
-	runGit(t, work, "push", remote, "HEAD:refs/merge-requests/7/head")
-	runGit(t, remote, "update-server-info")
+	gitfixture.Run(t, work, "add", ".")
+	gitfixture.Run(t, work, "commit", "-m", "gitlab merge request head")
+	headSHA := gitfixture.SHA(t, work, "HEAD")
+	gitfixture.Run(t, work, "push", remote, "HEAD:refs/merge-requests/7/head")
+	gitfixture.Run(t, remote, "update-server-info")
 	cloneURL := "http://" + platformHost + "/acme/widget.git"
 
 	hubDB := dbtest.Open(t)

--- a/internal/server/provider_descriptors_test.go
+++ b/internal/server/provider_descriptors_test.go
@@ -180,10 +180,10 @@ func TestNodeGitLabCloneReadsFetchMergeRequestHead(t *testing.T) {
 	})
 	t.Cleanup(func() { gracefulShutdown(t, nodeServer) })
 
-	response := doJSON(
+	response := testutil.DoJSON(
 		t, nodeServer, http.MethodGet,
-		"/api/v1/host/"+platformHost+"/pulls/gitlab/acme/widget/7/commits", nil,
-	)
+		"/api/v1/host/"+platformHost+"/pulls/gitlab/acme/widget/7/commits", nil)
+
 	require.Equal(http.StatusOK, response.Code, response.Body.String())
 	assert.Contains(response.Body.String(), headSHA)
 }
@@ -343,11 +343,11 @@ func TestRemoteAdHocWorkspaceCreationSeedsSpokeRepositoryCatalog(t *testing.T) {
 	})
 	t.Cleanup(func() { gracefulShutdown(t, spokeServer) })
 
-	response := doJSON(
+	response := testutil.DoJSON(
 		t, spokeServer, http.MethodPost,
 		"/api/v1/host/github.com/repo/github/acme/widget/workspaces",
-		map[string]any{"branch": "work/remote-create"},
-	)
+		map[string]any{"branch": "work/remote-create"})
+
 	require.Equal(http.StatusAccepted, response.Code, response.Body.String())
 	observed, err := spokeDB.GetRepositoryByProviderID(
 		t.Context(), "github", "github.com", "repo-acme-widget",
@@ -706,7 +706,7 @@ func TestNodeCloneReadsRequireFreshDescriptorAndComputeLocally(t *testing.T) {
 		"/api/v1/pulls/github/acme/widgets/1/file-preview?path=internal/cache.go",
 		"/api/v1/repo/github/acme/widgets/browser/refs",
 	} {
-		response := doJSON(t, nodeServer, http.MethodGet, path, nil)
+		response := testutil.DoJSON(t, nodeServer, http.MethodGet, path, nil)
 		require.Equal(http.StatusOK, response.Code, response.Body.String())
 	}
 
@@ -734,18 +734,18 @@ func TestNodeCloneReadsRequireFreshDescriptorAndComputeLocally(t *testing.T) {
 		},
 	)
 	t.Cleanup(func() { gracefulShutdown(t, credentiallessNode) })
-	credentialProblem := doJSON(
+	credentialProblem := testutil.DoJSON(
 		t, credentiallessNode, http.MethodGet,
-		"/api/v1/pulls/github/acme/widgets/1/diff", nil,
-	)
+		"/api/v1/pulls/github/acme/widgets/1/diff", nil)
+
 	require.Equal(http.StatusServiceUnavailable, credentialProblem.Code)
 	var problem httpapi.ProblemError
 	require.NoError(json.NewDecoder(credentialProblem.Body).Decode(&problem))
 	assert.Equal(httpapi.CodeGitCredentialUnavailable, problem.Code)
-	credentialBrowserProblem := doJSON(
+	credentialBrowserProblem := testutil.DoJSON(
 		t, credentiallessNode, http.MethodGet,
-		"/api/v1/repo/github/acme/widgets/browser/refs", nil,
-	)
+		"/api/v1/repo/github/acme/widgets/browser/refs", nil)
+
 	require.Equal(http.StatusServiceUnavailable, credentialBrowserProblem.Code)
 	require.NoError(json.NewDecoder(credentialBrowserProblem.Body).Decode(&problem))
 	assert.Equal(httpapi.CodeGitCredentialUnavailable, problem.Code)
@@ -755,17 +755,17 @@ func TestNodeCloneReadsRequireFreshDescriptorAndComputeLocally(t *testing.T) {
 	// the outage with httptest.Server.Close.
 	hubServer.Hub().Close()
 	hub.Close()
-	outage := doJSON(
+	outage := testutil.DoJSON(
 		t, nodeServer, http.MethodGet,
-		"/api/v1/pulls/github/acme/widgets/1/diff", nil,
-	)
+		"/api/v1/pulls/github/acme/widgets/1/diff", nil)
+
 	require.Equal(http.StatusServiceUnavailable, outage.Code, outage.Body.String())
 	require.NoError(json.NewDecoder(outage.Body).Decode(&problem))
 	assert.Equal(httpapi.CodeHubUnavailable, problem.Code)
-	browserOutage := doJSON(
+	browserOutage := testutil.DoJSON(
 		t, nodeServer, http.MethodGet,
-		"/api/v1/repo/github/acme/widgets/browser/refs", nil,
-	)
+		"/api/v1/repo/github/acme/widgets/browser/refs", nil)
+
 	require.Equal(http.StatusServiceUnavailable, browserOutage.Code)
 	require.NoError(json.NewDecoder(browserOutage.Body).Decode(&problem))
 	assert.Equal(httpapi.CodeHubUnavailable, problem.Code)

--- a/internal/server/provider_proxy_test.go
+++ b/internal/server/provider_proxy_test.go
@@ -26,6 +26,7 @@ import (
 	"go.kenn.io/forge/internal/server/issueapi"
 	"go.kenn.io/forge/internal/server/pullapi"
 	"go.kenn.io/forge/internal/server/workspaceapi"
+	"go.kenn.io/forge/internal/testutil"
 	"go.kenn.io/forge/internal/testutil/dbtest"
 	"go.kenn.io/forge/internal/workspace"
 )
@@ -64,7 +65,7 @@ func (*failingProviderResponseBody) Close() error { return nil }
 func TestProviderProxyPreservesHubResponse(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	t.Parallel()
+	runParallelServerTest(t)
 
 	hub := httptest.NewTLSServer(http.HandlerFunc(func(
 		w http.ResponseWriter, _ *http.Request,
@@ -99,7 +100,7 @@ func TestProviderProxyPreservesHubResponse(t *testing.T) {
 func TestHubUnavailableDoesNotFallBackToLocalProviderHandler(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	t.Parallel()
+	runParallelServerTest(t)
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(err)
@@ -130,7 +131,7 @@ func TestHubUnavailableDoesNotFallBackToLocalProviderHandler(t *testing.T) {
 func TestNodeHEADProviderReadUsesHubGETOwnership(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	t.Parallel()
+	runParallelServerTest(t)
 
 	var hubReads atomic.Int64
 	hub := httptest.NewTLSServer(http.HandlerFunc(func(
@@ -518,7 +519,7 @@ func TestSpokeUnassignedActivityUsesHubAssignmentWithoutLocalProviderRows(t *tes
 func TestNodeServerRoutesProviderReadsWithoutUsingLocalTables(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	t.Parallel()
+	runParallelServerTest(t)
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(err)
@@ -774,7 +775,7 @@ func TestFederatedReviewDraftHasOneHubOwner(t *testing.T) {
 		t, "66666666666666666666666666666666", hub.URL, hub.Client(),
 	)
 	path := "/api/v1/host/gitlab.example.com/pulls/gl/group/project/7/review-draft"
-	created := doJSON(t, nodeA, http.MethodPost, path+"/comments", map[string]any{
+	created := testutil.DoJSON(t, nodeA, http.MethodPost, path+"/comments", map[string]any{
 		"body": "comment from spoke A",
 		"range": map[string]any{
 			"path": "internal/server/provider_proxy_test.go", "side": "right",
@@ -782,6 +783,7 @@ func TestFederatedReviewDraftHasOneHubOwner(t *testing.T) {
 			"diff_head_sha": "abc123", "commit_sha": "abc123",
 		},
 	})
+
 	require.Equal(http.StatusCreated, created.Code, created.Body.String())
 	var createdComment struct {
 		ID string `json:"id"`
@@ -789,7 +791,7 @@ func TestFederatedReviewDraftHasOneHubOwner(t *testing.T) {
 	require.NoError(json.NewDecoder(created.Body).Decode(&createdComment))
 	require.NotEmpty(createdComment.ID)
 
-	edited := doJSON(t, nodeA, http.MethodPatch, path+"/comments/"+createdComment.ID, map[string]any{
+	edited := testutil.DoJSON(t, nodeA, http.MethodPatch, path+"/comments/"+createdComment.ID, map[string]any{
 		"body": "edited comment from spoke A",
 		"range": map[string]any{
 			"path": "internal/server/provider_proxy_test.go", "side": "right",
@@ -797,9 +799,10 @@ func TestFederatedReviewDraftHasOneHubOwner(t *testing.T) {
 			"diff_head_sha": "abc123", "commit_sha": "abc123",
 		},
 	})
+
 	require.Equal(http.StatusOK, edited.Code, edited.Body.String())
 
-	read := doJSON(t, nodeB, http.MethodGet, path, nil)
+	read := testutil.DoJSON(t, nodeB, http.MethodGet, path, nil)
 	require.Equal(http.StatusOK, read.Code, read.Body.String())
 	var draft map[string]any
 	require.NoError(json.NewDecoder(read.Body).Decode(&draft))
@@ -810,9 +813,10 @@ func TestFederatedReviewDraftHasOneHubOwner(t *testing.T) {
 	require.True(ok)
 	assert.Equal("edited comment from spoke A", comment["body"])
 
-	published := doJSON(t, nodeB, http.MethodPost, path+"/publish", map[string]any{
+	published := testutil.DoJSON(t, nodeB, http.MethodPost, path+"/publish", map[string]any{
 		"action": "comment",
 	})
+
 	require.Equal(http.StatusOK, published.Code, published.Body.String())
 	assert.Len(provider.publishedReviews, 1)
 
@@ -916,7 +920,7 @@ func newFederatedProviderNodeForTest(
 func TestProviderProxyMapsHubTimeoutToUnavailable(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	t.Parallel()
+	runParallelServerTest(t)
 
 	hub := httptest.NewTLSServer(http.HandlerFunc(func(
 		w http.ResponseWriter, r *http.Request,
@@ -998,7 +1002,7 @@ func newProviderProxyTestServer(
 }
 
 func TestProviderProxyHonorsCallerCancellation(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 
 	hub := httptest.NewTLSServer(http.HandlerFunc(func(
 		w http.ResponseWriter, r *http.Request,
@@ -1021,7 +1025,7 @@ func TestProviderProxyHonorsCallerCancellation(t *testing.T) {
 func TestProviderProxyRejectsOversizedHubResponse(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	t.Parallel()
+	runParallelServerTest(t)
 
 	hub := httptest.NewTLSServer(http.HandlerFunc(func(
 		w http.ResponseWriter, _ *http.Request,

--- a/internal/server/provider_route_policy_test.go
+++ b/internal/server/provider_route_policy_test.go
@@ -12,7 +12,7 @@ import (
 func TestProviderRouteCoverage(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	t.Parallel()
+	runParallelServerTest(t)
 
 	registered, err := RegisteredTransportOperations()
 	require.NoError(err)
@@ -43,7 +43,7 @@ func TestProviderRouteCoverage(t *testing.T) {
 }
 
 func TestProviderRouteCoverageRejectsUnknownAndDuplicateOperations(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 
 	registered := []RegisteredTransportOperation{{ID: "known"}}
 	_, err := buildProviderRouteRules(registered, []ProviderRouteRule{{
@@ -64,7 +64,7 @@ func TestProviderRouteCoverageRejectsUnknownAndDuplicateOperations(t *testing.T)
 
 func TestProviderRouteOwnershipExamples(t *testing.T) {
 	assert := assert.New(t)
-	t.Parallel()
+	runParallelServerTest(t)
 
 	rules, err := providerRouteRules()
 	require.NoError(t, err)

--- a/internal/server/roborev_proxy_test.go
+++ b/internal/server/roborev_proxy_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/config"
 	ghclient "go.kenn.io/forge/internal/github"
+	"go.kenn.io/forge/internal/testutil"
 	"go.kenn.io/forge/internal/testutil/dbtest"
 )
 
@@ -85,7 +86,7 @@ func TestRoborevProxyForwarding(t *testing.T) {
 
 	srv := setupTestServerWithRoborev(t, daemon.URL)
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/roborev/jobs", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/roborev/jobs", nil)
 	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
 
 	mu.Lock()
@@ -112,7 +113,7 @@ func TestRoborevProxyRejectsDeclaredStreamsWithoutAccept(t *testing.T) {
 		"/api/roborev/api/job/output?job_id=7&stream=1",
 	} {
 		t.Run(target, func(t *testing.T) {
-			rr := doJSON(t, srv, http.MethodGet, target, nil)
+			rr := testutil.DoJSON(t, srv, http.MethodGet, target, nil)
 
 			assert.Equal(t, http.StatusNotAcceptable, rr.Code)
 			assert.Contains(t, rr.Body.String(), "requires an explicit Accept header")
@@ -187,9 +188,9 @@ func TestRoborevProxy502(t *testing.T) {
 
 	srv := setupTestServerWithRoborev(t, "http://127.0.0.1:1")
 
-	rr := doJSON(
-		t, srv, http.MethodGet, "/api/roborev/jobs", nil,
-	)
+	rr := testutil.DoJSON(
+		t, srv, http.MethodGet, "/api/roborev/jobs", nil)
+
 	require.Equal(t, http.StatusBadGateway, rr.Code)
 
 	var body map[string]string
@@ -218,10 +219,10 @@ func TestRoborevHealthProbeAvailable(t *testing.T) {
 
 	srv := setupTestServerWithRoborev(t, daemon.URL)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodGet,
-		"/api/v1/roborev/status", nil,
-	)
+		"/api/v1/roborev/status", nil)
+
 	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
 
 	var resp roborevStatusResponse
@@ -236,10 +237,10 @@ func TestRoborevHealthProbeUnavailable(t *testing.T) {
 
 	srv := setupTestServerWithRoborev(t, "http://127.0.0.1:1")
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodGet,
-		"/api/v1/roborev/status", nil,
-	)
+		"/api/v1/roborev/status", nil)
+
 	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
 
 	var resp roborevStatusResponse

--- a/internal/server/roborev_repositories_test.go
+++ b/internal/server/roborev_repositories_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/projects"
+	"go.kenn.io/forge/internal/testutil"
 )
 
 func TestRoborevRepositoryProbeCachesDefinitiveResultsAndDeduplicatesIdentity(t *testing.T) {
@@ -466,7 +467,7 @@ func TestListRoborevConfiguredRepositories(t *testing.T) {
 		inspectHook:     func(string) (bool, error) { return true, nil },
 	})
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/roborev/configured-repositories", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/roborev/configured-repositories", nil)
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	var body struct {
 		Repositories []roborevConfiguredRepositoryResponse `json:"repositories"`
@@ -502,7 +503,7 @@ func TestListRoborevConfiguredRepositoriesMarksPartialResultsIncomplete(t *testi
 		inspectHook: func(string) (bool, error) { return true, nil },
 	})
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/roborev/configured-repositories", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/roborev/configured-repositories", nil)
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	var body roborevConfiguredRepositoriesResponse
 	require.NoError(json.NewDecoder(rr.Body).Decode(&body))
@@ -522,7 +523,7 @@ func TestListRoborevConfiguredRepositoriesReturnsTypedUnavailableWithoutBlocking
 		},
 	})
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/roborev/configured-repositories", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/roborev/configured-repositories", nil)
 	require.Equal(http.StatusServiceUnavailable, rr.Code)
 	assert.Equal("application/problem+json", rr.Header().Get("Content-Type"))
 	var problem struct {
@@ -535,6 +536,6 @@ func TestListRoborevConfiguredRepositoriesReturnsTypedUnavailableWithoutBlocking
 	assert.NotContains(rr.Body.String(), "private.invalid")
 	assert.NotContains(rr.Body.String(), "/private/checkout")
 
-	summaries := doJSON(t, srv, http.MethodGet, "/api/v1/repos/summary", nil)
+	summaries := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/repos/summary", nil)
 	assert.Equal(http.StatusOK, summaries.Code)
 }

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -35,6 +35,7 @@ import (
 	"go.kenn.io/forge/internal/stacks"
 	"go.kenn.io/forge/internal/testutil"
 	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 	"go.kenn.io/forge/internal/workspace"
 	"go.kenn.io/forge/internal/workspace/localruntime"
 )
@@ -4200,8 +4201,8 @@ base_url = %q
 	worktreeBase := t.TempDir()
 	canonicalWorktreeBase, err := filepath.EvalSymlinks(worktreeBase)
 	require.NoError(err)
-	runGit(t, worktreeBase, "init", "--initial-branch=main")
-	runGit(t, worktreeBase, "remote", "add", "origin", "https://github.com/acme/widget.git")
+	gitfixture.Run(t, worktreeBase, "init", "--initial-branch=main")
+	gitfixture.Run(t, worktreeBase, "remote", "add", "origin", "https://github.com/acme/widget.git")
 	response = testutil.DoJSON(
 		t, spoke, http.MethodPut,
 		"/api/v1/repo/github/acme/widget/worktree-base",
@@ -4270,8 +4271,8 @@ port = 8091
 	worktreeBase := t.TempDir()
 	canonicalWorktreeBase, err := filepath.EvalSymlinks(worktreeBase)
 	require.NoError(err)
-	runGit(t, worktreeBase, "init", "--initial-branch=main")
-	runGit(t, worktreeBase, "remote", "add", "origin", "https://github.com/acme/late.git")
+	gitfixture.Run(t, worktreeBase, "init", "--initial-branch=main")
+	gitfixture.Run(t, worktreeBase, "remote", "add", "origin", "https://github.com/acme/late.git")
 
 	response := testutil.DoJSON(
 		t, srv, http.MethodPut, "/api/v1/repo/github/acme/late/worktree-base",

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -33,6 +33,7 @@ import (
 	"go.kenn.io/forge/internal/providerplane"
 	"go.kenn.io/forge/internal/server/httpapi"
 	"go.kenn.io/forge/internal/stacks"
+	"go.kenn.io/forge/internal/testutil"
 	"go.kenn.io/forge/internal/testutil/dbtest"
 	"go.kenn.io/forge/internal/workspace"
 	"go.kenn.io/forge/internal/workspace/localruntime"
@@ -371,33 +372,6 @@ func (t *gitealikeImportTransport) ListStatuses(
 	return nil, gitealike.Page{}, errors.New("unexpected ListStatuses call")
 }
 
-func doJSON(
-	t *testing.T,
-	srv *Server,
-	method, path string,
-	body any,
-) *httptest.ResponseRecorder {
-	t.Helper()
-	var buf bytes.Buffer
-	if body != nil {
-		require.NoError(t, json.NewEncoder(&buf).Encode(body))
-	}
-	req := httptest.NewRequest(method, path, &buf)
-	// httptest.NewRequest defaults the Host to "example.com" via the
-	// "/path" URL; tests built on doJSON use either the cfg=nil
-	// test-friendly default (loopback IP at any port is allowed)
-	// or a validated cfg whose bind is 127.0.0.1:8091. Sending the
-	// bind value here keeps both paths happy through the Host
-	// validation middleware without per-test churn.
-	req.Host = "127.0.0.1:8091"
-	if method != http.MethodGet {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	rr := httptest.NewRecorder()
-	srv.ServeHTTP(rr, req)
-	return rr
-}
-
 func TestHandleGetSettings(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -417,7 +391,7 @@ label = "Codex"
 command = ["codex", "--full-auto"]
 `, &mockGH{})
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	assert.NotContains(rr.Body.String(), `"default_agent"`)
 	assert.Contains(rr.Body.String(), `"launch_targets"`)
@@ -470,7 +444,7 @@ diff_cache_mb = 256
 	})
 	srv.bootCfgSnapshot.RequireAuth = true
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	var resp settingsResponse
@@ -489,9 +463,10 @@ func TestHandleUpdateSettingsPersistsMCPAndReportsRestartRequired(t *testing.T) 
 	srv, _, cfgPath := setupTestServerWithConfig(t)
 
 	mcp := config.MCP{Enabled: true, Port: 9092, DiffCacheMB: 256}
-	rr := doJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{MCP: &mcpSettingsUpdate{
+	rr := testutil.DoJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{MCP: &mcpSettingsUpdate{
 		Enabled: new(true), Port: new(9092), DiffCacheMB: new(256),
 	}})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	var resp settingsResponse
@@ -517,15 +492,17 @@ func TestHandleUpdateSettingsMergesMCPFields(t *testing.T) {
 	srv.cfg.MCP = config.MCP{Port: 9092, DiffCacheMB: 256}
 	require.NoError(srv.cfg.Save(cfgPath))
 
-	rr := doJSON(t, srv, http.MethodPut, "/api/v1/settings", map[string]any{
+	rr := testutil.DoJSON(t, srv, http.MethodPut, "/api/v1/settings", map[string]any{
 		"mcp": map[string]any{"enabled": true},
 	})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	assert.Equal(config.MCP{Enabled: true, Port: 9092, DiffCacheMB: 256}, srv.cfg.MCP)
 
-	rr = doJSON(t, srv, http.MethodPut, "/api/v1/settings", map[string]any{
+	rr = testutil.DoJSON(t, srv, http.MethodPut, "/api/v1/settings", map[string]any{
 		"mcp": map[string]any{"port": 0},
 	})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	assert.Equal(config.MCP{Enabled: true, DiffCacheMB: 256}, srv.cfg.MCP)
 
@@ -539,9 +516,10 @@ func TestHandleUpdateSettingsPersistsRoborevManagedCloneInit(t *testing.T) {
 	assert := assert.New(t)
 	srv, _, cfgPath := setupTestServerWithConfig(t)
 
-	rr := doJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
+	rr := testutil.DoJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
 		Roborev: &roborevSettingsUpdate{InitManagedClones: new(true)},
 	})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	var resp settingsResponse
@@ -557,9 +535,10 @@ func TestHandleUpdateSettingsRejectsInvalidMCPWithoutPublishing(t *testing.T) {
 	assert := assert.New(t)
 	srv, _, cfgPath := setupTestServerWithConfig(t)
 
-	rr := doJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{MCP: &mcpSettingsUpdate{
+	rr := testutil.DoJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{MCP: &mcpSettingsUpdate{
 		Enabled: new(true), Port: new(8091),
 	}})
+
 	require.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
 	assert.Equal(config.MCP{}, srv.cfg.MCP)
 
@@ -583,7 +562,7 @@ owner = "acme"
 name = "widget"
 `, &mockGH{})
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	// kata_projects is a required non-null array in the schema. Assert on the
@@ -600,7 +579,7 @@ func TestHandleGetSettingsEncodesEmptyRepoPresetsAsArray(t *testing.T) {
 	assert := assert.New(t)
 	srv, _, _ := setupTestServerWithConfig(t)
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	var raw map[string]json.RawMessage
@@ -620,20 +599,21 @@ func TestRepoPresetMutationsAreAtomic(t *testing.T) {
 		Provider: "gitlab", PlatformHost: "git.example.com", PlatformRepoID: "42", RepoPath: "group/docs",
 	}}}
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/settings/repo-presets", first)
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/settings/repo-presets", first)
 	require.Equal(http.StatusCreated, rr.Code, rr.Body.String())
-	rr = doJSON(t, srv, http.MethodPost, "/api/v1/settings/repo-presets", second)
+	rr = testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/settings/repo-presets", second)
 	require.Equal(http.StatusCreated, rr.Code, rr.Body.String())
 
 	updatedRepos := []config.RepoPresetRepository{{
 		Provider: "github", PlatformHost: "github.com", PlatformRepoID: "R_tools", RepoPath: "acme/tools",
 	}}
-	rr = doJSON(t, srv, http.MethodPut, "/api/v1/settings/repo-presets/Review%20queue", struct {
+	rr = testutil.DoJSON(t, srv, http.MethodPut, "/api/v1/settings/repo-presets/Review%20queue", struct {
 		Repos []config.RepoPresetRepository `json:"repos"`
 	}{Repos: updatedRepos})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
-	rr = doJSON(t, srv, http.MethodDelete, "/api/v1/settings/repo-presets/Review%20queue", nil)
+	rr = testutil.DoJSON(t, srv, http.MethodDelete, "/api/v1/settings/repo-presets/Review%20queue", nil)
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	var resp settingsResponse
@@ -644,7 +624,7 @@ func TestRepoPresetMutationsAreAtomic(t *testing.T) {
 	require.NoError(err)
 	assert.Equal([]config.RepoPreset{second}, reloaded.RepoPresets)
 
-	rr = doJSON(t, srv, http.MethodPost, "/api/v1/settings/repo-presets", second)
+	rr = testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/settings/repo-presets", second)
 	assert.Equal(http.StatusConflict, rr.Code)
 }
 
@@ -671,7 +651,7 @@ repos = [{ provider = "github", platform_host = "github.com", platform_repo_id =
 	replacement := config.RepoPreset{Name: "Replacement", Repos: []config.RepoPresetRepository{{
 		Provider: "github", PlatformHost: "github.com", PlatformRepoID: "R_other", RepoPath: "acme/other",
 	}}}
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/settings/repo-presets", replacement)
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/settings/repo-presets", replacement)
 	require.Equal(http.StatusInternalServerError, rr.Code, rr.Body.String())
 	require.Equal([]config.RepoPreset{{Name: "Existing", Repos: []config.RepoPresetRepository{{
 		Provider: "github", PlatformHost: "github.com", PlatformRepoID: "R_widget", RepoPath: "acme/widget",
@@ -687,10 +667,10 @@ func TestHandleUpdateSettingsPersistsModes(t *testing.T) {
 	*modes.Docs = true
 	*modes.Workspaces = false
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodPut, "/api/v1/settings",
-		updateSettingsRequest{Modes: &modes},
-	)
+		updateSettingsRequest{Modes: &modes})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	var resp settingsResponse
@@ -724,10 +704,11 @@ func TestHandleUpdateSettingsPublishesPullConfigOnlyAfterPersistence(t *testing.
 	enabled := config.PullRequests{AllowMidStackMerges: true}
 	activityEnabled := srv.cfg.Activity
 	activityEnabled.UseWorkspaceActivityForRecency = true
-	rr := doJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
+	rr := testutil.DoJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
 		PullRequests: &enabled,
 		Activity:     &activityEnabled,
 	})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	require.True(srv.pullAPI.ConfigSnapshot().AllowMidStackMerges)
 	require.True(srv.pullAPI.ConfigSnapshot().UseWorkspaceActivityForRecency)
@@ -741,10 +722,11 @@ func TestHandleUpdateSettingsPublishesPullConfigOnlyAfterPersistence(t *testing.
 	disabled := config.PullRequests{AllowMidStackMerges: false}
 	activityDisabled := activityEnabled
 	activityDisabled.UseWorkspaceActivityForRecency = false
-	rr = doJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
+	rr = testutil.DoJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
 		PullRequests: &disabled,
 		Activity:     &activityDisabled,
 	})
+
 	require.Equal(http.StatusInternalServerError, rr.Code, rr.Body.String())
 	require.True(
 		srv.pullAPI.ConfigSnapshot().AllowMidStackMerges,
@@ -803,10 +785,10 @@ func TestHandleUpdateSettingsPersistsKataProjectMappings(t *testing.T) {
 			RepoPath:     "acme/widget",
 		},
 	}
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodPut, "/api/v1/settings",
-		updateSettingsRequest{KataProjects: &mappings},
-	)
+		updateSettingsRequest{KataProjects: &mappings})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	var resp settingsResponse
@@ -868,9 +850,9 @@ func TestHandleUpdateSettings(t *testing.T) {
 		Workspaces: &workspaces,
 		Terminal:   &terminal,
 	}
-	rr := doJSON(
-		t, srv, http.MethodPut, "/api/v1/settings", body,
-	)
+	rr := testutil.DoJSON(
+		t, srv, http.MethodPut, "/api/v1/settings", body)
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	// Verify persisted to disk.
@@ -903,9 +885,10 @@ func TestHandleUpdateSettingsMergesWorkspaceFields(t *testing.T) {
 	require.NoError(srv.cfg.Save(cfgPath))
 
 	defaultSidebarView := "item"
-	rr := doJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
+	rr := testutil.DoJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
 		Workspaces: &workspaceSettingsUpdate{DefaultSidebarView: &defaultSidebarView},
 	})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	cfg2, err := config.Load(cfgPath)
@@ -956,9 +939,10 @@ prefer_github_native_stacks = true
 	assert.Equal([]int64{11, 10}, stackMemberNumbers(*before.JSON200.Members))
 
 	disabled := config.PullRequests{}
-	rr := doJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
+	rr := testutil.DoJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
 		PullRequests: &disabled,
 	})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	after, err := client.HTTP.GetPullStackWithResponse(ctx, "gh", "acme", "widget", 10)
 	require.NoError(err)
@@ -1002,9 +986,9 @@ docs = false
 	body := updateSettingsRequest{
 		Terminal: &terminal,
 	}
-	rr := doJSON(
-		t, srv, http.MethodPut, "/api/v1/settings", body,
-	)
+	rr := testutil.DoJSON(
+		t, srv, http.MethodPut, "/api/v1/settings", body)
+
 	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
 
 	cfg2, err := config.Load(cfgPath)
@@ -1042,9 +1026,10 @@ name = "widget"
 	terminal := srv.cfg.Terminal
 	srv.cfgMu.Unlock()
 	terminal.TmuxMouse = new(false)
-	rr := doJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
+	rr := testutil.DoJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
 		Terminal: &terminal,
 	})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	assert.Equal(t, []string{
 		"-L kenn-forge list-sessions -F #{session_name}:#{@forge_owner}",
@@ -1074,9 +1059,10 @@ name = "widget"
 	terminal := srv.cfg.Terminal
 	srv.cfgMu.Unlock()
 	terminal.Graphics = new(false)
-	rr := doJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
+	rr := testutil.DoJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
 		Terminal: &terminal,
 	})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	assert.Equal(t, []string{
 		"-L kenn-forge set-option -q -g allow-passthrough off",
@@ -1105,9 +1091,9 @@ func TestHandleUpdateSettingsPersistsAgents(t *testing.T) {
 	}}
 
 	body := updateSettingsRequest{Agents: &agents}
-	rr := doJSON(
-		t, srv, http.MethodPut, "/api/v1/settings", body,
-	)
+	rr := testutil.DoJSON(
+		t, srv, http.MethodPut, "/api/v1/settings", body)
+
 	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
 
 	cfg2, err := config.Load(cfgPath)
@@ -1154,10 +1140,10 @@ name = "widget"
 		Label:   "Custom Codex",
 		Command: []string{agentPath, "--full-auto"},
 	}}
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodPut, "/api/v1/settings",
-		updateSettingsRequest{Agents: &agents},
-	)
+		updateSettingsRequest{Agents: &agents})
+
 	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
 
 	target := findRuntimeTargetForSettingsTest(
@@ -1194,9 +1180,9 @@ func TestHandleUpdateSettingsInvalid(t *testing.T) {
 	body := updateSettingsRequest{
 		Activity: &activity,
 	}
-	rr := doJSON(
-		t, srv, http.MethodPut, "/api/v1/settings", body,
-	)
+	rr := testutil.DoJSON(
+		t, srv, http.MethodPut, "/api/v1/settings", body)
+
 	require.Equal(t, http.StatusUnprocessableEntity, rr.Code, rr.Body.String())
 
 	// Verify config was NOT modified (rollback).
@@ -1214,9 +1200,9 @@ func TestHandleAddRepo(t *testing.T) {
 		"owner":    "other-org",
 		"name":     "other-repo",
 	}
-	rr := doJSON(
-		t, srv, http.MethodPost, "/api/v1/repos", body,
-	)
+	rr := testutil.DoJSON(
+		t, srv, http.MethodPost, "/api/v1/repos", body)
+
 	require.Equal(t, http.StatusCreated, rr.Code, rr.Body.String())
 
 	cfg2, err := config.Load(cfgPath)
@@ -1249,12 +1235,13 @@ owner = "acme"
 name = "widget"
 `, mock)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/repos", map[string]string{
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/repos", map[string]string{
 		"provider": "github",
 		"host":     "github.com",
 		"owner":    "other-org",
 		"name":     "frozen",
 	})
+
 	require.Equal(http.StatusCreated, rr.Code, rr.Body.String())
 
 	cfg2, err := config.Load(cfgPath)
@@ -1303,12 +1290,13 @@ name = "*"
 	// The repo gets archived on the provider; adding an overlapping exact
 	// entry must refresh the tracked ref, not keep the stale live one.
 	archivedNow.Store(true)
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/repos", map[string]string{
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/repos", map[string]string{
 		"provider": "github",
 		"host":     "github.com",
 		"owner":    "acme",
 		"name":     "widget",
 	})
+
 	require.Equal(http.StatusCreated, rr.Code, rr.Body.String())
 
 	assert.True(trackedRepoArchived(srv, "acme", "widget"),
@@ -1360,10 +1348,10 @@ name = "*"
 	// provider archives it must update the tracked ref even though the
 	// exact entry keeps it in the tracked set.
 	archivedNow.Store(true)
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodPost,
-		"/api/v1/repo/gh/acme/*/refresh", nil,
-	)
+		"/api/v1/repo/gh/acme/*/refresh", nil)
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	assert.True(trackedRepoArchived(srv, "acme", "widget"),
@@ -1478,10 +1466,10 @@ name = "*"
 	// the live lanes must stop touching it while the live sibling keeps
 	// syncing.
 	archivedNow.Store(true)
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodPost,
-		"/api/v1/repo/gh/acme/*/refresh", nil,
-	)
+		"/api/v1/repo/gh/acme/*/refresh", nil)
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	require.True(trackedRepoArchived(srv, "acme", "widget"))
 
@@ -1702,15 +1690,15 @@ name = "widget"
 	// cooldown path as a user clicking Sync right after a recent sync.
 	syncer.RunOnce(t.Context())
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodPost, "/api/v1/repos",
 		map[string]string{
 			"provider": "github",
 			"host":     "github.com",
 			"owner":    "other-org",
 			"name":     "other-repo",
-		},
-	)
+		})
+
 	require.Equal(http.StatusCreated, rr.Code, rr.Body.String())
 
 	require.Eventually(func() bool {
@@ -1740,9 +1728,9 @@ func TestHandleAddRepoDuplicate(t *testing.T) {
 		"owner":    "acme",
 		"name":     "widget",
 	}
-	rr := doJSON(
-		t, srv, http.MethodPost, "/api/v1/repos", body,
-	)
+	rr := testutil.DoJSON(
+		t, srv, http.MethodPost, "/api/v1/repos", body)
+
 	require.Equal(t, http.StatusBadRequest, rr.Code, rr.Body.String())
 }
 
@@ -1757,15 +1745,15 @@ func TestHandleDeleteRepo(t *testing.T) {
 		"owner":    "other-org",
 		"name":     "other-repo",
 	}
-	addRR := doJSON(
-		t, srv, http.MethodPost, "/api/v1/repos", addBody,
-	)
+	addRR := testutil.DoJSON(
+		t, srv, http.MethodPost, "/api/v1/repos", addBody)
+
 	require.Equal(http.StatusCreated, addRR.Code, addRR.Body.String())
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodDelete,
-		"/api/v1/repo/gh/acme/widget", nil,
-	)
+		"/api/v1/repo/gh/acme/widget", nil)
+
 	require.Equal(http.StatusNoContent, rr.Code, rr.Body.String())
 
 	cfg2, err := config.Load(cfgPath)
@@ -1785,9 +1773,9 @@ func TestHandleDeleteRepoPreservesKataProjectMappings(t *testing.T) {
 		"owner":    "other-org",
 		"name":     "other-repo",
 	}
-	addRR := doJSON(
-		t, srv, http.MethodPost, "/api/v1/repos", addBody,
-	)
+	addRR := testutil.DoJSON(
+		t, srv, http.MethodPost, "/api/v1/repos", addBody)
+
 	require.Equal(http.StatusCreated, addRR.Code, addRR.Body.String())
 
 	mappings := []config.KataProjectRepoMapping{
@@ -1806,16 +1794,16 @@ func TestHandleDeleteRepoPreservesKataProjectMappings(t *testing.T) {
 			RepoPath:     "other-org/other-repo",
 		},
 	}
-	updateRR := doJSON(
+	updateRR := testutil.DoJSON(
 		t, srv, http.MethodPut, "/api/v1/settings",
-		updateSettingsRequest{KataProjects: &mappings},
-	)
+		updateSettingsRequest{KataProjects: &mappings})
+
 	require.Equal(http.StatusOK, updateRR.Code, updateRR.Body.String())
 
-	deleteRR := doJSON(
+	deleteRR := testutil.DoJSON(
 		t, srv, http.MethodDelete,
-		"/api/v1/repo/gh/acme/widget", nil,
-	)
+		"/api/v1/repo/gh/acme/widget", nil)
+
 	require.Equal(http.StatusNoContent, deleteRR.Code, deleteRR.Body.String())
 
 	cfg2, err := config.Load(cfgPath)
@@ -1854,7 +1842,7 @@ func TestGetSettingsWithoutPersistence(t *testing.T) {
 	srv := New(database, syncer, nil, "/", cfg, ServerOptions{})
 
 	// GET /settings should work (read-only).
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	var resp settingsResponse
@@ -1864,21 +1852,24 @@ func TestGetSettingsWithoutPersistence(t *testing.T) {
 	assert.Equal("flat", resp.Activity.ViewMode)
 
 	// Mutations should be rejected (no cfgPath).
-	mutRR := doJSON(t, srv, http.MethodPut, "/api/v1/settings",
+	mutRR := testutil.DoJSON(t, srv, http.MethodPut, "/api/v1/settings",
 		updateSettingsRequest{Activity: &cfg.Activity})
+
 	assert.Equal(http.StatusNotFound, mutRR.Code)
 
-	addRR := doJSON(t, srv, http.MethodPost, "/api/v1/repos",
+	addRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/repos",
 		map[string]string{
 			"provider": "github",
 			"host":     "github.com",
 			"owner":    "x",
 			"name":     "y",
 		})
+
 	assert.Equal(http.StatusNotFound, addRR.Code)
 
-	delRR := doJSON(t, srv, http.MethodDelete,
+	delRR := testutil.DoJSON(t, srv, http.MethodDelete,
 		"/api/v1/repo/gh/acme/widget", nil)
+
 	assert.Equal(http.StatusNotFound, delRR.Code)
 }
 
@@ -1887,14 +1878,14 @@ func TestDetailSettingsReadPersistAndRejectInvalidLimit(t *testing.T) {
 	require := require.New(t)
 	srv, _, cfgPath := setupTestServerWithConfig(t)
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	var initial settingsResponse
 	require.NoError(json.NewDecoder(rr.Body).Decode(&initial))
 	assert.Equal(config.DefaultInitialTimelineEntryLimit, initial.Detail.InitialTimelineEntryLimit)
 
 	updated := config.Detail{InitialTimelineEntryLimit: 80}
-	rr = doJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{Detail: &updated})
+	rr = testutil.DoJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{Detail: &updated})
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	var saved settingsResponse
 	require.NoError(json.NewDecoder(rr.Body).Decode(&saved))
@@ -1904,7 +1895,7 @@ func TestDetailSettingsReadPersistAndRejectInvalidLimit(t *testing.T) {
 	assert.Equal(80, persisted.Detail.InitialTimelineEntryLimit)
 
 	invalid := config.Detail{InitialTimelineEntryLimit: 9}
-	rr = doJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{Detail: &invalid})
+	rr = testutil.DoJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{Detail: &invalid})
 	require.Equal(http.StatusUnprocessableEntity, rr.Code, rr.Body.String())
 	persisted, err = config.Load(cfgPath)
 	require.NoError(err)
@@ -1914,10 +1905,10 @@ func TestDetailSettingsReadPersistAndRejectInvalidLimit(t *testing.T) {
 func TestHandleDeleteLastRepo(t *testing.T) {
 	srv, _, cfgPath := setupTestServerWithConfig(t)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodDelete,
-		"/api/v1/repo/gh/acme/widget", nil,
-	)
+		"/api/v1/repo/gh/acme/widget", nil)
+
 	require.Equal(t, http.StatusNoContent, rr.Code, rr.Body.String())
 
 	cfg2, err := config.Load(cfgPath)
@@ -1962,7 +1953,7 @@ owner = "roborev-dev"
 name = "*"
 `, mock)
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	var resp settingsResponse
@@ -2012,10 +2003,10 @@ owner = "roborev-dev"
 name = "*"
 `, mock)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodPost,
-		"/api/v1/repo/gh/roborev-dev/*/refresh", nil,
-	)
+		"/api/v1/repo/gh/roborev-dev/*/refresh", nil)
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	var resp settingsResponse
@@ -2076,10 +2067,10 @@ name = "*"
 	srv.syncer.Stop()
 	includeRefreshRepo.Store(true)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodPost,
-		"/api/v1/repo/gh/roborev-dev/*/refresh", nil,
-	)
+		"/api/v1/repo/gh/roborev-dev/*/refresh", nil)
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	repos, err := database.ListRepos(t.Context())
@@ -2133,10 +2124,10 @@ owner = "roborev-dev"
 name = "worker"
 `, mock)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodPost,
-		"/api/v1/repo/gh/roborev-dev/*/refresh", nil,
-	)
+		"/api/v1/repo/gh/roborev-dev/*/refresh", nil)
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	var resp settingsResponse
@@ -2184,10 +2175,10 @@ owner = "roborev-dev"
 name = "tools"
 `, mock)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodDelete,
-		"/api/v1/repo/gh/roborev-dev/*", nil,
-	)
+		"/api/v1/repo/gh/roborev-dev/*", nil)
+
 	require.Equal(t, http.StatusNoContent, rr.Code, rr.Body.String())
 	assert.True(t, srv.syncer.IsTrackedRepo("roborev-dev", "tools"))
 	assert.False(t, srv.syncer.IsTrackedRepo("roborev-dev", "kenn-forge"))
@@ -2243,10 +2234,10 @@ name = "*"
 		},
 	})
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodDelete,
-		"/api/v1/repo/gh/acme/*", nil,
-	)
+		"/api/v1/repo/gh/acme/*", nil)
+
 	require.Equal(t, http.StatusNoContent, rr.Code, rr.Body.String())
 	assert.True(t, srv.syncer.IsTrackedRepo("acme", "tools-new"),
 		"deleting the glob must keep the renamed repo its exact entry still claims")
@@ -2296,10 +2287,10 @@ name = "*"
 	// Removing the exact entry keeps the repo through the glob, but its
 	// provenance now points at a config entry that no longer exists and
 	// must not survive to claim a future entry with the same path.
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodDelete,
-		"/api/v1/repo/gh/acme/tools", nil,
-	)
+		"/api/v1/repo/gh/acme/tools", nil)
+
 	require.Equal(t, http.StatusNoContent, rr.Code, rr.Body.String())
 	require.True(t, srv.syncer.IsTrackedRepo("acme", "tools-new"))
 	assert.Empty(t, trackedRepoProvenancePath(srv, "acme", "tools-new"),
@@ -2353,10 +2344,10 @@ platform_host = "ghe.example.com"
 
 	// The remaining acme/tools entry lives on a different host; it cannot
 	// keep the deleted github.com entry's provenance alive.
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodDelete,
-		"/api/v1/repo/gh/acme/tools", nil,
-	)
+		"/api/v1/repo/gh/acme/tools", nil)
+
 	require.Equal(t, http.StatusNoContent, rr.Code, rr.Body.String())
 	require.True(t, srv.syncer.IsTrackedRepo("acme", "tools-new"))
 	assert.Empty(t, trackedRepoProvenancePath(srv, "acme", "tools-new"),
@@ -2412,10 +2403,10 @@ name = "tools"
 	// The remaining acme/tools entry shares the host but belongs to a
 	// different provider; it cannot keep the deleted GitHub entry's
 	// provenance alive.
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodDelete,
-		"/api/v1/repo/gh/acme/tools", nil,
-	)
+		"/api/v1/repo/gh/acme/tools", nil)
+
 	require.Equal(t, http.StatusNoContent, rr.Code, rr.Body.String())
 	require.True(t, srv.syncer.IsTrackedRepo("acme", "tools-new"))
 	assert.Empty(t, trackedRepoProvenancePath(srv, "acme", "tools-new"),
@@ -2441,13 +2432,13 @@ owner = "acme"
 name = "widget"
 `, &mockGH{})
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodDelete,
-		"/api/v1/host/gitlab.com/repo/gl/acme/widget", nil,
-	)
+		"/api/v1/host/gitlab.com/repo/gl/acme/widget", nil)
+
 	require.Equal(http.StatusNoContent, rr.Code, rr.Body.String())
 
-	settingsRR := doJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
+	settingsRR := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
 	require.Equal(http.StatusOK, settingsRR.Code, settingsRR.Body.String())
 	var resp settingsResponse
 	require.NoError(json.NewDecoder(settingsRR.Body).Decode(&resp))
@@ -2492,10 +2483,10 @@ name = "*"
 		PlatformHost: "github.com",
 	}})
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodPost,
-		"/api/v1/repo/gh/roborev-dev/*/refresh", nil,
-	)
+		"/api/v1/repo/gh/roborev-dev/*/refresh", nil)
+
 	require.Equal(http.StatusBadGateway, rr.Code, rr.Body.String())
 	assert.True(srv.syncer.IsTrackedRepo("roborev-dev", "kenn-forge"))
 }
@@ -2551,7 +2542,7 @@ name = "widget"
 		ServerOptions{},
 	)
 
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	var resp settingsResponse
@@ -2585,10 +2576,10 @@ owner = "acme"
 name = "Widget-*"
 `, mock)
 
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodPost,
-		"/api/v1/repo/gh/acme/Widget-*/refresh", nil,
-	)
+		"/api/v1/repo/gh/acme/Widget-*/refresh", nil)
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	assert.True(srv.syncer.IsTrackedRepo("acme", "Widget-API"))
 }
@@ -2604,25 +2595,25 @@ func TestAddRepoDoesNotDropConcurrentActivityChange(t *testing.T) {
 	srv, _, cfgPath := setupTestServerWithConfig(t)
 
 	// Change activity via the update handler.
-	rr := doJSON(
+	rr := testutil.DoJSON(
 		t, srv, http.MethodPut, "/api/v1/settings",
 		updateSettingsRequest{
 			Activity: &config.Activity{
 				ViewMode:  "threaded",
 				TimeRange: "30d",
 			},
-		},
-	)
+		})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	// Add a new repo; handler should preserve activity.
-	addRR := doJSON(
+	addRR := testutil.DoJSON(
 		t, srv, http.MethodPost, "/api/v1/repos",
 		map[string]string{
 			"provider": "github", "host": "github.com",
 			"owner": "other-org", "name": "other-repo",
-		},
-	)
+		})
+
 	require.Equal(http.StatusCreated, addRR.Code, addRR.Body.String())
 
 	cfg2, err := config.Load(cfgPath)
@@ -2694,10 +2685,10 @@ name = "*"
 		require.FailNow("refresh did not reach the GH mock")
 	}
 
-	delRR := doJSON(
+	delRR := testutil.DoJSON(
 		t, srv, http.MethodDelete,
-		"/api/v1/repo/gh/roborev-dev/*", nil,
-	)
+		"/api/v1/repo/gh/roborev-dev/*", nil)
+
 	require.Equal(http.StatusNoContent, delRR.Code, delRR.Body.String())
 	require.False(srv.syncer.IsTrackedRepo("roborev-dev", "kenn-forge"))
 
@@ -2746,7 +2737,7 @@ command = ["systemd-run", "--user", "--scope", "tmux"]
 			TimeRange: "30d",
 		},
 	}
-	rr := doJSON(t, srv, http.MethodPut, "/api/v1/settings", body)
+	rr := testutil.DoJSON(t, srv, http.MethodPut, "/api/v1/settings", body)
 	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
 
 	reloaded, err := config.Load(cfgPath)
@@ -2818,12 +2809,13 @@ owner = "acme"
 name = "widget-*"
 `, mock)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/repos/preview", map[string]string{
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/repos/preview", map[string]string{
 		"provider": "github",
 		"host":     "github.com",
 		"owner":    " ACME ",
 		"pattern":  " Widget* ",
 	})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	var resp repoPreviewResponse
@@ -2889,10 +2881,11 @@ port = 8091
 		ServerOptions{HostCheckAllowLoopbackAnyPort: true})
 
 	preview := func(owner string) repoPreviewResponse {
-		rr := doJSON(t, srv, http.MethodPost, "/api/v1/repos/preview", map[string]string{
+		rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/repos/preview", map[string]string{
 			"provider": "github", "host": "github.com",
 			"owner": owner, "pattern": "*",
 		})
+
 		require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 		var resp repoPreviewResponse
 		require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
@@ -2938,10 +2931,11 @@ port = 8091
 	srv := NewWithConfig(database, syncer, nil, nil, cfg, cfgPath,
 		ServerOptions{HostCheckAllowLoopbackAnyPort: true})
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/repos/preview", map[string]string{
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/repos/preview", map[string]string{
 		"provider": "github", "host": "github.com",
 		"owner": "org-b", "pattern": "*",
 	})
+
 	require.Equal(http.StatusBadGateway, rr.Code, rr.Body.String())
 	assert.Contains(t, rr.Body.String(), "org-b")
 	assert.Contains(t, rr.Body.String(), "github.com")
@@ -2989,12 +2983,13 @@ host = "127.0.0.1"
 port = 8091
 `, mock)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/repos/preview", map[string]string{
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/repos/preview", map[string]string{
 		"provider": "github",
 		"host":     "github.com",
 		"owner":    "mariusvniekerk",
 		"pattern":  "dotfiles2026",
 	})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	var resp repoPreviewResponse
@@ -3051,12 +3046,13 @@ host = "127.0.0.1"
 port = 8091
 `, mock)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/repos/preview", map[string]string{
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/repos/preview", map[string]string{
 		"provider": "github",
 		"host":     "github.com",
 		"owner":    "anacondarecipes",
 		"pattern":  "tesseract-feedstock",
 	})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	var resp repoPreviewResponse
@@ -3079,21 +3075,23 @@ func TestHandlePreviewReposRejectsInvalidPattern(t *testing.T) {
 	require := require.New(t)
 	srv, _, _ := setupTestServerWithConfig(t)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/repos/preview", map[string]string{
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/repos/preview", map[string]string{
 		"provider": "github",
 		"host":     "github.com",
 		"owner":    "acme*",
 		"pattern":  "widget",
 	})
+
 	require.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
 	assert.Contains(rr.Body.String(), "glob syntax in owner is not supported")
 
-	rr = doJSON(t, srv, http.MethodPost, "/api/v1/repos/preview", map[string]string{
+	rr = testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/repos/preview", map[string]string{
 		"provider": "github",
 		"host":     "github.com",
 		"owner":    "acme",
 		"pattern":  "widget[",
 	})
+
 	require.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
 	assert.Contains(rr.Body.String(), "invalid glob pattern")
 }
@@ -3152,12 +3150,13 @@ owner = "Group/Subgroup"
 name = "Project"
 `, &mockGH{}, provider)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/repos/preview", map[string]string{
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/repos/preview", map[string]string{
 		"provider": "gitlab",
 		"host":     "gitlab.example.com",
 		"owner":    "Group/Subgroup",
 		"pattern":  "Project*",
 	})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	var resp repoPreviewResponse
@@ -3229,12 +3228,13 @@ name = "Widget"
 repo_path = "ForgeOrg/Widget"
 `, &mockGH{}, provider)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/repos/preview", map[string]string{
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/repos/preview", map[string]string{
 		"provider": "forgejo",
 		"host":     "codeberg.example.com",
 		"owner":    "ForgeOrg",
 		"pattern":  "Widget*",
 	})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	body := rr.Body.String()
@@ -3284,13 +3284,14 @@ name = "widget"
 `, mock)
 	callsAfterSetup := getCalls.Load()
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/repos/bulk", map[string]any{
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/repos/bulk", map[string]any{
 		"repos": []map[string]string{
 			{"provider": "github", "host": "github.com", "owner": " acme ", "name": " api ", "repo_path": " acme/api "},
 			{"provider": "github", "host": "github.com", "owner": "acme", "name": "worker", "repo_path": "acme/worker"},
 			{"provider": "github", "host": "github.com", "owner": "acme", "name": "api", "repo_path": "acme/api"},
 		},
 	})
+
 	require.Equal(http.StatusCreated, rr.Code, rr.Body.String())
 	assert.GreaterOrEqual(getCalls.Load(), callsAfterSetup+2)
 
@@ -3344,7 +3345,7 @@ host = "127.0.0.1"
 port = 8091
 `, &mockGH{}, provider)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/repos/bulk", map[string]any{
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/repos/bulk", map[string]any{
 		"repos": []map[string]string{
 			{
 				"provider":  "gitlab",
@@ -3353,6 +3354,7 @@ port = 8091
 			},
 		},
 	})
+
 	require.Equal(http.StatusCreated, rr.Code, rr.Body.String())
 
 	var resp settingsResponse
@@ -3669,7 +3671,7 @@ host = "127.0.0.1"
 port = 8091
 `, &mockGH{}, provider)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/repos/bulk", map[string]any{
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/repos/bulk", map[string]any{
 		"repos": []map[string]string{
 			{
 				"provider":  "gitea",
@@ -3678,6 +3680,7 @@ port = 8091
 			},
 		},
 	})
+
 	require.Equal(http.StatusCreated, rr.Code, rr.Body.String())
 
 	var resp settingsResponse
@@ -3742,12 +3745,13 @@ owner = "acme"
 name = "widget"
 `, mock)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/repos/bulk", map[string]any{
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/repos/bulk", map[string]any{
 		"repos": []map[string]string{
 			{"provider": "github", "host": "github.com", "owner": "acme", "name": "api", "repo_path": "acme/api"},
 			{"provider": "github", "host": "github.com", "owner": "acme", "name": "missing", "repo_path": "acme/missing"},
 		},
 	})
+
 	require.Equal(http.StatusBadGateway, rr.Code, rr.Body.String())
 	assert.False(srv.syncer.IsTrackedRepo("acme", "api"))
 
@@ -3784,12 +3788,13 @@ port = 8091
 owner = "acme"
 name = "api"
 `, mock)
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/repos/bulk", map[string]any{
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/repos/bulk", map[string]any{
 		"repos": []map[string]string{
 			{"provider": "github", "host": "github.com", "owner": "acme", "name": "api", "repo_path": "acme/api"},
 			{"provider": "github", "host": "github.com", "owner": "acme", "name": "worker", "repo_path": "acme/worker"},
 		},
 	})
+
 	require.Equal(http.StatusCreated, rr.Code, rr.Body.String())
 	assert.True(srv.syncer.IsTrackedRepo("acme", "worker"))
 
@@ -3825,11 +3830,12 @@ port = 8091
 owner = "acme"
 name = "api"
 `, mock)
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/repos/bulk", map[string]any{
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/repos/bulk", map[string]any{
 		"repos": []map[string]string{
 			{"provider": "github", "host": "github.com", "owner": "acme", "name": "api", "repo_path": "acme/api"},
 		},
 	})
+
 	require.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
 	assert.Contains(rr.Body.String(), "all selected repositories are already configured")
 }
@@ -3887,9 +3893,10 @@ name = "widget"
 	case <-time.After(5 * time.Second):
 		require.FailNow("bulk validation did not start")
 	}
-	addRR := doJSON(t, srv, http.MethodPost, "/api/v1/repos", map[string]string{
+	addRR := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/repos", map[string]string{
 		"provider": "github", "host": "github.com", "owner": "acme", "name": "api",
 	})
+
 	require.Equal(http.StatusCreated, addRR.Code, addRR.Body.String())
 	close(unblockGet)
 
@@ -3966,7 +3973,7 @@ state = "active"
 	`, &mockGH{})
 
 	get := func() fleetSettingsResponse {
-		response := doJSON(t, srv, http.MethodGet, "/api/v1/settings/fleet", nil)
+		response := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/settings/fleet", nil)
 		require.Equal(http.StatusOK, response.Code)
 		var result fleetSettingsResponse
 		require.NoError(json.NewDecoder(response.Body).Decode(&result))
@@ -3987,16 +3994,16 @@ state = "active"
 			"state": "active",
 		}},
 	}
-	response := doJSON(
-		t, srv, http.MethodPut, "/api/v1/settings/fleet", forbiddenLifecyclePayload,
-	)
+	response := testutil.DoJSON(
+		t, srv, http.MethodPut, "/api/v1/settings/fleet", forbiddenLifecyclePayload)
+
 	require.Equal(http.StatusUnprocessableEntity, response.Code)
 
 	payload := map[string]any{
 		"enabled":  true,
 		"sessions": map[string]any{"include_unmanaged_details": false},
 	}
-	response = doJSON(t, srv, http.MethodPut, "/api/v1/settings/fleet", payload)
+	response = testutil.DoJSON(t, srv, http.MethodPut, "/api/v1/settings/fleet", payload)
 	require.Equal(http.StatusOK, response.Code)
 	var updated fleetSettingsResponse
 	require.NoError(json.NewDecoder(response.Body).Decode(&updated))
@@ -4053,7 +4060,7 @@ base_url = "https://hub.example"
 		FederationEnrollments:         enrollments,
 		FederationCredentials:         credentials,
 	})
-	response := doJSON(t, srv, http.MethodGet, "/api/v1/settings/fleet", nil)
+	response := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/settings/fleet", nil)
 	require.Equal(http.StatusOK, response.Code)
 	assert.Contains(response.Body.String(), enrollmentID)
 	assert.NotContains(response.Body.String(), token.Token)
@@ -4145,49 +4152,61 @@ base_url = %q
 	t.Cleanup(func() { gracefulShutdown(t, spoke) })
 
 	autoAssign := true
-	response := doJSON(t, spoke, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
+	response := testutil.DoJSON(t, spoke, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
 		Detail:     &config.Detail{InitialTimelineEntryLimit: 75},
 		Workspaces: &workspaceSettingsUpdate{AutoAssignOnCreate: &autoAssign},
 	})
+
 	require.Equal(http.StatusBadRequest, response.Code, response.Body.String())
 	var problem httpapi.ProblemError
 	require.NoError(json.NewDecoder(response.Body).Decode(&problem))
 	assert.Equal(httpapi.CodeValidationError, problem.Code)
 	assert.Equal("mixedSettingsOwnership", problem.Details["reason"])
+	hub.cfgMu.Lock()
 	assert.Equal(50, hub.cfg.Detail.InitialTimelineEntryLimit)
 	assert.False(hub.cfg.Workspaces.AutoAssignOnCreate)
+	hub.cfgMu.Unlock()
+	spoke.cfgMu.Lock()
 	assert.Equal(25, spoke.cfg.Detail.InitialTimelineEntryLimit)
 	assert.False(spoke.cfg.Workspaces.AutoAssignOnCreate)
+	spoke.cfgMu.Unlock()
 
-	response = doJSON(t, spoke, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
+	response = testutil.DoJSON(t, spoke, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
 		Detail: &config.Detail{InitialTimelineEntryLimit: 75},
 	})
+
 	require.Equal(http.StatusOK, response.Code, response.Body.String())
-	response = doJSON(t, spoke, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
+	response = testutil.DoJSON(t, spoke, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
 		Workspaces: &workspaceSettingsUpdate{AutoAssignOnCreate: &autoAssign},
 	})
+
 	require.Equal(http.StatusOK, response.Code, response.Body.String())
-	response = doJSON(t, spoke, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
+	response = testutil.DoJSON(t, spoke, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
 		Roborev: &roborevSettingsUpdate{InitManagedClones: new(true)},
 	})
+
 	require.Equal(http.StatusOK, response.Code, response.Body.String())
 
+	hub.cfgMu.Lock()
 	assert.Equal(75, hub.cfg.Detail.InitialTimelineEntryLimit)
 	assert.False(hub.cfg.Workspaces.AutoAssignOnCreate)
+	hub.cfgMu.Unlock()
+	spoke.cfgMu.Lock()
 	assert.Equal(25, spoke.cfg.Detail.InitialTimelineEntryLimit)
 	assert.True(spoke.cfg.Workspaces.AutoAssignOnCreate)
 	assert.True(spoke.cfg.Roborev.InitManagedClones)
+	spoke.cfgMu.Unlock()
 
 	worktreeBase := t.TempDir()
 	canonicalWorktreeBase, err := filepath.EvalSymlinks(worktreeBase)
 	require.NoError(err)
 	runGit(t, worktreeBase, "init", "--initial-branch=main")
 	runGit(t, worktreeBase, "remote", "add", "origin", "https://github.com/acme/widget.git")
-	response = doJSON(
+	response = testutil.DoJSON(
 		t, spoke, http.MethodPut,
 		"/api/v1/repo/github/acme/widget/worktree-base",
-		repoWorktreeBaseRequest{WorktreeBasePath: worktreeBase},
-	)
+		repoWorktreeBaseRequest{WorktreeBasePath: worktreeBase})
+
 	require.Equal(http.StatusOK, response.Code, response.Body.String())
 	assert.Equal(canonicalWorktreeBase, spoke.cfg.Repos[0].WorktreeBasePath)
 	assert.Empty(hub.cfg.Repos[0].WorktreeBasePath)
@@ -4200,7 +4219,7 @@ base_url = %q
 	assert.True(settings.Workspaces.AutoAssignOnCreate)
 	assert.Equal(config.FleetRoleSpoke, settings.Fleet.Role)
 
-	response = doJSON(t, spoke, http.MethodGet, "/api/v1/settings", nil)
+	response = testutil.DoJSON(t, spoke, http.MethodGet, "/api/v1/settings", nil)
 	require.Equal(http.StatusOK, response.Code, response.Body.String())
 	require.NoError(json.NewDecoder(response.Body).Decode(&settings))
 	require.Len(settings.Repos, 1)
@@ -4254,10 +4273,10 @@ port = 8091
 	runGit(t, worktreeBase, "init", "--initial-branch=main")
 	runGit(t, worktreeBase, "remote", "add", "origin", "https://github.com/acme/late.git")
 
-	response := doJSON(
+	response := testutil.DoJSON(
 		t, srv, http.MethodPut, "/api/v1/repo/github/acme/late/worktree-base",
-		repoWorktreeBaseRequest{WorktreeBasePath: worktreeBase},
-	)
+		repoWorktreeBaseRequest{WorktreeBasePath: worktreeBase})
+
 	require.Equal(http.StatusOK, response.Code, response.Body.String())
 	require.Len(srv.cfg.Repos, 1)
 	assert.Equal(canonicalWorktreeBase, srv.cfg.Repos[0].WorktreeBasePath)
@@ -4270,11 +4289,11 @@ port = 8091
 	projection.RepositoryObservations[0].Name = "late-renamed"
 	projection.RepositoryObservations[0].RepoPath = "renamed/late-renamed"
 	projection.RepositoryObservations[0].ObservedAt = observedAt.Add(time.Minute)
-	response = doJSON(
+	response = testutil.DoJSON(
 		t, srv, http.MethodPut,
 		"/api/v1/repo/github/renamed/late-renamed/worktree-base",
-		repoWorktreeBaseRequest{},
-	)
+		repoWorktreeBaseRequest{})
+
 	require.Equal(http.StatusOK, response.Code, response.Body.String())
 	assert.Equal(int32(2), reads.Load(), "each mutation uses one pre-commit hub snapshot")
 	require.Len(srv.cfg.Repos, 1)
@@ -4310,7 +4329,7 @@ auto_assign_on_create = false
 	}
 	autoAssign := true
 
-	response := doJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
+	response := testutil.DoJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
 		Workspaces: &workspaceSettingsUpdate{AutoAssignOnCreate: &autoAssign},
 	})
 
@@ -4336,7 +4355,7 @@ func TestNodeSettingsLoadWhileFederationIsDisabled(t *testing.T) {
 		enabled: srv.federationEnabled,
 	}
 
-	response := doJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
+	response := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
 
 	require.Equal(http.StatusOK, response.Code, response.Body.String())
 	var settings settingsResponse
@@ -4372,13 +4391,14 @@ base_url = "https://hub.example"
 	require.NotNil(srv.providerSource)
 	require.Nil(srv.providerSource.client)
 
-	response := doJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
+	response := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
 	require.Equal(http.StatusOK, response.Code, response.Body.String())
 
 	autoAssign := true
-	response = doJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
+	response = testutil.DoJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
 		Workspaces: &workspaceSettingsUpdate{AutoAssignOnCreate: &autoAssign},
 	})
+
 	require.Equal(http.StatusOK, response.Code, response.Body.String())
 	assert.True(srv.cfg.Workspaces.AutoAssignOnCreate)
 	persisted, err := config.Load(configPath)
@@ -4571,9 +4591,10 @@ prefer_github_native_stacks = true
 	require.Equal([]int64{11, 10}, stackMemberNumbers(*before.JSON200.Members))
 
 	disabled := config.PullRequests{}
-	rr := doJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
+	rr := testutil.DoJSON(t, srv, http.MethodPut, "/api/v1/settings", updateSettingsRequest{
 		PullRequests: &disabled,
 	})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	after, err := client.HTTP.GetPullStackWithResponse(ctx, "gh", "acme", "removed", 10)

--- a/internal/server/settings_visibility_test.go
+++ b/internal/server/settings_visibility_test.go
@@ -17,6 +17,7 @@ import (
 	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/db"
 	ghclient "go.kenn.io/forge/internal/github"
+	"go.kenn.io/forge/internal/testutil"
 	"go.kenn.io/forge/internal/testutil/dbtest"
 )
 
@@ -42,7 +43,7 @@ func settingsReposFromBody(t *testing.T, body []byte) []ghclient.ConfiguredRepoS
 
 func listRepoNames(t *testing.T, srv *Server) []string {
 	t.Helper()
-	rr := doJSON(t, srv, http.MethodGet, "/api/v1/repos", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/repos", nil)
 	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
 	var repos []struct {
 		Name string `json:"name"`
@@ -69,10 +70,10 @@ func TestHandleUpdateRepoUIVisibilityHidesAndShows(t *testing.T) {
 	})
 	require.Equal([]string{"widget"}, listRepoNames(t, srv))
 
-	rr := doJSON(t, srv, http.MethodPut,
+	rr := testutil.DoJSON(t, srv, http.MethodPut,
 		"/api/v1/repo/github/acme/widget/ui-visibility",
-		map[string]bool{"hidden": true},
-	)
+		map[string]bool{"hidden": true})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	repos := settingsReposFromBody(t, rr.Body.Bytes())
 	require.Len(repos, 1)
@@ -82,16 +83,16 @@ func TestHandleUpdateRepoUIVisibilityHidesAndShows(t *testing.T) {
 		"interactive catalog omits the hidden repo")
 
 	// Settings remains the unfiltered management surface.
-	rr = doJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
+	rr = testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	repos = settingsReposFromBody(t, rr.Body.Bytes())
 	require.Len(repos, 1)
 	assert.True(repos[0].HiddenFromUI)
 
-	rr = doJSON(t, srv, http.MethodPut,
+	rr = testutil.DoJSON(t, srv, http.MethodPut,
 		"/api/v1/repo/github/acme/widget/ui-visibility",
-		map[string]bool{"hidden": false},
-	)
+		map[string]bool{"hidden": false})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	repos = settingsReposFromBody(t, rr.Body.Bytes())
 	require.Len(repos, 1)
@@ -122,10 +123,10 @@ func TestHandleUpdateRepoUIVisibilityFollowsRenamedRoute(t *testing.T) {
 		ConfiguredRepoPath: "acme/widget",
 	}})
 
-	rr := doJSON(t, srv, http.MethodPut,
+	rr := testutil.DoJSON(t, srv, http.MethodPut,
 		"/api/v1/repo/github/acme/widget/ui-visibility",
-		map[string]bool{"hidden": true},
-	)
+		map[string]bool{"hidden": true})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	repos := settingsReposFromBody(t, rr.Body.Bytes())
 	require.Len(repos, 1)
@@ -157,10 +158,10 @@ func TestRepoUIVisibilityDoesNotFollowReusedRoute(t *testing.T) {
 		PlatformExternalID: "R_old",
 		ConfiguredRepoPath: "acme/widget",
 	}})
-	rr := doJSON(t, srv, http.MethodPut,
+	rr := testutil.DoJSON(t, srv, http.MethodPut,
 		"/api/v1/repo/github/acme/widget/ui-visibility",
-		map[string]bool{"hidden": true},
-	)
+		map[string]bool{"hidden": true})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	// The provider deleted acme/widget and a different repository took over
@@ -185,7 +186,7 @@ func TestRepoUIVisibilityDoesNotFollowReusedRoute(t *testing.T) {
 		ConfiguredRepoPath: "acme/widget",
 	}})
 
-	rr = doJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
+	rr = testutil.DoJSON(t, srv, http.MethodGet, "/api/v1/settings", nil)
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	repos := settingsReposFromBody(t, rr.Body.Bytes())
 	require.Len(repos, 1)
@@ -195,10 +196,10 @@ func TestRepoUIVisibilityDoesNotFollowReusedRoute(t *testing.T) {
 		"replacement repo stays in the interactive catalog")
 
 	// Hiding the entry now targets the replacement's stable identity.
-	rr = doJSON(t, srv, http.MethodPut,
+	rr = testutil.DoJSON(t, srv, http.MethodPut,
 		"/api/v1/repo/github/acme/widget/ui-visibility",
-		map[string]bool{"hidden": true},
-	)
+		map[string]bool{"hidden": true})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	hidden, err := database.HiddenRepos(t.Context())
 	require.NoError(err)
@@ -244,10 +245,10 @@ func TestRepoUIVisibilityRejectsStaleTrackedIdentity(t *testing.T) {
 		ConfiguredRepoPath: "acme/widget",
 	}})
 
-	rr := doJSON(t, srv, http.MethodPut,
+	rr := testutil.DoJSON(t, srv, http.MethodPut,
 		"/api/v1/repo/github/acme/widget/ui-visibility",
-		map[string]bool{"hidden": true},
-	)
+		map[string]bool{"hidden": true})
+
 	require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
 	hidden, err := database.HiddenRepos(t.Context())
 	require.NoError(err)
@@ -302,19 +303,19 @@ name = "wid*"
 		ConfiguredRepoPath: "acme/widget",
 	}})
 
-	rr := doJSON(t, srv, http.MethodPut,
+	rr := testutil.DoJSON(t, srv, http.MethodPut,
 		"/api/v1/repo/github/acme/widget/ui-visibility",
-		map[string]bool{"hidden": true},
-	)
+		map[string]bool{"hidden": true})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	require.Empty(listRepoNames(t, srv))
 
 	// Removing the exact entry orphans the preference: the glob keeps the
 	// repository tracked, but glob rows have no visibility controls, so the
 	// preference must be released with its owning exact entry.
-	rr = doJSON(t, srv, http.MethodDelete,
-		"/api/v1/repo/github/acme/widget", nil,
-	)
+	rr = testutil.DoJSON(t, srv, http.MethodDelete,
+		"/api/v1/repo/github/acme/widget", nil)
+
 	require.Equal(http.StatusNoContent, rr.Code, rr.Body.String())
 	event := waitForConfigEvent(t, stream, 2*time.Second)
 	require.True(event.Valid, event.Error)
@@ -359,10 +360,10 @@ name = "wid*"
 		ConfiguredRepoPath: "acme/widget",
 	}})
 
-	rr := doJSON(t, srv, http.MethodPut,
+	rr := testutil.DoJSON(t, srv, http.MethodPut,
 		"/api/v1/repo/github/acme/widget/ui-visibility",
-		map[string]bool{"hidden": true},
-	)
+		map[string]bool{"hidden": true})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 
 	// A client can abandon the DELETE request after the config change
@@ -429,10 +430,10 @@ name = "wid*"
 		ConfiguredRepoPath: "acme/widget",
 	}})
 
-	rr := doJSON(t, srv, http.MethodPut,
+	rr := testutil.DoJSON(t, srv, http.MethodPut,
 		"/api/v1/repo/github/acme/widget/ui-visibility",
-		map[string]bool{"hidden": true},
-	)
+		map[string]bool{"hidden": true})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	require.Empty(listRepoNames(t, srv))
 
@@ -587,10 +588,10 @@ name = "widget"
 		ServerOptions{HostCheckAllowLoopbackAnyPort: true},
 	)
 
-	rr := doJSON(t, srv, http.MethodPut,
+	rr := testutil.DoJSON(t, srv, http.MethodPut,
 		"/api/v1/repo/github/acme/widget/ui-visibility",
-		map[string]bool{"hidden": true},
-	)
+		map[string]bool{"hidden": true})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	repos := settingsReposFromBody(t, rr.Body.Bytes())
 	require.Len(repos, 1)
@@ -625,10 +626,10 @@ func TestHandleUpdateRepoUIVisibilityReportsRouteOnlyTrackedRef(t *testing.T) {
 		ConfiguredRepoPath: "acme/widget",
 	}})
 
-	rr := doJSON(t, srv, http.MethodPut,
+	rr := testutil.DoJSON(t, srv, http.MethodPut,
 		"/api/v1/repo/github/acme/widget/ui-visibility",
-		map[string]bool{"hidden": true},
-	)
+		map[string]bool{"hidden": true})
+
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	repos := settingsReposFromBody(t, rr.Body.Bytes())
 	require.Len(repos, 1)
@@ -799,10 +800,10 @@ owner = "acme"
 name = "widget-*"
 `, &mockGH{})
 
-	rr := doJSON(t, srv, http.MethodPut,
+	rr := testutil.DoJSON(t, srv, http.MethodPut,
 		"/api/v1/repo/github/acme/widget-*/ui-visibility",
-		map[string]bool{"hidden": true},
-	)
+		map[string]bool{"hidden": true})
+
 	require.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
 }
 
@@ -810,10 +811,10 @@ func TestHandleUpdateRepoUIVisibilityUnknownRepo(t *testing.T) {
 	require := require.New(t)
 	srv, _, _ := setupTestServerWithConfig(t)
 
-	rr := doJSON(t, srv, http.MethodPut,
+	rr := testutil.DoJSON(t, srv, http.MethodPut,
 		"/api/v1/repo/github/acme/unrelated/ui-visibility",
-		map[string]bool{"hidden": true},
-	)
+		map[string]bool{"hidden": true})
+
 	require.Equal(http.StatusNotFound, rr.Code, rr.Body.String())
 }
 
@@ -824,9 +825,9 @@ func TestHandleUpdateRepoUIVisibilityRequiresVerifiedRepo(t *testing.T) {
 	// acme/widget is configured and tracked but has no catalog row yet
 	// (first sync has not verified it), so there is no stable identity to
 	// attach the preference to.
-	rr := doJSON(t, srv, http.MethodPut,
+	rr := testutil.DoJSON(t, srv, http.MethodPut,
 		"/api/v1/repo/github/acme/widget/ui-visibility",
-		map[string]bool{"hidden": true},
-	)
+		map[string]bool{"hidden": true})
+
 	require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
 }

--- a/internal/server/sync_routes_test.go
+++ b/internal/server/sync_routes_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/github"
+	"go.kenn.io/forge/internal/testutil"
 )
 
 func TestArchiveStartRejectsDisabledSyncer(t *testing.T) {
@@ -17,6 +18,6 @@ func TestArchiveStartRejectsDisabledSyncer(t *testing.T) {
 	syncer.DisableSync()
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/archive/start", map[string]bool{"all": true})
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/archive/start", map[string]bool{"all": true})
 	require.Equal(http.StatusServiceUnavailable, rr.Code, rr.Body.String())
 }

--- a/internal/server/tmux_wrapper_test.go
+++ b/internal/server/tmux_wrapper_test.go
@@ -344,7 +344,6 @@ func setupWrapperServerWithScriptAndDBAndServer(
 }
 
 func TestTmuxWrapperNewSession(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
 	assert := assert.New(t)
 	client, _, record := setupWrapperServer(t)
@@ -403,7 +402,6 @@ func TestTmuxWrapperNewSession(t *testing.T) {
 }
 
 func TestWorkspaceResponseIncludesTmuxWorkingState(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
 	assert := assert.New(t)
 	client, _, record := setupWrapperServer(t)
@@ -468,7 +466,6 @@ func TestWorkspaceResponseIncludesTmuxWorkingState(t *testing.T) {
 }
 
 func TestFilteredActivityIncrementalPollRetainsWorkspaceSubject(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
 	assert := assert.New(t)
 	script, record := writeTmuxRecorder(t)
@@ -587,7 +584,6 @@ func TestFilteredActivityIncrementalPollRetainsWorkspaceSubject(t *testing.T) {
 }
 
 func TestActivityAuthorsIncludeWorkspaceOnlySubject(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
 	assert := assert.New(t)
 	script, record := writeTmuxRecorder(t)
@@ -667,7 +663,6 @@ func TestActivityAuthorsIncludeWorkspaceOnlySubject(t *testing.T) {
 }
 
 func TestFederatedActivityIncludesNodeWorkspaceOnlySubject(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
 	script, record := writeTmuxRecorder(t)
 	setTmuxRecorderPaneOutput(t, record, "baseline output")
@@ -748,7 +743,6 @@ func TestFederatedActivityIncludesNodeWorkspaceOnlySubject(t *testing.T) {
 }
 
 func TestWorkspaceActivityNumberSearchIncludesEventlessSubject(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
 	assert := assert.New(t)
 	script, record := writeTmuxRecorder(t)
@@ -1265,7 +1259,7 @@ func TestWorkspaceRetryWhileCreatingQueuesAndRunsAfterFailureViaAPI(t *testing.T
 			ready = getResp.JSON200
 			return true
 		},
-		5*time.Second,
+		15*time.Second,
 		50*time.Millisecond,
 	)
 	require.NotNil(ready)

--- a/internal/server/tmux_wrapper_test.go
+++ b/internal/server/tmux_wrapper_test.go
@@ -33,6 +33,7 @@ import (
 	"go.kenn.io/forge/internal/procutil"
 	"go.kenn.io/forge/internal/server/workspaceapi"
 	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 )
 
 type lockedBuffer struct {
@@ -252,28 +253,28 @@ func setupWrapperServerWithScriptAndDBAndServer(
 	)
 	require.NoError(t, err)
 	tmpWork := filepath.Join(dir, "work")
-	runGit(t, dir, "init", "--bare", "--initial-branch=main", bare)
-	runGit(t, dir, "clone", bare, tmpWork)
-	runGit(t, tmpWork, "config", "user.email", "test@test.com")
-	runGit(t, tmpWork, "config", "user.name", "Test")
+	gitfixture.Run(t, dir, "init", "--bare", "--initial-branch=main", bare)
+	gitfixture.Run(t, dir, "clone", bare, tmpWork)
+	gitfixture.Run(t, tmpWork, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, tmpWork, "config", "user.name", "Test")
 	require.NoError(t, os.WriteFile(
 		filepath.Join(tmpWork, "base.txt"),
 		[]byte("base\n"), 0o644,
 	))
-	runGit(t, tmpWork, "add", ".")
-	runGit(t, tmpWork, "commit", "-m", "base commit")
-	runGit(t, tmpWork, "push", "origin", "main")
-	runGit(t, tmpWork, "checkout", "-b", "feature")
+	gitfixture.Run(t, tmpWork, "add", ".")
+	gitfixture.Run(t, tmpWork, "commit", "-m", "base commit")
+	gitfixture.Run(t, tmpWork, "push", "origin", "main")
+	gitfixture.Run(t, tmpWork, "checkout", "-b", "feature")
 	require.NoError(t, os.WriteFile(
 		filepath.Join(tmpWork, "new.txt"),
 		[]byte("new\n"), 0o644,
 	))
-	runGit(t, tmpWork, "add", ".")
-	runGit(t, tmpWork, "commit", "-m", "feature commit")
-	runGit(t, tmpWork, "push", "origin", "feature")
+	gitfixture.Run(t, tmpWork, "add", ".")
+	gitfixture.Run(t, tmpWork, "commit", "-m", "feature commit")
+	gitfixture.Run(t, tmpWork, "push", "origin", "feature")
 
 	// Point bare origin at itself so EnsureClone fetch works.
-	runGit(t, bare, "remote", "add", "origin", bare)
+	gitfixture.Run(t, bare, "remote", "add", "origin", bare)
 
 	worktreeDir := filepath.Join(dir, "worktrees")
 
@@ -344,6 +345,9 @@ func setupWrapperServerWithScriptAndDBAndServer(
 }
 
 func TestTmuxWrapperNewSession(t *testing.T) {
+	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
+
 	require := require.New(t)
 	assert := assert.New(t)
 	client, _, record := setupWrapperServer(t)
@@ -466,6 +470,9 @@ func TestWorkspaceResponseIncludesTmuxWorkingState(t *testing.T) {
 }
 
 func TestFilteredActivityIncrementalPollRetainsWorkspaceSubject(t *testing.T) {
+	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
+
 	require := require.New(t)
 	assert := assert.New(t)
 	script, record := writeTmuxRecorder(t)
@@ -584,6 +591,9 @@ func TestFilteredActivityIncrementalPollRetainsWorkspaceSubject(t *testing.T) {
 }
 
 func TestActivityAuthorsIncludeWorkspaceOnlySubject(t *testing.T) {
+	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
+
 	require := require.New(t)
 	assert := assert.New(t)
 	script, record := writeTmuxRecorder(t)
@@ -663,6 +673,9 @@ func TestActivityAuthorsIncludeWorkspaceOnlySubject(t *testing.T) {
 }
 
 func TestFederatedActivityIncludesNodeWorkspaceOnlySubject(t *testing.T) {
+	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
+
 	require := require.New(t)
 	script, record := writeTmuxRecorder(t)
 	setTmuxRecorderPaneOutput(t, record, "baseline output")
@@ -743,6 +756,9 @@ func TestFederatedActivityIncludesNodeWorkspaceOnlySubject(t *testing.T) {
 }
 
 func TestWorkspaceActivityNumberSearchIncludesEventlessSubject(t *testing.T) {
+	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
+
 	require := require.New(t)
 	assert := assert.New(t)
 	script, record := writeTmuxRecorder(t)
@@ -970,6 +986,9 @@ func TestWorkspaceCreateFailureLogsAndPersistsAuditEvent(t *testing.T) {
 }
 
 func TestWorkspaceShutdownCancellationPersistsFailureViaAPI(t *testing.T) {
+	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
+
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -1112,7 +1131,7 @@ func TestWorkspaceSetupFailureRollbackCleansWorktreeViaAPI(t *testing.T) {
 		"github", "github.com", "acme", "widget",
 	)
 	require.NoError(err)
-	featureSHA := testGitSHA(t, clonePath, "refs/heads/feature")
+	featureSHA := gitfixture.SHA(t, clonePath, "refs/heads/feature")
 
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
@@ -1150,7 +1169,7 @@ func TestWorkspaceSetupFailureRollbackCleansWorktreeViaAPI(t *testing.T) {
 	)
 
 	require.NotNil(failed)
-	assert.Equal(featureSHA, testGitSHA(t, clonePath, "refs/heads/feature"))
+	assert.Equal(featureSHA, gitfixture.SHA(t, clonePath, "refs/heads/feature"))
 	assert.Eventually(
 		func() bool {
 			_, err := os.Stat(failed.WorktreePath)
@@ -1168,6 +1187,9 @@ func TestWorkspaceSetupFailureRollbackCleansWorktreeViaAPI(t *testing.T) {
 }
 
 func TestWorkspaceRetryWhileCreatingQueuesAndRunsAfterFailureViaAPI(t *testing.T) {
+	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
+
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -1286,6 +1308,9 @@ func TestWorkspaceRetryWhileCreatingQueuesAndRunsAfterFailureViaAPI(t *testing.T
 }
 
 func TestWorkspaceShutdownCancellationDoesNotPersistAfterDeadlineBudgetExhausted(t *testing.T) {
+	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
+
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -1412,6 +1437,9 @@ func TestWorkspaceShutdownCancellationDoesNotPersistAfterDeadlineBudgetExhausted
 }
 
 func TestTmuxWrapperAttachSession(t *testing.T) {
+	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
+
 	require := require.New(t)
 	assert := assert.New(t)
 	client, baseURL, record := setupWrapperServer(t)
@@ -1728,6 +1756,9 @@ func TestReadTmuxRecordPreservesEmptyArgs(t *testing.T) {
 // This complements TestTmuxWrapperNewSession and TestTmuxWrapperAttachSession —
 // together they cover all three tmux verbs that cross the HTTP boundary.
 func TestTmuxWrapperKillSession(t *testing.T) {
+	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
+
 	require := require.New(t)
 	assert := assert.New(t)
 	client, _, record := setupWrapperServer(t)
@@ -1863,6 +1894,9 @@ func TestDeleteWorkspacePreservesRowWhenTmuxKillFails(t *testing.T) {
 }
 
 func TestDeleteWorkspaceTreatsTmuxServerExitAsGoneE2E(t *testing.T) {
+	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
+
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -1929,6 +1963,9 @@ func TestDeleteWorkspaceTreatsTmuxServerExitAsGoneE2E(t *testing.T) {
 }
 
 func TestDeleteErroredWorkspaceAllowsUnavailableTmux(t *testing.T) {
+	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
+
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -2006,6 +2043,9 @@ func TestDeleteErroredWorkspaceAllowsUnavailableTmux(t *testing.T) {
 // the terminal handler sees the error and closes the WebSocket with
 // StatusInternalError.
 func TestTmuxWrapperAttachSurfacesWrapperFailure(t *testing.T) {
+	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
+
 	record := filepath.Join(t.TempDir(), "record")
 	body := "#!/bin/sh\n" +
 		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
@@ -2100,6 +2140,9 @@ func attachWebsocketAndExpectInternalError(t *testing.T, scriptBody string) {
 // reviewer flagged — shell wrappers often exit 1 for their own
 // generic errors.
 func TestTmuxWrapperAttachSurfacesExit1Failure(t *testing.T) {
+	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
+
 	record := filepath.Join(t.TempDir(), "record")
 	body := "#!/bin/sh\n" +
 		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +
@@ -2121,6 +2164,9 @@ func TestTmuxWrapperAttachSurfacesExit1Failure(t *testing.T) {
 // "session absent." Pairs with the unit-level
 // TestManagerEnsureTmuxIgnoresAbsencePhraseOnStdout.
 func TestTmuxWrapperAttachIgnoresAbsencePhraseOnStdout(t *testing.T) {
+	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
+
 	record := filepath.Join(t.TempDir(), "record")
 	body := "#!/bin/sh\n" +
 		"TMUX_RECORD=" + shellquote.Join(record) + "\n" +

--- a/internal/server/workspace_runtime_agent_context_test.go
+++ b/internal/server/workspace_runtime_agent_context_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestLaunchWorkspaceRuntimeSessionPreparesAgentContext(t *testing.T) {
-	t.Parallel()
+	runParallelServerTest(t)
 	acquireRootWorkspaceGitSlot(t)
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/workspace_runtime_agent_context_test.go
+++ b/internal/server/workspace_runtime_agent_context_test.go
@@ -113,6 +113,9 @@ func TestLaunchWorkspaceRuntimeSessionPreparesAgentContext(t *testing.T) {
 }
 
 func TestWorkspaceRuntimeLaunchWritesAgentContextE2E(t *testing.T) {
+	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
+
 	assert := assert.New(t)
 	require := require.New(t)
 	dir := t.TempDir()
@@ -150,6 +153,9 @@ func TestWorkspaceRuntimeLaunchWritesAgentContextE2E(t *testing.T) {
 }
 
 func TestWorkspaceRuntimeLaunchRejectsUnsafeRepositoryAgentInstructionsE2E(t *testing.T) {
+	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
+
 	tests := []struct {
 		name      string
 		entry     string
@@ -200,6 +206,9 @@ func TestWorkspaceRuntimeLaunchRejectsUnsafeRepositoryAgentInstructionsE2E(t *te
 }
 
 func TestWorkspaceRuntimeLaunchWritesIssueAndKataAgentContextE2E(t *testing.T) {
+	runParallelServerTest(t)
+	acquireRootWorkspaceGitSlot(t)
+
 	assert := assert.New(t)
 	require := require.New(t)
 	dir := t.TempDir()

--- a/internal/server/workspace_runtime_test_helpers_test.go
+++ b/internal/server/workspace_runtime_test_helpers_test.go
@@ -6,9 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/coder/websocket"
 	shellquote "github.com/kballard/go-shellquote"
@@ -65,27 +63,4 @@ func dialWebSocketForTest(
 	}
 	require.NoError(t, err)
 	return conn
-}
-
-func readWebSocketBinaryUntil(
-	t *testing.T,
-	ctx context.Context,
-	conn *websocket.Conn,
-	timeout time.Duration,
-	needle string,
-) string {
-	t.Helper()
-	readCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	var got strings.Builder
-	for {
-		typ, data, err := conn.Read(readCtx)
-		require.NoError(t, err)
-		if typ == websocket.MessageBinary {
-			got.WriteString(string(data))
-		}
-		if strings.Contains(got.String(), needle) {
-			return got.String()
-		}
-	}
 }

--- a/internal/server/workspacetest/adhoc_workspace_test.go
+++ b/internal/server/workspacetest/adhoc_workspace_test.go
@@ -13,6 +13,7 @@ import (
 	"go.kenn.io/forge/internal/apiclient/generated"
 	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/gitclone"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 )
 
 // Starting new work needs no provider item: a tracked repository plus an
@@ -41,8 +42,8 @@ func TestCreateAdHocWorkspaceMaterializesRequestedBranch(t *testing.T) {
 	assert.Equal(branch, ready.GitHeadRef)
 	assert.Nil(ready.MrTitle)
 
-	head := testGitSHA(t, ready.WorktreePath, "HEAD")
-	assert.Equal(testGitSHA(t, fixture.remote, "refs/heads/main"), head,
+	head := gitfixture.SHA(t, ready.WorktreePath, "HEAD")
+	assert.Equal(gitfixture.SHA(t, fixture.remote, "refs/heads/main"), head,
 		"ad-hoc workspaces branch from the repository default branch")
 	checkedOut, err := os.ReadFile(filepath.Join(ready.WorktreePath, "base.txt"))
 	require.NoError(err)
@@ -59,12 +60,12 @@ func TestCreateAdHocWorkspaceAfterRepositoryRouteReuse(t *testing.T) {
 	)
 	require.NoError(err)
 	require.NotEqual(fixture.bare, replacementBare)
-	runGit(t, t.TempDir(), "clone", "--bare", fixture.remote, replacementBare)
-	runGit(
+	gitfixture.Run(t, t.TempDir(), "clone", "--bare", fixture.remote, replacementBare)
+	gitfixture.Run(
 		t, replacementBare, "remote", "set-url", "origin",
 		"https://github.com/acme/widget.git",
 	)
-	runGit(
+	gitfixture.Run(
 		t, replacementBare, "config", "--add",
 		"url."+fixture.remote+".insteadOf", "https://github.com/acme/widget.git",
 	)
@@ -191,8 +192,8 @@ func TestCreateAdHocWorkspaceExistingBranchIsUniquified(t *testing.T) {
 
 	fixture := setupWorkspaceServerFixture(t, nil)
 	branch := "spike/rate-limits"
-	mainSHA := testGitSHA(t, fixture.remote, "refs/heads/main")
-	runGit(t, fixture.bare, "update-ref", "refs/heads/"+branch, mainSHA)
+	mainSHA := gitfixture.SHA(t, fixture.remote, "refs/heads/main")
+	gitfixture.Run(t, fixture.bare, "update-ref", "refs/heads/"+branch, mainSHA)
 
 	resp, err := fixture.client.HTTP.CreateRepoWorkspaceWithResponse(
 		t.Context(), "gh", "acme", "widget",
@@ -216,8 +217,8 @@ func TestCreateAdHocWorkspaceReusesExistingBranchWhenAsked(t *testing.T) {
 
 	fixture := setupWorkspaceServerFixture(t, nil)
 	branch := "spike/rate-limits"
-	mainSHA := testGitSHA(t, fixture.remote, "refs/heads/main")
-	runGit(t, fixture.bare, "update-ref", "refs/heads/"+branch, mainSHA)
+	mainSHA := gitfixture.SHA(t, fixture.remote, "refs/heads/main")
+	gitfixture.Run(t, fixture.bare, "update-ref", "refs/heads/"+branch, mainSHA)
 	reuse := true
 
 	resp, err := fixture.client.HTTP.CreateRepoWorkspaceWithResponse(
@@ -269,8 +270,8 @@ func TestCreateAdHocWorkspaceReuseStartsFromDivergedBranchTip(t *testing.T) {
 	fixture := setupWorkspaceServerFixture(t, nil)
 	// The fixture's "feature" branch carries a commit that main does not.
 	branch := "feature"
-	featureSHA := testGitSHA(t, fixture.remote, "refs/heads/"+branch)
-	mainSHA := testGitSHA(t, fixture.remote, "refs/heads/main")
+	featureSHA := gitfixture.SHA(t, fixture.remote, "refs/heads/"+branch)
+	mainSHA := gitfixture.SHA(t, fixture.remote, "refs/heads/main")
 	require.NotEqual(mainSHA, featureSHA)
 	reuse := true
 
@@ -286,7 +287,7 @@ func TestCreateAdHocWorkspaceReuseStartsFromDivergedBranchTip(t *testing.T) {
 
 	ready := waitForWorkspaceReady(t, t.Context(), fixture.client, resp.JSON202.Id)
 	assert.Equal(branch, ready.GitHeadRef)
-	assert.Equal(featureSHA, testGitSHA(t, ready.WorktreePath, "HEAD"),
+	assert.Equal(featureSHA, gitfixture.SHA(t, ready.WorktreePath, "HEAD"),
 		"reuse adopts the existing branch tip, not origin/HEAD")
 	_, err = os.Stat(filepath.Join(ready.WorktreePath, "new.txt"))
 	assert.NoError(err, "the diverged commit's file should be checked out")
@@ -313,7 +314,7 @@ func TestCreateAdHocWorkspaceAfterInWorktreeBranchRename(t *testing.T) {
 	require.NotNil(created.JSON202)
 	ready := waitForWorkspaceReady(t, t.Context(), fixture.client, created.JSON202.Id)
 
-	runGit(t, ready.WorktreePath, "branch", "-m", original, renamed)
+	gitfixture.Run(t, ready.WorktreePath, "branch", "-m", original, renamed)
 
 	// Old name: still this workspace, because item_key is the creation-time
 	// branch and is never rewritten.

--- a/internal/server/workspacetest/fixtures_test.go
+++ b/internal/server/workspacetest/fixtures_test.go
@@ -23,7 +23,17 @@ import (
 	"go.kenn.io/forge/internal/testutil/dbtest"
 	"go.kenn.io/forge/internal/testutil/servertest"
 	gitcmd "go.kenn.io/kit/git/cmd"
+	"golang.org/x/sync/semaphore"
 )
+
+var parallelWorkspaceTestSlots = semaphore.NewWeighted(4)
+
+func runParallelWorkspaceTest(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+	require.NoError(t, parallelWorkspaceTestSlots.Acquire(t.Context(), 1))
+	t.Cleanup(func() { parallelWorkspaceTestSlots.Release(1) })
+}
 
 type workspaceServerFixture struct {
 	server           *server.Server

--- a/internal/server/workspacetest/fixtures_test.go
+++ b/internal/server/workspacetest/fixtures_test.go
@@ -21,18 +21,19 @@ import (
 	ghclient "go.kenn.io/forge/internal/github"
 	"go.kenn.io/forge/internal/server"
 	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 	"go.kenn.io/forge/internal/testutil/servertest"
-	gitcmd "go.kenn.io/kit/git/cmd"
 	"golang.org/x/sync/semaphore"
 )
 
 var parallelWorkspaceTestSlots = semaphore.NewWeighted(4)
 
-func runParallelWorkspaceTest(t *testing.T) {
+func runParallelWorkspacePTYTest(t *testing.T) {
 	t.Helper()
 	t.Parallel()
 	require.NoError(t, parallelWorkspaceTestSlots.Acquire(t.Context(), 1))
 	t.Cleanup(func() { parallelWorkspaceTestSlots.Release(1) })
+	acquireWorkspaceGitSlot(t)
 }
 
 type workspaceServerFixture struct {
@@ -100,29 +101,29 @@ func setupWorkspaceServerFixtureWithTmuxInjection(
 	remoteDir := filepath.Join(dir, "remote")
 	require.NoError(t, os.MkdirAll(remoteDir, 0o755))
 	remote := filepath.Join(remoteDir, "widget.git")
-	runGit(t, dir, "init", "--bare", "--initial-branch=main", remote)
+	gitfixture.Run(t, dir, "init", "--bare", "--initial-branch=main", remote)
 
 	tmpWork := filepath.Join(dir, "work")
-	runGit(t, dir, "clone", remote, tmpWork)
-	runGit(t, tmpWork, "config", "user.email", "test@test.com")
-	runGit(t, tmpWork, "config", "user.name", "Test")
+	gitfixture.Run(t, dir, "clone", remote, tmpWork)
+	gitfixture.Run(t, tmpWork, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, tmpWork, "config", "user.name", "Test")
 
 	require.NoError(t, os.WriteFile(
 		filepath.Join(tmpWork, "base.txt"),
 		[]byte("base\n"), 0o644,
 	))
-	runGit(t, tmpWork, "add", ".")
-	runGit(t, tmpWork, "commit", "-m", "base commit")
-	runGit(t, tmpWork, "push", "origin", "main")
+	gitfixture.Run(t, tmpWork, "add", ".")
+	gitfixture.Run(t, tmpWork, "commit", "-m", "base commit")
+	gitfixture.Run(t, tmpWork, "push", "origin", "main")
 
-	runGit(t, tmpWork, "checkout", "-b", "feature")
+	gitfixture.Run(t, tmpWork, "checkout", "-b", "feature")
 	require.NoError(t, os.WriteFile(
 		filepath.Join(tmpWork, "new.txt"),
 		[]byte("new\n"), 0o644,
 	))
-	runGit(t, tmpWork, "add", ".")
-	runGit(t, tmpWork, "commit", "-m", "feature commit")
-	runGit(t, tmpWork, "push", "origin", "feature")
+	gitfixture.Run(t, tmpWork, "add", ".")
+	gitfixture.Run(t, tmpWork, "commit", "-m", "feature commit")
+	gitfixture.Run(t, tmpWork, "push", "origin", "feature")
 
 	bareDir := filepath.Join(dir, "clones")
 	require.NoError(t, os.MkdirAll(bareDir, 0o755))
@@ -132,12 +133,12 @@ func setupWorkspaceServerFixtureWithTmuxInjection(
 		"github", "github.com", "acme", "widget",
 	)
 	require.NoError(t, err)
-	runGit(t, dir, "clone", "--bare", remote, bare)
-	runGit(
+	gitfixture.Run(t, dir, "clone", "--bare", remote, bare)
+	gitfixture.Run(
 		t, bare, "remote", "set-url", "origin",
 		"https://github.com/acme/widget.git",
 	)
-	runGit(
+	gitfixture.Run(
 		t, bare, "config", "--add",
 		"url."+remote+".insteadOf", "https://github.com/acme/widget.git",
 	)
@@ -232,20 +233,6 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
-}
-
-func runGit(t *testing.T, dir string, args ...string) {
-	t.Helper()
-	runner := gitcmd.New().WithConfig("init.defaultBranch", "main")
-	out, stderr, err := runner.Run(t.Context(), dir, nil, args...)
-	require.NoError(t, err, "git %v failed: %s%s", args, out, stderr)
-}
-
-func testGitSHA(t *testing.T, dir, ref string) string {
-	t.Helper()
-	out, err := gitcmd.New().Output(t.Context(), dir, "rev-parse", ref)
-	require.NoError(t, err)
-	return strings.TrimSpace(string(out))
 }
 
 func seedPROnHost(

--- a/internal/server/workspacetest/issue_workspace_conflict_test.go
+++ b/internal/server/workspacetest/issue_workspace_conflict_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/apiclient/generated"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 )
 
 // TestIssueWorkspaceConflictExposesTyped409ThroughGeneratedClient is a
@@ -38,8 +39,8 @@ func TestIssueWorkspaceConflictExposesTyped409ThroughGeneratedClient(t *testing.
 
 	// Pre-create the requested branch so the next workspace request hits
 	// the typed conflict path regardless of the default branch style.
-	mainSHA := testGitSHA(t, fixture.remote, "refs/heads/main")
-	runGit(
+	mainSHA := gitfixture.SHA(t, fixture.remote, "refs/heads/main")
+	gitfixture.Run(
 		t,
 		fixture.bare,
 		"update-ref", "refs/heads/"+branch, mainSHA,
@@ -88,8 +89,8 @@ func TestIssueWorkspaceReuseExistingBranchDoesNotReportCreated(t *testing.T) {
 	seedIssue(t, fixture.database, "acme", "widget", 7, "open")
 
 	branch := "kenn-forge/issue-7"
-	mainSHA := testGitSHA(t, fixture.remote, "refs/heads/main")
-	runGit(
+	mainSHA := gitfixture.SHA(t, fixture.remote, "refs/heads/main")
+	gitfixture.Run(
 		t,
 		fixture.bare,
 		"update-ref", "refs/heads/"+branch, mainSHA,

--- a/internal/server/workspacetest/issue_workspace_directory_recovery_test.go
+++ b/internal/server/workspacetest/issue_workspace_directory_recovery_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestIssueWorkspaceRecoversExpectedDirectory(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	assert := assert.New(t)
@@ -69,7 +69,7 @@ func TestIssueWorkspaceRecoversExpectedDirectory(t *testing.T) {
 }
 
 func TestIssueWorkspaceDirectoryRecoveryRejectsMissingPath(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	assert := assert.New(t)
@@ -157,7 +157,7 @@ func TestIssueWorkspaceDirectoryRecoveryReasons(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			runParallelWorkspaceTest(t)
 			acquireWorkspaceGitSlot(t)
 			assert := assert.New(t)
 			require := require.New(t)
@@ -201,7 +201,7 @@ func TestIssueWorkspaceDirectoryRecoveryReasons(t *testing.T) {
 }
 
 func TestIssueWorkspaceConflictRejectsAlternateBranchForExistingDirectory(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	assert := assert.New(t)
@@ -258,7 +258,7 @@ func TestIssueWorkspaceConflictRejectsAlternateBranchForExistingDirectory(t *tes
 }
 
 func TestIssueWorkspaceRejectsConflictingReuseOptions(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	assert := assert.New(t)

--- a/internal/server/workspacetest/issue_workspace_directory_recovery_test.go
+++ b/internal/server/workspacetest/issue_workspace_directory_recovery_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/apiclient/generated"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 )
 
 func TestIssueWorkspaceRecoversExpectedDirectory(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -27,11 +27,11 @@ func TestIssueWorkspaceRecoversExpectedDirectory(t *testing.T) {
 		"github", "github.com", "acme", "widget",
 		fmt.Sprintf("repo-%d", fixture.repoID), "issue-7",
 	)
-	runGit(
+	gitfixture.Run(
 		t, fixture.bare,
 		"worktree", "add", expectedPath, "-b", branch, "main",
 	)
-	wantHead := testGitSHA(t, expectedPath, "HEAD")
+	wantHead := gitfixture.SHA(t, expectedPath, "HEAD")
 	require.NoError(os.WriteFile(
 		filepath.Join(expectedPath, "base.txt"), []byte("dirty\n"), 0o644,
 	))
@@ -60,7 +60,7 @@ func TestIssueWorkspaceRecoversExpectedDirectory(t *testing.T) {
 		branch,
 		workspaceGitOutput(t, expectedPath, "branch", "--show-current"),
 	)
-	assert.Equal(wantHead, testGitSHA(t, expectedPath, "HEAD"))
+	assert.Equal(wantHead, gitfixture.SHA(t, expectedPath, "HEAD"))
 	assert.Equal(wantStatus, workspaceGitOutput(t, expectedPath, "status", "--short"))
 	tracked, err := os.ReadFile(filepath.Join(expectedPath, "base.txt"))
 	require.NoError(err)
@@ -69,8 +69,7 @@ func TestIssueWorkspaceRecoversExpectedDirectory(t *testing.T) {
 }
 
 func TestIssueWorkspaceDirectoryRecoveryRejectsMissingPath(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -121,22 +120,22 @@ func TestIssueWorkspaceDirectoryRecoveryReasons(t *testing.T) {
 			name: "wrong repository",
 			prepare: func(t *testing.T, _ workspaceServerFixture, path string) {
 				repo := filepath.Join(t.TempDir(), "other")
-				runGit(t, filepath.Dir(repo), "init", "--initial-branch=main", repo)
-				runGit(t, repo, "config", "user.email", "test@test.com")
-				runGit(t, repo, "config", "user.name", "Test")
+				gitfixture.Run(t, filepath.Dir(repo), "init", "--initial-branch=main", repo)
+				gitfixture.Run(t, repo, "config", "user.email", "test@test.com")
+				gitfixture.Run(t, repo, "config", "user.name", "Test")
 				require.NoError(t, os.WriteFile(
 					filepath.Join(repo, "base.txt"), []byte("base\n"), 0o644,
 				))
-				runGit(t, repo, "add", ".")
-				runGit(t, repo, "commit", "-m", "base")
-				runGit(t, repo, "worktree", "add", path, "-b", "kenn-forge/issue-7", "HEAD")
+				gitfixture.Run(t, repo, "add", ".")
+				gitfixture.Run(t, repo, "commit", "-m", "base")
+				gitfixture.Run(t, repo, "worktree", "add", path, "-b", "kenn-forge/issue-7", "HEAD")
 			},
 			wantReason: "repository_mismatch",
 		},
 		{
 			name: "wrong branch",
 			prepare: func(t *testing.T, fixture workspaceServerFixture, path string) {
-				runGit(t, fixture.bare, "worktree", "add", path, "-b", "other/branch", "main")
+				gitfixture.Run(t, fixture.bare, "worktree", "add", path, "-b", "other/branch", "main")
 			},
 			wantReason:    "branch_mismatch",
 			checkBranches: true,
@@ -146,7 +145,7 @@ func TestIssueWorkspaceDirectoryRecoveryReasons(t *testing.T) {
 		{
 			name: "detached head",
 			prepare: func(t *testing.T, fixture workspaceServerFixture, path string) {
-				runGit(t, fixture.bare, "worktree", "add", "--detach", path, "main")
+				gitfixture.Run(t, fixture.bare, "worktree", "add", "--detach", path, "main")
 			},
 			wantReason:    "branch_mismatch",
 			checkBranches: true,
@@ -157,8 +156,7 @@ func TestIssueWorkspaceDirectoryRecoveryReasons(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			runParallelWorkspaceTest(t)
-			acquireWorkspaceGitSlot(t)
+			runParallelWorkspaceGitTest(t)
 			assert := assert.New(t)
 			require := require.New(t)
 			fixture := setupWorkspaceServerFixture(t, nil)
@@ -201,8 +199,7 @@ func TestIssueWorkspaceDirectoryRecoveryReasons(t *testing.T) {
 }
 
 func TestIssueWorkspaceConflictRejectsAlternateBranchForExistingDirectory(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -215,7 +212,7 @@ func TestIssueWorkspaceConflictRejectsAlternateBranchForExistingDirectory(t *tes
 		"github", "github.com", "acme", "widget",
 		fmt.Sprintf("repo-%d", fixture.repoID), "issue-7",
 	)
-	runGit(t, fixture.bare, "worktree", "add", expectedPath, "-b", branch, "main")
+	gitfixture.Run(t, fixture.bare, "worktree", "add", expectedPath, "-b", branch, "main")
 
 	resp, err := fixture.client.HTTP.CreateIssueWorkspaceWithResponse(
 		t.Context(), "gh", "acme", "widget", 7,
@@ -258,8 +255,7 @@ func TestIssueWorkspaceConflictRejectsAlternateBranchForExistingDirectory(t *tes
 }
 
 func TestIssueWorkspaceRejectsConflictingReuseOptions(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/workspacetest/project_fixtures_test.go
+++ b/internal/server/workspacetest/project_fixtures_test.go
@@ -17,6 +17,7 @@ import (
 	ghclient "go.kenn.io/forge/internal/github"
 	"go.kenn.io/forge/internal/server"
 	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 	"go.kenn.io/forge/internal/testutil/servertest"
 	gitcmd "go.kenn.io/kit/git/cmd"
 )
@@ -62,12 +63,12 @@ func initLocalOnlyGitRepo(ctx context.Context, dir string) error {
 func initLifecycleRouteRepo(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
-	runGit(t, dir, "init", "--initial-branch=main")
-	runGit(t, dir, "config", "user.email", "test@example.com")
-	runGit(t, dir, "config", "user.name", "Test User")
+	gitfixture.Run(t, dir, "init", "--initial-branch=main")
+	gitfixture.Run(t, dir, "config", "user.email", "test@example.com")
+	gitfixture.Run(t, dir, "config", "user.name", "Test User")
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("# test\n"), 0o644))
-	runGit(t, dir, "add", "README.md")
-	runGit(t, dir, "commit", "-m", "initial")
+	gitfixture.Run(t, dir, "add", "README.md")
+	gitfixture.Run(t, dir, "commit", "-m", "initial")
 	return dir
 }
 

--- a/internal/server/workspacetest/project_git_routes_test.go
+++ b/internal/server/workspacetest/project_git_routes_test.go
@@ -14,10 +14,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/procutil"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 )
 
 func TestCloneProject(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -29,7 +30,7 @@ func TestCloneProject(t *testing.T) {
 	defer ts.Close()
 
 	source := initLifecycleRouteRepo(t)
-	runGit(t, source, "branch", "feat/clone")
+	gitfixture.Run(t, source, "branch", "feat/clone")
 	dest := filepath.Join(t.TempDir(), "cloned")
 
 	body := mustMarshal(t, map[string]any{
@@ -82,7 +83,7 @@ func TestCloneProjectBranchAndHomePath(t *testing.T) {
 	defer ts.Close()
 
 	source := initLifecycleRouteRepo(t)
-	runGit(t, source, "branch", "feat/clone")
+	gitfixture.Run(t, source, "branch", "feat/clone")
 
 	body := mustMarshal(t, map[string]any{
 		"url":    source,
@@ -111,7 +112,7 @@ func TestCloneProjectBranchAndHomePath(t *testing.T) {
 // request reserved, so an immediate retry reaches git again instead of
 // tripping destinationExists over a leftover partial checkout.
 func TestCloneProjectFailureCleansOwnedDestination(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -148,7 +149,7 @@ func TestCloneProjectFailureCleansOwnedDestination(t *testing.T) {
 }
 
 func TestListProjectBranches(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -160,8 +161,8 @@ func TestListProjectBranches(t *testing.T) {
 	defer ts.Close()
 
 	repo := initLifecycleRouteRepo(t)
-	runGit(t, repo, "branch", "feat/one")
-	runGit(t, repo, "branch", "feat/two")
+	gitfixture.Run(t, repo, "branch", "feat/one")
+	gitfixture.Run(t, repo, "branch", "feat/two")
 	projectID := registerProjectForTest(t, ts, repo)
 
 	resp := httpDo(t, ts, http.MethodGet,
@@ -184,7 +185,7 @@ func TestListProjectBranches(t *testing.T) {
 // GET /api/v1/projects/{pid}/worktrees/{wid}/inspect: dirty state, live
 // session count, and branch-delete eligibility for delete confirmation UIs.
 func TestInspectProjectWorktree(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -261,7 +262,7 @@ func TestInspectProjectWorktree(t *testing.T) {
 // runtime session) still counts as alive — otherwise delete confirmation
 // under-reports live work after a restart.
 func TestInspectProjectWorktreeCountsStoredTmuxSessions(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}

--- a/internal/server/workspacetest/project_handlers_test.go
+++ b/internal/server/workspacetest/project_handlers_test.go
@@ -13,10 +13,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 )
 
 func TestW1SliceAGate(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -191,7 +192,7 @@ func TestW1SliceAGate(t *testing.T) {
 }
 
 func TestRegisterProject_RejectsMissingPath(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -209,7 +210,7 @@ func TestRegisterProject_RejectsMissingPath(t *testing.T) {
 }
 
 func TestRegisterProject_PreservesExplicitProviderIdentity(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -261,7 +262,7 @@ func TestRegisterProject_PreservesExplicitProviderIdentity(t *testing.T) {
 }
 
 func TestRegisterProject_UsesConfiguredProviderForRemoteIdentity(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -282,8 +283,8 @@ host = "code.example.com"
 	defer ts.Close()
 
 	repoDir := t.TempDir()
-	runGit(t, repoDir, "init", "-q")
-	runGit(t, repoDir, "remote", "add", "origin", "git@code.example.com:group/subgroup/project.git")
+	gitfixture.Run(t, repoDir, "init", "-q")
+	gitfixture.Run(t, repoDir, "remote", "add", "origin", "git@code.example.com:group/subgroup/project.git")
 
 	body := mustMarshal(t, map[string]any{"local_path": repoDir})
 	resp := httpDo(t, ts, http.MethodPost, "/api/v1/projects", body)
@@ -301,7 +302,7 @@ host = "code.example.com"
 }
 
 func TestRegisterProject_UsesDefaultPlatformHostForRemoteIdentity(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -319,8 +320,8 @@ port = 8091
 	defer ts.Close()
 
 	repoDir := t.TempDir()
-	runGit(t, repoDir, "init", "-q")
-	runGit(t, repoDir, "remote", "add", "origin", "git@ghe.example.com:acme/widget.git")
+	gitfixture.Run(t, repoDir, "init", "-q")
+	gitfixture.Run(t, repoDir, "remote", "add", "origin", "git@ghe.example.com:acme/widget.git")
 
 	body := mustMarshal(t, map[string]any{"local_path": repoDir})
 	resp := httpDo(t, ts, http.MethodPost, "/api/v1/projects", body)
@@ -338,7 +339,7 @@ port = 8091
 }
 
 func TestRegisterProject_RejectsNonexistentPath(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := require.New(t)
 
 	srv, _ := setupProjectServer(t)
@@ -354,7 +355,7 @@ func TestRegisterProject_RejectsNonexistentPath(t *testing.T) {
 }
 
 func TestRegisterProject_DuplicatePathReturns409(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -378,7 +379,7 @@ func TestRegisterProject_DuplicatePathReturns409(t *testing.T) {
 }
 
 func TestRegisterProject_AcceptsCallerProvidedIdentity(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -452,7 +453,7 @@ func TestRegisterProject_AcceptsCallerProvidedIdentity(t *testing.T) {
 // to the sync set just by registering a project.
 
 func TestGetProject_NotFoundReturns404(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := require.New(t)
 
 	srv, _ := setupProjectServer(t)
@@ -469,7 +470,7 @@ func TestGetProject_NotFoundReturns404(t *testing.T) {
 // conflict: the row keeps its id and refreshes its branch. This lets explicit
 // registration converge with a row the background discovery pass created.
 func TestRegisterWorktree_SamePathSameProjectConverges(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -503,7 +504,7 @@ func TestRegisterWorktree_SamePathSameProjectConverges(t *testing.T) {
 // PUT .../session-backend persists the override, the worktree list reflects it,
 // and a worktree id under the valid project that does not exist is a 404.
 func TestSetWorktreeSessionBackendRoute(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -588,7 +589,7 @@ func TestSetWorktreeSessionBackendRoute(t *testing.T) {
 }
 
 func TestDeleteWorktreeRoute(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -644,7 +645,7 @@ func TestDeleteWorktreeRoute(t *testing.T) {
 // cross-project path collision a conflict; convergence only applies within the
 // owning project.
 func TestRegisterWorktree_SamePathDifferentProjectReturns409(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -708,7 +709,7 @@ func registerWorktreeForTest(
 }
 
 func TestListLaunchTargets_NotFoundReturns404(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := require.New(t)
 
 	srv, _ := setupProjectServer(t)
@@ -722,7 +723,7 @@ func TestListLaunchTargets_NotFoundReturns404(t *testing.T) {
 	resp.Body.Close()
 }
 func TestDeleteProjectRouteRemovesProject(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}

--- a/internal/server/workspacetest/project_validation_handlers_test.go
+++ b/internal/server/workspacetest/project_validation_handlers_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestRegisterProject_RejectsPartialPlatformIdentity(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -65,7 +65,7 @@ func TestRegisterProject_RejectsPartialPlatformIdentity(t *testing.T) {
 // recording the row.
 
 func TestRegisterProject_RejectsPathThatIsAFile(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -95,7 +95,7 @@ func TestRegisterProject_RejectsPathThatIsAFile(t *testing.T) {
 // still requires it.
 
 func TestRegisterWorktree_RejectsBlankFields(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -169,7 +169,7 @@ func TestRegisterWorktree_RejectsBlankFields(t *testing.T) {
 // register-project and register-worktree.
 
 func TestRegisterWorktree_NotFoundReturns404(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := require.New(t)
 
 	srv, _ := setupProjectServer(t)
@@ -194,7 +194,7 @@ func TestRegisterWorktree_NotFoundReturns404(t *testing.T) {
 // test catches a regression that lets the empty case marshal to null.
 
 func TestListProjects_ReturnsEmptyArrayNotNull(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 

--- a/internal/server/workspacetest/project_worktree_from_mr_test.go
+++ b/internal/server/workspacetest/project_worktree_from_mr_test.go
@@ -114,7 +114,7 @@ func seedMergeRequestForRepo(
 // same-repo merge request: the head branch is fetched from the project's
 // origin, materialized as a new worktree, and registered.
 func TestCreateWorktreeFromMergeRequestRoute(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := Require.New(t)
 	assert := assert.New(t)
 
@@ -313,7 +313,7 @@ func worktreeConfigForRoute(t *testing.T, dir, key string) string {
 // TestCreateWorktreeFromMergeRequestRouteUnknownNumber: an unsynced merge
 // request is a 404 with the pullNotFound code, and nothing touches disk.
 func TestCreateWorktreeFromMergeRequestRouteUnknownNumber(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := Require.New(t)
 	assert := assert.New(t)
 
@@ -346,7 +346,7 @@ func TestCreateWorktreeFromMergeRequestRouteUnknownNumber(t *testing.T) {
 // TestCreateWorktreeFromMergeRequestRouteNoIdentity: a local-only project
 // cannot resolve merge requests.
 func TestCreateWorktreeFromMergeRequestRouteNoIdentity(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := Require.New(t)
 
 	srv, _ := setupProjectServer(t)
@@ -371,7 +371,7 @@ func TestCreateWorktreeFromMergeRequestRouteNoIdentity(t *testing.T) {
 // import instead of failing with pullNotFound, so a caller (e.g. a fleet
 // hub proxying into this host) does not need a separate sync step.
 func TestCreateWorktreeFromMergeRequestRouteSyncsOnDemand(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := Require.New(t)
 	assert := assert.New(t)
 
@@ -461,7 +461,7 @@ func TestCreateWorktreeFromMergeRequestRouteSyncsOnDemand(t *testing.T) {
 }
 
 func TestCreateWorktreeFromMergeRequestRouteDoesNotSyncRemovedItem(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := Require.New(t)
 
 	repoPath := initLifecycleRouteRepo(t)

--- a/internal/server/workspacetest/project_worktree_lifecycle_test.go
+++ b/internal/server/workspacetest/project_worktree_lifecycle_test.go
@@ -36,7 +36,7 @@ func decodeProblemCode(t *testing.T, resp *http.Response) string {
 }
 
 func TestWorktreeCreateOnDiskRoute(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := Require.New(t)
 	assert := assert.New(t)
 
@@ -83,7 +83,7 @@ func TestWorktreeCreateOnDiskRoute(t *testing.T) {
 // TestWorktreeCreateOnDiskBranchInUse covers the distinct problem code for
 // attaching a branch that is already checked out (the primary checkout).
 func TestWorktreeCreateOnDiskBranchInUse(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := Require.New(t)
 	assert := assert.New(t)
 
@@ -113,7 +113,7 @@ func TestWorktreeCreateOnDiskBranchInUse(t *testing.T) {
 // response carries the hookFailed code with script detail, and the git work
 // is rolled back so nothing is registered and a retry is possible.
 func TestWorktreeCreateOnDiskHookFailure(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := Require.New(t)
 	assert := assert.New(t)
 
@@ -162,7 +162,7 @@ func TestWorktreeCreateOnDiskHookFailure(t *testing.T) {
 // succeeds but the registry insert hits a path conflict, the route rolls
 // the git work back so the conflicting state is not made worse.
 func TestWorktreeCreateOnDiskRollsBackWhenRowConflicts(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := Require.New(t)
 	assert := assert.New(t)
 
@@ -201,7 +201,7 @@ func TestWorktreeCreateOnDiskRollsBackWhenRowConflicts(t *testing.T) {
 // TestWorktreeDeleteFromDiskRoute covers the materializing delete: worktree
 // directory removed, branch deleted, registry row dropped.
 func TestWorktreeDeleteFromDiskRoute(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := Require.New(t)
 	assert := assert.New(t)
 
@@ -252,7 +252,7 @@ func TestWorktreeDeleteFromDiskRoute(t *testing.T) {
 // TestWorktreeDeleteFromDiskRefusesDirtyWithoutForce: dirty worktrees are
 // kept (registry row and disk both intact) unless force is set.
 func TestWorktreeDeleteFromDiskRefusesDirtyWithoutForce(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := Require.New(t)
 	assert := assert.New(t)
 
@@ -312,7 +312,7 @@ func TestWorktreeDeleteFromDiskRefusesDirtyWithoutForce(t *testing.T) {
 // TestWorktreeDeleteFromDiskRefusesDefaultBranch: a worktree on the
 // project's default branch is protected from disk-removing deletes.
 func TestWorktreeDeleteFromDiskRefusesDefaultBranch(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := Require.New(t)
 	assert := assert.New(t)
 
@@ -355,7 +355,7 @@ func TestWorktreeDeleteFromDiskRefusesDefaultBranch(t *testing.T) {
 // TestWorktreeDeleteFromDiskRunsTeardownHook: the teardown script runs in
 // the worktree before removal; its failure aborts the delete entirely.
 func TestWorktreeDeleteFromDiskRunsTeardownHook(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := Require.New(t)
 	assert := assert.New(t)
 
@@ -403,7 +403,7 @@ func TestWorktreeDeleteFromDiskRunsTeardownHook(t *testing.T) {
 // TestWorktreeDeleteFromDiskAbortsOnTeardownFailure: a failing teardown
 // keeps both the disk worktree and the registry row.
 func TestWorktreeDeleteFromDiskAbortsOnTeardownFailure(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := Require.New(t)
 	assert := assert.New(t)
 
@@ -454,7 +454,7 @@ func TestWorktreeDeleteFromDiskAbortsOnTeardownFailure(t *testing.T) {
 // TestWorktreeRegisterWithoutCreateOnDiskUnchanged pins the legacy
 // registry-only contract: path is required and no git work happens.
 func TestWorktreeRegisterWithoutCreateOnDiskUnchanged(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := Require.New(t)
 
 	srv, _ := setupProjectServer(t)
@@ -487,7 +487,7 @@ func TestWorktreeRegisterWithoutCreateOnDiskUnchanged(t *testing.T) {
 // barrier maximizes overlap, but a sequential interleaving also
 // satisfies (and must satisfy) the same contract.
 func TestWorktreeCreateOnDiskSameBranchConcurrent(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := Require.New(t)
 	assert := assert.New(t)
 

--- a/internal/server/workspacetest/pty_owner_e2e_test.go
+++ b/internal/server/workspacetest/pty_owner_e2e_test.go
@@ -3,16 +3,19 @@ package workspacetest
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"slices"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -24,7 +27,9 @@ import (
 	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/procutil"
 	"go.kenn.io/forge/internal/ptyowner"
+	"go.kenn.io/forge/internal/ptysize"
 	"go.kenn.io/forge/internal/server"
+	"go.kenn.io/forge/internal/server/workspaceapi"
 	"go.kenn.io/forge/internal/workspace"
 	"go.kenn.io/forge/internal/workspace/localruntime"
 )
@@ -90,7 +95,9 @@ func TestWorkspaceCreatesRustPtyManagerSessionE2E(t *testing.T) {
 			[]byte(`{"type":"resize","cols":133,"rows":37}`),
 		))
 		workspaceTerminalConnWriteRead(
-			t, ctx, conn, "printf 'size:'; stty size\r", "size:37 133",
+			t, ctx, conn,
+			"size=$(stty size); printf 'size:%s\\n' \"$size\"\r",
+			"size:37 133",
 		)
 	}
 
@@ -228,7 +235,7 @@ func TestWorkspaceRuntimeResizeOwnerFollowsLatestDeliberateClientE2E(t *testing.
 	))
 	workspaceTerminalConnWriteRead(
 		t, ctx, second,
-		"printf 'second-size:'; stty size\r",
+		"size=$(stty size); printf 'second-size:%s\\n' \"$size\"\r",
 		"second-size:30 100",
 	)
 
@@ -239,7 +246,7 @@ func TestWorkspaceRuntimeResizeOwnerFollowsLatestDeliberateClientE2E(t *testing.
 	))
 	workspaceTerminalConnWriteRead(
 		t, ctx, second,
-		"printf 'still-second:'; stty size\r",
+		"size=$(stty size); printf 'still-second:%s\\n' \"$size\"\r",
 		"still-second:30 100",
 	)
 
@@ -250,7 +257,7 @@ func TestWorkspaceRuntimeResizeOwnerFollowsLatestDeliberateClientE2E(t *testing.
 	))
 	workspaceTerminalConnWriteRead(
 		t, ctx, first,
-		"printf 'first-size:'; stty size\r",
+		"size=$(stty size); printf 'first-size:%s\\n' \"$size\"\r",
 		"first-size:40 120",
 	)
 
@@ -260,6 +267,1070 @@ func TestWorkspaceRuntimeResizeOwnerFollowsLatestDeliberateClientE2E(t *testing.
 	require.NoError(err)
 	require.Equal(http.StatusNoContent, stopResp.StatusCode())
 	deleteWorkspaceForPtyOwnerTest(t, ctx, fixture, ws.Id)
+}
+
+func TestWorkspaceRuntimeSessionTerminalWebSocketE2E(t *testing.T) {
+	require := require.New(t)
+	disableTmuxAgentSessions := false
+	cfg := &config.Config{Agents: []config.Agent{{
+		Key:     "helper",
+		Label:   "Helper",
+		Command: workspaceRuntimeHelperCommand("echo"),
+	}}, Tmux: config.Tmux{AgentSessions: &disableTmuxAgentSessions}}
+	fixture := setupWorkspaceServerFixture(t, cfg, server.ServerOptions{
+		DisableWorkspaceBackgroundMonitors: true,
+		HostCheckAllowLoopbackAnyPort:      true,
+		PtyOwnerInProcess:                  true,
+	})
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+
+	launchResp, err := fixture.client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: "helper",
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launchResp.StatusCode())
+	require.NotNil(launchResp.JSON200)
+	session := launchResp.JSON200
+
+	ts := httptest.NewServer(fixture.server)
+	t.Cleanup(ts.Close)
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
+		"/ws/v1/workspaces/" + ws.Id +
+		"/runtime/sessions/" + session.Key + "/terminal"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	workspaceTerminalConnWriteRead(t, ctx, conn, "ping\n", "echo:ping")
+}
+
+func TestWorkspaceRuntimeSessionTerminalWebSocketBasePathE2E(t *testing.T) {
+	require := require.New(t)
+	disableTmuxAgentSessions := false
+	cfg := &config.Config{
+		BasePath: "/kenn-forge/",
+		Agents: []config.Agent{{
+			Key:     "helper",
+			Label:   "Helper",
+			Command: workspaceRuntimeHelperCommand("echo"),
+		}},
+		Tmux: config.Tmux{AgentSessions: &disableTmuxAgentSessions},
+	}
+	fixture := setupWorkspaceServerFixture(t, cfg, server.ServerOptions{
+		DisableWorkspaceBackgroundMonitors: true,
+		HostCheckAllowLoopbackAnyPort:      true,
+		PtyOwnerInProcess:                  true,
+	})
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+
+	launchResp, err := fixture.client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: "helper",
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launchResp.StatusCode())
+	require.NotNil(launchResp.JSON200)
+	session := launchResp.JSON200
+
+	ts := httptest.NewServer(fixture.server)
+	t.Cleanup(ts.Close)
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
+		"/kenn-forge/ws/v1/workspaces/" + ws.Id +
+		"/runtime/sessions/" + session.Key + "/terminal"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	workspaceTerminalConnWriteRead(t, ctx, conn, "ping\n", "echo:ping")
+}
+
+func TestWorkspaceRuntimeSessionTerminalSkipsAltScreenReplayE2E(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	disableTmuxAgentSessions := false
+	cfg := &config.Config{Agents: []config.Agent{{
+		Key:     "helper",
+		Label:   "Helper",
+		Command: workspaceRuntimeHelperCommand("altscreen"),
+	}}, Tmux: config.Tmux{AgentSessions: &disableTmuxAgentSessions}}
+	fixture := setupWorkspaceServerFixture(t, cfg, server.ServerOptions{
+		DisableWorkspaceBackgroundMonitors: true,
+		HostCheckAllowLoopbackAnyPort:      true,
+		PtyOwnerInProcess:                  true,
+	})
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+
+	launchResp, err := fixture.client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: "helper",
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launchResp.StatusCode())
+	require.NotNil(launchResp.JSON200)
+	session := launchResp.JSON200
+
+	ts := httptest.NewServer(fixture.server)
+	t.Cleanup(ts.Close)
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
+		"/ws/v1/workspaces/" + ws.Id +
+		"/runtime/sessions/" + session.Key + "/terminal"
+
+	primingConn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(err)
+	workspaceTerminalConnWriteRead(t, ctx, primingConn, "prime\n", "codex screen")
+	require.NoError(primingConn.Close(websocket.StatusNormalClosure, "primed"))
+
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	type terminalRead struct {
+		typ  websocket.MessageType
+		data []byte
+		err  error
+	}
+	reads := make(chan terminalRead, 1)
+	readOnce := func() {
+		go func() {
+			typ, data, readErr := conn.Read(context.Background())
+			reads <- terminalRead{typ: typ, data: data, err: readErr}
+		}()
+	}
+	readOnce()
+	select {
+	case read := <-reads:
+		require.NoError(read.err)
+		require.Empty(
+			string(read.data),
+			"late attach must not replay stale alternate-screen output",
+		)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	require.NoError(conn.Write(
+		ctx, websocket.MessageBinary, []byte("paint\n"),
+	))
+	var got strings.Builder
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case read := <-reads:
+			require.NoError(read.err)
+			if read.typ == websocket.MessageBinary {
+				got.WriteString(string(read.data))
+			}
+			if strings.Contains(got.String(), "live:paint") {
+				break
+			}
+			readOnce()
+			continue
+		case <-deadline:
+			require.Contains(got.String(), "live:paint")
+		}
+		break
+	}
+	assert.NotContains(got.String(), "codex screen")
+	require.Contains(got.String(), "live:paint")
+}
+
+func TestWorkspaceRuntimeSessionTerminalAppliesInitialSizeE2E(t *testing.T) {
+	require := require.New(t)
+	// This intentionally goes through the generated HTTP client, the real
+	// httptest server, and the terminal websocket rather than attaching to
+	// localruntime directly. The helper exits quickly after printing the
+	// observed PTY size, so receiving size:41:177 exercises the full path
+	// that must preserve final terminal output before the exit frame wins.
+	disableTmuxAgentSessions := false
+	cfg := &config.Config{Agents: []config.Agent{{
+		Key:     "helper",
+		Label:   "Helper",
+		Command: workspaceRuntimeHelperCommand("size"),
+	}}, Tmux: config.Tmux{AgentSessions: &disableTmuxAgentSessions}}
+	fixture := setupWorkspaceServerFixture(t, cfg, server.ServerOptions{
+		DisableWorkspaceBackgroundMonitors: true,
+		HostCheckAllowLoopbackAnyPort:      true,
+		PtyOwnerInProcess:                  true,
+	})
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+
+	launchResp, err := fixture.client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: "helper",
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launchResp.StatusCode())
+	require.NotNil(launchResp.JSON200)
+	session := launchResp.JSON200
+
+	ts := httptest.NewServer(fixture.server)
+	t.Cleanup(ts.Close)
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
+		"/ws/v1/workspaces/" + ws.Id +
+		"/runtime/sessions/" + session.Key +
+		"/terminal?cols=177&rows=41"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	workspaceTerminalConnWriteRead(t, ctx, conn, "size\n", "size:41:177")
+}
+
+func TestWorkspacePtyOwnerTitleMarksWorkspaceWorkingE2E(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("workspace clone fixture uses Unix-style local remotes")
+	}
+	requirePTYAvailable(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+
+	dir := t.TempDir()
+	ptyOwnerDir := filepath.Join(dir, "pty-owner")
+	cfg := &config.Config{
+		Tmux:  config.Tmux{Command: []string{filepath.Join(dir, "missing-tmux")}},
+		Shell: config.Shell{Command: []string{"/bin/sh"}},
+	}
+	fixture := setupWorkspaceServerFixture(t, cfg, server.ServerOptions{
+		DisableWorkspaceBackgroundMonitors: true,
+		HostCheckAllowLoopbackAnyPort:      true,
+		PtyOwnerDir:                        ptyOwnerDir,
+		PtyOwnerInProcess:                  true,
+	})
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, ws.TmuxSession)
+
+	ts := httptest.NewServer(fixture.server)
+	t.Cleanup(ts.Close)
+
+	conn, _, err := workspaceTerminalDialWithQuery(ctx, ts.URL, ws.Id, "")
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+	workspaceTerminalConnWriteRead(
+		t, ctx, conn, "stty -echo\rprintf '%s\\n' $((40+2))\r", "42",
+	)
+	// The spinner glyph is sent as printf octal escapes (\342\240\264
+	// is "⠴") so the typed line stays pure ASCII. Raw multibyte bytes
+	// written to an interactive shell are interpreted by readline as
+	// meta editing commands when the host has no UTF-8 locale set,
+	// scrambling the command before it runs. The session still emits
+	// the real multibyte title for the pty owner to track.
+	workspaceTerminalConnWriteRead(
+		t, ctx, conn,
+		"printf 'title-sent\\n'; "+
+			"printf '\\033]0;\\342\\240\\264 t3code-b5014b03\\007'\r",
+		"t3code-b5014b03",
+	)
+
+	var got *generated.WorkspaceResponse
+	require.Eventually(func() bool {
+		resp, err := fixture.client.HTTP.GetWorkspaceWithResponse(ctx, ws.Id)
+		if err != nil || resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+			return false
+		}
+		got = resp.JSON200
+		return got.TmuxWorking &&
+			got.TmuxActivitySource == workspaceapi.TmuxActivitySourceTitle &&
+			got.TmuxPaneTitle != nil
+	}, 6*time.Second, 50*time.Millisecond)
+	require.NotNil(got)
+	assert.True(got.TmuxWorking)
+	assert.Equal(workspaceapi.TmuxActivitySourceTitle, got.TmuxActivitySource)
+	require.NotNil(got.TmuxPaneTitle)
+	assert.Equal("⠴ t3code-b5014b03", *got.TmuxPaneTitle)
+}
+
+func TestWorkspaceRuntimePlainShellUsesPtyOwnerWhenTmuxUnavailableE2E(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test fixture uses /bin/sh")
+	}
+
+	require := require.New(t)
+	assert := assert.New(t)
+
+	dir := t.TempDir()
+	ptyOwnerDir := filepath.Join(dir, "pty-owner")
+	cfg := &config.Config{
+		Tmux:  config.Tmux{Command: []string{filepath.Join(dir, "missing-tmux")}},
+		Shell: config.Shell{Command: []string{"/bin/sh"}},
+	}
+	fixture := setupWorkspaceServerFixture(t, cfg, server.ServerOptions{
+		DisableWorkspaceBackgroundMonitors: true,
+		HostCheckAllowLoopbackAnyPort:      true,
+		PtyOwnerDir:                        ptyOwnerDir,
+		PtyOwnerInProcess:                  true,
+	})
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+
+	launchResp, err := fixture.client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: string(localruntime.LaunchTargetPlainShell),
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launchResp.StatusCode(), string(launchResp.Body))
+	require.NotNil(launchResp.JSON200)
+	session := launchResp.JSON200
+	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, session.Key)
+	assert.Equal(string(localruntime.LaunchTargetPlainShell), session.TargetKey)
+	assert.Equal(string(localruntime.SessionStatusRunning), session.Status)
+
+	paths, err := ptyowner.NewSessionPaths(ptyOwnerDir, session.Key)
+	require.NoError(err)
+	_, err = os.Stat(paths.StatePath)
+	require.NoError(err)
+
+	storedTmux, err := fixture.database.ListWorkspaceRuntimeTmuxSessions(ctx, ws.Id)
+	require.NoError(err)
+	assert.Empty(storedTmux)
+
+	ts := httptest.NewServer(fixture.server)
+	t.Cleanup(ts.Close)
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
+		"/ws/v1/workspaces/" + ws.Id +
+		"/runtime/sessions/" + session.Key + "/terminal?cols=80&rows=24"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	workspaceTerminalConnWriteRead(
+		t, ctx, conn, "printf 'pty-owner-shell\\n'\r", "pty-owner-shell",
+	)
+}
+
+func TestRustPtyManagerRejectsConcurrentAttachmentsE2E(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("concurrent attach coverage is exercised by the Rust owner tests on Windows")
+	}
+	requirePTYAvailable(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+
+	managerPath := buildRustPtyManagerForTest(t)
+	ptyOwnerDir := longRustPtyOwnerDirForTest(t)
+	session := "kenn-forge-rust-concurrent"
+	command := []string{
+		"sh", "-c",
+		"printf ready; while IFS= read -r line; do echo got:$line; done",
+	}
+	client := ptyowner.Client{
+		Root:        ptyOwnerDir,
+		ManagerPath: managerPath,
+		Command:     command,
+	}
+	require.NoError(client.Ensure(t.Context(), session, t.TempDir()))
+	t.Cleanup(func() {
+		_ = client.Stop(context.Background(), session)
+	})
+
+	first, err := client.Attach(
+		context.Background(), session,
+		ptysize.Geometry{Cols: 120, Rows: 30},
+	)
+	require.NoError(err)
+	defer first.Close()
+	require.Contains(
+		readPtyOwnerOutputUntil(t, first.Output, "ready"),
+		"ready",
+	)
+	require.NoError(first.Write([]byte("before-second\r")))
+	require.Contains(
+		readPtyOwnerOutputUntil(t, first.Output, "got:before-second"),
+		"got:before-second",
+	)
+
+	second, err := client.Attach(
+		context.Background(), session,
+		ptysize.Geometry{Cols: 100, Rows: 20},
+	)
+	if second != nil {
+		second.Close()
+	}
+	require.Error(err)
+	assert.Contains(err.Error(), "already has an active attachment")
+
+	first.Close()
+	var third *ptyowner.Attachment
+	require.Eventually(func() bool {
+		var attachErr error
+		third, attachErr = client.Attach(
+			context.Background(), session,
+			ptysize.Geometry{Cols: 80, Rows: 24},
+		)
+		return attachErr == nil
+	}, 2*time.Second, 20*time.Millisecond)
+	defer third.Close()
+	require.NoError(third.Write([]byte("after-close\n")))
+	require.Contains(
+		readPtyOwnerOutputUntil(t, third.Output, "got:after-close"),
+		"got:after-close",
+	)
+}
+
+func TestWorkspacePtyOwnerTerminalRejectsConcurrentAttachmentsE2E(t *testing.T) {
+
+	require := require.New(t)
+	assert := assert.New(t)
+
+	dir := t.TempDir()
+	ptyOwnerDir := filepath.Join(dir, "pty-owner")
+	cfg := &config.Config{
+		Tmux:  config.Tmux{Command: []string{filepath.Join(dir, "missing-tmux")}},
+		Shell: config.Shell{Command: []string{"/bin/sh"}},
+	}
+	fixture := setupWorkspaceServerFixture(t, cfg, server.ServerOptions{
+		DisableWorkspaceBackgroundMonitors: true,
+		HostCheckAllowLoopbackAnyPort:      true,
+		PtyOwnerDir:                        ptyOwnerDir,
+		PtyOwnerInProcess:                  true,
+	})
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, ws.TmuxSession)
+
+	ts := httptest.NewServer(fixture.server)
+	t.Cleanup(ts.Close)
+
+	first, _, err := workspaceTerminalDialWithQuery(ctx, ts.URL, ws.Id, "")
+	require.NoError(err)
+	defer first.Close(websocket.StatusNormalClosure, "done")
+
+	second, resp, err := workspaceTerminalDialWithQuery(ctx, ts.URL, ws.Id, "")
+	require.Error(err)
+	if second != nil {
+		second.Close(websocket.StatusNormalClosure, "done")
+	}
+	require.NotNil(resp)
+	assert.Equal(http.StatusConflict, resp.StatusCode)
+	if resp.Body != nil {
+		resp.Body.Close()
+	}
+
+	require.NoError(first.Close(websocket.StatusNormalClosure, "done"))
+	third := workspaceTerminalDialEventually(t, ctx, ts.URL, ws.Id)
+	defer third.Close(websocket.StatusNormalClosure, "done")
+	workspaceTerminalConnWriteRead(
+		t, ctx, third, "printf 'owner-after-close\n'\n", "owner-after-close",
+	)
+}
+
+func TestWorkspacePtyOwnerTerminalFlushesFinalOutputOnExitE2E(t *testing.T) {
+
+	require := require.New(t)
+
+	dir := t.TempDir()
+	ptyOwnerDir := filepath.Join(dir, "pty-owner")
+	cfg := &config.Config{
+		Tmux:  config.Tmux{Command: []string{filepath.Join(dir, "missing-tmux")}},
+		Shell: config.Shell{Command: []string{"/bin/sh"}},
+	}
+	fixture := setupWorkspaceServerFixture(t, cfg, server.ServerOptions{
+		DisableWorkspaceBackgroundMonitors: true,
+		HostCheckAllowLoopbackAnyPort:      true,
+		PtyOwnerDir:                        ptyOwnerDir,
+		PtyOwnerInProcess:                  true,
+	})
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, ws.TmuxSession)
+
+	ts := httptest.NewServer(fixture.server)
+	t.Cleanup(ts.Close)
+
+	conn, _, err := workspaceTerminalDialWithQuery(ctx, ts.URL, ws.Id, "")
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	require.NoError(conn.Write(
+		ctx, websocket.MessageBinary,
+		[]byte("printf 'final-owner-output\n'; exit\n"),
+	))
+	readCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	var got strings.Builder
+	for {
+		typ, data, readErr := conn.Read(readCtx)
+		if readErr != nil {
+			break
+		}
+		if typ == websocket.MessageBinary {
+			got.WriteString(string(data))
+		}
+		if strings.Contains(got.String(), "final-owner-output") {
+			return
+		}
+	}
+	require.Contains(got.String(), "final-owner-output")
+}
+
+func TestWorkspaceRuntimeLaunchMultipleAndStopOneE2E(t *testing.T) {
+
+	require := require.New(t)
+	assert := assert.New(t)
+	disableTmuxAgentSessions := false
+	cfg := &config.Config{Agents: []config.Agent{{
+		Key:     "helper",
+		Label:   "Helper",
+		Command: workspaceRuntimeHelperCommand("echo"),
+	}}, Tmux: config.Tmux{AgentSessions: &disableTmuxAgentSessions}}
+	fixture := setupWorkspaceServerFixture(t, cfg)
+	client := fixture.client
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	firstResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: "helper",
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, firstResp.StatusCode())
+	require.NotNil(firstResp.JSON200)
+	first := firstResp.JSON200
+
+	secondResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: "helper",
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, secondResp.StatusCode())
+	require.NotNil(secondResp.JSON200)
+	second := secondResp.JSON200
+	assert.NotEqual(first.Key, second.Key)
+	assert.True(isRuntimeSessionKeyForWorkspace(ws.Id, first.Key))
+	assert.True(isRuntimeSessionKeyForWorkspace(ws.Id, second.Key))
+	assert.Equal("Helper", first.Label)
+	assert.Equal("Helper 2", second.Label)
+	assert.Equal(string(localruntime.SessionStatusRunning), first.Status)
+
+	renameResp, err := client.HTTP.RenameWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id, second.Key,
+		generated.RenameWorkspaceRuntimeSessionInputBody{Label: "Review helper"},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, renameResp.StatusCode(), string(renameResp.Body))
+	require.NotNil(renameResp.JSON200)
+	assert.Equal(second.Key, renameResp.JSON200.Key)
+	assert.Equal("Review helper", renameResp.JSON200.Label)
+
+	listResp, err := client.HTTP.GetWorkspaceRuntimeWithResponse(
+		ctx, ws.Id,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, listResp.StatusCode())
+	require.NotNil(listResp.JSON200)
+	require.NotNil(listResp.JSON200.Sessions)
+	require.Len(*listResp.JSON200.Sessions, 2)
+	assert.Equal(first.Key, (*listResp.JSON200.Sessions)[0].Key)
+	assert.Equal("Helper", (*listResp.JSON200.Sessions)[0].Label)
+	assert.Equal("Review helper", (*listResp.JSON200.Sessions)[1].Label)
+
+	stopResp, err := client.HTTP.StopWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id, first.Key,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusNoContent, stopResp.StatusCode())
+
+	afterStopResp, err := client.HTTP.GetWorkspaceRuntimeWithResponse(
+		ctx, ws.Id,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, afterStopResp.StatusCode())
+	require.NotNil(afterStopResp.JSON200)
+	require.NotNil(afterStopResp.JSON200.Sessions)
+	require.Len(*afterStopResp.JSON200.Sessions, 1)
+	assert.Equal(second.Key, (*afterStopResp.JSON200.Sessions)[0].Key)
+}
+
+func TestWorkspaceRuntimeNaturalAgentExitRemovesSessionE2E(t *testing.T) {
+
+	require := require.New(t)
+	assert := assert.New(t)
+	disableTmuxAgentSessions := false
+	cfg := &config.Config{Agents: []config.Agent{{
+		Key:     "helper",
+		Label:   "Helper",
+		Command: workspaceRuntimeHelperCommand("exit"),
+	}}, Tmux: config.Tmux{AgentSessions: &disableTmuxAgentSessions}}
+	fixture := setupWorkspaceServerFixture(t, cfg)
+	client := fixture.client
+	database := fixture.database
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	launchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: "helper",
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launchResp.StatusCode(), string(launchResp.Body))
+	require.NotNil(launchResp.JSON200)
+
+	require.Eventually(func() bool {
+		runtimeResp, runtimeErr := client.HTTP.GetWorkspaceRuntimeWithResponse(
+			ctx, ws.Id,
+		)
+		if runtimeErr != nil ||
+			runtimeResp.StatusCode() != http.StatusOK ||
+			runtimeResp.JSON200 == nil ||
+			runtimeResp.JSON200.Sessions == nil {
+			return false
+		}
+		return len(*runtimeResp.JSON200.Sessions) == 0
+	}, 2*time.Second, 20*time.Millisecond)
+	stored, err := database.ListWorkspaceRuntimeSessions(ctx, ws.Id)
+	require.NoError(err)
+	assert.Empty(stored)
+	assert.NotEmpty(launchResp.JSON200.Key)
+}
+
+func TestWorkspaceRuntimePtyOwnerQuickExitLaunchSucceedsE2E(t *testing.T) {
+
+	require := require.New(t)
+	assert := assert.New(t)
+	disableTmuxAgentSessions := false
+	cfg := &config.Config{Agents: []config.Agent{{
+		Key:     "helper",
+		Label:   "Helper",
+		Command: workspaceRuntimeHelperCommand("print-exit"),
+	}}, Tmux: config.Tmux{AgentSessions: &disableTmuxAgentSessions}}
+	fixture := setupWorkspaceServerFixture(t, cfg)
+	client := fixture.client
+	database := fixture.database
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	launchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: "helper",
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launchResp.StatusCode(), string(launchResp.Body))
+	require.NotNil(launchResp.JSON200)
+	assert.NotEmpty(launchResp.JSON200.Key)
+
+	require.Eventually(func() bool {
+		runtimeResp, runtimeErr := client.HTTP.GetWorkspaceRuntimeWithResponse(
+			ctx, ws.Id,
+		)
+		if runtimeErr != nil ||
+			runtimeResp.StatusCode() != http.StatusOK ||
+			runtimeResp.JSON200 == nil ||
+			runtimeResp.JSON200.Sessions == nil {
+			return false
+		}
+		return len(*runtimeResp.JSON200.Sessions) == 0
+	}, 2*time.Second, 20*time.Millisecond)
+	stored, err := database.ListWorkspaceRuntimeSessions(ctx, ws.Id)
+	require.NoError(err)
+	assert.Empty(stored)
+}
+
+// TestWorkspaceRuntimePlainShellTerminalWebSocketE2E exercises the runtime
+// session websocket path end-to-end with a custom Shell.Command. Hardened
+// deployments (e.g. systemd services with SystemCallFilter=~@privileged) need
+// the override so that zsh's startup setresuid is not SIGSYS'd by the parent's
+// seccomp filter; this test guards both the websocket route and the
+// config.Shell.Command -> manager.Options.ShellCommand wiring.
+func TestWorkspaceRuntimePlainShellTerminalWebSocketE2E(t *testing.T) {
+
+	require := require.New(t)
+	cfg := &config.Config{
+		Shell: config.Shell{
+			Command: workspaceRuntimeHelperCommand("echo"),
+		},
+	}
+	fixture := setupWorkspaceServerFixture(t, cfg, server.ServerOptions{
+		DisableWorkspaceBackgroundMonitors: true,
+		HostCheckAllowLoopbackAnyPort:      true,
+		PtyOwnerInProcess:                  true,
+	})
+	client := fixture.client
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	launchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: string(localruntime.LaunchTargetPlainShell),
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launchResp.StatusCode(), string(launchResp.Body))
+	require.NotNil(launchResp.JSON200)
+	shell := launchResp.JSON200
+
+	ts := httptest.NewServer(fixture.server)
+	t.Cleanup(ts.Close)
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
+		"/ws/v1/workspaces/" + ws.Id +
+		"/runtime/sessions/" + shell.Key + "/terminal?cols=80&rows=24"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	workspaceTerminalConnWriteRead(t, ctx, conn, "ping\n", "echo:ping")
+}
+
+// TestWorkspaceRuntimePlainShellTerminalDeliversActualExitCodeE2E pins the
+// websocket "exited" text frame contract through the real runtime stack. The
+// helper closes its PTY shortly before exiting so this exercises the window
+// where PTY EOF can arrive before process wait publishes the exit code.
+func TestWorkspaceRuntimePlainShellTerminalDeliversActualExitCodeE2E(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test fixture uses /bin/sh")
+	}
+
+	require := require.New(t)
+	dir := t.TempDir()
+	ptyOwnerDir := filepath.Join(dir, "pty-owner")
+	cfg := &config.Config{
+		Tmux: config.Tmux{
+			Command: []string{filepath.Join(dir, "missing-tmux")},
+		},
+		Shell: config.Shell{
+			Command: workspaceRuntimeHelperCommand("pty-close-on-input-then-exit"),
+		},
+	}
+	fixture := setupWorkspaceServerFixture(t, cfg, server.ServerOptions{
+		DisableWorkspaceBackgroundMonitors: true,
+		HostCheckAllowLoopbackAnyPort:      true,
+		PtyOwnerDir:                        ptyOwnerDir,
+		PtyOwnerInProcess:                  true,
+	})
+	client := fixture.client
+	srv := fixture.server
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	launchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: string(localruntime.LaunchTargetPlainShell),
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launchResp.StatusCode(), string(launchResp.Body))
+	require.NotNil(launchResp.JSON200)
+	shell := launchResp.JSON200
+	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, shell.Key)
+	stored, err := fixture.database.ListWorkspaceRuntimeSessions(ctx, ws.Id)
+	require.NoError(err)
+	require.Len(stored, 1)
+	require.Equal(shell.Key, stored[0].SessionKey)
+	require.Empty(stored[0].TmuxSession)
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
+		"/ws/v1/workspaces/" + ws.Id +
+		"/runtime/sessions/" + shell.Key + "/terminal?cols=80&rows=24"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	// Trigger after attach so the session cannot exit before the websocket
+	// connects. The helper's short delay makes PTY EOF reliably precede process
+	// exit while remaining inside the owner's bounded exit-code grace period.
+	require.NoError(conn.Write(ctx, websocket.MessageBinary, []byte("close\n")))
+	readCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	for {
+		typ, data, readErr := conn.Read(readCtx)
+		if readErr != nil {
+			require.Failf(
+				"never received exit frame",
+				"read err before exit frame: %v", readErr,
+			)
+		}
+		if typ != websocket.MessageText {
+			continue
+		}
+		var msg struct {
+			Type string `json:"type"`
+			Code int    `json:"code"`
+		}
+		require.NoError(json.Unmarshal(data, &msg))
+		require.Equal("exited", msg.Type)
+		require.Equal(7, msg.Code)
+		break
+	}
+
+	require.Eventually(func() bool {
+		runtimeResp, runtimeErr := client.HTTP.GetWorkspaceRuntimeWithResponse(
+			ctx, ws.Id,
+		)
+		if runtimeErr != nil || runtimeResp.StatusCode() != http.StatusOK ||
+			runtimeResp.JSON200 == nil {
+			return false
+		}
+		if runtimeResp.JSON200.Sessions != nil {
+			for _, session := range *runtimeResp.JSON200.Sessions {
+				if session.Key == shell.Key {
+					return false
+				}
+			}
+		}
+		rows, rowsErr := fixture.database.ListWorkspaceRuntimeSessions(ctx, ws.Id)
+		return rowsErr == nil && len(rows) == 0
+	}, 5*time.Second, 20*time.Millisecond)
+}
+
+func TestWorkspaceRuntimePtyOwnerQuickExitReportsExactStatusE2E(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test fixture uses Unix PTY exit semantics")
+	}
+
+	require := require.New(t)
+	dir := t.TempDir()
+	ptyOwnerDir := filepath.Join(dir, "pty-owner")
+	disableTmuxAgentSessions := false
+	cfg := &config.Config{
+		Agents: []config.Agent{{
+			Key:   "helper",
+			Label: "Helper",
+			// Keep the PTY open briefly after the shell exits so the owner can
+			// publish the exact status before output EOF reaches the bridge.
+			// Without this ordering, a loaded race runner can legitimately hit
+			// the owner's bounded unknown-status fallback instead.
+			Command: []string{
+				"sh", "-c", "IFS= read -r line; sleep 1 & exit 9",
+			},
+		}},
+		Tmux: config.Tmux{
+			Command:       []string{filepath.Join(dir, "missing-tmux")},
+			AgentSessions: &disableTmuxAgentSessions,
+		},
+	}
+	fixture := setupWorkspaceServerFixture(t, cfg, server.ServerOptions{
+		DisableWorkspaceBackgroundMonitors: true,
+		HostCheckAllowLoopbackAnyPort:      true,
+		PtyOwnerDir:                        ptyOwnerDir,
+		PtyOwnerInProcess:                  true,
+	})
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+
+	launchResp, err := fixture.client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{TargetKey: "helper"},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launchResp.StatusCode(), string(launchResp.Body))
+	require.NotNil(launchResp.JSON200)
+	session := launchResp.JSON200
+	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, session.Key)
+
+	stored, err := fixture.database.ListWorkspaceRuntimeSessions(ctx, ws.Id)
+	require.NoError(err)
+	require.Len(stored, 1)
+	require.Equal(session.Key, stored[0].SessionKey)
+
+	ts := httptest.NewServer(fixture.server)
+	t.Cleanup(ts.Close)
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
+		"/ws/v1/workspaces/" + ws.Id +
+		"/runtime/sessions/" + session.Key + "/terminal?cols=80&rows=24"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+	require.NoError(conn.Write(ctx, websocket.MessageBinary, []byte("exit\n")))
+
+	readCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	for {
+		typ, data, readErr := conn.Read(readCtx)
+		if readErr != nil {
+			require.Failf(
+				"never received exact exit frame",
+				"read err before exit frame: %v", readErr,
+			)
+		}
+		if typ != websocket.MessageText {
+			continue
+		}
+		var msg struct {
+			Type string `json:"type"`
+			Code int    `json:"code"`
+		}
+		require.NoError(json.Unmarshal(data, &msg))
+		require.Equal("exited", msg.Type)
+		require.Equal(9, msg.Code)
+		break
+	}
+
+	require.Eventually(func() bool {
+		runtimeResp, runtimeErr := fixture.client.HTTP.GetWorkspaceRuntimeWithResponse(
+			ctx, ws.Id,
+		)
+		if runtimeErr != nil || runtimeResp.StatusCode() != http.StatusOK ||
+			runtimeResp.JSON200 == nil || runtimeResp.JSON200.Sessions == nil ||
+			len(*runtimeResp.JSON200.Sessions) != 0 {
+			return false
+		}
+		stored, storedErr := fixture.database.ListWorkspaceRuntimeSessions(ctx, ws.Id)
+		return storedErr == nil && len(stored) == 0
+	}, 2*time.Second, 20*time.Millisecond)
+}
+
+// TestWorkspaceRuntimePlainShellAfterExitStartsFreshE2E pins the user-visible
+// no-tmux behavior that launching a shell after the terminal has reported exit
+// returns a fresh ptyowner-backed session, never the dead shell record the
+// frontend just auto-closed.
+func TestWorkspaceRuntimePlainShellAfterExitStartsFreshE2E(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test fixture uses /bin/sh")
+	}
+
+	require := require.New(t)
+	assert := assert.New(t)
+	cfg := &config.Config{
+		Tmux: config.Tmux{
+			Command: []string{filepath.Join(t.TempDir(), "missing-tmux")},
+		},
+		Shell: config.Shell{
+			Command: workspaceRuntimeHelperCommand("pty-close-on-input-then-sleep"),
+		},
+	}
+	ptyOwnerDir := filepath.Join(t.TempDir(), "pty-owner")
+	fixture := setupWorkspaceServerFixture(t, cfg, server.ServerOptions{
+		DisableWorkspaceBackgroundMonitors: true,
+		HostCheckAllowLoopbackAnyPort:      true,
+		PtyOwnerDir:                        ptyOwnerDir,
+		PtyOwnerInProcess:                  true,
+	})
+	client := fixture.client
+	srv := fixture.server
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	firstLaunchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: string(localruntime.LaunchTargetPlainShell),
+		},
+	)
+	require.NoError(err)
+	require.Equal(
+		http.StatusOK, firstLaunchResp.StatusCode(), string(firstLaunchResp.Body),
+	)
+	require.NotNil(firstLaunchResp.JSON200)
+	first := firstLaunchResp.JSON200
+	firstCreatedAt := first.CreatedAt
+	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, first.Key)
+
+	// Attach + drain to drive the helper through exit, then ensure
+	// the next shell open does not reuse the session that just
+	// reported an exit frame to the frontend.
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
+		"/ws/v1/workspaces/" + ws.Id +
+		"/runtime/sessions/" + first.Key + "/terminal?cols=80&rows=24"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(err)
+	require.NoError(conn.Write(ctx, websocket.MessageBinary, []byte("exit\n")))
+	readCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	for {
+		typ, data, readErr := conn.Read(readCtx)
+		if readErr != nil {
+			require.Failf(
+				"never received exit frame",
+				"read err before exit frame: %v", readErr,
+			)
+		}
+		if typ != websocket.MessageText {
+			continue
+		}
+		var msg struct {
+			Type string `json:"type"`
+		}
+		require.NoError(json.Unmarshal(data, &msg))
+		require.Equal("exited", msg.Type)
+		break
+	}
+	conn.Close(websocket.StatusNormalClosure, "done")
+
+	// Inside the zombie window: helper still sleeping, so cmd.Wait
+	// hasn't returned and watchSession hasn't run.
+	secondLaunchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: string(localruntime.LaunchTargetPlainShell),
+		},
+	)
+	require.NoError(err)
+	require.Equal(
+		http.StatusOK, secondLaunchResp.StatusCode(), string(secondLaunchResp.Body),
+	)
+	require.NotNil(secondLaunchResp.JSON200)
+	second := secondLaunchResp.JSON200
+	assert.NotEqual(
+		firstCreatedAt, second.CreatedAt,
+		"second shell launch must return a fresh session, not the zombie",
+	)
+	assert.Equal(string(localruntime.SessionStatusRunning), second.Status)
+}
+
+func readPtyOwnerOutputUntil(
+	t *testing.T,
+	output <-chan []byte,
+	needle string,
+) string {
+	t.Helper()
+
+	deadline := time.After(2 * time.Second)
+	var builder strings.Builder
+	for {
+		select {
+		case chunk, ok := <-output:
+			if !ok {
+				return builder.String()
+			}
+			builder.Write(chunk)
+			if strings.Contains(builder.String(), needle) {
+				return builder.String()
+			}
+		case <-deadline:
+			require.New(t).Failf(
+				"timed out waiting for output",
+				"wanted %q in %q", needle, builder.String(),
+			)
+		}
+	}
+}
+
+func isRuntimeSessionKeyForWorkspace(workspaceID string, key string) bool {
+	suffix := strings.TrimPrefix(key, workspaceID+"_")
+	return suffix != key &&
+		len(suffix) == 16 &&
+		strings.IndexFunc(suffix, func(r rune) bool {
+			return !strings.ContainsRune("0123456789abcdef", r)
+		}) == -1
 }
 
 func deleteWorkspaceForPtyOwnerTest(
@@ -410,6 +1481,32 @@ func workspaceTerminalDialWithQuery(
 	return websocket.Dial(ctx, wsURL, nil)
 }
 
+func workspaceTerminalDialEventually(
+	t *testing.T,
+	ctx context.Context,
+	serverURL string,
+	workspaceID string,
+) *websocket.Conn {
+	t.Helper()
+
+	var conn *websocket.Conn
+	require.Eventually(t, func() bool {
+		var resp *http.Response
+		var err error
+		conn, resp, err = workspaceTerminalDialWithQuery(
+			ctx, serverURL, workspaceID, "",
+		)
+		if err != nil && conn != nil {
+			conn.Close(websocket.StatusNormalClosure, "done")
+		}
+		if resp != nil && resp.Body != nil {
+			resp.Body.Close()
+		}
+		return err == nil
+	}, 2*time.Second, 20*time.Millisecond)
+	return conn
+}
+
 func workspaceRuntimeHelperCommand(mode string) []string {
 	return []string{
 		os.Args[0],
@@ -435,6 +1532,58 @@ func TestWorkspaceRuntimeHelperProcess(t *testing.T) {
 		for {
 			time.Sleep(time.Hour)
 		}
+	case "altscreen":
+		reader := bufio.NewReader(os.Stdin)
+		_, err := reader.ReadString('\n')
+		if err != nil {
+			for {
+				time.Sleep(time.Hour)
+			}
+		}
+		fmt.Print("\x1b[?1049h\x1b[Hcodex screen")
+		line, err := reader.ReadString('\n')
+		if err == nil {
+			fmt.Print("\x1b[Hlive:" + line)
+		}
+		for {
+			time.Sleep(time.Hour)
+		}
+	case "size":
+		line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		if err == nil {
+			rows, cols, sizeErr := pty.Getsize(os.Stdin)
+			if sizeErr == nil {
+				fmt.Printf("size:%d:%d:%s", rows, cols, line)
+			}
+		}
+		return
+	case "exit":
+		os.Exit(3)
+	case "print-exit":
+		fmt.Print("quick-api-output")
+		os.Exit(7)
+	case "pty-close-on-input-then-sleep":
+		_, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		if err != nil {
+			os.Exit(2)
+		}
+		signal.Ignore(syscall.SIGHUP, syscall.SIGTERM, syscall.SIGINT)
+		_ = os.Stdin.Close()
+		_ = os.Stdout.Close()
+		_ = os.Stderr.Close()
+		time.Sleep(2 * time.Second)
+		os.Exit(7)
+	case "pty-close-on-input-then-exit":
+		_, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		if err != nil {
+			os.Exit(2)
+		}
+		signal.Ignore(syscall.SIGHUP, syscall.SIGTERM, syscall.SIGINT)
+		_ = os.Stdin.Close()
+		_ = os.Stdout.Close()
+		_ = os.Stderr.Close()
+		time.Sleep(50 * time.Millisecond)
+		os.Exit(7)
 	default:
 		require.Failf(t, "unknown helper mode", "mode %q", args[sep+2])
 	}

--- a/internal/server/workspacetest/pty_owner_e2e_test.go
+++ b/internal/server/workspacetest/pty_owner_e2e_test.go
@@ -270,6 +270,8 @@ func TestWorkspaceRuntimeResizeOwnerFollowsLatestDeliberateClientE2E(t *testing.
 }
 
 func TestWorkspaceRuntimeSessionTerminalWebSocketE2E(t *testing.T) {
+	runParallelWorkspacePTYTest(t)
+
 	require := require.New(t)
 	disableTmuxAgentSessions := false
 	cfg := &config.Config{Agents: []config.Agent{{
@@ -309,6 +311,8 @@ func TestWorkspaceRuntimeSessionTerminalWebSocketE2E(t *testing.T) {
 }
 
 func TestWorkspaceRuntimeSessionTerminalWebSocketBasePathE2E(t *testing.T) {
+	runParallelWorkspacePTYTest(t)
+
 	require := require.New(t)
 	disableTmuxAgentSessions := false
 	cfg := &config.Config{
@@ -352,6 +356,8 @@ func TestWorkspaceRuntimeSessionTerminalWebSocketBasePathE2E(t *testing.T) {
 }
 
 func TestWorkspaceRuntimeSessionTerminalSkipsAltScreenReplayE2E(t *testing.T) {
+	runParallelWorkspacePTYTest(t)
+
 	require := require.New(t)
 	assert := assert.New(t)
 	disableTmuxAgentSessions := false
@@ -444,6 +450,8 @@ func TestWorkspaceRuntimeSessionTerminalSkipsAltScreenReplayE2E(t *testing.T) {
 }
 
 func TestWorkspaceRuntimeSessionTerminalAppliesInitialSizeE2E(t *testing.T) {
+	runParallelWorkspacePTYTest(t)
+
 	require := require.New(t)
 	// This intentionally goes through the generated HTTP client, the real
 	// httptest server, and the terminal websocket rather than attaching to
@@ -492,6 +500,7 @@ func TestWorkspacePtyOwnerTitleMarksWorkspaceWorkingE2E(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("workspace clone fixture uses Unix-style local remotes")
 	}
+	runParallelWorkspacePTYTest(t)
 	requirePTYAvailable(t)
 
 	require := require.New(t)
@@ -557,6 +566,7 @@ func TestWorkspaceRuntimePlainShellUsesPtyOwnerWhenTmuxUnavailableE2E(t *testing
 	if runtime.GOOS == "windows" {
 		t.Skip("test fixture uses /bin/sh")
 	}
+	runParallelWorkspacePTYTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -618,6 +628,7 @@ func TestRustPtyManagerRejectsConcurrentAttachmentsE2E(t *testing.T) {
 		t.Skip("concurrent attach coverage is exercised by the Rust owner tests on Windows")
 	}
 	requirePTYAvailable(t)
+	runParallelWorkspacePTYTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -684,6 +695,7 @@ func TestRustPtyManagerRejectsConcurrentAttachmentsE2E(t *testing.T) {
 }
 
 func TestWorkspacePtyOwnerTerminalRejectsConcurrentAttachmentsE2E(t *testing.T) {
+	runParallelWorkspacePTYTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -731,6 +743,7 @@ func TestWorkspacePtyOwnerTerminalRejectsConcurrentAttachmentsE2E(t *testing.T) 
 }
 
 func TestWorkspacePtyOwnerTerminalFlushesFinalOutputOnExitE2E(t *testing.T) {
+	runParallelWorkspacePTYTest(t)
 
 	require := require.New(t)
 
@@ -780,6 +793,7 @@ func TestWorkspacePtyOwnerTerminalFlushesFinalOutputOnExitE2E(t *testing.T) {
 }
 
 func TestWorkspaceRuntimeLaunchMultipleAndStopOneE2E(t *testing.T) {
+	runParallelWorkspacePTYTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -862,6 +876,7 @@ func TestWorkspaceRuntimeLaunchMultipleAndStopOneE2E(t *testing.T) {
 }
 
 func TestWorkspaceRuntimeNaturalAgentExitRemovesSessionE2E(t *testing.T) {
+	runParallelWorkspacePTYTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -906,6 +921,7 @@ func TestWorkspaceRuntimeNaturalAgentExitRemovesSessionE2E(t *testing.T) {
 }
 
 func TestWorkspaceRuntimePtyOwnerQuickExitLaunchSucceedsE2E(t *testing.T) {
+	runParallelWorkspacePTYTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -956,6 +972,7 @@ func TestWorkspaceRuntimePtyOwnerQuickExitLaunchSucceedsE2E(t *testing.T) {
 // seccomp filter; this test guards both the websocket route and the
 // config.Shell.Command -> manager.Options.ShellCommand wiring.
 func TestWorkspaceRuntimePlainShellTerminalWebSocketE2E(t *testing.T) {
+	runParallelWorkspacePTYTest(t)
 
 	require := require.New(t)
 	cfg := &config.Config{
@@ -1003,6 +1020,7 @@ func TestWorkspaceRuntimePlainShellTerminalDeliversActualExitCodeE2E(t *testing.
 	if runtime.GOOS == "windows" {
 		t.Skip("test fixture uses /bin/sh")
 	}
+	runParallelWorkspacePTYTest(t)
 
 	require := require.New(t)
 	dir := t.TempDir()
@@ -1103,6 +1121,7 @@ func TestWorkspaceRuntimePtyOwnerQuickExitReportsExactStatusE2E(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test fixture uses Unix PTY exit semantics")
 	}
+	runParallelWorkspacePTYTest(t)
 
 	require := require.New(t)
 	dir := t.TempDir()
@@ -1204,6 +1223,7 @@ func TestWorkspaceRuntimePlainShellAfterExitStartsFreshE2E(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test fixture uses /bin/sh")
 	}
+	runParallelWorkspacePTYTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/server/workspacetest/workspace_agent_activity_test.go
+++ b/internal/server/workspacetest/workspace_agent_activity_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/apiclient/generated"
 	"go.kenn.io/forge/internal/config"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 )
 
 func TestWorkspaceAgentActivityFlowsThroughHTTPResponsesE2E(t *testing.T) {
@@ -115,10 +116,10 @@ func TestWorkspaceAgentActivityFlowsThroughHTTPResponsesE2E(t *testing.T) {
 	require.NoError(os.WriteFile(
 		filepath.Join(ws.WorktreePath, "activity.txt"), []byte("activity\n"), 0o644,
 	))
-	runGit(t, ws.WorktreePath, "config", "user.email", "agent-activity@example.invalid")
-	runGit(t, ws.WorktreePath, "config", "user.name", "Agent Activity Fixture")
-	runGit(t, ws.WorktreePath, "add", "activity.txt")
-	runGit(t, ws.WorktreePath, "commit", "-m", "add activity fixture")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.email", "agent-activity@example.invalid")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.name", "Agent Activity Fixture")
+	gitfixture.Run(t, ws.WorktreePath, "add", "activity.txt")
+	gitfixture.Run(t, ws.WorktreePath, "commit", "-m", "add activity fixture")
 	pushResponse, err := fixture.client.HTTP.PushWorkspaceBranchWithResponse(ctx, ws.Id)
 	require.NoError(err)
 	require.Equal(http.StatusOK, pushResponse.StatusCode(), string(pushResponse.Body))

--- a/internal/server/workspacetest/workspace_branch_actions_test.go
+++ b/internal/server/workspacetest/workspace_branch_actions_test.go
@@ -12,27 +12,28 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/server/httpapi"
+	"go.kenn.io/forge/internal/testutil"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 	"go.kenn.io/forge/internal/workspace"
 )
 
 func TestWorkspacePushBranchRoutePushesAheadBranch(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	fixture := setupWorkspaceServerFixture(t, nil)
 	client, srv := fixture.client, fixture.server
 	ctx := context.Background()
 	ws := createReadyWorkspace(t, ctx, client)
-	runGit(t, ws.WorktreePath, "config", "user.email", "test@test.com")
-	runGit(t, ws.WorktreePath, "config", "user.name", "Test")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.name", "Test")
 	require.NoError(os.WriteFile(
 		filepath.Join(ws.WorktreePath, "ahead.txt"), []byte("ahead\n"), 0o644,
 	))
-	runGit(t, ws.WorktreePath, "add", ".")
-	runGit(t, ws.WorktreePath, "commit", "-m", "ahead")
+	gitfixture.Run(t, ws.WorktreePath, "add", ".")
+	gitfixture.Run(t, ws.WorktreePath, "commit", "-m", "ahead")
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/workspaces/"+ws.Id+"/push", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/workspaces/"+ws.Id+"/push", nil)
 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	div, ok, err := workspace.WorktreeDivergence(ctx, ws.WorktreePath)
@@ -42,15 +43,14 @@ func TestWorkspacePushBranchRoutePushesAheadBranch(t *testing.T) {
 }
 
 func TestWorkspacePullBranchRouteFastForwardsBehindBranch(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := require.New(t)
 	assert := assert.New(t)
 	fixture := setupWorkspaceServerFixture(t, nil)
 	client, srv := fixture.client, fixture.server
 	ctx := context.Background()
 	ws := createReadyWorkspace(t, ctx, client)
-	runGit(t, ws.WorktreePath, "push", "-u", "origin", "HEAD")
+	gitfixture.Run(t, ws.WorktreePath, "push", "-u", "origin", "HEAD")
 	upstreamRef := workspaceGitOutput(
 		t, ws.WorktreePath,
 		"rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}",
@@ -59,18 +59,18 @@ func TestWorkspacePullBranchRouteFastForwardsBehindBranch(t *testing.T) {
 
 	other := filepath.Join(t.TempDir(), "other")
 	originURL := workspaceGitOutput(t, ws.WorktreePath, "remote", "get-url", "origin")
-	runGit(t, t.TempDir(), "clone", originURL, other)
-	runGit(t, other, "config", "user.email", "test@test.com")
-	runGit(t, other, "config", "user.name", "Test")
-	runGit(t, other, "checkout", "-b", upstreamBranch, upstreamRef)
+	gitfixture.Run(t, t.TempDir(), "clone", originURL, other)
+	gitfixture.Run(t, other, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, other, "config", "user.name", "Test")
+	gitfixture.Run(t, other, "checkout", "-b", upstreamBranch, upstreamRef)
 	require.NoError(os.WriteFile(
 		filepath.Join(other, "remote.txt"), []byte("remote\n"), 0o644,
 	))
-	runGit(t, other, "add", ".")
-	runGit(t, other, "commit", "-m", "remote")
-	runGit(t, other, "push", "origin", upstreamBranch)
+	gitfixture.Run(t, other, "add", ".")
+	gitfixture.Run(t, other, "commit", "-m", "remote")
+	gitfixture.Run(t, other, "push", "origin", upstreamBranch)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/workspaces/"+ws.Id+"/pull", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/workspaces/"+ws.Id+"/pull", nil)
 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 	contents, err := os.ReadFile(filepath.Join(ws.WorktreePath, "remote.txt"))
@@ -79,8 +79,7 @@ func TestWorkspacePullBranchRouteFastForwardsBehindBranch(t *testing.T) {
 }
 
 func TestWorkspacePullBranchRouteRejectsDirtyWorktree(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	require := require.New(t)
 	fixture := setupWorkspaceServerFixture(t, nil)
 	client, srv := fixture.client, fixture.server
@@ -90,10 +89,10 @@ func TestWorkspacePullBranchRouteRejectsDirtyWorktree(t *testing.T) {
 		filepath.Join(ws.WorktreePath, "dirty.txt"), []byte("dirty\n"), 0o644,
 	))
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/workspaces/"+ws.Id+"/pull", nil)
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/workspaces/"+ws.Id+"/pull", nil)
 
 	require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
-	var problem rawProblemDetail
+	var problem httpapi.ProblemError
 	require.NoError(json.NewDecoder(rr.Body).Decode(&problem))
-	assert.New(t).Equal(string(httpapi.CodeWorktreeDirty), problem.Code)
+	assert.New(t).Equal(httpapi.CodeWorktreeDirty, problem.Code)
 }

--- a/internal/server/workspacetest/workspace_branch_actions_test.go
+++ b/internal/server/workspacetest/workspace_branch_actions_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestWorkspacePushBranchRoutePushesAheadBranch(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 	require := require.New(t)
 	assert := assert.New(t)
@@ -42,7 +42,7 @@ func TestWorkspacePushBranchRoutePushesAheadBranch(t *testing.T) {
 }
 
 func TestWorkspacePullBranchRouteFastForwardsBehindBranch(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 	require := require.New(t)
 	assert := assert.New(t)
@@ -79,7 +79,7 @@ func TestWorkspacePullBranchRouteFastForwardsBehindBranch(t *testing.T) {
 }
 
 func TestWorkspacePullBranchRouteRejectsDirtyWorktree(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 	require := require.New(t)
 	fixture := setupWorkspaceServerFixture(t, nil)

--- a/internal/server/workspacetest/workspace_clone_safety_test.go
+++ b/internal/server/workspacetest/workspace_clone_safety_test.go
@@ -27,7 +27,7 @@ func setupLifecycleWorkspaceServer(t *testing.T) (*apiclient.Client, *db.DB, str
 }
 
 func TestWorkspaceForceDeleteToleratesCorruptWorktreeGitfileE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -59,7 +59,6 @@ func TestWorkspaceForceDeleteToleratesCorruptWorktreeGitfileE2E(t *testing.T) {
 func TestWorkspaceForceDeleteQuarantinesReplacedWorktreeAndAllowsRecreateE2E(
 	t *testing.T,
 ) {
-	t.Parallel()
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -110,7 +109,7 @@ func TestWorkspaceForceDeleteQuarantinesReplacedWorktreeAndAllowsRecreateE2E(
 func TestWorkspaceForceDeleteQuarantinesReplacementFileAndAllowsRecreateE2E(
 	t *testing.T,
 ) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -156,7 +155,7 @@ func TestWorkspaceForceDeleteQuarantinesReplacementFileAndAllowsRecreateE2E(
 func TestWorkspaceForceDeleteReplacementCloneClearsManagedRegistrationE2E(
 	t *testing.T,
 ) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -219,7 +218,7 @@ func TestWorkspaceForceDeleteReplacementCloneClearsManagedRegistrationE2E(
 func TestWorkspaceForceDeletePreservesSameOriginForeignLinkedWorktreeE2E(
 	t *testing.T,
 ) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -294,7 +293,7 @@ func TestWorkspaceForceDeletePreservesSameOriginForeignLinkedWorktreeE2E(
 func TestWorkspaceForceDeletePreservesForeignLinkedWorktreeAfterManagedPruneE2E(
 	t *testing.T,
 ) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -362,7 +361,7 @@ func TestWorkspaceForceDeletePreservesForeignLinkedWorktreeAfterManagedPruneE2E(
 func TestWorkspaceForceDeleteRemovesSameRepoReplacementAfterManagedPruneE2E(
 	t *testing.T,
 ) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -415,7 +414,7 @@ func TestWorkspaceForceDeleteRemovesSameRepoReplacementAfterManagedPruneE2E(
 func TestWorkspaceForceDeleteRemovesPreMarkerWorkspaceAfterUpgradeE2E(
 	t *testing.T,
 ) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -457,7 +456,7 @@ func TestWorkspaceForceDeleteRemovesPreMarkerWorkspaceAfterUpgradeE2E(
 }
 
 func TestWorkspaceForceDeleteRetainsLockedWorktreeE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -515,7 +514,7 @@ func TestWorkspaceForceDeleteRetainsLockedWorktreeE2E(t *testing.T) {
 func TestWorkspaceForceDeleteForgetsSymlinkToSameRepoWorktreeE2E(
 	t *testing.T,
 ) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -565,7 +564,7 @@ func TestWorkspaceForceDeleteForgetsSymlinkToSameRepoWorktreeE2E(
 }
 
 func TestWorkspaceCreateRejectsSymlinkedReusableWorktreeE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -631,7 +630,7 @@ func TestWorkspaceCreateRejectsSymlinkedReusableWorktreeE2E(t *testing.T) {
 func TestWorkspaceRetryAcceptsPreMarkerWorkspaceAfterUpgradeE2E(
 	t *testing.T,
 ) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -674,7 +673,7 @@ func TestWorkspaceRetryAcceptsPreMarkerWorkspaceAfterUpgradeE2E(
 }
 
 func TestWorkspaceRetryCleansStalePreMarkerRegistrationE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -718,7 +717,7 @@ func TestWorkspaceRetryCleansStalePreMarkerRegistrationE2E(t *testing.T) {
 }
 
 func TestWorkspaceCreateOccupiedPathCreatesNoBranchesE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -794,7 +793,7 @@ func TestWorkspaceCreateOccupiedPathCreatesNoBranchesE2E(t *testing.T) {
 }
 
 func TestWorkspaceCreateSameRepoHeadCloneURLTracksOriginBranchE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -862,7 +861,6 @@ func requireGitRefMissing(t *testing.T, dir, ref string) {
 }
 
 func TestWorkspaceRetryUnknownHeadRepoFailsClosedE2E(t *testing.T) {
-	t.Parallel()
 	acquireWorkspaceGitSlot(t)
 
 	assert := assert.New(t)
@@ -935,7 +933,7 @@ func TestWorkspaceRetryUnknownHeadRepoFailsClosedE2E(t *testing.T) {
 }
 
 func TestWorkspaceDeletePreservesUserCreatedBranch(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	assert := assert.New(t)
@@ -977,7 +975,7 @@ func TestWorkspaceDeletePreservesUserCreatedBranch(t *testing.T) {
 }
 
 func TestWorkspaceDeleteDoesNotCleanupReplacementCloneE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	assert := assert.New(t)
@@ -1025,7 +1023,7 @@ func TestWorkspaceDeleteDoesNotCleanupReplacementCloneE2E(t *testing.T) {
 }
 
 func TestWorkspaceCreatePreservesExistingLocalPreferredBranch(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	assert := assert.New(t)
@@ -1087,7 +1085,7 @@ func TestWorkspaceCreatePreservesExistingLocalPreferredBranch(t *testing.T) {
 }
 
 func TestWorkspaceDeleteLegacySyntheticBranchAllowsRecreate(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	assert := assert.New(t)
@@ -1173,7 +1171,7 @@ func TestWorkspaceDeleteLegacySyntheticBranchAllowsRecreate(t *testing.T) {
 }
 
 func TestWorkspaceDeleteDirty(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)

--- a/internal/server/workspacetest/workspace_clone_safety_test.go
+++ b/internal/server/workspacetest/workspace_clone_safety_test.go
@@ -16,6 +16,7 @@ import (
 	"go.kenn.io/forge/internal/apiclient"
 	"go.kenn.io/forge/internal/apiclient/generated"
 	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 	"go.kenn.io/forge/internal/workspace"
 	gitcmd "go.kenn.io/kit/git/cmd"
 )
@@ -27,8 +28,7 @@ func setupLifecycleWorkspaceServer(t *testing.T) (*apiclient.Client, *db.DB, str
 }
 
 func TestWorkspaceForceDeleteToleratesCorruptWorktreeGitfileE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -59,7 +59,7 @@ func TestWorkspaceForceDeleteToleratesCorruptWorktreeGitfileE2E(t *testing.T) {
 func TestWorkspaceForceDeleteQuarantinesReplacedWorktreeAndAllowsRecreateE2E(
 	t *testing.T,
 ) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -109,8 +109,7 @@ func TestWorkspaceForceDeleteQuarantinesReplacedWorktreeAndAllowsRecreateE2E(
 func TestWorkspaceForceDeleteQuarantinesReplacementFileAndAllowsRecreateE2E(
 	t *testing.T,
 ) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -155,8 +154,7 @@ func TestWorkspaceForceDeleteQuarantinesReplacementFileAndAllowsRecreateE2E(
 func TestWorkspaceForceDeleteReplacementCloneClearsManagedRegistrationE2E(
 	t *testing.T,
 ) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -165,7 +163,7 @@ func TestWorkspaceForceDeleteReplacementCloneClearsManagedRegistrationE2E(
 
 	// Force setup onto the managed fallback branch so deletion has both a
 	// linked-worktree registration and a Kenn Forge branch to clear.
-	runGit(t, fixture.bare, "update-ref", "refs/heads/feature", "refs/heads/main")
+	gitfixture.Run(t, fixture.bare, "update-ref", "refs/heads/feature", "refs/heads/main")
 	ws := createReadyWorkspace(t, ctx, fixture.client)
 	worktreePath := ws.WorktreePath
 	assert.Equal(
@@ -174,15 +172,15 @@ func TestWorkspaceForceDeleteReplacementCloneClearsManagedRegistrationE2E(
 	)
 
 	require.NoError(os.RemoveAll(worktreePath))
-	runGit(t, filepath.Dir(worktreePath), "clone", fixture.remote, worktreePath)
-	runGit(
+	gitfixture.Run(t, filepath.Dir(worktreePath), "clone", fixture.remote, worktreePath)
+	gitfixture.Run(
 		t, worktreePath, "remote", "set-url", "origin",
 		"https://github.com/acme/widget.git",
 	)
 	require.NoError(os.WriteFile(
 		filepath.Join(worktreePath, "foreign.txt"), []byte("preserve me\n"), 0o644,
 	))
-	foreignHead := testGitSHA(t, worktreePath, "HEAD")
+	foreignHead := gitfixture.SHA(t, worktreePath, "HEAD")
 
 	force := true
 	deleteResp, err := fixture.client.HTTP.DeleteWorkspaceWithResponse(
@@ -196,7 +194,7 @@ func TestWorkspaceForceDeleteReplacementCloneClearsManagedRegistrationE2E(
 	stored, err := fixture.database.GetWorkspace(ctx, ws.Id)
 	require.NoError(err)
 	assert.Nil(stored)
-	assert.Equal(foreignHead, testGitSHA(t, worktreePath, "HEAD"))
+	assert.Equal(foreignHead, gitfixture.SHA(t, worktreePath, "HEAD"))
 	contents, err := os.ReadFile(filepath.Join(worktreePath, "foreign.txt"))
 	require.NoError(err)
 	assert.Equal("preserve me\n", string(contents))
@@ -218,15 +216,14 @@ func TestWorkspaceForceDeleteReplacementCloneClearsManagedRegistrationE2E(
 func TestWorkspaceForceDeletePreservesSameOriginForeignLinkedWorktreeE2E(
 	t *testing.T,
 ) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
 	fixture := setupWorkspaceServerFixture(t, nil)
 	ctx := t.Context()
 
-	runGit(t, fixture.bare, "update-ref", "refs/heads/feature", "refs/heads/main")
+	gitfixture.Run(t, fixture.bare, "update-ref", "refs/heads/feature", "refs/heads/main")
 	ws := createReadyWorkspace(t, ctx, fixture.client)
 	worktreePath := ws.WorktreePath
 	assert.Equal(
@@ -236,19 +233,19 @@ func TestWorkspaceForceDeletePreservesSameOriginForeignLinkedWorktreeE2E(
 
 	require.NoError(os.RemoveAll(worktreePath))
 	foreignGitDir := filepath.Join(t.TempDir(), "foreign.git")
-	runGit(t, filepath.Dir(foreignGitDir), "clone", "--bare", fixture.remote, foreignGitDir)
-	runGit(
+	gitfixture.Run(t, filepath.Dir(foreignGitDir), "clone", "--bare", fixture.remote, foreignGitDir)
+	gitfixture.Run(
 		t, foreignGitDir, "remote", "set-url", "origin",
 		"https://github.com/acme/widget.git",
 	)
-	runGit(
+	gitfixture.Run(
 		t, foreignGitDir, "worktree", "add", worktreePath,
 		"-b", "foreign/scratch", "HEAD",
 	)
 	require.NoError(os.WriteFile(
 		filepath.Join(worktreePath, "base.txt"), []byte("foreign dirty data\n"), 0o644,
 	))
-	foreignHead := testGitSHA(t, worktreePath, "HEAD")
+	foreignHead := gitfixture.SHA(t, worktreePath, "HEAD")
 
 	force := true
 	deleteResp, err := fixture.client.HTTP.DeleteWorkspaceWithResponse(
@@ -266,7 +263,7 @@ func TestWorkspaceForceDeletePreservesSameOriginForeignLinkedWorktreeE2E(
 	contents, err := os.ReadFile(filepath.Join(worktreePath, "base.txt"))
 	require.NoError(err)
 	assert.Equal("foreign dirty data\n", string(contents))
-	assert.Equal(foreignHead, testGitSHA(t, worktreePath, "HEAD"))
+	assert.Equal(foreignHead, gitfixture.SHA(t, worktreePath, "HEAD"))
 	assert.Contains(
 		workspaceGitOutput(t, worktreePath, "status", "--porcelain"),
 		"M base.txt",
@@ -281,7 +278,7 @@ func TestWorkspaceForceDeletePreservesSameOriginForeignLinkedWorktreeE2E(
 	)
 	requireGitRefMissing(t, fixture.bare, "refs/heads/kenn-forge/pr-1")
 
-	runGit(t, foreignGitDir, "worktree", "remove", "--force", worktreePath)
+	gitfixture.Run(t, foreignGitDir, "worktree", "remove", "--force", worktreePath)
 	recreated := createReadyWorkspace(t, ctx, fixture.client)
 	assert.Equal(worktreePath, recreated.WorktreePath)
 	assert.Equal(
@@ -293,15 +290,14 @@ func TestWorkspaceForceDeletePreservesSameOriginForeignLinkedWorktreeE2E(
 func TestWorkspaceForceDeletePreservesForeignLinkedWorktreeAfterManagedPruneE2E(
 	t *testing.T,
 ) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
 	fixture := setupWorkspaceServerFixture(t, nil)
 	ctx := t.Context()
 
-	runGit(t, fixture.bare, "update-ref", "refs/heads/feature", "refs/heads/main")
+	gitfixture.Run(t, fixture.bare, "update-ref", "refs/heads/feature", "refs/heads/main")
 	ws := createReadyWorkspace(t, ctx, fixture.client)
 	worktreePath := ws.WorktreePath
 	assert.Equal(
@@ -310,26 +306,26 @@ func TestWorkspaceForceDeletePreservesForeignLinkedWorktreeAfterManagedPruneE2E(
 	)
 
 	require.NoError(os.RemoveAll(worktreePath))
-	runGit(t, fixture.bare, "worktree", "prune")
+	gitfixture.Run(t, fixture.bare, "worktree", "prune")
 	assert.NotContains(
 		workspaceGitOutput(t, fixture.bare, "worktree", "list", "--porcelain"),
 		worktreePath,
 	)
 
 	foreignGitDir := filepath.Join(t.TempDir(), "foreign.git")
-	runGit(t, filepath.Dir(foreignGitDir), "clone", "--bare", fixture.remote, foreignGitDir)
-	runGit(
+	gitfixture.Run(t, filepath.Dir(foreignGitDir), "clone", "--bare", fixture.remote, foreignGitDir)
+	gitfixture.Run(
 		t, foreignGitDir, "remote", "set-url", "origin",
 		"https://github.com/acme/widget.git",
 	)
-	runGit(
+	gitfixture.Run(
 		t, foreignGitDir, "worktree", "add", worktreePath,
 		"-b", "foreign/scratch", "HEAD",
 	)
 	require.NoError(os.WriteFile(
 		filepath.Join(worktreePath, "base.txt"), []byte("foreign dirty data\n"), 0o644,
 	))
-	foreignHead := testGitSHA(t, worktreePath, "HEAD")
+	foreignHead := gitfixture.SHA(t, worktreePath, "HEAD")
 
 	force := true
 	deleteResp, err := fixture.client.HTTP.DeleteWorkspaceWithResponse(
@@ -347,7 +343,7 @@ func TestWorkspaceForceDeletePreservesForeignLinkedWorktreeAfterManagedPruneE2E(
 	contents, err := os.ReadFile(filepath.Join(worktreePath, "base.txt"))
 	require.NoError(err)
 	assert.Equal("foreign dirty data\n", string(contents))
-	assert.Equal(foreignHead, testGitSHA(t, worktreePath, "HEAD"))
+	assert.Equal(foreignHead, gitfixture.SHA(t, worktreePath, "HEAD"))
 	assert.Contains(
 		workspaceGitOutput(t, worktreePath, "status", "--porcelain"),
 		"M base.txt",
@@ -361,15 +357,14 @@ func TestWorkspaceForceDeletePreservesForeignLinkedWorktreeAfterManagedPruneE2E(
 func TestWorkspaceForceDeleteRemovesSameRepoReplacementAfterManagedPruneE2E(
 	t *testing.T,
 ) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
 	fixture := setupWorkspaceServerFixture(t, nil)
 	ctx := t.Context()
 
-	runGit(t, fixture.bare, "update-ref", "refs/heads/feature", "refs/heads/main")
+	gitfixture.Run(t, fixture.bare, "update-ref", "refs/heads/feature", "refs/heads/main")
 	ws := createReadyWorkspace(t, ctx, fixture.client)
 	worktreePath := ws.WorktreePath
 	assert.Equal(
@@ -378,15 +373,15 @@ func TestWorkspaceForceDeleteRemovesSameRepoReplacementAfterManagedPruneE2E(
 	)
 
 	require.NoError(os.RemoveAll(worktreePath))
-	runGit(t, fixture.bare, "worktree", "prune")
-	runGit(
+	gitfixture.Run(t, fixture.bare, "worktree", "prune")
+	gitfixture.Run(
 		t, fixture.bare, "worktree", "add", worktreePath,
 		"-b", "foreign/scratch", "HEAD",
 	)
 	require.NoError(os.WriteFile(
 		filepath.Join(worktreePath, "base.txt"), []byte("foreign dirty data\n"), 0o644,
 	))
-	foreignHead := testGitSHA(t, worktreePath, "HEAD")
+	foreignHead := gitfixture.SHA(t, worktreePath, "HEAD")
 
 	force := true
 	deleteResp, err := fixture.client.HTTP.DeleteWorkspaceWithResponse(
@@ -407,22 +402,21 @@ func TestWorkspaceForceDeleteRemovesSameRepoReplacementAfterManagedPruneE2E(
 	)
 	assert.Equal(
 		foreignHead,
-		testGitSHA(t, fixture.bare, "refs/heads/foreign/scratch"),
+		gitfixture.SHA(t, fixture.bare, "refs/heads/foreign/scratch"),
 	)
 }
 
 func TestWorkspaceForceDeleteRemovesPreMarkerWorkspaceAfterUpgradeE2E(
 	t *testing.T,
 ) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
 	fixture := setupWorkspaceServerFixture(t, nil)
 	ctx := t.Context()
 
-	runGit(t, fixture.bare, "update-ref", "refs/heads/feature", "refs/heads/main")
+	gitfixture.Run(t, fixture.bare, "update-ref", "refs/heads/feature", "refs/heads/main")
 	ws := createReadyWorkspace(t, ctx, fixture.client)
 	worktreePath := ws.WorktreePath
 	assert.Equal(
@@ -456,8 +450,7 @@ func TestWorkspaceForceDeleteRemovesPreMarkerWorkspaceAfterUpgradeE2E(
 }
 
 func TestWorkspaceForceDeleteRetainsLockedWorktreeE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -465,7 +458,7 @@ func TestWorkspaceForceDeleteRetainsLockedWorktreeE2E(t *testing.T) {
 	ctx := t.Context()
 
 	ws := createReadyWorkspace(t, ctx, fixture.client)
-	runGit(
+	gitfixture.Run(
 		t, fixture.bare, "worktree", "lock", "--reason", "test lock",
 		ws.WorktreePath,
 	)
@@ -498,7 +491,7 @@ func TestWorkspaceForceDeleteRetainsLockedWorktreeE2E(t *testing.T) {
 	require.NoError(err)
 	assert.Equal(ws.Id+"\n", string(marker))
 
-	runGit(t, fixture.bare, "worktree", "unlock", ws.WorktreePath)
+	gitfixture.Run(t, fixture.bare, "worktree", "unlock", ws.WorktreePath)
 	deleteResp, err = fixture.client.HTTP.DeleteWorkspaceWithResponse(
 		ctx, ws.Id, &generated.DeleteWorkspaceParams{Force: &force},
 	)
@@ -514,8 +507,7 @@ func TestWorkspaceForceDeleteRetainsLockedWorktreeE2E(t *testing.T) {
 func TestWorkspaceForceDeleteForgetsSymlinkToSameRepoWorktreeE2E(
 	t *testing.T,
 ) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -525,10 +517,10 @@ func TestWorkspaceForceDeleteForgetsSymlinkToSameRepoWorktreeE2E(
 	ws := createReadyWorkspace(t, ctx, fixture.client)
 	worktreePath := ws.WorktreePath
 	require.NoError(os.RemoveAll(worktreePath))
-	runGit(t, fixture.bare, "worktree", "prune")
+	gitfixture.Run(t, fixture.bare, "worktree", "prune")
 
 	targetPath := filepath.Join(t.TempDir(), "replacement-worktree")
-	runGit(
+	gitfixture.Run(
 		t, fixture.bare, "worktree", "add", targetPath,
 		"-b", "foreign/symlink-target", "HEAD",
 	)
@@ -536,7 +528,7 @@ func TestWorkspaceForceDeleteForgetsSymlinkToSameRepoWorktreeE2E(
 		filepath.Join(targetPath, "base.txt"), []byte("foreign dirty data\n"), 0o644,
 	))
 	require.NoError(os.Symlink(targetPath, worktreePath))
-	foreignHead := testGitSHA(t, targetPath, "HEAD")
+	foreignHead := gitfixture.SHA(t, targetPath, "HEAD")
 
 	force := true
 	deleteResp, err := fixture.client.HTTP.DeleteWorkspaceWithResponse(
@@ -556,7 +548,7 @@ func TestWorkspaceForceDeleteForgetsSymlinkToSameRepoWorktreeE2E(
 	contents, err := os.ReadFile(filepath.Join(targetPath, "base.txt"))
 	require.NoError(err)
 	assert.Equal("foreign dirty data\n", string(contents))
-	assert.Equal(foreignHead, testGitSHA(t, targetPath, "HEAD"))
+	assert.Equal(foreignHead, gitfixture.SHA(t, targetPath, "HEAD"))
 	assert.Contains(
 		workspaceGitOutput(t, fixture.bare, "worktree", "list", "--porcelain"),
 		targetPath,
@@ -564,8 +556,7 @@ func TestWorkspaceForceDeleteForgetsSymlinkToSameRepoWorktreeE2E(
 }
 
 func TestWorkspaceCreateRejectsSymlinkedReusableWorktreeE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -577,10 +568,10 @@ func TestWorkspaceCreateRejectsSymlinkedReusableWorktreeE2E(t *testing.T) {
 		fmt.Sprintf("repo-%d", fixture.repoID), "pr-1",
 	)
 	targetPath := filepath.Join(t.TempDir(), "linked-worktree")
-	runGit(t, fixture.bare, "worktree", "add", targetPath, "feature")
+	gitfixture.Run(t, fixture.bare, "worktree", "add", targetPath, "feature")
 	require.NoError(os.MkdirAll(filepath.Dir(worktreePath), 0o755))
 	require.NoError(os.Symlink(targetPath, worktreePath))
-	wantHead := testGitSHA(t, targetPath, "HEAD")
+	wantHead := gitfixture.SHA(t, targetPath, "HEAD")
 
 	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
@@ -614,7 +605,7 @@ func TestWorkspaceCreateRejectsSymlinkedReusableWorktreeE2E(t *testing.T) {
 	pathInfo, err := os.Lstat(worktreePath)
 	require.NoError(err)
 	assert.NotZero(pathInfo.Mode() & os.ModeSymlink)
-	assert.Equal(wantHead, testGitSHA(t, targetPath, "HEAD"))
+	assert.Equal(wantHead, gitfixture.SHA(t, targetPath, "HEAD"))
 	assert.Contains(
 		workspaceGitOutput(t, fixture.bare, "worktree", "list", "--porcelain"),
 		targetPath,
@@ -630,8 +621,7 @@ func TestWorkspaceCreateRejectsSymlinkedReusableWorktreeE2E(t *testing.T) {
 func TestWorkspaceRetryAcceptsPreMarkerWorkspaceAfterUpgradeE2E(
 	t *testing.T,
 ) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -673,8 +663,7 @@ func TestWorkspaceRetryAcceptsPreMarkerWorkspaceAfterUpgradeE2E(
 }
 
 func TestWorkspaceRetryCleansStalePreMarkerRegistrationE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -717,8 +706,7 @@ func TestWorkspaceRetryCleansStalePreMarkerRegistrationE2E(t *testing.T) {
 }
 
 func TestWorkspaceCreateOccupiedPathCreatesNoBranchesE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -734,8 +722,8 @@ func TestWorkspaceCreateOccupiedPathCreatesNoBranchesE2E(t *testing.T) {
 		t, fixture.database, "github.com", "acme", "widget", mrNumber,
 		"https://github.com/contributor/widget.git",
 	)
-	headSHA := testGitSHA(t, fixture.remote, "refs/heads/feature")
-	runGit(t, fixture.remote, "update-ref", "refs/pull/2/head", headSHA)
+	headSHA := gitfixture.SHA(t, fixture.remote, "refs/heads/feature")
+	gitfixture.Run(t, fixture.remote, "update-ref", "refs/pull/2/head", headSHA)
 	_, err := fixture.database.WriteDB().ExecContext(
 		ctx,
 		`UPDATE forge_merge_requests SET head_branch = ? WHERE number = ?`,
@@ -793,8 +781,7 @@ func TestWorkspaceCreateOccupiedPathCreatesNoBranchesE2E(t *testing.T) {
 }
 
 func TestWorkspaceCreateSameRepoHeadCloneURLTracksOriginBranchE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -802,9 +789,9 @@ func TestWorkspaceCreateSameRepoHeadCloneURLTracksOriginBranchE2E(t *testing.T) 
 	client, database, clonePath, remotePath := setupLifecycleWorkspaceServer(t)
 	ctx := t.Context()
 
-	headSHA := testGitSHA(t, remotePath, "refs/heads/feature")
-	runGit(t, remotePath, "update-ref", "refs/pull/2/head", headSHA)
-	runGit(t, clonePath, "update-ref", "refs/pull/2/head", headSHA)
+	headSHA := gitfixture.SHA(t, remotePath, "refs/heads/feature")
+	gitfixture.Run(t, remotePath, "update-ref", "refs/pull/2/head", headSHA)
+	gitfixture.Run(t, clonePath, "update-ref", "refs/pull/2/head", headSHA)
 	seedPROnHost(t, database, "github.com", "acme", "widget", 2)
 
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
@@ -830,7 +817,7 @@ func TestWorkspaceCreateSameRepoHeadCloneURLTracksOriginBranchE2E(t *testing.T) 
 	assert.Nil(stored.MRHeadRepo)
 	assert.Empty(stored.WorkspaceBranch)
 	assert.Equal("feature", workspaceGitOutput(t, ws.WorktreePath, "branch", "--show-current"))
-	assert.Equal(headSHA, testGitSHA(t, ws.WorktreePath, "HEAD"))
+	assert.Equal(headSHA, gitfixture.SHA(t, ws.WorktreePath, "HEAD"))
 	assert.Equal(
 		"origin/feature",
 		workspaceGitOutput(
@@ -861,7 +848,7 @@ func requireGitRefMissing(t *testing.T, dir, ref string) {
 }
 
 func TestWorkspaceRetryUnknownHeadRepoFailsClosedE2E(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -933,8 +920,7 @@ func TestWorkspaceRetryUnknownHeadRepoFailsClosedE2E(t *testing.T) {
 }
 
 func TestWorkspaceDeletePreservesUserCreatedBranch(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -957,8 +943,8 @@ func TestWorkspaceDeletePreservesUserCreatedBranch(t *testing.T) {
 	require.NotNil(createResp.JSON202)
 
 	ws := waitForWorkspaceReady(t, ctx, client, createResp.JSON202.Id)
-	runGit(t, ws.WorktreePath, "checkout", "-b", "user-scratch")
-	scratchSHA := testGitSHA(t, ws.WorktreePath, "HEAD")
+	gitfixture.Run(t, ws.WorktreePath, "checkout", "-b", "user-scratch")
+	scratchSHA := gitfixture.SHA(t, ws.WorktreePath, "HEAD")
 
 	force := true
 	deleteResp, err := client.HTTP.DeleteWorkspaceWithResponse(
@@ -970,13 +956,12 @@ func TestWorkspaceDeletePreservesUserCreatedBranch(t *testing.T) {
 
 	assert.Equal(
 		scratchSHA,
-		testGitSHA(t, clonePath, "refs/heads/user-scratch"),
+		gitfixture.SHA(t, clonePath, "refs/heads/user-scratch"),
 	)
 }
 
 func TestWorkspaceDeleteDoesNotCleanupReplacementCloneE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -985,13 +970,13 @@ func TestWorkspaceDeleteDoesNotCleanupReplacementCloneE2E(t *testing.T) {
 	ctx := t.Context()
 	const branch = "kenn-forge/pr-42"
 	replacementClone := filepath.Join(t.TempDir(), "replacement-clone")
-	runGit(t, filepath.Dir(replacementClone), "clone", remotePath, replacementClone)
-	runGit(
+	gitfixture.Run(t, filepath.Dir(replacementClone), "clone", remotePath, replacementClone)
+	gitfixture.Run(
 		t, replacementClone, "remote", "set-url", "origin",
 		"https://github.com/acme/widget.git",
 	)
-	runGit(t, replacementClone, "branch", branch, "HEAD")
-	branchSHA := testGitSHA(t, replacementClone, "refs/heads/"+branch)
+	gitfixture.Run(t, replacementClone, "branch", branch, "HEAD")
+	branchSHA := gitfixture.SHA(t, replacementClone, "refs/heads/"+branch)
 	wsID := "ws-replacement-clone"
 	require.NoError(database.InsertWorkspace(ctx, &workspace.Workspace{
 		ID:              wsID,
@@ -1016,15 +1001,14 @@ func TestWorkspaceDeleteDoesNotCleanupReplacementCloneE2E(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusNoContent, deleteResp.StatusCode())
 	assert.DirExists(replacementClone)
-	assert.Equal(branchSHA, testGitSHA(t, replacementClone, "refs/heads/"+branch))
+	assert.Equal(branchSHA, gitfixture.SHA(t, replacementClone, "refs/heads/"+branch))
 	got, err := database.GetWorkspace(ctx, wsID)
 	require.NoError(err)
 	assert.Nil(got)
 }
 
 func TestWorkspaceCreatePreservesExistingLocalPreferredBranch(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -1033,23 +1017,23 @@ func TestWorkspaceCreatePreservesExistingLocalPreferredBranch(t *testing.T) {
 	ctx := t.Context()
 
 	privateClone := filepath.Join(t.TempDir(), "private-clone")
-	runGit(t, filepath.Dir(privateClone), "clone", clonePath, privateClone)
-	runGit(t, privateClone, "config", "user.email", "test@test.com")
-	runGit(t, privateClone, "config", "user.name", "Test")
-	runGit(t, privateClone, "checkout", "feature")
+	gitfixture.Run(t, filepath.Dir(privateClone), "clone", clonePath, privateClone)
+	gitfixture.Run(t, privateClone, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, privateClone, "config", "user.name", "Test")
+	gitfixture.Run(t, privateClone, "checkout", "feature")
 
 	require.NoError(os.WriteFile(
 		filepath.Join(privateClone, "private.txt"),
 		[]byte("private\n"), 0o644,
 	))
-	runGit(t, privateClone, "add", "private.txt")
-	runGit(t, privateClone, "commit", "-m", "private commit")
-	privateSHA := testGitSHA(t, privateClone, "HEAD")
-	runGit(t, privateClone, "push", clonePath, "HEAD:feature")
+	gitfixture.Run(t, privateClone, "add", "private.txt")
+	gitfixture.Run(t, privateClone, "commit", "-m", "private commit")
+	privateSHA := gitfixture.SHA(t, privateClone, "HEAD")
+	gitfixture.Run(t, privateClone, "push", clonePath, "HEAD:feature")
 
-	originSHA := testGitSHA(t, remotePath, "refs/heads/feature")
+	originSHA := gitfixture.SHA(t, remotePath, "refs/heads/feature")
 	assert.NotEqual(originSHA, privateSHA)
-	assert.Equal(privateSHA, testGitSHA(t, clonePath, "refs/heads/feature"))
+	assert.Equal(privateSHA, gitfixture.SHA(t, clonePath, "refs/heads/feature"))
 
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
@@ -1070,8 +1054,8 @@ func TestWorkspaceCreatePreservesExistingLocalPreferredBranch(t *testing.T) {
 		"kenn-forge/pr-1",
 		workspaceGitOutput(t, ws.WorktreePath, "branch", "--show-current"),
 	)
-	assert.Equal(originSHA, testGitSHA(t, ws.WorktreePath, "HEAD"))
-	assert.Equal(privateSHA, testGitSHA(t, clonePath, "refs/heads/feature"))
+	assert.Equal(originSHA, gitfixture.SHA(t, ws.WorktreePath, "HEAD"))
+	assert.Equal(privateSHA, gitfixture.SHA(t, clonePath, "refs/heads/feature"))
 
 	force := true
 	deleteResp, err := client.HTTP.DeleteWorkspaceWithResponse(
@@ -1081,12 +1065,11 @@ func TestWorkspaceCreatePreservesExistingLocalPreferredBranch(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusNoContent, deleteResp.StatusCode())
 
-	assert.Equal(privateSHA, testGitSHA(t, clonePath, "refs/heads/feature"))
+	assert.Equal(privateSHA, gitfixture.SHA(t, clonePath, "refs/heads/feature"))
 }
 
 func TestWorkspaceDeleteLegacySyntheticBranchAllowsRecreate(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -1095,19 +1078,19 @@ func TestWorkspaceDeleteLegacySyntheticBranchAllowsRecreate(t *testing.T) {
 	ctx := t.Context()
 
 	privateClone := filepath.Join(t.TempDir(), "legacy-private-clone")
-	runGit(t, filepath.Dir(privateClone), "clone", clonePath, privateClone)
-	runGit(t, privateClone, "config", "user.email", "test@test.com")
-	runGit(t, privateClone, "config", "user.name", "Test")
-	runGit(t, privateClone, "checkout", "feature")
+	gitfixture.Run(t, filepath.Dir(privateClone), "clone", clonePath, privateClone)
+	gitfixture.Run(t, privateClone, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, privateClone, "config", "user.name", "Test")
+	gitfixture.Run(t, privateClone, "checkout", "feature")
 	require.NoError(os.WriteFile(
 		filepath.Join(privateClone, "legacy-private.txt"),
 		[]byte("legacy private\n"), 0o644,
 	))
-	runGit(t, privateClone, "add", "legacy-private.txt")
-	runGit(t, privateClone, "commit", "-m", "legacy private commit")
-	privateSHA := testGitSHA(t, privateClone, "HEAD")
-	runGit(t, privateClone, "push", clonePath, "HEAD:feature")
-	originSHA := testGitSHA(t, remotePath, "refs/heads/feature")
+	gitfixture.Run(t, privateClone, "add", "legacy-private.txt")
+	gitfixture.Run(t, privateClone, "commit", "-m", "legacy private commit")
+	privateSHA := gitfixture.SHA(t, privateClone, "HEAD")
+	gitfixture.Run(t, privateClone, "push", clonePath, "HEAD:feature")
+	originSHA := gitfixture.SHA(t, remotePath, "refs/heads/feature")
 	assert.NotEqual(originSHA, privateSHA)
 
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
@@ -1146,7 +1129,7 @@ func TestWorkspaceDeleteLegacySyntheticBranchAllowsRecreate(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusNoContent, deleteResp.StatusCode())
 
-	runGit(t, clonePath, "fetch", "--prune", "origin")
+	gitfixture.Run(t, clonePath, "fetch", "--prune", "origin")
 
 	recreateResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
@@ -1167,12 +1150,11 @@ func TestWorkspaceDeleteLegacySyntheticBranchAllowsRecreate(t *testing.T) {
 		"kenn-forge/pr-1",
 		workspaceGitOutput(t, recreated.WorktreePath, "branch", "--show-current"),
 	)
-	assert.Equal(originSHA, testGitSHA(t, recreated.WorktreePath, "HEAD"))
+	assert.Equal(originSHA, gitfixture.SHA(t, recreated.WorktreePath, "HEAD"))
 }
 
 func TestWorkspaceDeleteDirty(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/server/workspacetest/workspace_concurrent_e2e_test.go
+++ b/internal/server/workspacetest/workspace_concurrent_e2e_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 func TestWorkspaceForceDeleteWaitsForInFlightSetupE2E(t *testing.T) {
-	t.Parallel()
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -97,7 +96,7 @@ func TestWorkspaceForceDeleteWaitsForInFlightSetupE2E(t *testing.T) {
 }
 
 func TestWorkspaceForceDeleteRejectsConcurrentRetrySetupE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -212,7 +211,7 @@ exec "$@"
 // must not move the durable row back to creating or attach a setup worker to
 // resources that teardown already owns.
 func TestWorkspaceRetryDuringFailedDeleteIsRejectedE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -333,7 +332,7 @@ exec "$@"
 // reopen setup admission, and a retry during the overlap must remain rejected
 // until the surviving DELETE finishes.
 func TestWorkspaceFailedConcurrentDeleteKeepsSetupBlockedE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -472,7 +471,7 @@ exec "$@"
 // consistent state — no wedged worktree, no half-created branch, no
 // corrupt `worktrees/` metadata.
 func TestWorkspaceConcurrentSameRepoOperationsE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)

--- a/internal/server/workspacetest/workspace_concurrent_e2e_test.go
+++ b/internal/server/workspacetest/workspace_concurrent_e2e_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestWorkspaceForceDeleteWaitsForInFlightSetupE2E(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -96,8 +96,7 @@ func TestWorkspaceForceDeleteWaitsForInFlightSetupE2E(t *testing.T) {
 }
 
 func TestWorkspaceForceDeleteRejectsConcurrentRetrySetupE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -211,8 +210,7 @@ exec "$@"
 // must not move the durable row back to creating or attach a setup worker to
 // resources that teardown already owns.
 func TestWorkspaceRetryDuringFailedDeleteIsRejectedE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -332,8 +330,7 @@ exec "$@"
 // reopen setup admission, and a retry during the overlap must remain rejected
 // until the surviving DELETE finishes.
 func TestWorkspaceFailedConcurrentDeleteKeepsSetupBlockedE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -471,8 +468,7 @@ exec "$@"
 // consistent state — no wedged worktree, no half-created branch, no
 // corrupt `worktrees/` metadata.
 func TestWorkspaceConcurrentSameRepoOperationsE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/server/workspacetest/workspace_crud_test.go
+++ b/internal/server/workspacetest/workspace_crud_test.go
@@ -92,7 +92,7 @@ func seedIssueOnHost(
 }
 
 func TestWorkspaceCRUDE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -180,7 +180,7 @@ func TestWorkspaceCRUDE2E(t *testing.T) {
 }
 
 func TestWorkspaceRetryErroredWorkspaceE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -225,7 +225,7 @@ func TestWorkspaceRetryErroredWorkspaceE2E(t *testing.T) {
 }
 
 func TestWorkspaceRetryReadyWorkspaceConflictE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -283,7 +283,7 @@ func TestWorkspaceRetryReadyWorkspaceConflictE2E(t *testing.T) {
 // reacted to status=ready could read a setup-event list still missing its
 // last row, which made retry-conflict event-count assertions flake on CI.
 func TestWorkspaceReadyStatusImpliesReadySetupEventE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -326,7 +326,7 @@ func TestWorkspaceReadyStatusImpliesReadySetupEventE2E(t *testing.T) {
 }
 
 func TestWorkspaceCreateNotFound(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -365,7 +365,7 @@ func TestWorkspaceCreateNotFound(t *testing.T) {
 }
 
 func TestWorkspaceCreateHidesRemovedUpstreamItems(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -414,7 +414,7 @@ func TestWorkspaceCreateHidesRemovedUpstreamItems(t *testing.T) {
 }
 
 func TestWorkspaceListRetainsWorkspaceWithoutRemovedPullMetadata(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -462,7 +462,7 @@ func TestWorkspaceListRetainsWorkspaceWithoutRemovedPullMetadata(t *testing.T) {
 }
 
 func TestWorkspaceMRDetailHasWorkspace(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -512,7 +512,7 @@ func TestWorkspaceMRDetailHasWorkspace(t *testing.T) {
 }
 
 func TestWorkspaceCreateDuplicate(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -547,7 +547,7 @@ func TestWorkspaceCreateDuplicate(t *testing.T) {
 }
 
 func TestWorkspaceCreateFetchesCloneThroughAPI(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -592,7 +592,7 @@ func TestWorkspaceCreateFetchesCloneThroughAPI(t *testing.T) {
 }
 
 func TestWorkspaceCreateIssueE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	assert := assert.New(t)
@@ -647,7 +647,7 @@ func TestWorkspaceCreateIssueE2E(t *testing.T) {
 }
 
 func TestWorkspaceCreateIssueUsesTitleSlugInBranch(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	assert := assert.New(t)
@@ -684,7 +684,7 @@ func TestWorkspaceCreateIssueUsesTitleSlugInBranch(t *testing.T) {
 }
 
 func TestWorkspaceCreateIssueBareStyleConfigOptOut(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	assert := assert.New(t)
@@ -722,7 +722,7 @@ func TestWorkspaceCreateIssueBareStyleConfigOptOut(t *testing.T) {
 }
 
 func TestWorkspaceCreateIssueIsIdempotent(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	assert := assert.New(t)
@@ -760,7 +760,7 @@ func TestWorkspaceCreateIssueIsIdempotent(t *testing.T) {
 }
 
 func TestWorkspaceCreateIssueAfterDeleteRecreatesBranch(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	assert := assert.New(t)
@@ -816,7 +816,7 @@ func TestWorkspaceCreateIssueAfterDeleteRecreatesBranch(t *testing.T) {
 }
 
 func TestWorkspaceCreatePRAndIssueCanCoexistForSameRepoNumber(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	assert := assert.New(t)

--- a/internal/server/workspacetest/workspace_crud_test.go
+++ b/internal/server/workspacetest/workspace_crud_test.go
@@ -1,12 +1,9 @@
 package workspacetest
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -19,49 +16,10 @@ import (
 	"go.kenn.io/forge/internal/apiclient/generated"
 	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/db"
-	"go.kenn.io/forge/internal/server"
+	"go.kenn.io/forge/internal/testutil"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 	gitcmd "go.kenn.io/kit/git/cmd"
 )
-
-type rawWorkspaceStatusResponse struct {
-	ID           string  `json:"id"`
-	ItemType     string  `json:"item_type"`
-	ItemNumber   int     `json:"item_number"`
-	GitHeadRef   string  `json:"git_head_ref"`
-	Status       string  `json:"status"`
-	ErrorMessage *string `json:"error_message"`
-	Created      bool    `json:"created"`
-}
-
-type rawIssueWorkspaceRef struct {
-	ID     string `json:"id"`
-	Status string `json:"status"`
-}
-
-type rawIssueDetailResponse struct {
-	Workspace *rawIssueWorkspaceRef `json:"workspace"`
-}
-
-func doJSON(
-	t *testing.T, srv *server.Server, method, path string, body any,
-) *httptest.ResponseRecorder {
-	t.Helper()
-	var reader io.Reader
-	if body != nil {
-		payload, err := json.Marshal(body)
-		require.NoError(t, err)
-		reader = bytes.NewReader(payload)
-	}
-	req := httptest.NewRequest(method, path, reader)
-	req.Host = "forge.test"
-	if body != nil || method == http.MethodPost || method == http.MethodDelete ||
-		method == http.MethodPut || method == http.MethodPatch {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	rr := httptest.NewRecorder()
-	srv.ServeHTTP(rr, req)
-	return rr
-}
 
 func workspaceGitOutput(t *testing.T, dir string, args ...string) string {
 	t.Helper()
@@ -92,8 +50,7 @@ func seedIssueOnHost(
 }
 
 func TestWorkspaceCRUDE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -180,8 +137,7 @@ func TestWorkspaceCRUDE2E(t *testing.T) {
 }
 
 func TestWorkspaceRetryErroredWorkspaceE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -225,8 +181,7 @@ func TestWorkspaceRetryErroredWorkspaceE2E(t *testing.T) {
 }
 
 func TestWorkspaceRetryReadyWorkspaceConflictE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -283,8 +238,7 @@ func TestWorkspaceRetryReadyWorkspaceConflictE2E(t *testing.T) {
 // reacted to status=ready could read a setup-event list still missing its
 // last row, which made retry-conflict event-count assertions flake on CI.
 func TestWorkspaceReadyStatusImpliesReadySetupEventE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 
@@ -326,8 +280,7 @@ func TestWorkspaceReadyStatusImpliesReadySetupEventE2E(t *testing.T) {
 }
 
 func TestWorkspaceCreateNotFound(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 
@@ -365,8 +318,7 @@ func TestWorkspaceCreateNotFound(t *testing.T) {
 }
 
 func TestWorkspaceCreateHidesRemovedUpstreamItems(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	fixture := setupWorkspaceServerFixture(t, nil)
@@ -414,8 +366,7 @@ func TestWorkspaceCreateHidesRemovedUpstreamItems(t *testing.T) {
 }
 
 func TestWorkspaceListRetainsWorkspaceWithoutRemovedPullMetadata(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	fixture := setupWorkspaceServerFixture(t, nil)
@@ -462,8 +413,7 @@ func TestWorkspaceListRetainsWorkspaceWithoutRemovedPullMetadata(t *testing.T) {
 }
 
 func TestWorkspaceMRDetailHasWorkspace(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -512,8 +462,7 @@ func TestWorkspaceMRDetailHasWorkspace(t *testing.T) {
 }
 
 func TestWorkspaceCreateDuplicate(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 
@@ -547,8 +496,7 @@ func TestWorkspaceCreateDuplicate(t *testing.T) {
 }
 
 func TestWorkspaceCreateFetchesCloneThroughAPI(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -557,20 +505,20 @@ func TestWorkspaceCreateFetchesCloneThroughAPI(t *testing.T) {
 	ctx := t.Context()
 
 	remoteWork := filepath.Join(t.TempDir(), "remote-work")
-	runGit(t, t.TempDir(), "clone", fixture.remote, remoteWork)
-	runGit(t, remoteWork, "config", "user.email", "test@test.com")
-	runGit(t, remoteWork, "config", "user.name", "Test")
-	runGit(t, remoteWork, "checkout", "feature")
+	gitfixture.Run(t, t.TempDir(), "clone", fixture.remote, remoteWork)
+	gitfixture.Run(t, remoteWork, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, remoteWork, "config", "user.name", "Test")
+	gitfixture.Run(t, remoteWork, "checkout", "feature")
 	require.NoError(os.WriteFile(
 		filepath.Join(remoteWork, "after-fetch.txt"),
 		[]byte("fetched through workspace API\n"),
 		0o644,
 	))
-	runGit(t, remoteWork, "add", ".")
-	runGit(t, remoteWork, "commit", "-m", "feature after fixture clone")
-	runGit(t, remoteWork, "push", "origin", "feature")
+	gitfixture.Run(t, remoteWork, "add", ".")
+	gitfixture.Run(t, remoteWork, "commit", "-m", "feature after fixture clone")
+	gitfixture.Run(t, remoteWork, "push", "origin", "feature")
 	featureSHA := workspaceGitOutput(t, remoteWork, "rev-parse", "HEAD")
-	runGit(t, fixture.remote, "update-ref", "refs/pull/1/head", featureSHA)
+	gitfixture.Run(t, fixture.remote, "update-ref", "refs/pull/1/head", featureSHA)
 
 	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
@@ -592,8 +540,7 @@ func TestWorkspaceCreateFetchesCloneThroughAPI(t *testing.T) {
 }
 
 func TestWorkspaceCreateIssueE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -603,7 +550,7 @@ func TestWorkspaceCreateIssueE2E(t *testing.T) {
 
 	seedIssueOnHost(t, fixture.database, "github.com", "acme", "widget", 7, "open", "Test Issue")
 
-	createRR := doJSON(
+	createRR := testutil.DoJSON(
 		t,
 		fixture.server,
 		http.MethodPost,
@@ -612,25 +559,25 @@ func TestWorkspaceCreateIssueE2E(t *testing.T) {
 	)
 	require.Equal(http.StatusAccepted, createRR.Code, createRR.Body.String())
 
-	var created rawWorkspaceStatusResponse
+	var created generated.WorkspaceResponse
 	require.NoError(json.NewDecoder(createRR.Body).Decode(&created))
-	require.NotEmpty(created.ID)
+	require.NotEmpty(created.Id)
 	assert.Equal("issue", created.ItemType)
-	assert.Equal(7, created.ItemNumber)
+	assert.Equal(int64(7), created.ItemNumber)
 	// seedIssue uses title "Test Issue" → slug style appends "-test-issue".
 	assert.Equal("kenn-forge/issue-7-test-issue", created.GitHeadRef)
 
-	ready := waitForWorkspaceReady(t, ctx, fixture.client, created.ID)
+	ready := waitForWorkspaceReady(t, ctx, fixture.client, created.Id)
 	assert.Equal(
 		"kenn-forge/issue-7-test-issue",
 		workspaceGitOutput(t, ready.WorktreePath, "branch", "--show-current"),
 	)
 	assert.Equal(
-		testGitSHA(t, fixture.remote, "refs/heads/main"),
-		testGitSHA(t, ready.WorktreePath, "HEAD"),
+		gitfixture.SHA(t, fixture.remote, "refs/heads/main"),
+		gitfixture.SHA(t, ready.WorktreePath, "HEAD"),
 	)
 
-	getIssueRR := doJSON(
+	getIssueRR := testutil.DoJSON(
 		t,
 		fixture.server,
 		http.MethodGet,
@@ -639,16 +586,15 @@ func TestWorkspaceCreateIssueE2E(t *testing.T) {
 	)
 	require.Equal(http.StatusOK, getIssueRR.Code, getIssueRR.Body.String())
 
-	var issueDetail rawIssueDetailResponse
+	var issueDetail generated.IssueDetailResponse
 	require.NoError(json.NewDecoder(getIssueRR.Body).Decode(&issueDetail))
 	require.NotNil(issueDetail.Workspace)
-	assert.Equal(created.ID, issueDetail.Workspace.ID)
+	assert.Equal(created.Id, issueDetail.Workspace.Id)
 	assert.NotEmpty(issueDetail.Workspace.Status)
 }
 
 func TestWorkspaceCreateIssueUsesTitleSlugInBranch(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -663,7 +609,7 @@ func TestWorkspaceCreateIssueUsesTitleSlugInBranch(t *testing.T) {
 		"open", "Add foo to bar",
 	)
 
-	createRR := doJSON(
+	createRR := testutil.DoJSON(
 		t,
 		fixture.server,
 		http.MethodPost,
@@ -672,11 +618,11 @@ func TestWorkspaceCreateIssueUsesTitleSlugInBranch(t *testing.T) {
 	)
 	require.Equal(http.StatusAccepted, createRR.Code, createRR.Body.String())
 
-	var created rawWorkspaceStatusResponse
+	var created generated.WorkspaceResponse
 	require.NoError(json.NewDecoder(createRR.Body).Decode(&created))
 	assert.Equal("kenn-forge/issue-8-add-foo-to-bar", created.GitHeadRef)
 
-	ready := waitForWorkspaceReady(t, ctx, fixture.client, created.ID)
+	ready := waitForWorkspaceReady(t, ctx, fixture.client, created.Id)
 	assert.Equal(
 		"kenn-forge/issue-8-add-foo-to-bar",
 		workspaceGitOutput(t, ready.WorktreePath, "branch", "--show-current"),
@@ -684,8 +630,7 @@ func TestWorkspaceCreateIssueUsesTitleSlugInBranch(t *testing.T) {
 }
 
 func TestWorkspaceCreateIssueBareStyleConfigOptOut(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -701,7 +646,7 @@ func TestWorkspaceCreateIssueBareStyleConfigOptOut(t *testing.T) {
 		"open", "Add foo to bar",
 	)
 
-	createRR := doJSON(
+	createRR := testutil.DoJSON(
 		t,
 		fixture.server,
 		http.MethodPost,
@@ -710,11 +655,11 @@ func TestWorkspaceCreateIssueBareStyleConfigOptOut(t *testing.T) {
 	)
 	require.Equal(http.StatusAccepted, createRR.Code, createRR.Body.String())
 
-	var created rawWorkspaceStatusResponse
+	var created generated.WorkspaceResponse
 	require.NoError(json.NewDecoder(createRR.Body).Decode(&created))
 	assert.Equal("kenn-forge/issue-9", created.GitHeadRef)
 
-	ready := waitForWorkspaceReady(t, ctx, fixture.client, created.ID)
+	ready := waitForWorkspaceReady(t, ctx, fixture.client, created.Id)
 	assert.Equal(
 		"kenn-forge/issue-9",
 		workspaceGitOutput(t, ready.WorktreePath, "branch", "--show-current"),
@@ -722,8 +667,7 @@ func TestWorkspaceCreateIssueBareStyleConfigOptOut(t *testing.T) {
 }
 
 func TestWorkspaceCreateIssueIsIdempotent(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -734,34 +678,34 @@ func TestWorkspaceCreateIssueIsIdempotent(t *testing.T) {
 
 	path := "/api/v1/issues/gh/acme/widget/7/workspace"
 
-	firstRR := doJSON(
+	firstRR := testutil.DoJSON(
 		t, fixture.server, http.MethodPost, path, map[string]string{},
 	)
 	require.Equal(http.StatusAccepted, firstRR.Code, firstRR.Body.String())
 
-	var first rawWorkspaceStatusResponse
+	var first generated.WorkspaceResponse
 	require.NoError(json.NewDecoder(firstRR.Body).Decode(&first))
-	require.NotEmpty(first.ID)
-	assert.True(first.Created, "the fresh create response must mark itself as newly created")
+	require.NotEmpty(first.Id)
+	require.NotNil(first.Created)
+	assert.True(*first.Created, "the fresh create response must mark itself as newly created")
 
-	secondRR := doJSON(
+	secondRR := testutil.DoJSON(
 		t, fixture.server, http.MethodPost, path, map[string]string{},
 	)
 	require.Equal(http.StatusAccepted, secondRR.Code, secondRR.Body.String())
 
-	var second rawWorkspaceStatusResponse
+	var second generated.WorkspaceResponse
 	require.NoError(json.NewDecoder(secondRR.Body).Decode(&second))
-	assert.Equal(first.ID, second.ID)
+	assert.Equal(first.Id, second.Id)
 	assert.Equal("issue", second.ItemType)
-	assert.Equal(7, second.ItemNumber)
-	assert.False(second.Created, "a reused existing workspace must not be marked as newly created")
+	assert.Equal(int64(7), second.ItemNumber)
+	assert.Nil(second.Created, "a reused existing workspace must not be marked as newly created")
 
-	waitForWorkspaceReady(t, ctx, fixture.client, second.ID)
+	waitForWorkspaceReady(t, ctx, fixture.client, second.Id)
 }
 
 func TestWorkspaceCreateIssueAfterDeleteRecreatesBranch(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -771,7 +715,7 @@ func TestWorkspaceCreateIssueAfterDeleteRecreatesBranch(t *testing.T) {
 
 	seedIssueOnHost(t, fixture.database, "github.com", "acme", "widget", 7, "open", "Test Issue")
 
-	createRR := doJSON(
+	createRR := testutil.DoJSON(
 		t,
 		fixture.server,
 		http.MethodPost,
@@ -780,9 +724,9 @@ func TestWorkspaceCreateIssueAfterDeleteRecreatesBranch(t *testing.T) {
 	)
 	require.Equal(http.StatusAccepted, createRR.Code, createRR.Body.String())
 
-	var created rawWorkspaceStatusResponse
+	var created generated.WorkspaceResponse
 	require.NoError(json.NewDecoder(createRR.Body).Decode(&created))
-	ready := waitForWorkspaceReady(t, ctx, fixture.client, created.ID)
+	ready := waitForWorkspaceReady(t, ctx, fixture.client, created.Id)
 	assert.Equal(
 		"kenn-forge/issue-7-test-issue",
 		workspaceGitOutput(t, ready.WorktreePath, "branch", "--show-current"),
@@ -791,13 +735,13 @@ func TestWorkspaceCreateIssueAfterDeleteRecreatesBranch(t *testing.T) {
 	force := true
 	deleteResp, err := fixture.client.HTTP.DeleteWorkspaceWithResponse(
 		ctx,
-		created.ID,
+		created.Id,
 		&generated.DeleteWorkspaceParams{Force: &force},
 	)
 	require.NoError(err)
 	require.Equal(http.StatusNoContent, deleteResp.StatusCode())
 
-	recreateRR := doJSON(
+	recreateRR := testutil.DoJSON(
 		t,
 		fixture.server,
 		http.MethodPost,
@@ -806,9 +750,9 @@ func TestWorkspaceCreateIssueAfterDeleteRecreatesBranch(t *testing.T) {
 	)
 	require.Equal(http.StatusAccepted, recreateRR.Code, recreateRR.Body.String())
 
-	var recreated rawWorkspaceStatusResponse
+	var recreated generated.WorkspaceResponse
 	require.NoError(json.NewDecoder(recreateRR.Body).Decode(&recreated))
-	recreatedReady := waitForWorkspaceReady(t, ctx, fixture.client, recreated.ID)
+	recreatedReady := waitForWorkspaceReady(t, ctx, fixture.client, recreated.Id)
 	assert.Equal(
 		"kenn-forge/issue-7-test-issue",
 		workspaceGitOutput(t, recreatedReady.WorktreePath, "branch", "--show-current"),
@@ -816,8 +760,7 @@ func TestWorkspaceCreateIssueAfterDeleteRecreatesBranch(t *testing.T) {
 }
 
 func TestWorkspaceCreatePRAndIssueCanCoexistForSameRepoNumber(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/workspacetest/workspace_diff_test.go
+++ b/internal/server/workspacetest/workspace_diff_test.go
@@ -22,11 +22,20 @@ import (
 	"go.kenn.io/forge/internal/apiclient/generated"
 	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/server"
+	"go.kenn.io/forge/internal/server/httpapi"
+	"go.kenn.io/forge/internal/testutil"
 	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 	"go.kenn.io/forge/internal/workspace"
 )
 
 var workspaceGitSlots = semaphore.NewWeighted(8)
+
+func runParallelWorkspaceGitTest(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+	acquireWorkspaceGitSlot(t)
+}
 
 func acquireWorkspaceGitSlot(t *testing.T) {
 	t.Helper()
@@ -35,8 +44,7 @@ func acquireWorkspaceGitSlot(t *testing.T) {
 }
 
 func TestWorkspaceDiffEndpointsReportHeadAndPushedE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -46,15 +54,15 @@ func TestWorkspaceDiffEndpointsReportHeadAndPushedE2E(t *testing.T) {
 	ctx := context.Background()
 	ws := createReadyWorkspace(t, ctx, client)
 
-	runGit(t, ws.WorktreePath, "config", "user.email", "test@test.com")
-	runGit(t, ws.WorktreePath, "config", "user.name", "Test")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.name", "Test")
 
 	require.NoError(os.WriteFile(
 		filepath.Join(ws.WorktreePath, "committed.go"),
 		[]byte("package committed\n"), 0o644,
 	))
-	runGit(t, ws.WorktreePath, "add", ".")
-	runGit(t, ws.WorktreePath, "commit", "-m", "local workspace commit")
+	gitfixture.Run(t, ws.WorktreePath, "add", ".")
+	gitfixture.Run(t, ws.WorktreePath, "commit", "-m", "local workspace commit")
 	require.NoError(os.WriteFile(
 		filepath.Join(ws.WorktreePath, "dirty.go"),
 		[]byte("package dirty\n"), 0o644,
@@ -129,8 +137,7 @@ func TestWorkspaceDiffEndpointsReportHeadAndPushedE2E(t *testing.T) {
 }
 
 func TestWorkspaceFilePreviewEndpointReturnsRequestedDiffSideContentE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -140,8 +147,8 @@ func TestWorkspaceFilePreviewEndpointReturnsRequestedDiffSideContentE2E(t *testi
 	ctx := context.Background()
 	ws := createReadyWorkspace(t, ctx, client)
 
-	runGit(t, ws.WorktreePath, "config", "user.email", "test@test.com")
-	runGit(t, ws.WorktreePath, "config", "user.name", "Test")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.name", "Test")
 
 	path := "preview.go"
 	require.NoError(os.WriteFile(
@@ -149,8 +156,8 @@ func TestWorkspaceFilePreviewEndpointReturnsRequestedDiffSideContentE2E(t *testi
 		[]byte("package preview\n\nfunc value() string {\n\treturn \"base\"\n}\n"),
 		0o644,
 	))
-	runGit(t, ws.WorktreePath, "add", ".")
-	runGit(t, ws.WorktreePath, "commit", "-m", "add preview fixture")
+	gitfixture.Run(t, ws.WorktreePath, "add", ".")
+	gitfixture.Run(t, ws.WorktreePath, "commit", "-m", "add preview fixture")
 	require.NoError(os.WriteFile(
 		filepath.Join(ws.WorktreePath, path),
 		[]byte("package preview\n\nfunc value() string {\n\treturn \"worktree\"\n}\n"),
@@ -173,23 +180,22 @@ func TestWorkspaceFilePreviewEndpointReturnsRequestedDiffSideContentE2E(t *testi
 }
 
 func TestWorkspaceDiffEndpointsReturnPierreTreeOrderE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 
 	dir := t.TempDir()
 	worktreePath := filepath.Join(dir, "worktree")
-	runGit(t, dir, "init", "--initial-branch=main", worktreePath)
-	runGit(t, worktreePath, "config", "user.email", "test@test.com")
-	runGit(t, worktreePath, "config", "user.name", "Test")
+	gitfixture.Run(t, dir, "init", "--initial-branch=main", worktreePath)
+	gitfixture.Run(t, worktreePath, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, worktreePath, "config", "user.name", "Test")
 	require.NoError(os.WriteFile(
 		filepath.Join(worktreePath, "base.txt"),
 		[]byte("base\n"),
 		0o644,
 	))
-	runGit(t, worktreePath, "add", ".")
-	runGit(t, worktreePath, "commit", "-m", "base commit")
+	gitfixture.Run(t, worktreePath, "add", ".")
+	gitfixture.Run(t, worktreePath, "commit", "-m", "base commit")
 
 	database := dbtest.Open(t)
 	identity := db.GitHubRepoIdentity("github.com", "acme", "widget")
@@ -247,8 +253,7 @@ func TestWorkspaceDiffEndpointsReturnPierreTreeOrderE2E(t *testing.T) {
 }
 
 func TestWorkspaceCommitsEndpointListsBranchCommitsE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -258,21 +263,21 @@ func TestWorkspaceCommitsEndpointListsBranchCommitsE2E(t *testing.T) {
 	ctx := context.Background()
 	ws := createReadyWorkspace(t, ctx, client)
 
-	runGit(t, ws.WorktreePath, "config", "user.email", "test@test.com")
-	runGit(t, ws.WorktreePath, "config", "user.name", "Test")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.name", "Test")
 
 	require.NoError(os.WriteFile(
 		filepath.Join(ws.WorktreePath, "local-one.go"),
 		[]byte("package one\n"), 0o644,
 	))
-	runGit(t, ws.WorktreePath, "add", ".")
-	runGit(t, ws.WorktreePath, "commit", "-m", "local one")
+	gitfixture.Run(t, ws.WorktreePath, "add", ".")
+	gitfixture.Run(t, ws.WorktreePath, "commit", "-m", "local one")
 	require.NoError(os.WriteFile(
 		filepath.Join(ws.WorktreePath, "local-two.go"),
 		[]byte("package two\n"), 0o644,
 	))
-	runGit(t, ws.WorktreePath, "add", ".")
-	runGit(t, ws.WorktreePath, "commit", "-m", "local two")
+	gitfixture.Run(t, ws.WorktreePath, "add", ".")
+	gitfixture.Run(t, ws.WorktreePath, "commit", "-m", "local two")
 
 	commits := requestWorkspaceCommits(t, srv, ws.Id)
 	require.NotNil(commits.Commits)
@@ -283,8 +288,7 @@ func TestWorkspaceCommitsEndpointListsBranchCommitsE2E(t *testing.T) {
 }
 
 func TestWorkspaceDiffEndpointsAcceptCommitAndRangeScopesE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 
@@ -293,21 +297,21 @@ func TestWorkspaceDiffEndpointsAcceptCommitAndRangeScopesE2E(t *testing.T) {
 	ctx := context.Background()
 	ws := createReadyWorkspace(t, ctx, client)
 
-	runGit(t, ws.WorktreePath, "config", "user.email", "test@test.com")
-	runGit(t, ws.WorktreePath, "config", "user.name", "Test")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.name", "Test")
 
 	require.NoError(os.WriteFile(
 		filepath.Join(ws.WorktreePath, "local-one.go"),
 		[]byte("package one\n"), 0o644,
 	))
-	runGit(t, ws.WorktreePath, "add", ".")
-	runGit(t, ws.WorktreePath, "commit", "-m", "local one")
+	gitfixture.Run(t, ws.WorktreePath, "add", ".")
+	gitfixture.Run(t, ws.WorktreePath, "commit", "-m", "local one")
 	require.NoError(os.WriteFile(
 		filepath.Join(ws.WorktreePath, "local-two.go"),
 		[]byte("package two\n"), 0o644,
 	))
-	runGit(t, ws.WorktreePath, "add", ".")
-	runGit(t, ws.WorktreePath, "commit", "-m", "local two")
+	gitfixture.Run(t, ws.WorktreePath, "add", ".")
+	gitfixture.Run(t, ws.WorktreePath, "commit", "-m", "local two")
 	require.NoError(os.WriteFile(
 		filepath.Join(ws.WorktreePath, "dirty.go"),
 		[]byte("package dirty\n"), 0o644,
@@ -359,8 +363,7 @@ func TestWorkspaceDiffEndpointsAcceptCommitAndRangeScopesE2E(t *testing.T) {
 }
 
 func TestWorkspaceDiffEndpointReportsMergeTargetE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -371,26 +374,26 @@ func TestWorkspaceDiffEndpointReportsMergeTargetE2E(t *testing.T) {
 	ws := createReadyWorkspace(t, ctx, client)
 
 	targetWork := filepath.Join(t.TempDir(), "target")
-	runGit(t, filepath.Dir(targetWork), "clone", remote, targetWork)
-	runGit(t, targetWork, "config", "user.email", "test@test.com")
-	runGit(t, targetWork, "config", "user.name", "Test")
+	gitfixture.Run(t, filepath.Dir(targetWork), "clone", remote, targetWork)
+	gitfixture.Run(t, targetWork, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, targetWork, "config", "user.name", "Test")
 	require.NoError(os.WriteFile(
 		filepath.Join(targetWork, "target-only.txt"),
 		[]byte("target\n"), 0o644,
 	))
-	runGit(t, targetWork, "add", ".")
-	runGit(t, targetWork, "commit", "-m", "advance main")
-	runGit(t, targetWork, "push", "origin", "main")
-	runGit(t, ws.WorktreePath, "fetch", "origin", "main")
+	gitfixture.Run(t, targetWork, "add", ".")
+	gitfixture.Run(t, targetWork, "commit", "-m", "advance main")
+	gitfixture.Run(t, targetWork, "push", "origin", "main")
+	gitfixture.Run(t, ws.WorktreePath, "fetch", "origin", "main")
 
-	runGit(t, ws.WorktreePath, "config", "user.email", "test@test.com")
-	runGit(t, ws.WorktreePath, "config", "user.name", "Test")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.name", "Test")
 	require.NoError(os.WriteFile(
 		filepath.Join(ws.WorktreePath, "committed.go"),
 		[]byte("package committed\n"), 0o644,
 	))
-	runGit(t, ws.WorktreePath, "add", ".")
-	runGit(t, ws.WorktreePath, "commit", "-m", "local workspace commit")
+	gitfixture.Run(t, ws.WorktreePath, "add", ".")
+	gitfixture.Run(t, ws.WorktreePath, "commit", "-m", "local workspace commit")
 	require.NoError(os.WriteFile(
 		filepath.Join(ws.WorktreePath, "dirty.go"),
 		[]byte("package dirty\n"), 0o644,
@@ -414,8 +417,7 @@ func TestWorkspaceDiffEndpointReportsMergeTargetE2E(t *testing.T) {
 }
 
 func TestWorkspaceDiffEndpointReportsMergeTargetForAssociatedKataWorkspaceE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -426,26 +428,26 @@ func TestWorkspaceDiffEndpointReportsMergeTargetForAssociatedKataWorkspaceE2E(t 
 	ws := createReadyWorkspace(t, ctx, client)
 
 	targetWork := filepath.Join(t.TempDir(), "target")
-	runGit(t, filepath.Dir(targetWork), "clone", remote, targetWork)
-	runGit(t, targetWork, "config", "user.email", "test@test.com")
-	runGit(t, targetWork, "config", "user.name", "Test")
+	gitfixture.Run(t, filepath.Dir(targetWork), "clone", remote, targetWork)
+	gitfixture.Run(t, targetWork, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, targetWork, "config", "user.name", "Test")
 	require.NoError(os.WriteFile(
 		filepath.Join(targetWork, "target-only.txt"),
 		[]byte("target\n"), 0o644,
 	))
-	runGit(t, targetWork, "add", ".")
-	runGit(t, targetWork, "commit", "-m", "advance main")
-	runGit(t, targetWork, "push", "origin", "main")
-	runGit(t, ws.WorktreePath, "fetch", "origin", "main")
+	gitfixture.Run(t, targetWork, "add", ".")
+	gitfixture.Run(t, targetWork, "commit", "-m", "advance main")
+	gitfixture.Run(t, targetWork, "push", "origin", "main")
+	gitfixture.Run(t, ws.WorktreePath, "fetch", "origin", "main")
 
-	runGit(t, ws.WorktreePath, "config", "user.email", "test@test.com")
-	runGit(t, ws.WorktreePath, "config", "user.name", "Test")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.name", "Test")
 	require.NoError(os.WriteFile(
 		filepath.Join(ws.WorktreePath, "kata-local.go"),
 		[]byte("package kata\n"), 0o644,
 	))
-	runGit(t, ws.WorktreePath, "add", ".")
-	runGit(t, ws.WorktreePath, "commit", "-m", "kata workspace commit")
+	gitfixture.Run(t, ws.WorktreePath, "add", ".")
+	gitfixture.Run(t, ws.WorktreePath, "commit", "-m", "kata workspace commit")
 
 	associatedPRNumber := 1
 	require.NoError(database.InsertWorkspace(ctx, &db.Workspace{
@@ -479,8 +481,7 @@ func TestWorkspaceDiffEndpointReportsMergeTargetForAssociatedKataWorkspaceE2E(t 
 }
 
 func TestWorkspaceDiffEndpointRejectsOriginBaseE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 
@@ -501,14 +502,13 @@ func TestWorkspaceDiffEndpointRejectsOriginBaseE2E(t *testing.T) {
 
 	require.Equal(http.StatusBadRequest, resp.StatusCode)
 
-	var body rawProblemDetail
+	var body httpapi.ProblemError
 	require.NoError(json.NewDecoder(resp.Body).Decode(&body))
 	require.Contains(body.Detail, "base must be head, pushed, or merge-target")
 }
 
 func TestWorkspaceDiffEndpointHandlesUntrackedSymlinkAndLargeFileE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -534,7 +534,7 @@ func TestWorkspaceDiffEndpointHandlesUntrackedSymlinkAndLargeFileE2E(t *testing.
 	diff := requestWorkspaceDiff(t, srv, ws.Id, "head")
 	require.NotNil(diff.Files)
 
-	symlink := requireWorkspaceDiffFile(t, *diff.Files, "secret-link")
+	symlink := testutil.RequireWorkspaceDiffFile(t, *diff.Files, "secret-link")
 	assert.Equal("added", symlink.Status)
 	assert.False(symlink.IsBinary)
 	assert.Equal(int64(1), symlink.Additions)
@@ -546,7 +546,7 @@ func TestWorkspaceDiffEndpointHandlesUntrackedSymlinkAndLargeFileE2E(t *testing.
 	assert.Equal(secretPath, line.Content)
 	assert.NotContains(line.Content, "do not expose")
 
-	large := requireWorkspaceDiffFile(t, *diff.Files, "large.txt")
+	large := testutil.RequireWorkspaceDiffFile(t, *diff.Files, "large.txt")
 	assert.Equal("added", large.Status)
 	assert.True(large.IsBinary)
 	assert.Zero(large.Additions)
@@ -555,8 +555,7 @@ func TestWorkspaceDiffEndpointHandlesUntrackedSymlinkAndLargeFileE2E(t *testing.
 }
 
 func TestWorkspaceDiffEndpointMarksGeneratedFilesE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -586,20 +585,19 @@ func TestWorkspaceDiffEndpointMarksGeneratedFilesE2E(t *testing.T) {
 
 	files := requestWorkspaceFiles(t, srv, ws.Id, "head")
 	require.NotNil(files.Files)
-	assert.True(requireWorkspaceDiffFile(t, *files.Files, "dist/api.ts").IsGenerated)
-	assert.False(requireWorkspaceDiffFile(t, *files.Files, "bun.lock").IsGenerated)
-	assert.False(requireWorkspaceDiffFile(t, *files.Files, "src.ts").IsGenerated)
+	assert.True(testutil.RequireWorkspaceDiffFile(t, *files.Files, "dist/api.ts").IsGenerated)
+	assert.False(testutil.RequireWorkspaceDiffFile(t, *files.Files, "bun.lock").IsGenerated)
+	assert.False(testutil.RequireWorkspaceDiffFile(t, *files.Files, "src.ts").IsGenerated)
 
 	diff := requestWorkspaceDiff(t, srv, ws.Id, "head")
 	require.NotNil(diff.Files)
-	assert.True(requireWorkspaceDiffFile(t, *diff.Files, "dist/api.ts").IsGenerated)
-	assert.False(requireWorkspaceDiffFile(t, *diff.Files, "bun.lock").IsGenerated)
-	assert.False(requireWorkspaceDiffFile(t, *diff.Files, "src.ts").IsGenerated)
+	assert.True(testutil.RequireWorkspaceDiffFile(t, *diff.Files, "dist/api.ts").IsGenerated)
+	assert.False(testutil.RequireWorkspaceDiffFile(t, *diff.Files, "bun.lock").IsGenerated)
+	assert.False(testutil.RequireWorkspaceDiffFile(t, *diff.Files, "src.ts").IsGenerated)
 }
 
 func TestWorkspaceDiffEndpointScopesPatchByPathE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -623,20 +621,19 @@ func TestWorkspaceDiffEndpointScopesPatchByPathE2E(t *testing.T) {
 }
 
 func TestWorkspaceDiffPathPrefersCurrentPathOverEarlierRenameE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
 	fixture := setupWorkspaceServerFixture(t, nil)
 	ws := createReadyWorkspace(t, context.Background(), fixture.client)
-	runGit(t, ws.WorktreePath, "config", "user.email", "test@test.com")
-	runGit(t, ws.WorktreePath, "config", "user.name", "Test")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.name", "Test")
 	require.NoError(os.WriteFile(filepath.Join(ws.WorktreePath, "z.txt"), []byte("renamed content\n"), 0o644))
-	runGit(t, ws.WorktreePath, "add", "z.txt")
-	runGit(t, ws.WorktreePath, "commit", "-m", "add rename source")
+	gitfixture.Run(t, ws.WorktreePath, "add", "z.txt")
+	gitfixture.Run(t, ws.WorktreePath, "commit", "-m", "add rename source")
 	require.NoError(os.Rename(filepath.Join(ws.WorktreePath, "z.txt"), filepath.Join(ws.WorktreePath, "a.txt")))
-	runGit(t, ws.WorktreePath, "add", "-A")
+	gitfixture.Run(t, ws.WorktreePath, "add", "-A")
 	require.NoError(os.WriteFile(filepath.Join(ws.WorktreePath, "z.txt"), []byte("new current path\n"), 0o644))
 
 	diff := requestWorkspaceDiffForPath(t, fixture.server, ws.Id, "head", "z.txt")
@@ -653,30 +650,29 @@ func TestWorkspaceDiffPathPrefersCurrentPathOverEarlierRenameE2E(t *testing.T) {
 }
 
 func TestWorkspaceDiffEndpointKeepsModifiedSourcePatchSeparateFromCopyE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
 	fixture := setupWorkspaceServerFixture(t, nil)
 	ws := createReadyWorkspace(t, context.Background(), fixture.client)
-	runGit(t, ws.WorktreePath, "config", "user.email", "test@test.com")
-	runGit(t, ws.WorktreePath, "config", "user.name", "Test")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.name", "Test")
 
 	sourcePath := filepath.Join(ws.WorktreePath, "src", "a.txt")
 	copiedPath := filepath.Join(ws.WorktreePath, "src", "z.txt")
 	require.NoError(os.MkdirAll(filepath.Dir(sourcePath), 0o755))
 	require.NoError(os.WriteFile(sourcePath, []byte("base line\nshared line\n"), 0o644))
-	runGit(t, ws.WorktreePath, "add", ".")
-	runGit(t, ws.WorktreePath, "commit", "-m", "add copy source fixture")
+	gitfixture.Run(t, ws.WorktreePath, "add", ".")
+	gitfixture.Run(t, ws.WorktreePath, "commit", "-m", "add copy source fixture")
 	require.NoError(os.WriteFile(copiedPath, []byte("base line\nshared line\n"), 0o644))
 	require.NoError(os.WriteFile(sourcePath, []byte("changed line\nshared line\n"), 0o644))
-	runGit(t, ws.WorktreePath, "add", "src/z.txt")
+	gitfixture.Run(t, ws.WorktreePath, "add", "src/z.txt")
 
 	diff := requestWorkspaceDiff(t, fixture.server, ws.Id, "head")
 	require.NotNil(diff.Files)
-	source := requireWorkspaceDiffFile(t, *diff.Files, "src/a.txt")
-	copied := requireWorkspaceDiffFile(t, *diff.Files, "src/z.txt")
+	source := testutil.RequireWorkspaceDiffFile(t, *diff.Files, "src/a.txt")
+	copied := testutil.RequireWorkspaceDiffFile(t, *diff.Files, "src/z.txt")
 	assert.Equal("modified", source.Status)
 	assert.Equal(int64(1), source.Additions)
 	assert.Equal(int64(1), source.Deletions)
@@ -694,19 +690,18 @@ func TestWorkspaceDiffEndpointKeepsModifiedSourcePatchSeparateFromCopyE2E(t *tes
 }
 
 func TestWorkspaceDiffEndpointQuotesDangerousPathsE2E(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
 	dir := t.TempDir()
 	worktreePath := filepath.Join(dir, "worktree")
-	runGit(t, dir, "init", "--initial-branch=main", worktreePath)
-	runGit(t, worktreePath, "config", "user.email", "test@test.com")
-	runGit(t, worktreePath, "config", "user.name", "Test")
+	gitfixture.Run(t, dir, "init", "--initial-branch=main", worktreePath)
+	gitfixture.Run(t, worktreePath, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, worktreePath, "config", "user.name", "Test")
 	require.NoError(os.WriteFile(filepath.Join(worktreePath, "base.txt"), []byte("base\n"), 0o644))
-	runGit(t, worktreePath, "add", ".")
-	runGit(t, worktreePath, "commit", "-m", "base commit")
+	gitfixture.Run(t, worktreePath, "add", ".")
+	gitfixture.Run(t, worktreePath, "commit", "-m", "base commit")
 
 	maliciousPath := "src/evil\n--- forged\n+++ forged\n@@ -1,1 +1,1 @@"
 	require.NoError(os.MkdirAll(filepath.Join(worktreePath, "src"), 0o755))
@@ -730,7 +725,7 @@ func TestWorkspaceDiffEndpointQuotesDangerousPathsE2E(t *testing.T) {
 
 	diff := requestWorkspaceDiff(t, srv, "ws-control-paths", "head")
 	require.NotNil(diff.Files)
-	file := requireWorkspaceDiffFile(t, *diff.Files, filepath.ToSlash(maliciousPath))
+	file := testutil.RequireWorkspaceDiffFile(t, *diff.Files, filepath.ToSlash(maliciousPath))
 	assert.Contains(file.Patch, `diff --git "a/src/evil\n--- forged\n+++ forged\n@@ -1,1 +1,1 @@" "b/src/evil\n--- forged\n+++ forged\n@@ -1,1 +1,1 @@"`)
 	assert.Contains(file.Patch, `+++ "b/src/evil\n--- forged\n+++ forged\n@@ -1,1 +1,1 @@"`)
 	assert.NotContains(file.Patch, "\n--- forged\n")
@@ -738,7 +733,7 @@ func TestWorkspaceDiffEndpointQuotesDangerousPathsE2E(t *testing.T) {
 	assert.NotContains(file.Patch, "\n@@ -1,1 +1,1 @@\n")
 	assert.Equal(1, strings.Count(file.Patch, "\n@@ "))
 
-	unicodeFile := requireWorkspaceDiffFile(t, *diff.Files, filepath.ToSlash(unicodeSeparatorPath))
+	unicodeFile := testutil.RequireWorkspaceDiffFile(t, *diff.Files, filepath.ToSlash(unicodeSeparatorPath))
 	assert.Contains(unicodeFile.Patch, `diff --git "a/src/unicode\u2028separator\u2029file.go" "b/src/unicode\u2028separator\u2029file.go"`)
 	assert.Contains(unicodeFile.Patch, `+++ "b/src/unicode\u2028separator\u2029file.go"`)
 	assert.NotContains(unicodeFile.Patch, "\u2028")
@@ -880,17 +875,6 @@ func newWorkspaceFixtureRequest(method, target string, body io.Reader) *http.Req
 	return req
 }
 
-func requireWorkspaceDiffFile(t *testing.T, files []generated.DiffFile, path string) generated.DiffFile {
-	t.Helper()
-	for _, file := range files {
-		if file.Path == path {
-			return file
-		}
-	}
-	require.Failf(t, "workspace diff file not found", "path %q", path)
-	return generated.DiffFile{}
-}
-
 func assertWorkspaceDiffPaths(t *testing.T, files []generated.DiffFile, want []string) {
 	t.Helper()
 	assert.Equal(t, want, workspaceDiffPaths(files))
@@ -902,12 +886,6 @@ func workspaceDiffPaths(files []generated.DiffFile) []string {
 		paths = append(paths, file.Path)
 	}
 	return paths
-}
-
-type rawProblemDetail struct {
-	Detail  string         `json:"detail"`
-	Code    string         `json:"code"`
-	Details map[string]any `json:"details"`
 }
 
 func gracefulShutdown(t *testing.T, srv *server.Server) {

--- a/internal/server/workspacetest/workspace_diff_test.go
+++ b/internal/server/workspacetest/workspace_diff_test.go
@@ -35,7 +35,7 @@ func acquireWorkspaceGitSlot(t *testing.T) {
 }
 
 func TestWorkspaceDiffEndpointsReportHeadAndPushedE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -129,7 +129,7 @@ func TestWorkspaceDiffEndpointsReportHeadAndPushedE2E(t *testing.T) {
 }
 
 func TestWorkspaceFilePreviewEndpointReturnsRequestedDiffSideContentE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -173,7 +173,7 @@ func TestWorkspaceFilePreviewEndpointReturnsRequestedDiffSideContentE2E(t *testi
 }
 
 func TestWorkspaceDiffEndpointsReturnPierreTreeOrderE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -247,7 +247,7 @@ func TestWorkspaceDiffEndpointsReturnPierreTreeOrderE2E(t *testing.T) {
 }
 
 func TestWorkspaceCommitsEndpointListsBranchCommitsE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -283,7 +283,7 @@ func TestWorkspaceCommitsEndpointListsBranchCommitsE2E(t *testing.T) {
 }
 
 func TestWorkspaceDiffEndpointsAcceptCommitAndRangeScopesE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -359,7 +359,7 @@ func TestWorkspaceDiffEndpointsAcceptCommitAndRangeScopesE2E(t *testing.T) {
 }
 
 func TestWorkspaceDiffEndpointReportsMergeTargetE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -414,7 +414,7 @@ func TestWorkspaceDiffEndpointReportsMergeTargetE2E(t *testing.T) {
 }
 
 func TestWorkspaceDiffEndpointReportsMergeTargetForAssociatedKataWorkspaceE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -479,7 +479,7 @@ func TestWorkspaceDiffEndpointReportsMergeTargetForAssociatedKataWorkspaceE2E(t 
 }
 
 func TestWorkspaceDiffEndpointRejectsOriginBaseE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -507,7 +507,7 @@ func TestWorkspaceDiffEndpointRejectsOriginBaseE2E(t *testing.T) {
 }
 
 func TestWorkspaceDiffEndpointHandlesUntrackedSymlinkAndLargeFileE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -555,7 +555,7 @@ func TestWorkspaceDiffEndpointHandlesUntrackedSymlinkAndLargeFileE2E(t *testing.
 }
 
 func TestWorkspaceDiffEndpointMarksGeneratedFilesE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -598,7 +598,7 @@ func TestWorkspaceDiffEndpointMarksGeneratedFilesE2E(t *testing.T) {
 }
 
 func TestWorkspaceDiffEndpointScopesPatchByPathE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -623,7 +623,7 @@ func TestWorkspaceDiffEndpointScopesPatchByPathE2E(t *testing.T) {
 }
 
 func TestWorkspaceDiffPathPrefersCurrentPathOverEarlierRenameE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -653,7 +653,7 @@ func TestWorkspaceDiffPathPrefersCurrentPathOverEarlierRenameE2E(t *testing.T) {
 }
 
 func TestWorkspaceDiffEndpointKeepsModifiedSourcePatchSeparateFromCopyE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)
@@ -694,7 +694,7 @@ func TestWorkspaceDiffEndpointKeepsModifiedSourcePatchSeparateFromCopyE2E(t *tes
 }
 
 func TestWorkspaceDiffEndpointQuotesDangerousPathsE2E(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)

--- a/internal/server/workspacetest/workspace_enrichment_wire_test.go
+++ b/internal/server/workspacetest/workspace_enrichment_wire_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestWorkspaceListReportsCommitsAheadBehindE2E(t *testing.T) {
-	t.Parallel()
 	acquireWorkspaceGitSlot(t)
 
 	require := require.New(t)

--- a/internal/server/workspacetest/workspace_enrichment_wire_test.go
+++ b/internal/server/workspacetest/workspace_enrichment_wire_test.go
@@ -13,10 +13,11 @@ import (
 	"go.kenn.io/forge/internal/apiclient/generated"
 	"go.kenn.io/forge/internal/server"
 	"go.kenn.io/forge/internal/server/workspaceapi"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 )
 
 func TestWorkspaceListReportsCommitsAheadBehindE2E(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -51,12 +52,12 @@ func TestWorkspaceListReportsCommitsAheadBehindE2E(t *testing.T) {
 			*initial.CommitsBehind == 0 && !*initial.WorktreeDirty
 	}, 10*time.Second, 10*time.Millisecond)
 
-	runGit(t, ws.WorktreePath, "config", "user.email", "test@test.com")
-	runGit(t, ws.WorktreePath, "config", "user.name", "Test")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.email", "test@test.com")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.name", "Test")
 	for _, name := range []string{"ahead-1.txt", "ahead-2.txt"} {
 		require.NoError(os.WriteFile(filepath.Join(ws.WorktreePath, name), []byte(name+"\n"), 0o644))
-		runGit(t, ws.WorktreePath, "add", ".")
-		runGit(t, ws.WorktreePath, "commit", "-m", name)
+		gitfixture.Run(t, ws.WorktreePath, "add", ".")
+		gitfixture.Run(t, ws.WorktreePath, "commit", "-m", name)
 	}
 	require.NoError(os.WriteFile(filepath.Join(ws.WorktreePath, "uncommitted.txt"), []byte("dirty\n"), 0o644))
 	clockNow.Store(now.Add(workspaceapi.EnrichmentTTL + time.Second).UnixNano())

--- a/internal/server/workspacetest/workspace_lifecycle_edge_test.go
+++ b/internal/server/workspacetest/workspace_lifecycle_edge_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestWorkspaceCreateUsesPRBranchAndFallbackBranch(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 	assert := assert.New(t)
 	require := require.New(t)
@@ -46,7 +46,7 @@ func TestWorkspaceCreateUsesPRBranchAndFallbackBranch(t *testing.T) {
 }
 
 func TestWorkspaceDeleteRecreatesForkBranchName(t *testing.T) {
-	t.Parallel()
+	runParallelWorkspaceTest(t)
 	acquireWorkspaceGitSlot(t)
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/workspacetest/workspace_lifecycle_edge_test.go
+++ b/internal/server/workspacetest/workspace_lifecycle_edge_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/apiclient/generated"
 	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 	gitcmd "go.kenn.io/kit/git/cmd"
 )
 
 func TestWorkspaceCreateUsesPRBranchAndFallbackBranch(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	fixture := setupWorkspaceServerFixture(t, nil)
@@ -38,16 +38,15 @@ func TestWorkspaceCreateUsesPRBranchAndFallbackBranch(t *testing.T) {
 	tracked := create(1)
 	assert.Equal("feature", gitOutputForLifecycle(t, tracked.WorktreePath, "branch", "--show-current"))
 	assert.Equal("origin", gitOutputForLifecycle(t, tracked.WorktreePath, "config", "--get", "branch.feature.remote"))
-	runGit(t, fixture.bare, "fetch", "--prune", "origin")
+	gitfixture.Run(t, fixture.bare, "fetch", "--prune", "origin")
 
 	fallback := create(2)
 	assert.Equal("kenn-forge/pr-2", gitOutputForLifecycle(t, fallback.WorktreePath, "branch", "--show-current"))
-	assert.Equal(testGitSHA(t, tracked.WorktreePath, "HEAD"), testGitSHA(t, fallback.WorktreePath, "HEAD"))
+	assert.Equal(gitfixture.SHA(t, tracked.WorktreePath, "HEAD"), gitfixture.SHA(t, fallback.WorktreePath, "HEAD"))
 }
 
 func TestWorkspaceDeleteRecreatesForkBranchName(t *testing.T) {
-	runParallelWorkspaceTest(t)
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	assert := assert.New(t)
 	require := require.New(t)
 	fixture := setupWorkspaceServerFixture(t, nil)
@@ -56,9 +55,9 @@ func TestWorkspaceDeleteRecreatesForkBranchName(t *testing.T) {
 	)
 	require.NoError(err)
 	require.NotNil(repo)
-	headSHA := testGitSHA(t, fixture.remote, "feature")
-	runGit(t, fixture.remote, "update-ref", "refs/heads/fork-feature", headSHA)
-	runGit(
+	headSHA := gitfixture.SHA(t, fixture.remote, "feature")
+	gitfixture.Run(t, fixture.remote, "update-ref", "refs/heads/fork-feature", headSHA)
+	gitfixture.Run(
 		t, fixture.bare, "config", "--add",
 		"url."+fixture.remote+".insteadOf", "https://github.com/fork/widget.git",
 	)
@@ -98,7 +97,7 @@ func TestWorkspaceDeleteRecreatesForkBranchName(t *testing.T) {
 
 	second := create()
 	assert.Equal("fork-feature", gitOutputForLifecycle(t, second.WorktreePath, "branch", "--show-current"))
-	assert.Equal(headSHA, testGitSHA(t, second.WorktreePath, "HEAD"))
+	assert.Equal(headSHA, gitfixture.SHA(t, second.WorktreePath, "HEAD"))
 }
 
 func gitOutputForLifecycle(t *testing.T, dir string, args ...string) string {

--- a/internal/server/workspacetest/workspace_server_e2e_test.go
+++ b/internal/server/workspacetest/workspace_server_e2e_test.go
@@ -1,0 +1,279 @@
+package workspacetest
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kballard/go-shellquote"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/apiclient/generated"
+	"go.kenn.io/forge/internal/config"
+	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/procutil"
+	"go.kenn.io/forge/internal/server/workspaceapi"
+	"go.kenn.io/forge/internal/workspace/localruntime"
+)
+
+func TestListWorkspacesIncludesKataMetadata(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := setupWorkspaceServerFixture(t, nil)
+	client := fixture.client
+	database := fixture.database
+	ctx := t.Context()
+
+	repo, err := database.GetRepoByID(ctx, fixture.repoID)
+	require.NoError(err)
+	require.NotNil(repo)
+
+	metadata := db.WorkspaceKataMetadata{
+		DaemonID:    "desktop",
+		ProjectUID:  "project-kata",
+		ProjectName: "Widget",
+		IssueUID:    "issue-kata-1",
+		ShortID:     "task-123",
+		QualifiedID: "Kata#task-123",
+		Title:       "Wire kata workspace sidebar",
+	}
+	itemKey := db.KataWorkspaceItemKey(metadata)
+	require.NotEmpty(itemKey)
+	require.NoError(database.InsertWorkspace(ctx, &db.Workspace{
+		ID:           "ws-kata-list",
+		Platform:     "github",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     db.WorkspaceItemTypeKataTask,
+		ItemKey:      itemKey,
+		GitHeadRef:   "kenn-forge/kata/task-123-abcd1234",
+		WorktreePath: filepath.Join(t.TempDir(), "ws-kata-list"),
+		TmuxSession:  "kenn-forge-ws-kata-list",
+		Status:       "creating",
+		CreatedAt:    time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC),
+		KataMetadata: &metadata,
+	}))
+
+	// The workspace list UI reloads from GET /workspaces, so the kata owner
+	// metadata it renders must survive the DB summary hydration on that path,
+	// not just the create response.
+	resp, err := client.HTTP.ListWorkspacesWithResponse(ctx)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.NotNil(resp.JSON200.Workspaces)
+
+	var kata *generated.WorkspaceResponse
+	for i := range *resp.JSON200.Workspaces {
+		if (*resp.JSON200.Workspaces)[i].Id == "ws-kata-list" {
+			kata = &(*resp.JSON200.Workspaces)[i]
+			break
+		}
+	}
+	require.NotNil(kata)
+	assert.Equal(db.WorkspaceItemTypeKataTask, kata.ItemType)
+	assert.Equal(itemKey, kata.ItemKey)
+	// item_number is always emitted and is 0 (ignored) for Kata workspaces.
+	assert.Equal(int64(0), kata.ItemNumber)
+	require.NotNil(kata.Kata)
+	assert.Equal("desktop", kata.Kata.DaemonId)
+	assert.Equal("issue-kata-1", kata.Kata.IssueUid)
+	assert.Equal("project-kata", kata.Kata.ProjectUid)
+	require.NotNil(kata.Kata.ProjectName)
+	assert.Equal("Widget", *kata.Kata.ProjectName)
+	require.NotNil(kata.Kata.ShortId)
+	assert.Equal("task-123", *kata.Kata.ShortId)
+	require.NotNil(kata.Kata.QualifiedId)
+	assert.Equal("Kata#task-123", *kata.Kata.QualifiedId)
+	require.NotNil(kata.Kata.Title)
+	assert.Equal("Wire kata workspace sidebar", *kata.Kata.Title)
+}
+
+func TestWorkspaceRuntimeNaturalTmuxAgentExitForgetsStoredSessionE2E(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dir := t.TempDir()
+	tmuxPath := filepath.Join(dir, "fake-tmux")
+	require.NoError(os.WriteFile(tmuxPath, []byte("#!/bin/sh\n"+
+		`if [ "$1" = "-u" ]; then shift; fi
+case "$1" in
+  has-session)
+    echo "can't find session: $3" >&2
+    exit 1
+    ;;
+  new-session|set-option|attach-session)
+    exit 0
+    ;;
+esac
+exit 0
+`), 0o755))
+
+	cfg := &config.Config{
+		Agents: []config.Agent{{
+			Key:     "helper",
+			Label:   "Helper",
+			Command: []string{"/bin/sh", "-lc", "exit 0"},
+		}},
+		Tmux: config.Tmux{Command: []string{tmuxPath}},
+	}
+	fixture := setupWorkspaceServerFixture(t, cfg)
+	client := fixture.client
+	database := fixture.database
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	launchResp, err := client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{
+			TargetKey: "helper",
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launchResp.StatusCode())
+	require.NotNil(launchResp.JSON200)
+
+	require.Eventually(func() bool {
+		runtimeResp, runtimeErr := client.HTTP.GetWorkspaceRuntimeWithResponse(
+			ctx, ws.Id,
+		)
+		if runtimeErr != nil ||
+			runtimeResp.StatusCode() != http.StatusOK ||
+			runtimeResp.JSON200 == nil ||
+			runtimeResp.JSON200.Sessions == nil {
+			return false
+		}
+		return len(*runtimeResp.JSON200.Sessions) == 0
+	}, 2*time.Second, 20*time.Millisecond)
+
+	require.Eventually(func() bool {
+		stored, storedErr := database.ListWorkspaceRuntimeTmuxSessions(ctx, ws.Id)
+		return storedErr == nil && len(stored) == 0
+	}, 2*time.Second, 20*time.Millisecond)
+	assert.NotEmpty(launchResp.JSON200.Key)
+}
+
+func TestWorkspaceResponseUsesStoredRuntimeTmuxSessionsAfterRestartE2E(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dir := t.TempDir()
+	tmuxPath := filepath.Join(dir, "fake-tmux")
+	liveSessionsFile := filepath.Join(dir, "live-sessions")
+	require.NoError(os.WriteFile(tmuxPath, []byte("#!/bin/sh\n"+
+		"TMUX_LIVE_SESSIONS_FILE="+shellquote.Join(liveSessionsFile)+"\n"+
+		`target=""
+mode=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "-t" ]; then target="$a"; fi
+  if [ "$a" = "display-message" ]; then mode="display-message"; fi
+  if [ "$a" = "capture-pane" ]; then mode="capture-pane"; fi
+  if [ "$a" = "list-sessions" ]; then
+    [ -f "$TMUX_LIVE_SESSIONS_FILE" ] && cat "$TMUX_LIVE_SESSIONS_FILE"
+    exit 0
+  fi
+  prev="$a"
+done
+if [ "$mode" = "display-message" ]; then
+  case "$target" in
+    *-claude) printf '⠴ claude-activity\n' ;;
+    *) printf 'idle\n' ;;
+  esac
+  exit 0
+fi
+if [ "$mode" = "capture-pane" ]; then
+  printf 'stable\n'
+  exit 0
+fi
+exit 0
+	`), 0o755))
+	cfg := &config.Config{Tmux: config.Tmux{Command: []string{tmuxPath}}}
+	fixture := setupWorkspaceServerFixture(t, cfg)
+	client := fixture.client
+	database := fixture.database
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+	require.NotEmpty(ws.TmuxSession)
+	require.NoError(os.WriteFile(liveSessionsFile, []byte(strings.Join([]string{
+		ws.TmuxSession,
+		ws.TmuxSession + "-codex",
+		ws.TmuxSession + "-claude",
+	}, "\n")+"\n"), 0o644))
+	for _, targetKey := range []string{"codex", "claude"} {
+		sessionKey, err := localruntime.NewSessionKey(ws.Id)
+		require.NoError(err)
+		require.NoError(database.UpsertWorkspaceRuntimeSession(
+			ctx,
+			&db.WorkspaceRuntimeSession{
+				WorkspaceID: ws.Id,
+				SessionKey:  sessionKey,
+				TargetKey:   targetKey,
+				Label:       targetKey,
+				Kind:        string(localruntime.LaunchTargetAgent),
+				Scope:       "session",
+				TmuxSession: ws.TmuxSession + "-" + targetKey,
+			},
+		))
+	}
+
+	var listed *generated.WorkspaceResponse
+	require.Eventually(func() bool {
+		listResp, err := client.HTTP.ListWorkspacesWithResponse(ctx)
+		require.NoError(err)
+		if listResp.StatusCode() != http.StatusOK ||
+			listResp.JSON200 == nil || listResp.JSON200.Workspaces == nil {
+			return false
+		}
+		listed = nil
+		for i := range *listResp.JSON200.Workspaces {
+			if (*listResp.JSON200.Workspaces)[i].Id == ws.Id {
+				listed = &(*listResp.JSON200.Workspaces)[i]
+				break
+			}
+		}
+		return listed != nil && listed.TmuxWorking &&
+			listed.TmuxActivitySource == workspaceapi.TmuxActivitySourceTitle &&
+			listed.TmuxPaneTitle != nil
+	}, 6*time.Second, 10*time.Millisecond)
+	require.NotNil(listed)
+	assert.True(listed.TmuxWorking)
+	assert.Equal(workspaceapi.TmuxActivitySourceTitle, listed.TmuxActivitySource)
+	require.NotNil(listed.TmuxPaneTitle)
+	assert.Equal("⠴ claude-activity", *listed.TmuxPaneTitle)
+}
+
+func TestWorkspaceDiffCacheHitReturnsWhileGitCapacityIsHeldE2E(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	restoreLimiter := procutil.SetDefaultLimiterForTest(
+		procutil.NewLimiterWithAcquireTimeout(1, 500*time.Millisecond),
+	)
+	t.Cleanup(restoreLimiter)
+
+	fixture := setupWorkspaceServerFixture(t, nil)
+	ws := createReadyWorkspace(t, context.Background(), fixture.client)
+	initial := requestWorkspaceDiff(t, fixture.server, ws.Id, "head")
+	assert.False(initial.Stale)
+
+	releaseHeld, err := procutil.TryAcquire(
+		context.Background(), "test-held workspace diff capacity",
+	)
+	require.NoError(err)
+	defer releaseHeld()
+
+	started := time.Now()
+	cached := requestWorkspaceDiff(t, fixture.server, ws.Id, "head")
+	elapsed := time.Since(started)
+	releaseHeld()
+
+	assert.False(cached.Stale)
+	assert.Less(elapsed, 200*time.Millisecond)
+}

--- a/internal/server/workspacetest/workspace_test.go
+++ b/internal/server/workspacetest/workspace_test.go
@@ -22,6 +22,7 @@ import (
 	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/procutil"
 	"go.kenn.io/forge/internal/server"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 	"go.kenn.io/forge/internal/workspace/localruntime"
 )
 
@@ -316,15 +317,15 @@ func TestWorkspaceCommitsFlagsUnpushedCommitsE2E(t *testing.T) {
 	// Commit locally without pushing. A brand-new commit is unpushed no matter
 	// how the worktree tracks its upstream, so the commits endpoint must flag
 	// it - this proves the push status reaches the wire for a real workspace.
-	runGit(t, ws.WorktreePath, "config", "user.email", "ws@test.com")
-	runGit(t, ws.WorktreePath, "config", "user.name", "Workspace")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.email", "ws@test.com")
+	gitfixture.Run(t, ws.WorktreePath, "config", "user.name", "Workspace")
 	require.NoError(os.WriteFile(
 		filepath.Join(ws.WorktreePath, "local-only.txt"),
 		[]byte("local\n"), 0o644,
 	))
-	runGit(t, ws.WorktreePath, "add", ".")
-	runGit(t, ws.WorktreePath, "commit", "-m", "local only commit")
-	localSHA := testGitSHA(t, ws.WorktreePath, "HEAD")
+	gitfixture.Run(t, ws.WorktreePath, "add", ".")
+	gitfixture.Run(t, ws.WorktreePath, "commit", "-m", "local only commit")
+	localSHA := gitfixture.SHA(t, ws.WorktreePath, "HEAD")
 
 	resp, err := fixture.client.HTTP.GetWorkspaceCommitsWithResponse(ctx, ws.Id)
 	require.NoError(err)
@@ -350,7 +351,7 @@ func TestWorkspaceCommitsOmitsPushStatusWithoutUpstreamE2E(t *testing.T) {
 	// untracked, so provider reconciliation cannot add a base-repository
 	// upstream while this request runs.
 	forkURL := "https://github.com/fork/widget.git"
-	runGit(t, fixture.bare, "config", "--add", "url."+fixture.remote+".insteadOf", forkURL)
+	gitfixture.Run(t, fixture.bare, "config", "--add", "url."+fixture.remote+".insteadOf", forkURL)
 	seedPRWithHeadRepo(t, fixture.database, "github.com", "acme", "widget", 2, forkURL)
 	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
 		ctx, generated.CreateWorkspaceInputBody{

--- a/internal/server/workspacetest/worktree_stale_test.go
+++ b/internal/server/workspacetest/worktree_stale_test.go
@@ -20,7 +20,7 @@ import (
 // vanished from `git worktree list`) is removed by fleet scoped key; removing a
 // missing or already-removed key is a 404.
 func TestRemoveStaleWorktreeRoute(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -86,7 +86,7 @@ func TestRemoveStaleWorktreeRoute(t *testing.T) {
 }
 
 func TestRemoveStaleWorktreeRoute_RefusesNonStaleAndReappeared(t *testing.T) {
-	acquireWorkspaceGitSlot(t)
+	runParallelWorkspaceGitTest(t)
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}

--- a/internal/testutil/diff_assertions.go
+++ b/internal/testutil/diff_assertions.go
@@ -1,0 +1,24 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/apiclient/generated"
+)
+
+// RequireWorkspaceDiffFile returns the response file with path or fails the test.
+func RequireWorkspaceDiffFile(
+	t testing.TB,
+	files []generated.DiffFile,
+	path string,
+) generated.DiffFile {
+	t.Helper()
+	for _, file := range files {
+		if file.Path == path {
+			return file
+		}
+	}
+	require.Failf(t, "workspace diff file not found", "path %q", path)
+	return generated.DiffFile{}
+}

--- a/internal/testutil/gitfixture/history.go
+++ b/internal/testutil/gitfixture/history.go
@@ -54,6 +54,12 @@ func Run(t *testing.T, dir string, args ...string) []byte {
 	return out
 }
 
+// SHA resolves ref in dir and returns the trimmed object ID.
+func SHA(t *testing.T, dir, ref string) string {
+	t.Helper()
+	return strings.TrimSpace(string(Run(t, dir, "rev-parse", ref)))
+}
+
 // AppendFileCommits adds count commits that successively replace path on ref.
 // It uses one fast-import process so boundary-size histories do not exhaust
 // shared subprocess capacity when Go packages run concurrently.

--- a/internal/testutil/gitfixture/repository.go
+++ b/internal/testutil/gitfixture/repository.go
@@ -1,0 +1,78 @@
+package gitfixture
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/testutil/gitsafe"
+)
+
+// Repository is a temporary Git repository for tests, optionally connected to
+// a bare origin that tracks its main branch.
+type Repository struct {
+	Dir    string
+	Remote string
+}
+
+// NewRepository creates a repository with one seed commit. When withUpstream
+// is true, it also creates a bare origin and configures main to track it.
+func NewRepository(t *testing.T, withUpstream bool) *Repository {
+	t.Helper()
+	if _, err := gitsafe.Runner().Output(t.Context(), "", "--version"); err != nil {
+		t.Skip("git binary unavailable")
+	}
+
+	repo := &Repository{
+		Dir:    t.TempDir(),
+		Remote: t.TempDir(),
+	}
+	Run(t, repo.Dir, "init", "-b", "main")
+	Run(t, repo.Dir, "config", "user.email", "kenn-forge-fixture@example.invalid")
+	Run(t, repo.Dir, "config", "user.name", "Kenn Forge Fixture")
+	Run(t, repo.Dir, "config", "commit.gpgsign", "false")
+	Run(t, repo.Dir, "config", "tag.gpgsign", "false")
+	Run(t, repo.Dir, "config", "core.hooksPath", ".git/hooks")
+	repo.Write(t, "seed.md", "seed\n")
+	Run(t, repo.Dir, "add", "seed.md")
+	Run(t, repo.Dir, "commit", "-m", "seed")
+	if withUpstream {
+		Run(t, repo.Remote, "init", "--bare")
+		Run(t, repo.Dir, "remote", "add", "origin", repo.Remote)
+		Run(t, repo.Dir, "push", "-u", "origin", "main")
+	}
+	return repo
+}
+
+// Write writes body to rel within the repository worktree.
+func (r *Repository) Write(t *testing.T, rel, body string) {
+	t.Helper()
+	full := filepath.Join(r.Dir, filepath.FromSlash(rel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+	require.NoError(t, os.WriteFile(full, []byte(body), 0o644))
+}
+
+// Stage stages paths as literal pathspecs.
+func (r *Repository) Stage(t *testing.T, paths ...string) {
+	t.Helper()
+	Run(t, r.Dir, append([]string{"add", "--"}, paths...)...)
+}
+
+// RemoteCommit advances Remote through a scratch clone and returns its head.
+func (r *Repository) RemoteCommit(t *testing.T, rel, body string) string {
+	t.Helper()
+	clone := t.TempDir()
+	Run(t, r.Dir, "clone", r.Remote, clone)
+	Run(t, clone, "checkout", "main")
+	Run(t, clone, "config", "user.email", "kenn-forge-fixture@example.invalid")
+	Run(t, clone, "config", "user.name", "Kenn Forge Fixture")
+	Run(t, clone, "config", "commit.gpgsign", "false")
+	cloneRepo := &Repository{Dir: clone}
+	cloneRepo.Write(t, rel, body)
+	Run(t, clone, "add", "--", rel)
+	Run(t, clone, "commit", "-m", "remote update")
+	Run(t, clone, "push", "origin", "main")
+	return strings.TrimSpace(string(Run(t, clone, "rev-parse", "HEAD")))
+}

--- a/internal/testutil/http.go
+++ b/internal/testutil/http.go
@@ -1,0 +1,34 @@
+package testutil
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// DoJSON serves a JSON request from a loopback client through handler.
+func DoJSON(
+	t testing.TB,
+	handler http.Handler,
+	method, path string,
+	body any,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		require.NoError(t, json.NewEncoder(&buf).Encode(body))
+	}
+	req := httptest.NewRequest(method, path, &buf)
+	req.Host = "127.0.0.1:8091"
+	req.RemoteAddr = "127.0.0.1:12345"
+	if method != http.MethodGet {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	return rr
+}

--- a/scripts/test-package-times.sh
+++ b/scripts/test-package-times.sh
@@ -6,12 +6,14 @@ if [ "${#packages[@]}" -eq 0 ]; then
   packages=(
     ./internal/server
     ./internal/server/apitest
+    ./internal/server/docstest
+    ./internal/server/e2etest
+    ./internal/server/workspacetest
     ./internal/github
     ./internal/db
     ./internal/workspace
     ./internal/workspace/gitstatustest
     ./internal/ratelimit
-    .
   )
 fi
 


### PR DESCRIPTION
Moves the remaining self-contained docs routes and workspace runtime flows out
of the root server test binary, then runs isolated Git, tmux, and workspace
fixtures concurrently behind bounded package-local limits. Shared Git and HTTP
fixture operations stay in `internal/testutil`, and moved response assertions
use generated or server-owned Go types.

The scheduling limits are deliberately conservative. Three tmux/workspace
tests stayed serial after full-package or full-suite race runs showed that
their eventual assertions were load-sensitive.

## Measured result

With `GOMAXPROCS=4 GOFLAGS='-p=4' make race-times` on the same machine:

| Package | Before concurrency pass | Final | Change |
| --- | ---: | ---: | ---: |
| `internal/server` | 561.581s | 451.509s | 110.072s faster, 19.6% lower |
| `internal/server/workspacetest` | 359.472s | 299.054s | 60.418s faster, 16.8% lower |

The final constrained race run passed all ten timed packages. Lint, Testify
helper checks, repository guardrails, NilAway, and context structure checks
also pass.
