### PR TITLE
fix: start dev-stack processes from a non-login shell

### DIFF
--- a/process-compose.yml
+++ b/process-compose.yml
@@ -3,7 +3,11 @@ is_strict: true
 
 shell:
   shell_command: "sh"
-  shell_argument: "-lc"
+  # Not a login shell: on macOS a login sh runs /etc/profile, which calls
+  # path_helper and moves the system directories ahead of the user's own
+  # PATH. The daemon started here hands its environment to every agent it
+  # launches, so keep the PATH process-compose was started with.
+  shell_argument: "-c"
 
 processes:
   backend:


### PR DESCRIPTION
The dev stack ran every process-compose process through `sh -lc`. On macOS a login `sh` sources `/etc/profile`, which runs `path_helper` and rebuilds PATH with the system directories first and the developer's own entries appended after. The dev daemon inherited that order and handed it to every agent it launched, so agents picked up Apple's `/usr/bin/git` ahead of a newer Homebrew git. Apple's git predates config-based hooks, so global pre-commit hooks silently never ran inside agent sessions.

- Run dev-stack processes with `sh -c`. process-compose already inherits the caller's PATH, so the login shell added nothing.

This fixes the developer stack only. A daemon started from somewhere without the user's shell environment still passes that environment to agents; resolving PATH from the login shell at agent launch is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
