### PR TITLE
fix: show agent icons on launched sessions

### DIFF
--- a/frontend/src/lib/components/terminal/TerminalSplitTree.svelte
+++ b/frontend/src/lib/components/terminal/TerminalSplitTree.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
   import { Effect } from "effect";
   import { untrack } from "svelte";
-  import { SplitResizeHandle, type SplitResizeEvent } from "@kenn-io/kit-ui";
+  import {
+    HarnessIcon,
+    SplitResizeHandle,
+    type HarnessIconId,
+    type SplitResizeEvent,
+  } from "@kenn-io/kit-ui";
   import { clearActiveTabbedPanelDrag, startTabbedPanelTabDrag } from "../shared/tabbed-panel-drag.js";
   import type { RuntimeSession } from "../../api/types.js";
   import XIcon from "@lucide/svelte/icons/x";
@@ -31,6 +36,7 @@
     beginTerminalGeometryIntent,
     extendTerminalGeometryIntent,
   } from "./terminalGeometryIntent.js";
+  import { launchTargetHarness } from "./agentHarness";
 
   const runtime = getAppRuntime();
 
@@ -122,6 +128,10 @@
 
   function labelFor(session: RuntimeSession): string {
     return displayLabels[session.key] ?? session.label;
+  }
+
+  function sessionHarness(session: RuntimeSession): HarnessIconId | null {
+    return launchTargetHarness({ kind: session.kind, key: session.target_key });
   }
 
   function startSessionDrag(
@@ -319,6 +329,7 @@
     ]}
   >
     {#if session}
+      {@const harness = sessionHarness(session)}
       {#if sessions.length > 1}
         <div
           class="leaf-header"
@@ -343,6 +354,8 @@
             <span class="leaf-icon" aria-hidden="true">
               {#if session.kind === "plain_shell"}
                 <TerminalIcon size="12" strokeWidth="2" />
+              {:else if harness}
+                <HarnessIcon {harness} size={12} decorative />
               {:else}
                 <SparklesIcon size="12" strokeWidth="2" />
               {/if}

--- a/frontend/src/lib/components/terminal/TerminalSplitTree.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalSplitTree.test.ts
@@ -125,6 +125,32 @@ describe("TerminalSplitTree", () => {
     }
   });
 
+  it("uses the launch target harness icon in an agent pane header", () => {
+    const agentSessions = [
+      {
+        ...sessions[0]!,
+        key: "ws-1:codex-review",
+        target_key: "codex-review",
+        label: "Review Agent",
+        kind: "agent" as const,
+      },
+      sessions[1]!,
+    ];
+    renderTerminalSplitTree({
+      workspaceId: "ws-1",
+      node: {
+        ...split(),
+        first: leaf("leaf-a", agentSessions[0]!.key),
+      },
+      sessions: agentSessions,
+      displayLabels: {},
+      activeSessionKey: agentSessions[0]!.key,
+    });
+
+    const header = screen.getByRole("group", { name: "Review Agent terminal pane" });
+    expect(header.querySelector(".kit-harness-icon--openai")).not.toBeNull();
+  });
+
   it("hides every leaf while the host is parked", async () => {
     renderTerminalSplitTree({
       workspaceId: "ws-1",

--- a/frontend/src/lib/components/terminal/WorkflowSplitTree.svelte
+++ b/frontend/src/lib/components/terminal/WorkflowSplitTree.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { HarnessIcon, type HarnessIconId } from "@kenn-io/kit-ui";
   import type { Snippet } from "svelte";
   import XIcon from "@lucide/svelte/icons/x";
   import MoveIcon from "@lucide/svelte/icons/move";
@@ -15,6 +16,7 @@
     readWorkflowTabDrag,
     startWorkflowTabDrag,
   } from "./terminal-drag";
+  import { launchTargetHarness } from "./agentHarness";
 
   /**
    * How this tree's session tabs relate to the detail panes they can be promoted
@@ -31,6 +33,7 @@
   export interface WorkflowTabDescriptor extends TabbedPanelDescriptor {
     key: WorkflowTabKey;
     kind: "home" | "terminal" | "agent" | "plain_shell";
+    targetKey?: string | undefined;
     renamable?: boolean | undefined;
     movableToTerminal?: boolean | undefined;
     closable?: boolean | undefined;
@@ -131,6 +134,12 @@
     return (tab as WorkflowTabDescriptor).kind;
   }
 
+  function tabHarness(tab: TabbedPanelDescriptor): HarnessIconId | null {
+    const workflowTab = tab as WorkflowTabDescriptor;
+    if (workflowTab.kind !== "agent" || workflowTab.targetKey === undefined) return null;
+    return launchTargetHarness({ kind: "agent", key: workflowTab.targetKey });
+  }
+
   function isRenamable(tab: TabbedPanelDescriptor): boolean {
     return (tab as WorkflowTabDescriptor).renamable === true;
   }
@@ -190,10 +199,13 @@
   {/snippet}
 
   {#snippet tabIcon(tab)}
+    {@const harness = tabHarness(tab)}
     {#if tabKind(tab) === "home"}
       <HouseIcon size="13" strokeWidth="2" />
     {:else if tabKind(tab) === "plain_shell" || tabKind(tab) === "terminal"}
       <TerminalIcon size="13" strokeWidth="2" />
+    {:else if harness}
+      <HarnessIcon {harness} size={13} decorative />
     {:else}
       <SparklesIcon size="13" strokeWidth="2" />
     {/if}

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -1263,6 +1263,7 @@
         key: workflowTabKeyForSession(session.key),
         label,
         kind: session.kind === "plain_shell" ? "plain_shell" : "agent",
+        targetKey: session.target_key,
         status: workflowSessionStatus(session, label),
         renamable: true,
         movableToTerminal: true,

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -907,6 +907,24 @@ describe("WorkspaceTerminalView", () => {
     expect(screen.getByLabelText("Helper running").classList.contains("kit-status-dot--idle")).toBe(true);
   });
 
+  it("uses the launch target harness icon for a workflow session tab", async () => {
+    const codexSession = {
+      ...runningSession,
+      target_key: "codex-review",
+      label: "Review Agent",
+    } satisfies RuntimeSession;
+    mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithCodexTarget(true, [codexSession]));
+
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+      },
+    });
+
+    const tab = await screen.findByRole("tab", { name: "Review Agent, Review Agent running" });
+    expect(tab.querySelector(".kit-harness-icon--openai")).not.toBeNull();
+  });
+
   it("persists toolbar font zoom through shared settings", async () => {
     render(WorkspaceTerminalView, {
       props: {


### PR DESCRIPTION
Launched agent sessions now keep the same product icon shown in their run configuration.

- Show harness icons in workflow tabs and split terminal pane headers.
- Keep the generic sparkle for unrecognized agent targets.

![Launched Codex session with its product icon in the workflow tab](https://github.com/user-attachments/assets/761f27d7-1b8b-410d-8da2-d0392de958eb)
