### PR TITLE
fix: restore standalone workspace and comment mutations

### DIFF
--- a/context/fleet-architecture.md
+++ b/context/fleet-architecture.md
@@ -349,6 +349,9 @@ change-driven and idle-cheap:
   daemon. Before sealing local writes it first proves the pending hub is
   reachable and pins that enrollment; hub failure before that point
   leaves the standalone provider plane open.
+- A daemon without a local federation enrollment starts with provider writes
+  open and does not restore fleet preparation state
+  (`internal/server/server.go::newServer`).
 - Once quiescing begins, the provider-write barrier survives restarts. Only
   `fleet abort-preparation` may reopen it before activation, after admitted work
   drains. A spoke-shaped process requires restart before standalone provider work;

--- a/context/server-runtime.md
+++ b/context/server-runtime.md
@@ -185,6 +185,9 @@ and the root event stream.
 - Trusted forwarded-host support adds validation of the canonical forwarded
   authority; it never replaces validation of the raw backend `Host`
   (`internal/server/host_check.go::checkHost`).
+- After trusted forwarded-host validation, mutation origin checks compare with
+  that public authority rather than the reverse proxy's backend `Host`
+  (`internal/server/server.go::checkCrossOrigin`).
 
 ## Event Replay
 

--- a/internal/providerplane/write_gate.go
+++ b/internal/providerplane/write_gate.go
@@ -31,11 +31,14 @@ type ProviderWriteGate struct {
 	loadErr        error
 }
 
-func NewProviderWriteGate(database *db.DB) *ProviderWriteGate {
+func NewProviderWriteGate(database *db.DB, restoreDurableState bool) *ProviderWriteGate {
 	gate := &ProviderWriteGate{database: database, phase: db.SpokePreparationOpen}
 	if database == nil {
 		gate.phase = db.SpokePreparationQuiescing
 		gate.loadErr = errors.New("provider write gate database is unavailable")
+		return gate
+	}
+	if !restoreDurableState {
 		return gate
 	}
 	state, err := database.GetSpokePreparation(context.Background())

--- a/internal/providerplane/write_gate_test.go
+++ b/internal/providerplane/write_gate_test.go
@@ -15,7 +15,7 @@ func TestSpokePreparationWriteGateSurvivesRestartAndTracksDeferredWork(t *testin
 	require := require.New(t)
 	path := filepath.Join(t.TempDir(), "gate.db")
 	database := dbtest.OpenAt(t, path)
-	gate := NewProviderWriteGate(database)
+	gate := NewProviderWriteGate(database, true)
 
 	releaseWrite, err := gate.Admit(t.Context())
 	require.NoError(err)
@@ -42,7 +42,7 @@ func TestSpokePreparationWriteGateSurvivesRestartAndTracksDeferredWork(t *testin
 	require.NoError(database.Close())
 
 	database = dbtest.OpenPreparedAt(t, path)
-	restarted := NewProviderWriteGate(database)
+	restarted := NewProviderWriteGate(database, true)
 	_, err = restarted.Admit(t.Context())
 	require.ErrorIs(err, ErrSpokePreparationInProgress)
 	require.NoError(restarted.AbortPreparation(t.Context()))
@@ -52,7 +52,7 @@ func TestSpokePreparationWriteGateSurvivesRestartAndTracksDeferredWork(t *testin
 	require.NoError(database.Close())
 
 	database = dbtest.OpenPreparedAt(t, path)
-	afterAbortRestart := NewProviderWriteGate(database)
+	afterAbortRestart := NewProviderWriteGate(database, true)
 	release, err = afterAbortRestart.Admit(t.Context())
 	require.NoError(err, "aborting preparation must durably reopen provider writes")
 	release()
@@ -66,7 +66,7 @@ func TestAbortPreparationRecoversUnreadableDurableState(t *testing.T) {
 		"UPDATE forge_spoke_preparation SET updated_at = 'not-a-time' WHERE singleton_id = 1",
 	)
 	require.NoError(err)
-	gate := NewProviderWriteGate(database)
+	gate := NewProviderWriteGate(database, true)
 
 	require.NoError(gate.CanAbortPreparation())
 	require.NoError(gate.AbortPreparation(t.Context()))

--- a/internal/server/host_check_test.go
+++ b/internal/server/host_check_test.go
@@ -346,6 +346,59 @@ func TestHostCheckForwardedHost(t *testing.T) {
 	}
 }
 
+func TestCrossOriginProtectionUsesValidatedForwardedHost(t *testing.T) {
+	cases := []struct {
+		name       string
+		header     string
+		value      string
+		origin     string
+		wantStatus int
+	}{
+		{
+			name:       "X-Forwarded-Host matches Origin",
+			header:     "X-Forwarded-Host",
+			value:      "forge.example:8080",
+			origin:     "http://forge.example:8080",
+			wantStatus: http.StatusAccepted,
+		},
+		{
+			name:       "Forwarded host matches Origin",
+			header:     "Forwarded",
+			value:      "for=192.0.2.10;host=forge.example:8080",
+			origin:     "http://forge.example:8080",
+			wantStatus: http.StatusAccepted,
+		},
+		{
+			name:       "forwarded host does not match Origin",
+			header:     "X-Forwarded-Host",
+			value:      "forge.example:8080",
+			origin:     "http://other.example:8080",
+			wantStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := setupHostCheckServer(t, HostCheckOptions{
+				Bind: bindLoopback8091(),
+				Allowed: []config.HostKey{
+					{Host: "forge.example", Port: "8080"},
+				},
+				TrustReverseProxy: true,
+			})
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/sync", nil)
+			req.Host = "127.0.0.1:8091"
+			req.Header.Set(tc.header, tc.value)
+			req.Header.Set("Origin", tc.origin)
+			rr := httptest.NewRecorder()
+
+			srv.ServeHTTP(rr, req)
+
+			require.Equal(t, tc.wantStatus, rr.Code, rr.Body.String())
+		})
+	}
+}
+
 // TestHostCheck403BodyShape pins the 403 body shape used by the
 // middleware. The body must be valid JSON of the form
 // {"error":"..."} and the value must name both config knobs so an

--- a/internal/server/provider_quiesce_test.go
+++ b/internal/server/provider_quiesce_test.go
@@ -6,10 +6,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/federation"
 	"go.kenn.io/forge/internal/providerplane"
 	"go.kenn.io/forge/internal/server/httpapi"
 	"go.kenn.io/forge/internal/testutil/dbtest"
@@ -31,11 +33,61 @@ func authenticatedProviderRequest(
 	return response
 }
 
+func TestStandaloneProviderWritesDoNotRequireSpokePreparationState(t *testing.T) {
+	database := dbtest.Open(t)
+	_, err := database.WriteDB().ExecContext(t.Context(), "DROP TABLE forge_spoke_preparation")
+	require.NoError(t, err)
+
+	srv := New(database, nil, nil, "/", nil, ServerOptions{})
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/pulls/github/acme/widget/1/comments",
+		bytes.NewReader([]byte(`{"body":""}`)),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	srv.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code, rr.Body.String())
+	require.NotContains(t, rr.Body.String(), "spoke preparation")
+}
+
+func TestLocalEnrollmentRestoresSpokePreparationBarrier(t *testing.T) {
+	database := dbtest.Open(t)
+	gate := providerplane.NewProviderWriteGate(database, true)
+	_, err := gate.BeginQuiesce(t.Context(), db.SpokePreparationBinding{
+		EnrollmentID: preparationEnrollmentID, HubNodeID: preparationHubNodeID,
+		LocalNodeID: preparationLocalNodeID, ProtocolVersion: federation.ProtocolVersion,
+	})
+	require.NoError(t, err)
+
+	enrollments, _ := openFederationPreparationStores(t, "restore-barrier")
+	require.NoError(t, enrollments.SaveLocal(t.Context(), federation.LocalEnrollment{
+		EnrollmentID: preparationEnrollmentID, NodeID: preparationLocalNodeID,
+		SpokeBaseURL: "https://spoke.example", HubID: preparationHubNodeID,
+		HubURL: "https://hub.example", ProtocolVersion: federation.ProtocolVersion,
+		State: federation.EnrollmentPending, ExpiresAt: time.Now().Add(time.Hour),
+	}))
+
+	srv := New(database, nil, nil, "/", nil, ServerOptions{
+		DaemonAccess:          DaemonAccessOptions{Token: "local-secret", RequireAPIAuth: true},
+		FederationEnrollments: enrollments,
+	})
+	daemon := httptest.NewServer(srv)
+	t.Cleanup(daemon.Close)
+	blocked := authenticatedProviderRequest(
+		t, daemon, http.MethodPost, "/api/v1/notifications/read",
+	)
+
+	require.Equal(t, http.StatusConflict, blocked.StatusCode)
+}
+
 func TestSpokePreparationBarrierGatesAuthenticatedProviderWritesAndSurvivesRestart(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	database := dbtest.Open(t)
-	gate := providerplane.NewProviderWriteGate(database)
+	gate := providerplane.NewProviderWriteGate(database, true)
 	releaseWrite, err := gate.Admit(t.Context())
 	require.NoError(err)
 	releaseDeferred, err := gate.BeginDeferredMerge(t.Context())
@@ -79,7 +131,7 @@ func TestSpokePreparationBarrierGatesAuthenticatedProviderWritesAndSurvivesResta
 	require.NoError(err)
 	assert.NotNil(status.DrainAckGeneration)
 
-	restarted := providerplane.NewProviderWriteGate(database)
+	restarted := providerplane.NewProviderWriteGate(database, true)
 	second := newDaemon(restarted)
 	blocked = authenticatedProviderRequest(
 		t, second, http.MethodPost, "/api/v1/notifications/read",

--- a/internal/server/pullapi/deferred_merge_test.go
+++ b/internal/server/pullapi/deferred_merge_test.go
@@ -188,7 +188,7 @@ func TestClearDeferredMergeInFlightKeepsNewerHandle(t *testing.T) {
 
 func TestSpokePreparationTracksDeferredMergeUntilClearOrSupersede(t *testing.T) {
 	require := require.New(t)
-	gate := providerplane.NewProviderWriteGate(dbtest.Open(t))
+	gate := providerplane.NewProviderWriteGate(dbtest.Open(t), true)
 	handler := New(Deps{ProviderWriteGate: gate})
 	key := "github:github.com:acme/widget#7"
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -872,7 +872,11 @@ func newServer(
 	}
 	s.providerWriteGate = options.ProviderWriteGate
 	if s.providerWriteGate == nil {
-		s.providerWriteGate = providerplane.NewProviderWriteGate(database)
+		restoreDurableState := false
+		if options.FederationEnrollments != nil {
+			_, restoreDurableState = options.FederationEnrollments.Local()
+		}
+		s.providerWriteGate = providerplane.NewProviderWriteGate(database, restoreDurableState)
 	}
 	if cfg != nil && cfg.Fleet.RoleOrDefault() == config.FleetRoleSpoke {
 		s.providerRouteSpoke = true

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1569,7 +1569,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if r.Method != http.MethodGet && s.isMutatingAPIRequest(r) {
-		if !checkCrossOrigin(w, r) {
+		if !checkCrossOrigin(w, r, hostOpts.TrustReverseProxy) {
 			return
 		}
 		if s.isMutatingDocsAPIRequest(r) && !isLoopbackRemoteAddr(r.RemoteAddr) {
@@ -1766,8 +1766,27 @@ func authorityIsLoopbackHost(hostHeader string) bool {
 
 // checkCrossOrigin rejects cross-origin browser requests. Returns true if
 // the request is allowed, false if it was rejected (response written).
-func checkCrossOrigin(w http.ResponseWriter, r *http.Request) bool {
-	if err := crossOriginProtection.Check(r); err != nil {
+func checkCrossOrigin(w http.ResponseWriter, r *http.Request, trustReverseProxy bool) bool {
+	request := r
+	if trustReverseProxy {
+		// Host validation has already accepted the forwarded public authority.
+		// Use it for the Origin comparison instead of the proxy's backend Host.
+		publicHost := ""
+		if values := r.Header.Values("X-Forwarded-Host"); len(values) > 0 {
+			if key, err := parseXForwardedHost(strings.Join(values, ",")); err == nil {
+				publicHost = key.String()
+			}
+		} else if values := r.Header.Values("Forwarded"); len(values) > 0 {
+			if key, err := parseForwardedHost(strings.Join(values, ",")); err == nil {
+				publicHost = key.String()
+			}
+		}
+		if publicHost != "" {
+			request = r.Clone(r.Context())
+			request.Host = publicHost
+		}
+	}
+	if err := crossOriginProtection.Check(request); err != nil {
 		writeError(w, http.StatusForbidden, "cross-origin requests are not allowed")
 		return false
 	}


### PR DESCRIPTION
Standalone Forge deployments behind a reverse proxy can create workspaces and comments again.

- Validate browser writes against the configured forwarded origin and host while continuing to reject untrusted origins.
- Allow standalone provider writes without fleet preparation state; hub and spoke deployments retain their existing preparation gate.