### PR TITLE
feat: open terminal links to tracked repository items inside the app

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -48,6 +48,9 @@ Interactive surfaces must agree on which item is selected.
   `item-ref` anchors that resolve through the shared click handler, with the
   provider URL kept as the untracked-repo fallback
   (`frontend/src/lib/utils/item-reference.ts::parseProviderItemURL`).
+- Terminal item links use the same resolver: match provider hosts from the
+  configured repos, never a hardcoded host list, and let the resolve endpoint
+  decide tracked-vs-external (`frontend/src/lib/utils/item-reference.ts::parseConfiguredProviderItemURL`).
 - When a view changes from item A to item B, reset transient action state that
   could otherwise submit or render against the wrong item.
 - A response confirming a server-side outcome (a completed delete or create)

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -15,6 +15,8 @@ const {
   imageAddonCtor,
   imageAddons,
   ligaturesAddonCtor,
+  mockItemResolvePost,
+  mockNavigate,
   mockShowFlash,
   mockWebglCtor,
   mouseDragEndPointerGesture,
@@ -40,6 +42,8 @@ const {
   imageAddonCtor: vi.fn(),
   imageAddons: [] as Array<{ dispose: ReturnType<typeof vi.fn> }>,
   ligaturesAddonCtor: vi.fn(),
+  mockItemResolvePost: vi.fn(),
+  mockNavigate: vi.fn(),
   mockShowFlash: vi.fn(),
   mockWebglCtor: vi.fn(),
   mouseDragEndPointerGesture: vi.fn(),
@@ -78,6 +82,7 @@ let configuredLetterSpacing = 0;
 let configuredCursorBlink = true;
 let configuredFontLigatures = false;
 let terminalSettingsStore: SettingsStore;
+let configuredRepos: Array<{ provider: string; platform_host: string }> = [];
 let mockSockets: MockWebSocket[] = [];
 let mockSocketsStartOpen = true;
 let initialTerminalDimensions = { cols: 80, rows: 24 };
@@ -156,9 +161,28 @@ vi.mock("../../context.js", () => ({
       getTerminalCursorBlink: () => configuredCursorBlink,
       getTerminalFontLigatures: () => configuredFontLigatures,
       getTerminalGraphics: () => terminalSettingsStore.getTerminalGraphics(),
+      getConfiguredRepos: () => configuredRepos,
     },
   }),
 }));
+
+vi.mock("../../api/runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/runtime.js")>();
+  return {
+    ...actual,
+    client: {
+      POST: mockItemResolvePost,
+    },
+  };
+});
+
+vi.mock("../../stores/router.svelte.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../stores/router.svelte.js")>();
+  return {
+    ...actual,
+    navigate: mockNavigate,
+  };
+});
 
 vi.mock("../../stores/flash.svelte.js", () => ({
   showFlash: mockShowFlash,
@@ -324,6 +348,9 @@ describe("TerminalPane", () => {
     configuredCursorBlink = true;
     configuredFontLigatures = false;
     terminalSettingsStore = createSettingsStore();
+    configuredRepos = [];
+    mockItemResolvePost.mockReset();
+    mockNavigate.mockReset();
     initialTerminalDimensions = { cols: 80, rows: 24 };
     fitDimensions = { cols: 80, rows: 24 };
     ligaturesAddonCtor.mockReset();
@@ -536,6 +563,80 @@ describe("TerminalPane", () => {
 
     expect(open).toHaveBeenCalledTimes(1);
     expect(open).toHaveBeenCalledWith("https://example.com/docs", "_blank", "noopener,noreferrer");
+  });
+
+  it("routes tracked repository item links through the app instead of a new tab", async () => {
+    configuredRepos = [{ provider: "github", platform_host: "github.com" }];
+    mockItemResolvePost.mockResolvedValue({
+      data: { repo_tracked: true, item_type: "pr" },
+      error: undefined,
+      response: { status: 200 },
+    });
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    render(TerminalPane, { props: { workspaceId: "ws-123" } });
+    await waitFor(() => expect(xtermTerminalCtor).toHaveBeenCalled());
+    const activate = xtermTerminalCtor.mock.calls[0]![0].linkHandler.activate;
+    const modifier = /Mac/.test(navigator.platform) ? { metaKey: true } : { ctrlKey: true };
+
+    activate(new MouseEvent("click", modifier), "https://github.com/acme/widgets/pull/1028");
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/pulls/github/acme/widgets/1028"));
+    expect(mockItemResolvePost).toHaveBeenCalledWith("/repo/{provider}/{owner}/{name}/resolve/{number}", {
+      signal: expect.any(AbortSignal),
+      params: { path: { provider: "github", owner: "acme", name: "widgets", number: 1028 } },
+    });
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("opens item links for untracked repositories externally after resolving", async () => {
+    configuredRepos = [{ provider: "github", platform_host: "github.com" }];
+    mockItemResolvePost.mockResolvedValue({
+      data: { repo_tracked: false },
+      error: undefined,
+      response: { status: 200 },
+    });
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    render(TerminalPane, { props: { workspaceId: "ws-123" } });
+    await waitFor(() => expect(xtermTerminalCtor).toHaveBeenCalled());
+    const activate = xtermTerminalCtor.mock.calls[0]![0].linkHandler.activate;
+    const modifier = /Mac/.test(navigator.platform) ? { metaKey: true } : { ctrlKey: true };
+
+    activate(new MouseEvent("click", modifier), "https://github.com/other/repo/issues/7");
+
+    await waitFor(() =>
+      expect(open).toHaveBeenCalledWith("https://github.com/other/repo/issues/7", "_blank", "noopener,noreferrer"),
+    );
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("keeps opening links on unconfigured hosts externally without resolving", async () => {
+    configuredRepos = [{ provider: "gitlab", platform_host: "gitlab.example.com" }];
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    render(TerminalPane, { props: { workspaceId: "ws-123" } });
+    await waitFor(() => expect(xtermTerminalCtor).toHaveBeenCalled());
+    const activate = xtermTerminalCtor.mock.calls[0]![0].linkHandler.activate;
+    const modifier = /Mac/.test(navigator.platform) ? { metaKey: true } : { ctrlKey: true };
+
+    activate(new MouseEvent("click", modifier), "https://github.com/acme/widgets/pull/1028");
+
+    expect(open).toHaveBeenCalledWith("https://github.com/acme/widgets/pull/1028", "_blank", "noopener,noreferrer");
+    expect(mockItemResolvePost).not.toHaveBeenCalled();
+  });
+
+  it("tells the user a hovered item link opens inside the app", async () => {
+    configuredRepos = [{ provider: "github", platform_host: "github.com" }];
+    const view = render(TerminalPane, { props: { workspaceId: "ws-123" } });
+    await waitFor(() => expect(xtermTerminalCtor).toHaveBeenCalled());
+    const linkHandler = xtermTerminalCtor.mock.calls[0]![0].linkHandler;
+    const modifier = /Mac/.test(navigator.platform) ? "Cmd" : "Ctrl";
+
+    linkHandler.hover(new MouseEvent("mouseover"), "https://github.com/acme/widgets/issues/3");
+    await tick();
+    expect(view.getByText(`${modifier}+Click to open in kenn-forge`)).toBeTruthy();
+
+    linkHandler.hover(new MouseEvent("mouseover"), "https://github.com/acme/widgets/commit/abc");
+    await tick();
+    expect(view.getByText(`${modifier}+Click to open link`)).toBeTruthy();
   });
 
   it("forwards accepted tmux OSC 52 text to the authorized clipboard writer", async () => {

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -5,6 +5,8 @@
   import { observeResize } from "../../browser/observers.js";
   import { getStores } from "../../context.js";
   import { showFlash } from "../../stores/flash.svelte.js";
+  import { parseConfiguredProviderItemURL } from "../../utils/item-reference.js";
+  import { resolveItemReference } from "../../utils/itemRefHandler.js";
   import { Terminal } from "@xterm/xterm";
   import type { ILinkHandler } from "@xterm/xterm";
   import { FitAddon } from "@xterm/addon-fit";
@@ -94,6 +96,10 @@
   let containerEl: HTMLElement;
   let terminal: Terminal | null = $state(null);
   let hoveredTerminalLink: string | null = $state(null);
+  let itemLinkExecution: { interrupt: () => void } | null = null;
+  const hoveredTerminalLinkIsItem = $derived(
+    hoveredTerminalLink !== null && configuredItemReference(hoveredTerminalLink) !== null,
+  );
   let fitAddon: FitAddon | null = null;
   let imageAddon: ImageAddon | null = null;
   let ligaturesAddon: LigaturesAddon | null = null;
@@ -206,7 +212,21 @@
     }
     if (url.protocol !== "http:" && url.protocol !== "https:") return;
 
+    // Pull request and issue links for a configured repository stay inside
+    // the app: the resolve endpoint decides whether the repo is tracked and
+    // falls back to opening the provider page when it is not.
+    const itemRef = configuredItemReference(url.href);
+    if (itemRef) {
+      itemLinkExecution?.interrupt();
+      itemLinkExecution = resolveItemReference(runtime, itemRef);
+      return;
+    }
+
     window.open(url.href, "_blank", "noopener,noreferrer");
+  }
+
+  function configuredItemReference(href: string) {
+    return parseConfiguredProviderItemURL(href, settingsStore.getConfiguredRepos());
   }
 
   function terminalLinkModifierPressed(event: MouseEvent): boolean {
@@ -933,6 +953,8 @@
   function cleanup(): void {
     disposed = true;
     pointerOrigin = null;
+    itemLinkExecution?.interrupt();
+    itemLinkExecution = null;
     clipboardWriter?.dispose();
     clipboardWriter = undefined;
     mouseDragAutoscroll?.dispose();
@@ -1272,7 +1294,7 @@
   {#if hoveredTerminalLink}
     <div class="terminal-link-tooltip">
       <span>{hoveredTerminalLink}</span>
-      <small>{terminalLinkModifierLabel}+Click to open link</small>
+      <small>{terminalLinkModifierLabel}+Click to {hoveredTerminalLinkIsItem ? "open in kenn-forge" : "open link"}</small>
     </div>
     {/if}
 </div>

--- a/frontend/src/lib/utils/item-reference.test.ts
+++ b/frontend/src/lib/utils/item-reference.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vite-plus/test";
+import { parseConfiguredProviderItemURL } from "./item-reference.js";
+
+describe("parseConfiguredProviderItemURL", () => {
+  const repos = [
+    { provider: "github", platform_host: "github.com" },
+    { provider: "gh", platform_host: "github.com" },
+    { provider: "gitlab", platform_host: "gitlab.example.com" },
+    { provider: "forgejo", platform_host: "codeberg.org" },
+  ];
+
+  it("matches pull request and issue links on any configured provider host", () => {
+    expect(parseConfiguredProviderItemURL("https://github.com/acme/widgets/pull/1028", repos)).toMatchObject({
+      provider: "github",
+      platformHost: "github.com",
+      owner: "acme",
+      name: "widgets",
+      repoPath: "acme/widgets",
+      number: 1028,
+      itemType: "pr",
+      externalUrl: "https://github.com/acme/widgets/pull/1028",
+    });
+    expect(
+      parseConfiguredProviderItemURL("https://gitlab.example.com/group/sub/project/-/issues/9", repos),
+    ).toMatchObject({
+      provider: "gitlab",
+      platformHost: "gitlab.example.com",
+      repoPath: "group/sub/project",
+      number: 9,
+      itemType: "issue",
+    });
+    expect(parseConfiguredProviderItemURL("https://codeberg.org/org/tool/pulls/4", repos)).toMatchObject({
+      provider: "forgejo",
+      repoPath: "org/tool",
+      number: 4,
+      itemType: "pr",
+    });
+  });
+
+  it("ignores links on hosts without a configured repository and non-item pages", () => {
+    expect(parseConfiguredProviderItemURL("https://gitlab.com/group/project/-/issues/9", repos)).toBeNull();
+    expect(parseConfiguredProviderItemURL("https://github.com/acme/widgets/commit/abc123", repos)).toBeNull();
+    expect(parseConfiguredProviderItemURL("https://github.com/acme/widgets/pull/1028", [])).toBeNull();
+    expect(parseConfiguredProviderItemURL("not a url", repos)).toBeNull();
+  });
+});

--- a/frontend/src/lib/utils/item-reference.ts
+++ b/frontend/src/lib/utils/item-reference.ts
@@ -127,6 +127,28 @@ export function parseProviderItemURL(
   };
 }
 
+// Recognizes a provider URL against the hosts of the configured repositories,
+// so surfaces without a repository context (such as a terminal) can turn a
+// printed pull request or issue link into an in-app item reference. Each
+// distinct provider/host pair is tried once; whether the matched repository is
+// actually tracked is decided by the resolve endpoint, not here.
+export function parseConfiguredProviderItemURL(
+  raw: string,
+  repos: ReadonlyArray<{ provider: string; platform_host?: string | undefined }>,
+): ResolvableItemReference | null {
+  const seen = new Set<string>();
+  for (const repo of repos) {
+    const provider = canonicalProvider(repo.provider);
+    const platformHost = repo.platform_host?.trim() || undefined;
+    const key = `${provider}\u0000${(platformHost ?? "").toLowerCase()}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const ref = parseProviderItemURL(raw, { provider, platformHost });
+    if (ref) return ref;
+  }
+  return null;
+}
+
 export function buildItemReferenceHref(ref: ResolvableItemReference): string {
   if (ref.itemType === "pr") {
     return buildRoutedItemRoute({ ...ref, itemType: "pr" });

--- a/frontend/src/lib/utils/itemRefHandler.ts
+++ b/frontend/src/lib/utils/itemRefHandler.ts
@@ -4,8 +4,7 @@ import { client } from "../api/runtime.js";
 import type { AppExecution, AppRuntime } from "../app/runtime.js";
 import { navigate, buildItemRoute } from "../stores/router.svelte.js";
 import { showFlash } from "../stores/flash.svelte.js";
-
-type ItemRefType = "pr" | "issue";
+import type { ResolvableItemReference } from "./item-reference.js";
 
 function safeExternalURL(raw: string | undefined): string | null {
   if (!raw) return null;
@@ -31,24 +30,16 @@ function findItemRef(target: EventTarget | null): HTMLAnchorElement | null {
   return null;
 }
 
-function resolveAndNavigate(
-  provider: string,
-  platformHost: string | undefined,
-  owner: string,
-  name: string,
-  repoPath: string,
-  number: number,
-  itemType: ItemRefType | undefined,
-  externalUrl: string | undefined,
-): Effect.Effect<void, unknown> {
+function resolveAndNavigate(ref: ResolvableItemReference): Effect.Effect<void, unknown> {
+  const { provider, platformHost, owner, name, repoPath, number, itemType, externalUrl } = ref;
   return Effect.tryPromise({
     try: (signal) => {
-      const ref = { provider, platformHost, owner, name, repoPath };
+      const routeRef = { provider, platformHost, owner, name, repoPath };
       const itemTypeHint = canonicalProvider(provider) === "gitlab" ? itemType : undefined;
-      return client.POST(providerRepoPath(ref, "/resolve/{number}"), {
+      return client.POST(providerRepoPath(routeRef, "/resolve/{number}"), {
         signal,
         params: {
-          path: { ...providerRouteParams(ref), number },
+          path: { ...providerRouteParams(routeRef), number },
           ...(itemTypeHint && { query: { item_type: itemTypeHint } }),
         },
       });
@@ -57,7 +48,6 @@ function resolveAndNavigate(
   }).pipe(
     Effect.andThen(({ data, error, response }) =>
       Effect.sync(() => {
-        const ref = { provider, platformHost, owner, name, repoPath };
         if (error) {
           if (response.status === 404) {
             showFlash(`Item ${owner}/${name}#${number} not found.`, { tone: "danger" });
@@ -79,8 +69,8 @@ function resolveAndNavigate(
 
         const path = buildItemRoute({
           itemType: data.item_type === "pr" ? "pr" : "issue",
-          provider: ref.provider,
-          platformHost: ref.platformHost,
+          provider,
+          platformHost,
           owner,
           name,
           repoPath,
@@ -90,6 +80,26 @@ function resolveAndNavigate(
       }),
     ),
   );
+}
+
+// Resolves an item reference through the repo resolve endpoint and either
+// navigates to the internal item route (tracked repo) or opens the provider
+// URL externally (untracked repo). Shared by rendered item-ref anchors and
+// the terminal link handler.
+export function resolveItemReference(runtime: AppRuntime, ref: ResolvableItemReference): AppExecution<void, unknown> {
+  return runtime.runCommand(resolveAndNavigate(ref), {
+    operation: "resolve item reference",
+    safeContext: {
+      provider: ref.provider,
+      platformHost: ref.platformHost ?? "",
+      owner: ref.owner,
+      name: ref.name,
+      number: ref.number.toString(),
+    },
+    onFailure: () => {
+      showFlash("Failed to resolve item reference. Check your connection.", { tone: "danger" });
+    },
+  });
 }
 
 export function initItemRefHandler(runtime: AppRuntime): () => void {
@@ -114,16 +124,16 @@ export function initItemRefHandler(runtime: AppRuntime): () => void {
 
     e.preventDefault();
     execution?.interrupt();
-    execution = runtime.runCommand(
-      resolveAndNavigate(provider, platformHost, owner, name, repoPath, parseInt(numberStr, 10), itemType, externalUrl),
-      {
-        operation: "resolve item reference",
-        safeContext: { provider, platformHost: platformHost ?? "", owner, name, number: numberStr },
-        onFailure: () => {
-          showFlash("Failed to resolve item reference. Check your connection.", { tone: "danger" });
-        },
-      },
-    );
+    execution = resolveItemReference(runtime, {
+      provider,
+      platformHost,
+      owner,
+      name,
+      repoPath,
+      number: parseInt(numberStr, 10),
+      itemType,
+      externalUrl,
+    });
   }
 
   document.addEventListener("click", handleClick);


### PR DESCRIPTION
Agents running in a workspace terminal print pull request and issue URLs for the repository they work on. Modifier-clicking one opened the provider website in a new tab, even when kenn-forge already tracks that repository and has its own page for the item.

- Modifier-clicking a pull request or issue URL in the terminal now opens the internal item page when the repository is tracked.
- Links to untracked repositories and to non-item pages such as commits still open in a new tab.
- The hover hint says when a link opens in kenn-forge.
- Hosts are taken from the configured repositories, so self-hosted GitLab, Forgejo, and Gitea instances are recognized too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
