### PR TITLE
fix: report missing repository preview credentials as a bad request

### DIFF
--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -4175,10 +4175,7 @@ func clientForRegistry(registry *platform.Registry, repo RepoRef) (Client, error
 	host := repoHost(repo)
 	provider, err := registry.Provider(repoPlatform(repo), host)
 	if err != nil {
-		if errors.Is(err, platform.ErrSyncDisabled) {
-			return nil, err
-		}
-		return nil, fmt.Errorf("no client configured for host %s", host)
+		return nil, err
 	}
 	legacy, ok := provider.(interface{ GitHubClient() Client })
 	if !ok || legacy.GitHubClient() == nil {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -7791,6 +7791,22 @@ func TestClientForRepoMatchesCaseInsensitively(t *testing.T) {
 	require.Same(mc, client)
 }
 
+func TestDirectClientForHostReportsMissingProvider(t *testing.T) {
+	require := require.New(t)
+	syncer := NewSyncer(nil, openTestDB(t), nil, nil, time.Minute, nil, nil)
+	t.Cleanup(syncer.Stop)
+
+	client, err := syncer.DirectClientForHost("github.com")
+	require.Nil(client)
+	require.ErrorIs(err, platform.ErrProviderNotConfigured)
+
+	var platformErr *platform.Error
+	require.ErrorAs(err, &platformErr)
+	require.Equal(platform.ErrCodeProviderNotConfigured, platformErr.Code)
+	require.Equal(platform.KindGitHub, platformErr.Provider)
+	require.Equal("github.com", platformErr.PlatformHost)
+}
+
 func TestSyncerClientLookupReportsMissingProvider(t *testing.T) {
 	require := require.New(t)
 	syncer := NewSyncer(nil, openTestDB(t), nil, []RepoRef{{

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -2901,7 +2901,46 @@ port = 8091
 	assert.Equal("repo-b", orgB.Repos[0].Name)
 }
 
+func TestHandlePreviewReposReportsUnconfiguredGitHubProvider(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	t.Setenv("MIDDLEMAN_GITHUB_TOKEN", "")
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	require.NoError(os.WriteFile(cfgPath, []byte(`
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+`), 0o644))
+	cfg, err := config.Load(cfgPath)
+	require.NoError(err)
+	database := dbtest.Open(t)
+	syncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
+	t.Cleanup(syncer.Stop)
+	srv := NewWithConfig(database, syncer, nil, nil, cfg, cfgPath,
+		ServerOptions{HostCheckAllowLoopbackAnyPort: true})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+
+	rr := testutil.DoJSON(t, srv, http.MethodPost, "/api/v1/repos/preview", map[string]string{
+		"provider": "github", "host": "github.com",
+		"owner": "acme", "pattern": "widget",
+	})
+
+	require.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
+	assert.True(strings.HasPrefix(
+		rr.Header().Get("Content-Type"), "application/problem+json",
+	))
+	var problem httpapi.ProblemError
+	require.NoError(json.NewDecoder(rr.Body).Decode(&problem))
+	assert.Equal(httpapi.CodeBadRequest, problem.Code)
+	assert.Contains(problem.Detail, "provider_not_configured")
+	assert.Contains(problem.Detail, "github.com")
+}
+
 func TestHandlePreviewReposReportsMissingOwnerRoute(t *testing.T) {
+	assert := assert.New(t)
 	require := require.New(t)
 	router, err := ghclient.NewHostRouter(
 		"github.com",
@@ -2938,9 +2977,12 @@ port = 8091
 	})
 
 	require.Equal(http.StatusBadGateway, rr.Code, rr.Body.String())
-	assert.Contains(t, rr.Body.String(), "org-b")
-	assert.Contains(t, rr.Body.String(), "github.com")
-	assert.NotContains(t, rr.Body.String(), "org-a")
+	assert.Contains(rr.Body.String(), "org-b")
+	assert.Contains(rr.Body.String(), "github.com")
+	assert.NotContains(rr.Body.String(), "org-a")
+	var problem httpapi.ProblemError
+	require.NoError(json.NewDecoder(rr.Body).Decode(&problem))
+	assert.Equal(httpapi.CodeUpstreamError, problem.Code)
 }
 
 func TestHandlePreviewReposFallsBackToListWhenExactLookupFails(t *testing.T) {


### PR DESCRIPTION
Repository previews now return a 400 bad request when GitHub credentials are not configured, matching the existing runtime-token and registry-backed provider behavior. The legacy GitHub client adapter preserves the typed `provider_not_configured` error so the shared HTTP problem mapper applies that classification, while configured-client failures without a local configuration classification remain 502.

This change covers the preview handler, provider registry, GitHub adapter, and HTTP problem mapper path described in @Technophobe01's report at https://github.com/kenn-io/forge/issues/675. The status contract follows the runtime-token handling introduced by @cpcloud in https://github.com/kenn-io/forge/pull/450.

Closes kenn-io/forge#675

<sup>generated by a clanker</sup>
