### PR TITLE
feat: show stack position in the pull request list

### DIFF
--- a/context/db-migrations.md
+++ b/context/db-migrations.md
@@ -60,6 +60,12 @@ schema migrations.
   reader reloads the stored statistics (`internal/db/db.go::Optimize`).
 - Migrations must never drop or rebuild `sqlite_stat1`, and a query-plan assertion
   needs seeded rows plus `DB.Optimize` first (`internal/db/db.go::Optimize`).
+- Lookups keyed by an unbounded ID list, such as pull-list enrichment, must not
+  expand the list into `IN (?, ?, ...)` placeholders: SQLite caps a statement at
+  32,766 bound variables. Bind the list once as a JSON array through
+  `json_each(?)`, or batch it
+  (`internal/db/queries_stacks.go::ListStackPlacementsForMRs`,
+  `internal/db/queries.go::GetWorktreeLinksForMRs`).
 
 ## Federation Spoke Preparation
 

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -500,10 +500,13 @@ Repository import requests and route/query shapes should carry
   pushed-head refresh, manual workspace refresh, and on-demand worktree sync
   must check item visibility before item-specific provider access. Workspace and
   Fleet projections retain local records but omit removed parent metadata;
-  visible stack members are renumbered contiguously after filtering.
+  visible stack members are renumbered contiguously after filtering, and the
+  pull list's per-row stack placement must report the same position and size
+  as the detail stack context.
   `inaccessible` items remain visible.
   (`internal/server/pullapi/helpers.go::visibleMergeRequest`,
-  `internal/server/issueapi/mutation_handlers.go::requireVisibleIssue`)
+  `internal/server/issueapi/mutation_handlers.go::requireVisibleIssue`,
+  `internal/db/queries_stacks.go::ListStackPlacementsForMRs`)
 - Embedded navigation events for repo-bound routes must publish identity from
   parsed route state, not from global embed config. When a route carries repo
   identity, event payloads should include `provider`, `platform_host`, and

--- a/context/testing.md
+++ b/context/testing.md
@@ -187,6 +187,10 @@ the diff, so scope diff locators to `.diff-area`.
 Pane tab headers are `role="tab"` with an `aria-label`, so use
 `getByRole("tab", { name })` — `getByRole(..., { hasText })` is not a valid
 option and silently matches every tab.
+The mock Playwright config's 30 s timeout covers the whole test, and every
+`page.goto` is a full Vite dev-server load that slows several-fold under CI's
+14 workers; keep a test to two navigations or split it, or it fails on the
+first attempt and only passes on retry. (`frontend/playwright.config.ts`)
 Sidebar item rows are `<button>`s whose accessible name concatenates every
 descendant label, including indicator `aria-label`s such as "Stacked: 2/7", so
 a page-wide `getByRole("button", { name })` for a detail chip also matches the

--- a/context/testing.md
+++ b/context/testing.md
@@ -187,6 +187,10 @@ the diff, so scope diff locators to `.diff-area`.
 Pane tab headers are `role="tab"` with an `aria-label`, so use
 `getByRole("tab", { name })` — `getByRole(..., { hasText })` is not a valid
 option and silently matches every tab.
+Sidebar item rows are `<button>`s whose accessible name concatenates every
+descendant label, including indicator `aria-label`s such as "Stacked: 2/7", so
+a page-wide `getByRole("button", { name })` for a detail chip also matches the
+row; scope chip assertions to the chip's test id.
 
 Every `@lucide/svelte/icons/<name>` import added anywhere in `frontend/src`
 must also be added to the `optimizeDeps.include` list in

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -5081,6 +5081,8 @@ components:
           type:
             - array
             - "null"
+        stack:
+          $ref: "#/components/schemas/StackPlacementResponse"
         workspace:
           $ref: "#/components/schemas/WorkspaceRef"
         worktree_links:
@@ -8662,6 +8664,21 @@ components:
         - is_draft
         - base_branch
         - blocked_by
+      type: object
+    StackPlacementResponse:
+      additionalProperties: false
+      properties:
+        position:
+          description: 1-based position of this pull request in its stack
+          format: int64
+          type: integer
+        size:
+          description: Number of visible pull requests in the stack
+          format: int64
+          type: integer
+      required:
+        - position
+        - size
       type: object
     StackResponse:
       additionalProperties: false

--- a/frontend/src/lib/api/generated/schema.ts
+++ b/frontend/src/lib/api/generated/schema.ts
@@ -7399,6 +7399,7 @@ export interface components {
             repo_name: string;
             repo_owner: string;
             requested_reviewers?: string[] | null;
+            stack?: components["schemas"]["StackPlacementResponse"];
             workspace?: components["schemas"]["WorkspaceRef"];
             worktree_links: components["schemas"]["WorktreeLinkResponse"][] | null;
         };
@@ -8983,6 +8984,18 @@ export interface components {
             review_decision: string;
             state: string;
             title: string;
+        };
+        StackPlacementResponse: {
+            /**
+             * Format: int64
+             * @description 1-based position of this pull request in its stack
+             */
+            position: number;
+            /**
+             * Format: int64
+             * @description Number of visible pull requests in the stack
+             */
+            size: number;
         };
         StackResponse: {
             health: string;

--- a/frontend/src/lib/components/detail/StackStatus.svelte
+++ b/frontend/src/lib/components/detail/StackStatus.svelte
@@ -278,7 +278,7 @@
         {expanded}
       >
         <Layers2Icon size={12} strokeWidth={2.3} aria-hidden="true" />
-        <span class="stack-chip-label">Stacked: {data.position}/{data.size}</span>
+        <span class="stack-chip-label">{data.position}/{data.size}</span>
         {#if downstackBlockerCount > 0}
           <span class="stack-chip-failure" aria-hidden="true">
             <XIcon size={14} strokeWidth={2.8} /><span class="stack-chip-failure-count">{downstackBlockerCount}</span>

--- a/frontend/src/lib/components/sidebar/PullItem.svelte
+++ b/frontend/src/lib/components/sidebar/PullItem.svelte
@@ -12,6 +12,7 @@
   import CITokenCluster, { composeAriaLabel } from "../shared/CITokenCluster.svelte";
   import CircleAlertIcon from "@lucide/svelte/icons/circle-alert";
   import CircleCheckBigIcon from "@lucide/svelte/icons/circle-check-big";
+  import Layers2Icon from "@lucide/svelte/icons/layers-2";
   import OctagonXIcon from "@lucide/svelte/icons/octagon-x";
   import LabelRow from "../shared/LabelRow.svelte";
   import WorkspaceIndicator from "../shared/WorkspaceIndicator.svelte";
@@ -220,6 +221,16 @@
           <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
             <path d="M5 3.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm0 2.122a2.25 2.25 0 10-1.5 0v.878A2.25 2.25 0 005.75 8.5h1.5v2.128a2.251 2.251 0 101.5 0V8.5h1.5a2.25 2.25 0 002.25-2.25v-.878a2.25 2.25 0 10-1.5 0v.878a.75.75 0 01-.75.75h-5.5a.75.75 0 01-.75-.75v-.878zM8 12.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm3.25-9.75a.75.75 0 100 1.5.75.75 0 000-1.5z"/>
           </svg>
+        </span>
+      {/if}
+      {#if pr.stack}
+        <span
+          class="stack-indicator"
+          aria-label={`Stacked: ${pr.stack.position}/${pr.stack.size}`}
+          title={`Stacked: ${pr.stack.position}/${pr.stack.size}`}
+        >
+          <Layers2Icon size={13} strokeWidth={2.2} aria-hidden="true" />
+          <span class="stack-indicator-count" aria-hidden="true">{pr.stack.position}/{pr.stack.size}</span>
         </span>
       {/if}
       {#if parsed.error !== null}
@@ -440,6 +451,21 @@
     color: var(--accent-red);
   }
 
+  .stack-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    flex: 0 0 auto;
+    color: var(--text-muted);
+  }
+
+  .stack-indicator-count {
+    font-size: var(--font-size-2xs);
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+  }
+
   .ci-unavailable {
     color: var(--state-warn, var(--accent-amber, #c08a2a));
     opacity: 0.85;
@@ -553,6 +579,7 @@
   :global(.mobile-main) .meta-text,
   :global(.mobile-main) .time,
   :global(.mobile-main) .worktree-name,
+  :global(.mobile-main) .stack-indicator-count,
   :global(.mobile-main) .item-number,
   :global(.mobile-main) .repo-name {
     font-size: var(--font-size-sm);

--- a/frontend/src/lib/components/sidebar/PullItem.test.ts
+++ b/frontend/src/lib/components/sidebar/PullItem.test.ts
@@ -293,6 +293,20 @@ describe("PullItem kanban status", () => {
     expect(screen.getByLabelText("Workspace attached (ready)")).toBeTruthy();
   });
 
+  it("shows the stack position and size when the PR belongs to a stack", () => {
+    renderItem(mkPR({ stack: { position: 4, size: 7 } }));
+
+    const indicator = screen.getByLabelText("Stacked: 4/7");
+    expect(indicator.textContent?.trim()).toBe("4/7");
+    expect(indicator.querySelector("svg")).toBeTruthy();
+  });
+
+  it("hides the stack indicator when the PR is not stacked", () => {
+    renderItem(mkPR({}));
+
+    expect(screen.queryByLabelText(/^Stacked:/)).toBeNull();
+  });
+
   it("shows an approved indicator when the PR is approved", () => {
     renderItem(
       mkPR({

--- a/frontend/tests/e2e/stack-status.spec.ts
+++ b/frontend/tests/e2e/stack-status.spec.ts
@@ -546,8 +546,9 @@ test("stack status follows refreshed detail stack data", async ({ page }) => {
   ];
   await emitPRDetailRefreshed(page, 102);
 
-  await expect(page.getByRole("button", { name: /Stacked: 2\/2/i })).toBeVisible();
-  await expect(page.getByRole("button", { name: /Stacked: 2\/7/i })).toHaveCount(0);
+  // Scope to the chip: the sidebar row button also exposes "Stacked: n/m"
+  // through its accessible name, so a page-wide role query would match it.
+  await expect(page.getByTestId("stack-chip")).toHaveAccessibleName(/Stacked: 2\/2/i);
 
   currentStackMembers = [];
   await emitPRDetailRefreshed(page, 102);

--- a/frontend/tests/e2e/stack-status.spec.ts
+++ b/frontend/tests/e2e/stack-status.spec.ts
@@ -220,7 +220,11 @@ async function mockStackedPR(
     const method = route.request().method();
 
     if (method === "GET" && pathname === "/api/v1/pulls") {
-      await fulfillJson(route, [pr]);
+      const currentStackMembers = options.stackMembers?.() ?? stackMembers;
+      const position = currentStackMembers.findIndex((member) => member.number === pr.Number) + 1;
+      const stack =
+        position > 0 && currentStackMembers.length > 1 ? { position, size: currentStackMembers.length } : undefined;
+      await fulfillJson(route, [{ ...pr, stack }]);
       return;
     }
 
@@ -446,6 +450,11 @@ test("stack status shares the PR detail expandable slot with CI", async ({ page 
   await mockStackedPR(page);
 
   await page.goto("/pulls/github/acme/widgets/102");
+
+  const listStackIndicator = page.locator(".pull-item").getByLabel("Stacked: 2/7");
+  await expect(listStackIndicator).toHaveText("2/7");
+  await expect(page.getByTestId("stack-chip")).toContainText("2/7");
+  await expect(page.getByTestId("stack-chip")).not.toContainText("Stacked");
 
   await page.getByTestId("ci-chip").click();
   await expect(page.getByText("frontend / vp check")).toBeVisible();

--- a/frontend/tests/e2e/stack-status.spec.ts
+++ b/frontend/tests/e2e/stack-status.spec.ts
@@ -556,6 +556,31 @@ test("stack status follows refreshed detail stack data", async ({ page }) => {
   await expect(page.getByTestId("stack-chip")).toHaveCount(0);
 });
 
+test("phone pull rows fit the stack indicator beside the other indicators", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await mockStackedPR(page);
+
+  await page.goto("/m/pulls");
+  const row = page.locator(".mobile-shell .pull-item").first();
+  const indicator = row.getByLabel("Stacked: 2/7");
+  await expect(indicator).toHaveText("2/7");
+  // The fixture also renders the approved review, CI cluster, and time
+  // indicators, so the row exercises the full trailing cluster.
+  await expect(row.locator(".review-indicator--approved")).toBeVisible();
+  await expect(row.locator(".ci")).toBeVisible();
+
+  const rowBox = await row.boundingBox();
+  const indicatorBox = await indicator.boundingBox();
+  expect(rowBox).not.toBeNull();
+  expect(indicatorBox).not.toBeNull();
+  if (rowBox && indicatorBox) {
+    expect(rowBox.x + rowBox.width).toBeLessThanOrEqual(390);
+    expect(indicatorBox.x).toBeGreaterThanOrEqual(rowBox.x);
+    expect(indicatorBox.x + indicatorBox.width).toBeLessThanOrEqual(rowBox.x + rowBox.width);
+  }
+  expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(390);
+});
+
 test("stack status stays rendered while navigating to a stack member", async ({ page }) => {
   let releaseStackResponse: () => void = () => {};
   const delayedStackResponse = new Promise<void>((resolve) => {

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -4689,7 +4689,10 @@ test.describe("workspace list bubble opens right sidebar", () => {
     expect(maxRight - minRight).toBeLessThanOrEqual(1);
   });
 
-  test("workspace recency uses item-list typography without phone overflow", async ({ page }) => {
+  // Desktop and phone parity are separate tests: each full navigation through
+  // the Vite dev server is slow under CI worker load, and four in one test
+  // exhausted the per-test budget on the first attempt.
+  test("workspace recency uses item-list typography on desktop", async ({ page }) => {
     await setupTerminalMocks(page);
     await page.addInitScript(() => {
       localStorage.setItem("kenn-forge:workspaceListSort", "created");
@@ -4711,6 +4714,13 @@ test.describe("workspace list bubble opens right sidebar", () => {
       return { fontFamily: style.fontFamily, fontSize: style.fontSize, lineHeight: style.lineHeight };
     });
     expect(desktopTypography).toEqual(pullTypography);
+  });
+
+  test("workspace recency uses item-list typography on phones without overflow", async ({ page }) => {
+    await setupTerminalMocks(page);
+    await page.addInitScript(() => {
+      localStorage.setItem("kenn-forge:workspaceListSort", "created");
+    });
 
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto("/m/pulls");

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -3516,6 +3516,7 @@ type MergeRequestResponse struct {
 	RepoName                string                           `json:"repo_name"`
 	RepoOwner               string                           `json:"repo_owner"`
 	RequestedReviewers      *[]string                        `json:"requested_reviewers,omitempty"`
+	Stack                   *StackPlacementResponse          `json:"stack,omitempty"`
 	Workspace               *WorkspaceRef                    `json:"workspace,omitempty"`
 	WorktreeLinks           *[]WorktreeLinkResponse          `json:"worktree_links"`
 }
@@ -5097,6 +5098,15 @@ type StackMemberResponse struct {
 	ReviewDecision string `json:"review_decision"`
 	State          string `json:"state"`
 	Title          string `json:"title"`
+}
+
+// StackPlacementResponse defines model for StackPlacementResponse.
+type StackPlacementResponse struct {
+	// Position 1-based position of this pull request in its stack
+	Position int64 `json:"position"`
+
+	// Size Number of visible pull requests in the stack
+	Size int64 `json:"size"`
 }
 
 // StackResponse defines model for StackResponse.

--- a/internal/db/queries_stacks.go
+++ b/internal/db/queries_stacks.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -363,20 +364,24 @@ func (d *DB) getStackForPRWhere(ctx context.Context, where string, args ...any) 
 // ListStackPlacementsForMRs returns the visible stack position and size for
 // each merge request that belongs to a stack. Members hidden as removed
 // upstream are excluded and the remaining members are renumbered contiguously,
-// matching GetStackForPR.
+// matching GetStackForPR. The IDs are bound once as a JSON array so the pull
+// list size is not limited by SQLite's bind-parameter ceiling.
 func (d *DB) ListStackPlacementsForMRs(ctx context.Context, mrIDs []int64) (map[int64]StackPlacement, error) {
 	placements := make(map[int64]StackPlacement)
 	if len(mrIDs) == 0 {
 		return placements, nil
 	}
 
-	args := make([]any, len(mrIDs))
-	for i, id := range mrIDs {
-		args[i] = id
+	payload, err := json.Marshal(mrIDs)
+	if err != nil {
+		return nil, fmt.Errorf("encode stack placement ids: %w", err)
 	}
 
 	rows, err := d.roQueryContext(ctx, `
-		WITH visible AS (
+		WITH requested AS (
+		    SELECT CAST(value AS INTEGER) AS merge_request_id FROM json_each(?)
+		),
+		visible AS (
 		    SELECT sm.stack_id, sm.merge_request_id,
 		           ROW_NUMBER() OVER (PARTITION BY sm.stack_id ORDER BY sm.position) AS position,
 		           COUNT(*) OVER (PARTITION BY sm.stack_id) AS size
@@ -384,7 +389,7 @@ func (d *DB) ListStackPlacementsForMRs(ctx context.Context, mrIDs []int64) (map[
 		    JOIN forge_merge_requests p ON p.id = sm.merge_request_id
 		    WHERE sm.stack_id IN (
 		        SELECT stack_id FROM forge_stack_members
-		        WHERE merge_request_id IN (`+sqlPlaceholders(len(mrIDs))+`)
+		        WHERE merge_request_id IN (SELECT merge_request_id FROM requested)
 		    )
 		    AND NOT EXISTS (
 		        SELECT 1 FROM forge_archive_items ai
@@ -396,8 +401,8 @@ func (d *DB) ListStackPlacementsForMRs(ctx context.Context, mrIDs []int64) (map[
 		)
 		SELECT merge_request_id, position, size
 		FROM visible
-		WHERE merge_request_id IN (`+sqlPlaceholders(len(mrIDs))+`)`,
-		append(append([]any{}, args...), args...)...,
+		WHERE merge_request_id IN (SELECT merge_request_id FROM requested)`,
+		string(payload),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("list stack placements: %w", err)

--- a/internal/db/queries_stacks.go
+++ b/internal/db/queries_stacks.go
@@ -360,6 +360,61 @@ func (d *DB) getStackForPRWhere(ctx context.Context, where string, args ...any) 
 	return &stack, members, rows.Err()
 }
 
+// ListStackPlacementsForMRs returns the visible stack position and size for
+// each merge request that belongs to a stack. Members hidden as removed
+// upstream are excluded and the remaining members are renumbered contiguously,
+// matching GetStackForPR.
+func (d *DB) ListStackPlacementsForMRs(ctx context.Context, mrIDs []int64) (map[int64]StackPlacement, error) {
+	placements := make(map[int64]StackPlacement)
+	if len(mrIDs) == 0 {
+		return placements, nil
+	}
+
+	args := make([]any, len(mrIDs))
+	for i, id := range mrIDs {
+		args[i] = id
+	}
+
+	rows, err := d.roQueryContext(ctx, `
+		WITH visible AS (
+		    SELECT sm.stack_id, sm.merge_request_id,
+		           ROW_NUMBER() OVER (PARTITION BY sm.stack_id ORDER BY sm.position) AS position,
+		           COUNT(*) OVER (PARTITION BY sm.stack_id) AS size
+		    FROM forge_stack_members sm
+		    JOIN forge_merge_requests p ON p.id = sm.merge_request_id
+		    WHERE sm.stack_id IN (
+		        SELECT stack_id FROM forge_stack_members
+		        WHERE merge_request_id IN (`+sqlPlaceholders(len(mrIDs))+`)
+		    )
+		    AND NOT EXISTS (
+		        SELECT 1 FROM forge_archive_items ai
+		        WHERE ai.repo_id = p.repo_id
+		          AND ai.item_type = 'merge_request'
+		          AND ai.item_number = p.number
+		          AND ai.lifecycle_state = 'removed_upstream'
+		    )
+		)
+		SELECT merge_request_id, position, size
+		FROM visible
+		WHERE merge_request_id IN (`+sqlPlaceholders(len(mrIDs))+`)`,
+		append(append([]any{}, args...), args...)...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list stack placements: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id int64
+		var placement StackPlacement
+		if err := rows.Scan(&id, &placement.Position, &placement.Size); err != nil {
+			return nil, fmt.Errorf("scan stack placement: %w", err)
+		}
+		placements[id] = placement
+	}
+	return placements, rows.Err()
+}
+
 // ListMRsBlockedByStackConflicts returns merge request IDs whose stack has an
 // earlier non-merged dirty member. It is used by API response assembly to
 // surface the stack-root conflict without mutating the provider-sourced PR row.

--- a/internal/db/queries_stacks_test.go
+++ b/internal/db/queries_stacks_test.go
@@ -253,6 +253,18 @@ func TestListStackPlacementsForMRs(t *testing.T) {
 	empty, err := d.ListStackPlacementsForMRs(ctx, nil)
 	require.NoError(err)
 	assert.Empty(empty)
+
+	// The pull list has no size cap, so the lookup must survive an ID set far
+	// beyond SQLite's bind-parameter ceiling (32,766 variables).
+	large := make([]int64, 0, 70_000)
+	for id := int64(1_000_000); id < 1_070_000; id++ {
+		large = append(large, id)
+	}
+	large = append(large, mrID3, mrID4)
+	placements, err = d.ListStackPlacementsForMRs(ctx, large)
+	require.NoError(err)
+	assert.Len(placements, 2)
+	assert.Equal(StackPlacement{Position: 2, Size: 3}, placements[mrID3])
 }
 
 func TestDeleteStaleStacks(t *testing.T) {

--- a/internal/db/queries_stacks_test.go
+++ b/internal/db/queries_stacks_test.go
@@ -202,6 +202,59 @@ func TestListMRsBlockedByStackConflicts(t *testing.T) {
 	assert.True(blocked[mrID3])
 }
 
+func TestListStackPlacementsForMRs(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	repoID := insertTestRepo(t, d, "org", "repo")
+
+	mrID1 := insertTestMRWithBranches(t, d, repoID, 1, "feature/a", "main", "merged")
+	mrID2 := insertTestMRWithBranches(t, d, repoID, 2, "feature/b", "feature/a", "open")
+	mrID3 := insertTestMRWithBranches(t, d, repoID, 3, "feature/c", "feature/b", "open")
+	mrID4 := insertTestMRWithBranches(t, d, repoID, 4, "feature/d", "feature/c", "open")
+	soloID := insertTestMRWithBranches(t, d, repoID, 9, "solo", "main", "open")
+	stackID, err := d.UpsertStack(ctx, repoID, 1, "feature")
+	require.NoError(err)
+	err = d.ReplaceStackMembers(ctx, stackID, []StackMember{
+		{StackID: stackID, MergeRequestID: mrID1, Position: 1},
+		{StackID: stackID, MergeRequestID: mrID2, Position: 2},
+		{StackID: stackID, MergeRequestID: mrID3, Position: 3},
+		{StackID: stackID, MergeRequestID: mrID4, Position: 4},
+	})
+	require.NoError(err)
+
+	placements, err := d.ListStackPlacementsForMRs(ctx, []int64{mrID2, mrID4, soloID})
+	require.NoError(err)
+	assert.Equal(StackPlacement{Position: 2, Size: 4}, placements[mrID2])
+	assert.Equal(StackPlacement{Position: 4, Size: 4}, placements[mrID4])
+	_, requested := placements[mrID1]
+	assert.False(requested, "unrequested members must not be returned")
+	_, inStack := placements[soloID]
+	assert.False(inStack, "merge requests outside a stack must not be returned")
+
+	// Hiding a member removed upstream renumbers the visible members.
+	_, err = d.WriteDB().ExecContext(ctx, `
+		INSERT INTO forge_archive_items (
+			repo_id, item_type, item_number, provider_item_id,
+			provider_created_at, provider_updated_at, lifecycle_state
+		) VALUES (?, 'merge_request', 2, 'pull-2', ?, ?, 'removed_upstream')`,
+		repoID, baseTime(), baseTime(),
+	)
+	require.NoError(err)
+
+	placements, err = d.ListStackPlacementsForMRs(ctx, []int64{mrID2, mrID3, mrID4})
+	require.NoError(err)
+	_, hidden := placements[mrID2]
+	assert.False(hidden, "hidden members must not be returned")
+	assert.Equal(StackPlacement{Position: 2, Size: 3}, placements[mrID3])
+	assert.Equal(StackPlacement{Position: 3, Size: 3}, placements[mrID4])
+
+	empty, err := d.ListStackPlacementsForMRs(ctx, nil)
+	require.NoError(err)
+	assert.Empty(empty)
+}
+
 func TestDeleteStaleStacks(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -1179,6 +1179,13 @@ type StackMemberWithPR struct {
 	MergeableState string
 }
 
+// StackPlacement is a merge request's contiguous position within its stack
+// after hidden members are filtered, plus the visible stack size.
+type StackPlacement struct {
+	Position int
+	Size     int
+}
+
 // GitHubNativeStack is a cached GitHub stack resource. It remains separate
 // from Stack, which is the provider-neutral projection served to the UI.
 type GitHubNativeStack struct {

--- a/internal/server/pullapi/handler_test.go
+++ b/internal/server/pullapi/handler_test.go
@@ -147,6 +147,64 @@ func TestListPullsTreatsAssociatedWorkspaceSubjectAsHasWorkspace(t *testing.T) {
 	assert.Equal(t, "ws-adhoc", result.Body[0].Workspace.ID)
 }
 
+func TestListPullsReportsStackPlacementForMultiMemberStacks(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	ctx := t.Context()
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	identity := db.GitHubRepoIdentity("github.com", "acme", "widget")
+	identity.PlatformRepoID = "repo-acme-widget"
+	repoID, err := database.UpsertRepo(ctx, identity)
+	require.NoError(err)
+	insert := func(number int, head, base string) int64 {
+		id, err := database.UpsertMergeRequest(ctx, &db.MergeRequest{
+			RepoID: repoID, PlatformID: int64(number), Number: number, Title: "PR",
+			Author: "alice", State: db.MergeRequestStateOpen, HeadBranch: head, BaseBranch: base,
+			CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+		})
+		require.NoError(err)
+		return id
+	}
+	firstID := insert(1, "feature/a", "main")
+	secondID := insert(2, "feature/b", "feature/a")
+	thirdID := insert(3, "feature/c", "feature/b")
+	insert(4, "solo", "main")
+	loneID := insert(5, "lone", "main")
+
+	stackID, err := database.UpsertStack(ctx, repoID, 1, "feature")
+	require.NoError(err)
+	require.NoError(database.ReplaceStackMembers(ctx, stackID, []db.StackMember{
+		{StackID: stackID, MergeRequestID: firstID, Position: 1},
+		{StackID: stackID, MergeRequestID: secondID, Position: 2},
+		{StackID: stackID, MergeRequestID: thirdID, Position: 3},
+	}))
+	loneStackID, err := database.UpsertStack(ctx, repoID, 5, "lone")
+	require.NoError(err)
+	require.NoError(database.ReplaceStackMembers(ctx, loneStackID, []db.StackMember{
+		{StackID: loneStackID, MergeRequestID: loneID, Position: 1},
+	}))
+
+	handler := New(Deps{
+		DB:       database,
+		Resolver: httpapi.NewRepositoryResolver(httpapi.RepositoryResolverDeps{DB: database}),
+	})
+	result, err := handler.listPulls(ctx, &listPullsInput{State: "open"})
+	require.NoError(err)
+
+	byNumber := map[int]MergeRequestResponse{}
+	for _, row := range result.Body {
+		byNumber[row.Number] = row
+	}
+	require.Len(byNumber, 5)
+	require.NotNil(byNumber[2].Stack)
+	assert.Equal(StackPlacementResponse{Position: 2, Size: 3}, *byNumber[2].Stack)
+	require.NotNil(byNumber[3].Stack)
+	assert.Equal(StackPlacementResponse{Position: 3, Size: 3}, *byNumber[3].Stack)
+	assert.Nil(byNumber[4].Stack, "pull requests outside a stack carry no placement")
+	assert.Nil(byNumber[5].Stack, "single-member stacks are not shown as stacked")
+}
+
 type stubPullProviderSource struct {
 	rows   []MergeRequestResponse
 	detail MergeRequestDetailResponse

--- a/internal/server/pullapi/routes.go
+++ b/internal/server/pullapi/routes.go
@@ -453,6 +453,10 @@ func (s *Handler) listPullsRouteCore(ctx context.Context, input *listPullsInput)
 	if err != nil {
 		return nil, httpapi.Internal("load stack conflict state failed")
 	}
+	stackPlacements, err := s.db.ListStackPlacementsForMRs(ctx, mrIDs)
+	if err != nil {
+		return nil, httpapi.Internal("load stack placements failed")
+	}
 	links, err := s.db.GetWorktreeLinksForMRs(ctx, mrIDs)
 	if err != nil {
 		return nil, httpapi.Internal("load worktree links failed")
@@ -494,6 +498,9 @@ func (s *Handler) listPullsRouteCore(ctx context.Context, input *listPullsInput)
 		}
 		if mr.DetailFetchedAt != nil {
 			resp.DetailFetchedAt = formatUTCRFC3339(*mr.DetailFetchedAt)
+		}
+		if placement, ok := stackPlacements[mr.ID]; ok && placement.Size > 1 {
+			resp.Stack = &StackPlacementResponse{Position: placement.Position, Size: placement.Size}
 		}
 		out = append(out, resp)
 	}

--- a/internal/server/pullapi/types.go
+++ b/internal/server/pullapi/types.go
@@ -26,6 +26,16 @@ type MergeRequestResponse struct {
 	LastWorkspaceActivityAt string                     `json:"last_workspace_activity_at,omitempty" format:"date-time"`
 	DetailLoaded            bool                       `json:"detail_loaded"`
 	DetailFetchedAt         string                     `json:"detail_fetched_at,omitempty"`
+	// Stack is present only when the pull request belongs to a stack with more
+	// than one visible member, so list rows can show a stack indicator without
+	// loading the full stack context.
+	Stack *StackPlacementResponse `json:"stack,omitempty"`
+}
+
+// StackPlacementResponse is a pull request's position within its stack.
+type StackPlacementResponse struct {
+	Position int `json:"position" doc:"1-based position of this pull request in its stack"`
+	Size     int `json:"size" doc:"Number of visible pull requests in the stack"`
 }
 
 type mergeRequestEventResponse struct {


### PR DESCRIPTION
Stacked pull requests were indistinguishable from standalone ones in the sidebar. You had to open each one to learn whether it was part of a stack and where it sat. Each list row now carries the stack icon with the pull request's position and stack size, placed just before the CI cluster, so a stack reads at a glance from the list.

- Sidebar PR rows show a stack indicator such as "4/7" when the pull request belongs to a stack with more than one visible member. The hover title and accessible name read "Stacked: 4/7".
- The detail view's stack chip drops the word "Stacked" and shows only the icon and count. The accessible name keeps the full wording.
- The pull list API returns a per-row `stack` placement so the sidebar does not fetch stack context for every row. Members hidden as removed upstream are excluded and the rest renumbered, matching the detail stack context.

- Also splits the workspace recency typography e2e test into desktop and phone tests. It made four dev-server page loads inside the 30 second per-test budget and failed its first attempt in every CI job since it landed, passing only on retry.

Sidebar row with the new indicator before the CI cluster, and the shortened detail chip (synthetic fixture data):

![stack-indicator-row.png](https://github.com/user-attachments/assets/51691778-ca4e-40e6-92ab-4557e90cdf54)

![stack-indicator.png](https://github.com/user-attachments/assets/6dea8c2e-930b-44c9-bac3-fc2b8d53dc1e)

🤖 Generated with Claude Code (claude-fable-5-1)


