### PR TITLE
fix: place outdated review comments after changed files

### DIFF
--- a/context/inline-review-comments.md
+++ b/context/inline-review-comments.md
@@ -20,6 +20,7 @@ published review-thread ingestion, or review controls in shared diff UI.
 - Bind drafts to the full provider reference, pull request number, and diff head
   SHA. Reject publish when the saved diff head is stale
   (`internal/server/pullapi/diff_review_handlers.go::Handler.publishDiffReviewDraft`).
+- Known-stale published line threads stay visible after the rendered file and never attach by numeric coincidence; current or head-unknown representable threads stay inline, while true file-level comments remain at the file header (`frontend/src/lib/components/diff/review-thread-context.ts::reviewThreadSnapshotState`, `frontend/src/lib/components/diff/DiffFile.svelte`, `frontend/src/lib/components/diff/DiffRichPreview.svelte`).
 - Review ranges stay within one file and one diff side and are contiguous in
   rendered order. Full pull-request head diffs are reviewable; single-commit and
   arbitrary range diffs remain disabled until their coordinate mapping is

--- a/frontend/src/lib/components/diff/DiffFile.svelte
+++ b/frontend/src/lib/components/diff/DiffFile.svelte
@@ -445,7 +445,7 @@
 
   function selectedRangeForDraftComment(comment: DiffReviewDraftComment): SelectedLineRange | null {
     if (comment.line_type === "file") return null;
-    if (!commentMatchesCurrentDiff(comment)) return null;
+    if (reviewThreadSnapshotState(comment, diffHeadSHA) === "stale") return null;
     const endSide = commentSide(comment);
     const end = refForSelection(comment.line, endSide);
     if (!end) return null;
@@ -456,10 +456,6 @@
       return selectedLinesFor(end, end);
     }
     return selectedLinesFor(start, end);
-  }
-
-  function commentMatchesCurrentDiff(comment: DiffReviewDraftComment): boolean {
-    return !comment.diff_head_sha || !diffHeadSHA || comment.diff_head_sha === diffHeadSHA;
   }
 
   function reviewSideFromValue(side: string): ReviewSide {

--- a/frontend/src/lib/components/diff/DiffFile.svelte
+++ b/frontend/src/lib/components/diff/DiffFile.svelte
@@ -17,9 +17,11 @@
   import DiffRichPreview from "./DiffRichPreview.svelte";
   import { CopyButton, DiffStats } from "@kenn-io/kit-ui";
   import {
+    reviewThreadSnapshotState,
     reviewThreadTargetLine,
     reviewThreadTargetSide,
     type ReviewThread,
+    type ReviewThreadCardPlacement,
   } from "./review-thread-context.js";
   import PierreFileDiff from "./PierreFileDiff.svelte";
 
@@ -136,7 +138,7 @@
       }
     }
     for (const thread of fileReviewThreads) {
-      if (!threadMatchesCurrentDiff(thread) || thread.line_type === "file") continue;
+      if (reviewThreadPlacement(thread) !== "inline") continue;
       annotations.push({
         side: pierreSide(reviewThreadTargetSide(thread)),
         lineNumber: reviewThreadTargetLine(thread),
@@ -260,16 +262,10 @@
       (!!thread.old_path && !!file.old_path && thread.old_path === file.old_path);
   }
 
-  function threadMatchesCurrentDiff(thread: ReviewThread): boolean {
-    return !thread.diff_head_sha || !diffHeadSHA || thread.diff_head_sha === diffHeadSHA;
-  }
-
   function lineMatchesReviewThread(
     line: DiffFileType["hunks"][number]["lines"][number],
     thread: ReviewThread,
   ): boolean {
-    if (!threadMatchesCurrentDiff(thread)) return false;
-    if (thread.line_type === "file") return false;
     const lineNumber = reviewThreadTargetSide(thread) === "left"
       ? line.old_num
       : line.new_num;
@@ -283,14 +279,21 @@
     );
   }
 
-  function reviewThreadIsFileLevelCard(thread: ReviewThread): boolean {
-    return thread.line_type === "file" ||
-      !threadMatchesCurrentDiff(thread) ||
-      !hasRenderedReviewThread(thread);
+  function reviewThreadPlacement(thread: ReviewThread): ReviewThreadCardPlacement {
+    if (thread.line_type === "file") return "file";
+    if (reviewThreadSnapshotState(thread, diffHeadSHA) === "stale") return "outdated";
+    if (hasRenderedReviewThread(thread)) return "inline";
+    return "unavailable";
   }
 
-  const fileLevelReviewThreads = $derived(
-    fileReviewThreads.filter((thread) => reviewThreadIsFileLevelCard(thread)),
+  const fileHeaderReviewThreads = $derived(
+    fileReviewThreads.filter((thread) => reviewThreadPlacement(thread) === "file"),
+  );
+  const detachedReviewThreads = $derived(
+    fileReviewThreads.filter((thread) => {
+      const placement = reviewThreadPlacement(thread);
+      return placement === "outdated" || placement === "unavailable";
+    }),
   );
 
   function lineRef(
@@ -646,8 +649,8 @@
           />
         {/key}
       {:else}
-        {#each fileLevelReviewThreads as thread (thread.id)}
-          <DiffReviewThreadInlineComment {runtime} {thread} fileLevel={true} />
+        {#each fileHeaderReviewThreads as thread (thread.id)}
+          <DiffReviewThreadInlineComment {runtime} {thread} placement="file" />
         {/each}
         {#if file.is_binary}
           <div class="binary-notice">Binary file changed</div>
@@ -673,6 +676,13 @@
             />
           {/key}
         {/if}
+        {#each detachedReviewThreads as thread (thread.id)}
+          <DiffReviewThreadInlineComment
+            {runtime}
+            {thread}
+            placement={reviewThreadPlacement(thread)}
+          />
+        {/each}
       {/if}
     </div>
   {/if}

--- a/frontend/src/lib/components/diff/DiffFile.test.ts
+++ b/frontend/src/lib/components/diff/DiffFile.test.ts
@@ -1098,6 +1098,32 @@ describe("DiffFile", () => {
     });
   });
 
+  it("does not restore a saved draft range from an older diff snapshot", async () => {
+    renderDiffFile(makeFile(), {
+      reviewEnabled: true,
+      diffHeadSHA: "current-diff-head",
+      draftComments: [
+        {
+          id: "draft-stale",
+          body: "Stale draft range",
+          path: "src/foo.ts",
+          side: "right",
+          line: 2,
+          new_line: 2,
+          line_type: "add",
+          diff_head_sha: "older-diff-head",
+          created_at: "2026-03-30T14:01:00Z",
+          updated_at: "2026-03-30T14:01:00Z",
+        },
+      ],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Stale draft range")).toBeTruthy();
+    });
+    expect(selectedPierreLines()).toHaveLength(0);
+  });
+
   it("opens a new inline composer on a line that already has a saved draft", async () => {
     renderDiffFile(makeFile(), {
       reviewEnabled: true,

--- a/frontend/src/lib/components/diff/DiffFile.test.ts
+++ b/frontend/src/lib/components/diff/DiffFile.test.ts
@@ -1951,7 +1951,7 @@ describe("DiffFile", () => {
     );
   });
 
-  it("keeps unmapped markdown rich preview threads in file-level fallback cards", async () => {
+  it("keeps unmapped markdown rich preview threads in line-unavailable fallback cards", async () => {
     renderDiffFile(
       makeFile({
         path: "README.md",
@@ -1979,7 +1979,9 @@ describe("DiffFile", () => {
     const comment = document.querySelector("[data-review-thread-id='thread-1']");
     expect(comment?.closest(".markdown-rich-diff--unified")).toBeNull();
     expect(comment?.classList.contains("inline-review-thread--file-level")).toBe(true);
-    expect(comment?.textContent).toContain("File");
+    expect(comment?.textContent).toContain("Line unavailable");
+    const preview = document.querySelector(".markdown-rich-diff--unified");
+    expect(preview?.compareDocumentPosition(comment!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it("does not anchor markdown rich preview threads to hidden source gaps inside spanning blocks", async () => {
@@ -2032,6 +2034,33 @@ describe("DiffFile", () => {
     const comment = document.querySelector("[data-review-thread-id='thread-1']");
     expect(comment?.closest(".markdown-rich-diff--unified")).toBeNull();
     expect(comment?.classList.contains("inline-review-thread--file-level")).toBe(true);
+    expect(comment?.textContent).toContain("Line unavailable");
+    const preview = document.querySelector(".markdown-rich-diff--unified");
+    expect(preview?.compareDocumentPosition(comment!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("keeps stale markdown rich preview threads after the rendered preview", async () => {
+    renderDiffFile(makeFile({ path: "README.md", old_path: "README.md" }), {
+      richPreview: true,
+      diffHeadSHA: "current-head",
+      reviewThreads: [
+        makeReviewThread({
+          path: "README.md",
+          old_path: "README.md",
+          diff_head_sha: "stale-head",
+          body: "Stale rich preview note",
+        }),
+      ],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Stale rich preview note")).toBeTruthy();
+    });
+    const comment = document.querySelector("[data-review-thread-id='thread-1']");
+    const preview = document.querySelector(".markdown-rich-diff--unified");
+    expect(screen.getByText("Outdated")).toBeTruthy();
+    expect(comment?.closest(".markdown-rich-diff--unified")).toBeNull();
+    expect(preview?.compareDocumentPosition(comment!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it("lets published inline review threads be replied to", async () => {
@@ -2068,13 +2097,64 @@ describe("DiffFile", () => {
     });
   });
 
-  it("does not render stale-head review threads under a matching current line", async () => {
+  it("places the reported outdated review comment after the rendered file", async () => {
+    const reviewBody =
+      "I'm wondering if we should rename this to CompactionJob and make it a union, and the field a list so we can extend it if we need to support different state for different types of compactions, or multiple jobs per compaction. On the other hand we could just keep it simple for now and bump the version when we need/want to handle those things.";
+    renderDiffFile(makeFile({ path: "schemas/compactor.fbs", old_path: "schemas/compactor.fbs" }), {
+      reviewEnabled: true,
+      diffHeadSHA: "3a6aab8fea50618d913847928c49dc4ece5e3cf0",
+      reviewThreads: [
+        makeReviewThread({
+          path: "schemas/compactor.fbs",
+          line: 97,
+          new_line: 97,
+          body: reviewBody,
+          diff_head_sha: "0e1da4256897ac5ccf479b3ab7dd410244149f0c",
+        }),
+      ],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(reviewBody)).toBeTruthy();
+    });
+    expect(screen.getByText("Outdated")).toBeTruthy();
+    const comment = document.querySelector("[data-review-thread-id='thread-1']");
+    const diff = document.querySelector(".pierre-diff");
+    expect(comment?.parentElement?.classList.contains("file-content")).toBe(true);
+    expect(comment?.closest("[slot^='annotation-']")).toBeNull();
+    expect(diff?.compareDocumentPosition(comment!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("keeps a stale review thread detached when its numeric line still exists", async () => {
     renderDiffFile(makeFile(), {
       reviewEnabled: true,
       diffHeadSHA: "current-head",
+      reviewThreads: [makeReviewThread({ diff_head_sha: "stale-head" })],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Published review note")).toBeTruthy();
+    });
+    expect(screen.getByText("Outdated")).toBeTruthy();
+    const comment = document.querySelector("[data-review-thread-id='thread-1']");
+    const diff = document.querySelector(".pierre-diff");
+    expect(comment?.closest("[slot^='annotation-']")).toBeNull();
+    expect(diff?.compareDocumentPosition(comment!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it.each([
+    ["fresh unavailable", "diff-head", "diff-head", 99, "Line unavailable"],
+    ["head-unknown thread inline", undefined, "diff-head", 2, ""],
+    ["head-unknown diff inline", "diff-head", undefined, 2, ""],
+  ] as const)("keeps %s", async (_label, threadHead, diffHead, line, expectedLabel) => {
+    renderDiffFile(makeFile(), {
+      reviewEnabled: true,
+      ...(diffHead === undefined ? {} : { diffHeadSHA: diffHead }),
       reviewThreads: [
         makeReviewThread({
-          diff_head_sha: "stale-head",
+          line,
+          new_line: line,
+          ...(threadHead === undefined ? {} : { diff_head_sha: threadHead }),
         }),
       ],
     });
@@ -2082,10 +2162,14 @@ describe("DiffFile", () => {
     await waitFor(() => {
       expect(screen.getByText("Published review note")).toBeTruthy();
     });
-    expect(screen.getByText("File")).toBeTruthy();
     const comment = document.querySelector("[data-review-thread-id='thread-1']");
-    expect(comment?.parentElement?.classList.contains("file-content")).toBe(true);
-    expect(comment?.closest("[slot^='annotation-']")).toBeNull();
+    if (expectedLabel) {
+      expect(screen.getByText(expectedLabel)).toBeTruthy();
+      expect(comment?.closest("[slot^='annotation-']")).toBeNull();
+    } else {
+      expect(comment?.closest("[slot^='annotation-']")).toBeTruthy();
+      expect(screen.queryByText("Line unavailable")).toBeNull();
+    }
   });
 
   it("does not match added-file threads only because old paths are empty", () => {
@@ -2111,7 +2195,11 @@ describe("DiffFile", () => {
     expect(screen.queryByText("Wrong added file note")).toBeNull();
   });
 
-  it("renders unmatched review threads at the file header", () => {
+  it.each([
+    ["fresh", "diff-head", "diff-head"],
+    ["stale", "diff-head", "other-head"],
+    ["head-unknown", undefined, "diff-head"],
+  ] as const)("renders %s file-level review threads at the file header", (_label, diffHead, threadHead) => {
     renderDiffFile(
       makeFile({
         patch: `diff --git a/src/foo.ts b/src/foo.ts
@@ -2138,6 +2226,7 @@ describe("DiffFile", () => {
         ],
       }),
       {
+        ...(diffHead === undefined ? {} : { diffHeadSHA: diffHead }),
         reviewThreads: [
           makeReviewThread({
             id: "thread-file",
@@ -2145,6 +2234,7 @@ describe("DiffFile", () => {
             new_line: 1,
             line_type: "file",
             body: "File-level note",
+            diff_head_sha: threadHead,
           }),
         ],
       },
@@ -2153,7 +2243,45 @@ describe("DiffFile", () => {
     expect(screen.getByText("File-level note")).toBeTruthy();
     expect(screen.getByText("File")).toBeTruthy();
     const comment = document.querySelector("[data-review-thread-id='thread-file']");
+    const diff = document.querySelector(".pierre-diff");
     expect(comment?.parentElement?.classList.contains("file-content")).toBe(true);
+    expect(comment?.compareDocumentPosition(diff!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it.each([
+    ["fresh", "diff-head", "diff-head", "Line unavailable"],
+    ["stale", "diff-head", "other-head", "Outdated"],
+    ["head-unknown", undefined, "diff-head", "Line unavailable"],
+  ] as const)("keeps binary review threads visible for %s snapshots", async (_label, diffHead, threadHead, status) => {
+    renderDiffFile(makeFile({ is_binary: true, hunks: [] }), {
+      ...(diffHead === undefined ? {} : { diffHeadSHA: diffHead }),
+      reviewThreads: [
+        makeReviewThread({
+          diff_head_sha: threadHead,
+          line: 99,
+          new_line: 99,
+        }),
+      ],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Published review note")).toBeTruthy();
+    });
+    const notice = screen.getByText("Binary file changed");
+    const comment = document.querySelector("[data-review-thread-id='thread-1']");
+    expect(screen.getByText(status)).toBeTruthy();
+    expect(notice.compareDocumentPosition(comment!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("keeps workspace review authoring disabled", async () => {
+    renderDiffFile(makeFile(), {
+      reviewEnabled: false,
+      diffHeadSHA: "diff-head",
+    });
+
+    await expectPierreDiffText(/old linenew line/);
+    expect(screen.queryByPlaceholderText("Leave a comment")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Publish review" })).toBeNull();
   });
 
   it("clears an open inline composer when review context changes", async () => {

--- a/frontend/src/lib/components/diff/DiffFile.test.ts
+++ b/frontend/src/lib/components/diff/DiffFile.test.ts
@@ -521,6 +521,50 @@ describe("DiffFile", () => {
     });
   });
 
+  it("does not classify inactive markdown review threads as unavailable", async () => {
+    const visibleObserver = (globalThis as GlobalWithIO).IntersectionObserver;
+    class InactiveIntersectionObserverStub {
+      root: Element | null = null;
+      rootMargin = "";
+      thresholds: readonly number[] = [];
+      constructor(private readonly callback: IntersectionObserverCallback) {}
+      observe(target: Element): void {
+        const entry = {
+          isIntersecting: false,
+          intersectionRatio: 0,
+          target,
+          boundingClientRect: {} as DOMRectReadOnly,
+          intersectionRect: {} as DOMRectReadOnly,
+          rootBounds: null,
+          time: 0,
+        } as IntersectionObserverEntry;
+        this.callback([entry], this as unknown as IntersectionObserver);
+      }
+      unobserve(): void {}
+      disconnect(): void {}
+      takeRecords(): IntersectionObserverEntry[] {
+        return [];
+      }
+    }
+    (globalThis as GlobalWithIO).IntersectionObserver = InactiveIntersectionObserverStub;
+
+    try {
+      renderDiffFile(makeFile({ path: "README.md", old_path: "README.md" }), {
+        richPreview: true,
+        diffHeadSHA: "diff-head",
+        reviewThreads: [makeReviewThread({ path: "README.md", diff_head_sha: "diff-head" })],
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Loading preview")).toBeTruthy();
+      });
+      expect(screen.queryByText("Published review note")).toBeNull();
+      expect(screen.queryByText("Line unavailable")).toBeNull();
+    } finally {
+      (globalThis as GlobalWithIO).IntersectionObserver = visibleObserver;
+    }
+  });
+
   it("keeps structural markdown rich preview changes visibly highlighted", async () => {
     renderDiffFile(
       makeFile({

--- a/frontend/src/lib/components/diff/DiffReviewThreadInlineComment.svelte
+++ b/frontend/src/lib/components/diff/DiffReviewThreadInlineComment.svelte
@@ -11,13 +11,13 @@
   import { makeAnimationFrameScheduler } from "../../browser/animation-frame.js";
   import { observeResize } from "../../browser/observers.js";
   import type { MutationCallbacks } from "../../stores/ordered-mutations.js";
-  import type { ReviewThread } from "./review-thread-context.js";
+  import type { ReviewThread, ReviewThreadCardPlacement } from "./review-thread-context.js";
   import { reviewThreadLineLabel, reviewThreadProviderHiddenState } from "./review-thread-context.js";
 
   interface Props {
     runtime: AppRuntime;
     thread: ReviewThread;
-    fileLevel?: boolean;
+    placement?: ReviewThreadCardPlacement;
     canReply?: boolean;
     onreply?: ((thread: ReviewThread, body: string, callbacks: MutationCallbacks) => void) | undefined;
   }
@@ -25,7 +25,7 @@
   const {
     runtime,
     thread,
-    fileLevel = false,
+    placement = "inline",
     canReply = false,
     onreply,
   }: Props = $props();
@@ -159,7 +159,7 @@
 
 <div
   class="inline-review-thread"
-  class:inline-review-thread--file-level={fileLevel}
+  class:inline-review-thread--file-level={placement !== "inline"}
   class:inline-review-thread--idle-reply={bodyVisible && canReply && !thread.resolved && !replying}
   data-review-thread-id={thread.id}
   {@attach setupThreadLayout}
@@ -172,8 +172,12 @@
     {#if thread.resolved}
       <span class="review-thread-status">Resolved</span>
     {/if}
-    {#if fileLevel}
+    {#if placement === "file"}
       <span class="review-thread-status review-thread-status--outdated">File</span>
+    {:else if placement === "outdated"}
+      <span class="review-thread-status review-thread-status--outdated">Outdated</span>
+    {:else if placement === "unavailable"}
+      <span class="review-thread-status review-thread-status--outdated">Line unavailable</span>
     {/if}
   </div>
   {#if thread.author_login}

--- a/frontend/src/lib/components/diff/DiffReviewThreadInlineComment.test.ts
+++ b/frontend/src/lib/components/diff/DiffReviewThreadInlineComment.test.ts
@@ -125,4 +125,26 @@ describe("DiffReviewThreadInlineComment", () => {
 
     expect(screen.getByText("Published review note")).toBeTruthy();
   });
+
+  it.each([
+    ["inline", null],
+    ["file", "File"],
+    ["outdated", "Outdated"],
+    ["unavailable", "Line unavailable"],
+  ] as const)("presents the %s review placement", (placement, label) => {
+    render(DiffReviewThreadInlineComment, {
+      props: {
+        thread: makeReviewThread(),
+        placement,
+      },
+    });
+
+    if (label) {
+      expect(screen.getByText(label)).toBeTruthy();
+    } else {
+      expect(screen.queryByText("File")).toBeNull();
+      expect(screen.queryByText("Outdated")).toBeNull();
+      expect(screen.queryByText("Line unavailable")).toBeNull();
+    }
+  });
 });

--- a/frontend/src/lib/components/diff/DiffRichPreview.svelte
+++ b/frontend/src/lib/components/diff/DiffRichPreview.svelte
@@ -89,7 +89,9 @@
   const displayText = $derived(formatText(file.path, text));
   const fallbackReviewThreads = $derived<ReviewThreadPlacement[]>(
     markdownPreview?.fallbackReviewThreads ??
-      reviewThreads.map((thread) => ({ thread, placement: reviewThreadFallbackPlacement(thread) })),
+      (isMarkdownFile
+        ? []
+        : reviewThreads.map((thread) => ({ thread, placement: reviewThreadFallbackPlacement(thread) }))),
   );
   const fileHeaderReviewThreads = $derived(
     fallbackReviewThreads.filter(({ placement }) => placement === "file"),

--- a/frontend/src/lib/components/diff/DiffRichPreview.svelte
+++ b/frontend/src/lib/components/diff/DiffRichPreview.svelte
@@ -12,9 +12,11 @@
   } from "../../utils/markdown-rich-preview.js";
   import DiffReviewThreadInlineComment from "./DiffReviewThreadInlineComment.svelte";
   import {
+    reviewThreadSnapshotState,
     reviewThreadTargetLine,
     reviewThreadTargetSide,
     type ReviewThread,
+    type ReviewThreadCardPlacement,
   } from "./review-thread-context.js";
 
   interface Props {
@@ -54,7 +56,7 @@
 
   type ReviewThreadPlacement = {
     thread: ReviewThread;
-    fileLevel: boolean;
+    placement: ReviewThreadCardPlacement;
   };
   type DiffHunk = DiffFile["hunks"][number];
   type DiffHunkLine = DiffHunk["lines"][number];
@@ -87,7 +89,13 @@
   const displayText = $derived(formatText(file.path, text));
   const fallbackReviewThreads = $derived<ReviewThreadPlacement[]>(
     markdownPreview?.fallbackReviewThreads ??
-      reviewThreads.map((thread) => ({ thread, fileLevel: threadLineIsFileLevelCard(thread) })),
+      reviewThreads.map((thread) => ({ thread, placement: reviewThreadFallbackPlacement(thread) })),
+  );
+  const fileHeaderReviewThreads = $derived(
+    fallbackReviewThreads.filter(({ placement }) => placement === "file"),
+  );
+  const detachedReviewThreads = $derived(
+    fallbackReviewThreads.filter(({ placement }) => placement === "outdated" || placement === "unavailable"),
   );
 
   $effect(() => {
@@ -183,17 +191,21 @@
     }));
     const fallbackReviewThreads: ReviewThreadPlacement[] = [];
     for (const thread of threads) {
-      const fileLevel = threadLineIsFileLevelCard(thread);
-      if (fileLevel) {
-        fallbackReviewThreads.push({ thread, fileLevel });
+      const snapshotState = reviewThreadSnapshotState(thread, diffHeadSHA);
+      if (thread.line_type === "file") {
+        fallbackReviewThreads.push({ thread, placement: "file" });
+        continue;
+      }
+      if (snapshotState === "stale") {
+        fallbackReviewThreads.push({ thread, placement: "outdated" });
         continue;
       }
       const block = blocks.find((candidate) => blockContainsReviewThread(candidate, thread));
       if (!block) {
-        fallbackReviewThreads.push({ thread, fileLevel: true });
+        fallbackReviewThreads.push({ thread, placement: "unavailable" });
         continue;
       }
-      const placement = { thread, fileLevel };
+      const placement = { thread, placement: "inline" as const };
       block.reviewThreads.push(placement);
       if (reviewThreadTargetSide(thread) === "left") {
         block.leftReviewThreads.push(placement);
@@ -217,7 +229,7 @@
     const splitOldLines: number[] = [];
     const splitNewLines: number[] = [];
     for (const thread of threads) {
-      if (threadLineIsFileLevelCard(thread)) continue;
+      if (thread.line_type === "file" || reviewThreadSnapshotState(thread, diffHeadSHA) === "stale") continue;
       const side = reviewThreadTargetSide(thread);
       const targetLine = reviewThreadTargetLine(thread);
       const match = findReviewThreadDiffLine(source, side, targetLine);
@@ -500,7 +512,7 @@
   }
 
   function blockContainsReviewThread(block: MarkdownRichPreviewBlock, thread: ReviewThread): boolean {
-    if (threadLineIsFileLevelCard(thread)) return false;
+    if (thread.line_type === "file" || reviewThreadSnapshotState(thread, diffHeadSHA) === "stale") return false;
     const line = reviewThreadTargetLine(thread);
     if (reviewThreadTargetSide(thread) === "left") {
       return lineInMappedBlock(line, block.oldLines, block.oldStart, block.oldEnd);
@@ -526,27 +538,24 @@
     return start != null && end != null && line >= start && line <= end;
   }
 
-  function threadLineIsFileLevelCard(thread: ReviewThread): boolean {
-    return thread.line_type === "file" || !threadMatchesCurrentDiff(thread);
-  }
-
-  function threadMatchesCurrentDiff(thread: ReviewThread): boolean {
-    return !thread.diff_head_sha || !diffHeadSHA || thread.diff_head_sha === diffHeadSHA;
+  function reviewThreadFallbackPlacement(thread: ReviewThread): ReviewThreadCardPlacement {
+    if (thread.line_type === "file") return "file";
+    return reviewThreadSnapshotState(thread, diffHeadSHA) === "stale" ? "outdated" : "unavailable";
   }
 </script>
 
 <div class="preview-shell">
   {#if isMarkdownFile}
+    {#each fileHeaderReviewThreads as placement (placement.thread.id)}
+      <DiffReviewThreadInlineComment
+        {runtime}
+        thread={placement.thread}
+        placement={placement.placement}
+        canReply={canReplyToThreads}
+        {onreply}
+      />
+    {/each}
     {#if markdownPreview}
-      {#each fallbackReviewThreads as placement (placement.thread.id)}
-        <DiffReviewThreadInlineComment
-          {runtime}
-          thread={placement.thread}
-          fileLevel={placement.fileLevel}
-          canReply={canReplyToThreads}
-          {onreply}
-        />
-      {/each}
       {#if viewMode === "split"}
         <div class="diff-rich-preview markdown-rich-diff markdown-rich-diff--split">
           <div class="markdown-rich-diff__split-header" aria-hidden="true">
@@ -572,7 +581,7 @@
                     <DiffReviewThreadInlineComment
                       {runtime}
                       thread={placement.thread}
-                      fileLevel={placement.fileLevel}
+                      placement={placement.placement}
                       canReply={canReplyToThreads}
                       {onreply}
                     />
@@ -590,7 +599,7 @@
                     <DiffReviewThreadInlineComment
                       {runtime}
                       thread={placement.thread}
-                      fileLevel={placement.fileLevel}
+                      placement={placement.placement}
                       canReply={canReplyToThreads}
                       {onreply}
                     />
@@ -610,7 +619,7 @@
               <DiffReviewThreadInlineComment
                 {runtime}
                 thread={placement.thread}
-                fileLevel={placement.fileLevel}
+                placement={placement.placement}
                 canReply={canReplyToThreads}
                 {onreply}
               />
@@ -618,15 +627,33 @@
           {/each}
         </div>
       {/if}
+      {#each detachedReviewThreads as placement (placement.thread.id)}
+        <DiffReviewThreadInlineComment
+          {runtime}
+          thread={placement.thread}
+          placement={placement.placement}
+          canReply={canReplyToThreads}
+          {onreply}
+        />
+      {/each}
     {:else}
       <div class="preview-state">Loading preview</div>
+      {#each detachedReviewThreads as placement (placement.thread.id)}
+        <DiffReviewThreadInlineComment
+          {runtime}
+          thread={placement.thread}
+          placement={placement.placement}
+          canReply={canReplyToThreads}
+          {onreply}
+        />
+      {/each}
     {/if}
   {:else}
-    {#each fallbackReviewThreads as placement (placement.thread.id)}
+    {#each fileHeaderReviewThreads as placement (placement.thread.id)}
       <DiffReviewThreadInlineComment
         {runtime}
         thread={placement.thread}
-        fileLevel={placement.fileLevel}
+        placement={placement.placement}
         canReply={canReplyToThreads}
         {onreply}
       />
@@ -659,6 +686,15 @@
     {:else}
       <div class="preview-state">Loading preview</div>
     {/if}
+    {#each detachedReviewThreads as placement (placement.thread.id)}
+      <DiffReviewThreadInlineComment
+        {runtime}
+        thread={placement.thread}
+        placement={placement.placement}
+        canReply={canReplyToThreads}
+        {onreply}
+      />
+    {/each}
   {/if}
 </div>
 

--- a/frontend/src/lib/components/diff/review-thread-context.test.ts
+++ b/frontend/src/lib/components/diff/review-thread-context.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import type { DiffResult, PREvent } from "../../api/types.js";
-import { reviewThreadContext, reviewThreadsFromEvents, type ReviewThread } from "./review-thread-context.js";
+import {
+  reviewThreadContext,
+  reviewThreadSnapshotState,
+  reviewThreadsFromEvents,
+  type ReviewThread,
+} from "./review-thread-context.js";
 
 function makeThread(overrides: Partial<ReviewThread> = {}): ReviewThread {
   return {
@@ -51,6 +56,17 @@ function makeDiff(): DiffResult {
 }
 
 describe("reviewThreadContext", () => {
+  it.each([
+    ["fresh", "thread-head", "thread-head"],
+    ["stale", "thread-head", "other-head"],
+    ["head-unknown", undefined, "thread-head"],
+    ["head-unknown", "thread-head", undefined],
+    ["head-unknown", "", "thread-head"],
+    ["head-unknown", "thread-head", ""],
+  ] as const)("classifies %s thread and diff heads", (expected, threadHead, diffHead) => {
+    expect(reviewThreadSnapshotState(makeThread({ diff_head_sha: threadHead }), diffHead)).toBe(expected);
+  });
+
   it("extracts review threads from generated client event casing", () => {
     const thread = makeThread({ id: "thread-pascal" });
     const event = { DiffThread: thread } as unknown as PREvent;

--- a/frontend/src/lib/components/diff/review-thread-context.ts
+++ b/frontend/src/lib/components/diff/review-thread-context.ts
@@ -3,6 +3,18 @@ import type { DiffLine, DiffResult, PREvent } from "../../api/types.js";
 
 export type ReviewThread = components["schemas"]["DiffReviewThreadResponse"];
 
+export type ReviewThreadSnapshotState = "fresh" | "stale" | "head-unknown";
+
+export type ReviewThreadCardPlacement = "inline" | "file" | "outdated" | "unavailable";
+
+export function reviewThreadSnapshotState(
+  thread: ReviewThread,
+  diffHeadSHA: string | undefined,
+): ReviewThreadSnapshotState {
+  if (!thread.diff_head_sha || !diffHeadSHA) return "head-unknown";
+  return thread.diff_head_sha === diffHeadSHA ? "fresh" : "stale";
+}
+
 export type ReviewThreadContextLine = {
   key: string;
   type: DiffLine["type"];

--- a/frontend/src/lib/components/diff/review-thread-context.ts
+++ b/frontend/src/lib/components/diff/review-thread-context.ts
@@ -8,7 +8,7 @@ export type ReviewThreadSnapshotState = "fresh" | "stale" | "head-unknown";
 export type ReviewThreadCardPlacement = "inline" | "file" | "outdated" | "unavailable";
 
 export function reviewThreadSnapshotState(
-  thread: ReviewThread,
+  thread: Pick<ReviewThread, "diff_head_sha">,
   diffHeadSHA: string | undefined,
 ): ReviewThreadSnapshotState {
   if (!thread.diff_head_sha || !diffHeadSHA) return "head-unknown";

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -2706,7 +2706,7 @@ test.describe("diff view", () => {
     await expect(deletedPreview.locator(".inline-review-thread").filter({ hasText: "Deleted last" })).toBeVisible();
   });
 
-  test("rich preview keeps unmapped review thread cards visible as file-level fallback", async ({ page }) => {
+  test("rich preview keeps unmapped review thread cards visible as line-unavailable fallback", async ({ page }) => {
     const reviewBody = "Unmapped rich preview note should stay visible";
     await mockDiffApi(page, previewDiff);
     await mockFilePreviewApi(page);
@@ -2725,10 +2725,13 @@ test.describe("diff view", () => {
     });
     await expect(fallbackCard).toBeVisible();
     await expect(fallbackCard).toHaveClass(/inline-review-thread--file-level/);
-    await expect(fallbackCard).toContainText("File");
+    await expect(fallbackCard).toContainText("Line unavailable");
     await expect(
       markdownFile.locator(".markdown-rich-diff--unified .inline-review-thread").filter({ hasText: reviewBody }),
     ).toHaveCount(0);
+    await expect(
+      markdownFile.locator(".markdown-rich-diff--unified ~ .inline-review-thread").filter({ hasText: reviewBody }),
+    ).toHaveCount(1);
   });
 
   test("rich preview hides synthetic hunk separators inside spanning markdown blocks", async ({ page }) => {
@@ -2750,7 +2753,7 @@ test.describe("diff view", () => {
     await expect(markdownPreview.locator("hr")).toHaveCount(0);
   });
 
-  test("rich preview keeps hidden hunk-gap review threads as file-level fallback", async ({ page }) => {
+  test("rich preview keeps hidden hunk-gap review threads as line-unavailable fallback", async ({ page }) => {
     const reviewBody = "Hidden hunk gap review note should stay fallback";
     await mockDiffApi(page, multiHunkMarkdownDiff);
     await mockReviewThreadOnPreviewMarkdown(page, reviewBody, 6, "docs/multihunk.md");
@@ -2767,9 +2770,13 @@ test.describe("diff view", () => {
     });
     await expect(fallbackCard).toBeVisible();
     await expect(fallbackCard).toHaveClass(/inline-review-thread--file-level/);
+    await expect(fallbackCard).toContainText("Line unavailable");
     await expect(
       markdownFile.locator(".markdown-rich-diff--unified .inline-review-thread").filter({ hasText: reviewBody }),
     ).toHaveCount(0);
+    await expect(
+      markdownFile.locator(".markdown-rich-diff--unified ~ .inline-review-thread").filter({ hasText: reviewBody }),
+    ).toHaveCount(1);
   });
 
   test("rich preview refetches blob content after a same-PR diff reload", async ({ page }) => {


### PR DESCRIPTION
Diff renderers now keep current line comments attached to their line or Markdown block, true file comments at the file header, and detached comments after the rendered file with an `Outdated` or `Line unavailable` label. Known-stale comments cannot attach to a coincidentally matching line number in a newer diff. The behavior covers text and rich-preview renderers, context expansion, and annotation wrappers.

This change follows [@criccomini's reproduction](https://github.com/kenn-io/forge/issues/572) and preserves the mapped Markdown placement established by [@mariusvniekerk in PR #539](https://github.com/kenn-io/forge/pull/539).

![Outdated review comment placed after the diff](https://raw.githubusercontent.com/rodboev/forge/screenshots/forge-572-after.png)

Closes kenn-io/forge#572

<sup>generated by a clanker</sup>
