### PR TITLE
feat: rank current item participants first in @ mention suggestions

### DIFF
--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -21264,6 +21264,24 @@ paths:
           schema:
             format: int64
             type: integer
+        - description: Optional item the comment targets; requires item_number.
+          explode: false
+          in: query
+          name: item_type
+          schema:
+            description: Optional item the comment targets; requires item_number.
+            enum:
+              - pr
+              - issue
+            type: string
+        - description: Optional item number the comment targets; requires item_type.
+          explode: false
+          in: query
+          name: item_number
+          schema:
+            description: Optional item number the comment targets; requires item_type.
+            format: int64
+            type: integer
       responses:
         "200":
           content:

--- a/frontend/src/lib/api/generated/schema.ts
+++ b/frontend/src/lib/api/generated/schema.ts
@@ -19019,6 +19019,10 @@ export interface operations {
                 trigger?: string;
                 q?: string;
                 limit?: number;
+                /** @description Optional item the comment targets; requires item_number. */
+                item_type?: "pr" | "issue";
+                /** @description Optional item number the comment targets; requires item_type. */
+                item_number?: number;
             };
             header?: never;
             path: {
@@ -21189,6 +21193,7 @@ export const pathsActivityThreadEventsGetParametersQueryItem_typeValues: Readonl
 export const pathsHostPlatform_hostPullsProviderOwnerNameNumberFilePreviewGetParametersQuerySideValues: ReadonlyArray<FlattenedDeepRequired<paths>["/host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/file-preview"]["get"]["parameters"]["query"]["side"]> = ["old", "new"];
 export const pathsHostPlatform_hostRepoProviderOwnerNameResolveNumberPostParametersQueryItem_typeValues: ReadonlyArray<FlattenedDeepRequired<paths>["/host/{platform_host}/repo/{provider}/{owner}/{name}/resolve/{number}"]["post"]["parameters"]["query"]["item_type"]> = ["pr", "issue"];
 export const pathsPullsProviderOwnerNameNumberFilePreviewGetParametersQuerySideValues: ReadonlyArray<FlattenedDeepRequired<paths>["/pulls/{provider}/{owner}/{name}/{number}/file-preview"]["get"]["parameters"]["query"]["side"]> = ["old", "new"];
+export const pathsRepoProviderOwnerNameCommentAutocompleteGetParametersQueryItem_typeValues: ReadonlyArray<FlattenedDeepRequired<paths>["/repo/{provider}/{owner}/{name}/comment-autocomplete"]["get"]["parameters"]["query"]["item_type"]> = ["pr", "issue"];
 export const pathsRepoProviderOwnerNameResolveNumberPostParametersQueryItem_typeValues: ReadonlyArray<FlattenedDeepRequired<paths>["/repo/{provider}/{owner}/{name}/resolve/{number}"]["post"]["parameters"]["query"]["item_type"]> = ["pr", "issue"];
 export const pathsStarredDeleteParametersQueryItem_typeValues: ReadonlyArray<FlattenedDeepRequired<paths>["/starred"]["delete"]["parameters"]["query"]["item_type"]> = ["pr", "issue"];
 export const pathsWorkspacesIdFilePreviewGetParametersQueryBaseValues: ReadonlyArray<FlattenedDeepRequired<paths>["/workspaces/{id}/file-preview"]["get"]["parameters"]["query"]["base"]> = ["head", "pushed", "merge-target"];

--- a/frontend/src/lib/components/detail-comment-persistence.test.ts
+++ b/frontend/src/lib/components/detail-comment-persistence.test.ts
@@ -718,7 +718,7 @@ describe("comment draft persistence", () => {
     });
   });
 
-  it.each(["pull", "issue"] as const)("passes the platform host to %s comment autocomplete", async (kind) => {
+  it.each(["pull", "issue"] as const)("passes the host and item to %s comment autocomplete", async (kind) => {
     const autocompleteQueries: Array<Record<string, unknown> | undefined> = [];
 
     renderCommentHarness({
@@ -747,6 +747,11 @@ describe("comment draft persistence", () => {
     expect(autocompleteQueries.at(-1)).toMatchObject({
       path: {
         platform_host: "ghe.example.com",
+      },
+      query: {
+        trigger: "@",
+        item_type: kind === "pull" ? "pr" : "issue",
+        item_number: 1,
       },
     });
   });

--- a/frontend/src/lib/components/detail/CommentBox.svelte
+++ b/frontend/src/lib/components/detail/CommentBox.svelte
@@ -95,6 +95,8 @@
         {provider}
         {platformHost}
         {repoPath}
+        itemType="pull"
+        itemNumber={number}
         value={body}
         disabled={isPostingCurrent || disabled}
         oninput={(nextBody) => {

--- a/frontend/src/lib/components/detail/CommentEditor.svelte
+++ b/frontend/src/lib/components/detail/CommentEditor.svelte
@@ -37,6 +37,9 @@
     provider: string;
     platformHost?: string | undefined;
     repoPath: string;
+    /** Item the comment targets; its participants lead @ mention suggestions. */
+    itemType?: "pull" | "issue" | undefined;
+    itemNumber?: number | undefined;
     value: string;
     disabled?: boolean;
     autofocus?: boolean;
@@ -68,6 +71,8 @@
     provider,
     platformHost,
     repoPath,
+    itemType = undefined,
+    itemNumber = undefined,
     value,
     disabled = false,
     autofocus = false,
@@ -177,6 +182,9 @@
             trigger,
             q: query,
             limit: 8,
+            ...(trigger === "@" && itemType !== undefined && itemNumber !== undefined
+              ? { item_type: itemType === "pull" ? "pr" : "issue", item_number: itemNumber }
+              : {}),
           },
         },
       }),

--- a/frontend/src/lib/components/detail/EventTimeline.svelte
+++ b/frontend/src/lib/components/detail/EventTimeline.svelte
@@ -64,6 +64,7 @@
     repoName?: string;
     repoPath?: string | undefined;
     number?: number | undefined;
+    itemType?: "pull" | "issue" | undefined;
     currentHeadSHA?: string | undefined;
     canResolveReviewThreads?: boolean;
     canReplyToThreads?: boolean;
@@ -112,6 +113,7 @@
     repoName,
     repoPath,
     number = undefined,
+    itemType = undefined,
     currentHeadSHA = "",
     canResolveReviewThreads = false,
     canReplyToThreads = false,
@@ -1652,6 +1654,8 @@
             owner={repoOwner}
             name={repoName}
             {repoPath}
+            {itemType}
+            itemNumber={number}
             value={editDraft}
             disabled={savingEditId === event.ID}
             autofocus
@@ -1772,6 +1776,8 @@
           owner={repoOwner}
           name={repoName}
           {repoPath}
+          {itemType}
+          itemNumber={number}
           value={editDraft}
           disabled={savingEditId === event.ID}
           autofocus
@@ -1827,6 +1833,8 @@
 	      owner={repoOwner}
 	      name={repoName}
 	      {repoPath}
+	      {itemType}
+	      itemNumber={number}
 	      value={replyDraft}
 	      placeholder="Reply to thread... (Cmd+Enter to submit)"
 	      disabled={savingReplyThreadID === targetID}

--- a/frontend/src/lib/components/detail/IssueCommentBox.svelte
+++ b/frontend/src/lib/components/detail/IssueCommentBox.svelte
@@ -95,6 +95,8 @@
         {provider}
         {platformHost}
         {repoPath}
+        itemType="issue"
+        itemNumber={number}
         value={body}
         disabled={isPostingCurrent || disabled}
         oninput={(nextBody) => {

--- a/frontend/src/lib/components/detail/IssueDetail.svelte
+++ b/frontend/src/lib/components/detail/IssueDetail.svelte
@@ -1568,6 +1568,7 @@
             repoName={name}
             {repoPath}
             {number}
+            itemType="issue"
             activityViewMode={detailActivityView.getMode()}
             initialEntryLimit={settings.getDetailSettings().initial_timeline_entry_limit}
             itemIdentity={`${provider}:${platformHost ?? ""}:${repoPath}:${number}`}

--- a/frontend/src/lib/components/detail/PullDetail.svelte
+++ b/frontend/src/lib/components/detail/PullDetail.svelte
@@ -3178,6 +3178,7 @@
             repoName={name}
             {repoPath}
             {number}
+            itemType="pull"
             currentHeadSHA={latestPlatformHeadSha}
             canResolveReviewThreads={capabilities.review_thread_resolution && !resolveThreadGate.unavailable}
             canReplyToThreads={capabilities.thread_reply && !stalePR && !replyThreadGate.unavailable}

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1097,6 +1097,24 @@ func (e GetPullFilePreviewParamsSide) Valid() bool {
 	}
 }
 
+// Defines values for GetCommentAutocompleteParamsItemType.
+const (
+	GetCommentAutocompleteParamsItemTypeIssue GetCommentAutocompleteParamsItemType = "issue"
+	GetCommentAutocompleteParamsItemTypePr    GetCommentAutocompleteParamsItemType = "pr"
+)
+
+// Valid indicates whether the value is a known member of the GetCommentAutocompleteParamsItemType enum.
+func (e GetCommentAutocompleteParamsItemType) Valid() bool {
+	switch e {
+	case GetCommentAutocompleteParamsItemTypeIssue:
+		return true
+	case GetCommentAutocompleteParamsItemTypePr:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ResolveRepoItemParamsItemType.
 const (
 	ResolveRepoItemParamsItemTypeIssue ResolveRepoItemParamsItemType = "issue"
@@ -6300,7 +6318,16 @@ type GetCommentAutocompleteParams struct {
 	Trigger *string `form:"trigger,omitempty" json:"trigger,omitempty"`
 	Q       *string `form:"q,omitempty" json:"q,omitempty"`
 	Limit   *int64  `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// ItemType Optional item the comment targets; requires item_number.
+	ItemType *GetCommentAutocompleteParamsItemType `form:"item_type,omitempty" json:"item_type,omitempty"`
+
+	// ItemNumber Optional item number the comment targets; requires item_type.
+	ItemNumber *int64 `form:"item_number,omitempty" json:"item_number,omitempty"`
 }
+
+// GetCommentAutocompleteParamsItemType defines parameters for GetCommentAutocomplete.
+type GetCommentAutocompleteParamsItemType string
 
 // GetRepoCommitDiffParams defines parameters for GetRepoCommitDiff.
 type GetRepoCommitDiffParams struct {
@@ -35205,6 +35232,30 @@ func NewGetCommentAutocompleteRequest(server string, provider string, owner stri
 		if params.Limit != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "limit", *params.Limit, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: "int64"}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.ItemType != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "item_type", *params.ItemType, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.ItemNumber != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "item_number", *params.ItemNumber, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: "int64"}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -4061,10 +4061,20 @@ func (d *DB) ListIssueEvents(ctx context.Context, issueID int64) ([]IssueEvent, 
 	return events, rows.Err()
 }
 
+// CommentAutocompleteItem identifies the item a comment is being written on.
+// Its author, assignees, requested reviewers, and event authors rank ahead of
+// other repository users in mention suggestions.
+type CommentAutocompleteItem struct {
+	Kind   string // "pull" or "issue"
+	Number int64
+}
+
 // ListCommentAutocompleteUsers returns repo-scoped username suggestions for comment mentions.
+// When item is non-nil, users already participating in that item sort first.
 func (d *DB) ListCommentAutocompleteUsers(
 	ctx context.Context,
 	platform, platformHost, owner, name, query string,
+	item *CommentAutocompleteItem,
 	limit int,
 ) ([]string, error) {
 	platform = canonicalRepoPlatform(platform)
@@ -4075,6 +4085,12 @@ func (d *DB) ListCommentAutocompleteUsers(
 	query = strings.TrimSpace(query)
 	containsQuery := "%" + strings.ToLower(query) + "%"
 	prefixQuery := strings.ToLower(query) + "%"
+	itemKind := ""
+	var itemNumber int64
+	if item != nil {
+		itemKind = item.Kind
+		itemNumber = item.Number
+	}
 
 	rows, err := d.roQueryContext(ctx, `
 		WITH repo AS (
@@ -4082,7 +4098,39 @@ func (d *DB) ListCommentAutocompleteUsers(
 			FROM forge_repos
 			WHERE platform = ? AND platform_host = ? AND owner_key = ? AND name_key = ?
 			  AND lifecycle_state = 'active'
+		), current_mr AS (
+			SELECT mr.id, mr.author, mr.assignees_json, mr.reviewers_json, mr.last_activity_at
+			FROM forge_merge_requests mr
+			WHERE ? = 'pull' AND mr.repo_id = (SELECT id FROM repo) AND mr.number = ?
+		), current_issue AS (
+			SELECT i.id, i.author, i.assignees_json, i.last_activity_at
+			FROM forge_issues i
+			WHERE ? = 'issue' AND i.repo_id = (SELECT id FROM repo) AND i.number = ?
+		), participants AS (
+			SELECT author AS login, last_activity_at AS last_seen FROM current_mr
+			UNION
+			SELECT json_each.value, current_mr.last_activity_at FROM current_mr, json_each(
+				CASE WHEN json_valid(current_mr.assignees_json) THEN current_mr.assignees_json ELSE '[]' END
+			)
+			UNION
+			SELECT json_each.value, current_mr.last_activity_at FROM current_mr, json_each(
+				CASE WHEN json_valid(current_mr.reviewers_json) THEN current_mr.reviewers_json ELSE '[]' END
+			)
+			UNION
+			SELECT e.author, e.created_at FROM forge_mr_events e
+			WHERE e.merge_request_id = (SELECT id FROM current_mr)
+			UNION
+			SELECT author AS login, last_activity_at AS last_seen FROM current_issue
+			UNION
+			SELECT json_each.value, current_issue.last_activity_at FROM current_issue, json_each(
+				CASE WHEN json_valid(current_issue.assignees_json) THEN current_issue.assignees_json ELSE '[]' END
+			)
+			UNION
+			SELECT e.author, e.created_at FROM forge_issue_events e
+			WHERE e.issue_id = (SELECT id FROM current_issue)
 		), candidates AS (
+			SELECT login, last_seen FROM participants
+			UNION ALL
 			SELECT mr.author AS login, mr.last_activity_at AS last_seen
 			FROM forge_merge_requests mr
 			WHERE mr.repo_id = (SELECT id FROM repo)
@@ -4129,7 +4177,8 @@ func (d *DB) ListCommentAutocompleteUsers(
 				  AND a.lifecycle_state = 'removed_upstream'
 			  )
 		), ranked AS (
-			SELECT login, MAX(last_seen) AS last_seen
+			SELECT login, MAX(last_seen) AS last_seen,
+			  EXISTS (SELECT 1 FROM participants p WHERE p.login = candidates.login) AS participant
 			FROM candidates
 			WHERE login <> ''
 			  AND (? = '' OR LOWER(login) LIKE ?)
@@ -4138,11 +4187,14 @@ func (d *DB) ListCommentAutocompleteUsers(
 		SELECT login
 		FROM ranked
 		ORDER BY
+			participant DESC,
 			CASE WHEN ? <> '' AND LOWER(login) LIKE ? THEN 0 ELSE 1 END,
 			last_seen DESC,
 			login ASC
 		LIMIT ?`,
 		platform, platformHost, owner, name,
+		itemKind, itemNumber,
+		itemKind, itemNumber,
 		query, containsQuery,
 		query, prefixQuery,
 		limit,

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -1265,7 +1265,7 @@ func TestProviderCanonicalReadPathsUseLookupKeys(t *testing.T) {
 	assert.NotNil(refreshedIssue.DetailFetchedAt)
 
 	users, err := d.ListCommentAutocompleteUsers(
-		ctx, "gitlab", "gitlab.example.com", "group/subgroup", "projectname", "auth", 10,
+		ctx, "gitlab", "gitlab.example.com", "group/subgroup", "projectname", "auth", nil, 10,
 	)
 	require.NoError(err)
 	assert.Equal([]string{"author"}, users)
@@ -3774,13 +3774,67 @@ func TestListCommentAutocompleteUsers(t *testing.T) {
 		DedupeKey: "issue-comment-1",
 	}}))
 
-	users, err := d.ListCommentAutocompleteUsers(ctx, "github", "github.com", "acme", "widget", "al", 10)
+	users, err := d.ListCommentAutocompleteUsers(ctx, "github", "github.com", "acme", "widget", "al", nil, 10)
 	require.NoError(err)
 	assert.Equal([]string{"alice", "albert", "alex"}, users)
 
-	users, err = d.ListCommentAutocompleteUsers(ctx, "github", "github.com", "acme", "widget", "bert", 10)
+	users, err = d.ListCommentAutocompleteUsers(ctx, "github", "github.com", "acme", "widget", "bert", nil, 10)
 	require.NoError(err)
 	assert.Equal([]string{"albert"}, users)
+}
+
+func TestListCommentAutocompleteUsersRanksCurrentItemParticipantsFirst(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	base := baseTime()
+
+	repoID := insertTestRepo(t, d, "acme", "widget")
+	// The most recently active user in the repo is unrelated to the target
+	// item; without an item hint they should lead the list.
+	insertTestMRWithOptions(t, d, testMR(repoID, 30, withMRAuthor("zed"), withMRActivity(base.Add(10*time.Hour))))
+	mrID := insertTestMRWithOptions(t, d, testMR(repoID, 12, withMRAuthor("alice"), withMRActivity(base.Add(2*time.Hour))))
+	require.NoError(d.UpdateMergeRequestAssignees(ctx, repoID, mrID, []string{"bob"}))
+	require.NoError(d.UpdateMergeRequestReviewers(ctx, repoID, mrID, []string{"carol"}))
+	require.NoError(d.UpsertMREvents(ctx, []MREvent{{
+		MergeRequestID: mrID,
+		EventType:      "comment",
+		Author:         "dave",
+		CreatedAt:      base.Add(time.Hour),
+		DedupeKey:      "mr-12-comment-1",
+	}}))
+	issueID := insertTestIssueWithOptions(t, d, testIssue(repoID, 7, withIssueAuthor("erin"), withIssueActivity(base.Add(3*time.Hour))))
+	require.NoError(d.UpdateIssueAssignees(ctx, repoID, issueID, []string{"frank"}))
+
+	users, err := d.ListCommentAutocompleteUsers(ctx, "github", "github.com", "acme", "widget", "", nil, 10)
+	require.NoError(err)
+	assert.Equal("zed", users[0], "without an item hint recency wins")
+
+	users, err = d.ListCommentAutocompleteUsers(
+		ctx, "github", "github.com", "acme", "widget", "",
+		&CommentAutocompleteItem{Kind: "pull", Number: 12}, 10,
+	)
+	require.NoError(err)
+	assert.Equal(
+		[]string{"alice", "bob", "carol", "dave", "zed", "erin"}, users,
+		"author, assignee, reviewer, and commenter lead; the rest keep recency order",
+	)
+
+	users, err = d.ListCommentAutocompleteUsers(
+		ctx, "github", "github.com", "acme", "widget", "",
+		&CommentAutocompleteItem{Kind: "issue", Number: 7}, 10,
+	)
+	require.NoError(err)
+	assert.Equal([]string{"erin", "frank", "zed", "alice", "dave"}, users, "issue author and assignee lead")
+
+	// A participant that does not match the query is still filtered out.
+	users, err = d.ListCommentAutocompleteUsers(
+		ctx, "github", "github.com", "acme", "widget", "z",
+		&CommentAutocompleteItem{Kind: "pull", Number: 12}, 10,
+	)
+	require.NoError(err)
+	assert.Equal([]string{"zed"}, users)
 }
 
 func TestListCommentAutocompleteUsersScopesByProvider(t *testing.T) {
@@ -3816,11 +3870,11 @@ func TestListCommentAutocompleteUsersScopesByProvider(t *testing.T) {
 		withIssueActivity(base.Add(2*time.Hour)),
 	))
 
-	users, err := d.ListCommentAutocompleteUsers(ctx, "gitea", "github.com", "acme", "widget", "", 10)
+	users, err := d.ListCommentAutocompleteUsers(ctx, "gitea", "github.com", "acme", "widget", "", nil, 10)
 	require.NoError(err)
 	assert.Equal([]string{"gina"}, users)
 
-	users, err = d.ListCommentAutocompleteUsers(ctx, "github", "github.com", "acme", "widget", "", 10)
+	users, err = d.ListCommentAutocompleteUsers(ctx, "github", "github.com", "acme", "widget", "", nil, 10)
 	require.NoError(err)
 	assert.Equal([]string{"alice"}, users)
 }
@@ -3862,7 +3916,7 @@ func TestListCommentAutocompleteUsersHidesOnlyRemovedUpstreamItems(t *testing.T)
 	}))
 
 	users, err := d.ListCommentAutocompleteUsers(
-		ctx, "github", "github.com", "acme", "widget", "", 20,
+		ctx, "github", "github.com", "acme", "widget", "", nil, 20,
 	)
 	require.NoError(err)
 	require.ElementsMatch([]string{

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -8123,6 +8123,21 @@ func TestAPICommentAutocomplete(t *testing.T) {
 	assert.Equal([]string{"albert", "alex", "alice"}, userBody.Users)
 	assert.Empty(userBody.References)
 
+	// Naming the target item promotes its author and participants ahead of
+	// the recency ordering.
+	itemReq := httptest.NewRequest(http.MethodGet, "/api/v1/repo/gh/acme/widget/comment-autocomplete?trigger=@&q=al&limit=10&item_type=issue&item_number=17", nil)
+	itemRR := httptest.NewRecorder()
+	srv.ServeHTTP(itemRR, itemReq)
+	require.Equal(http.StatusOK, itemRR.Code, itemRR.Body.String())
+	var itemBody commentAutocompleteResponse
+	require.NoError(json.NewDecoder(itemRR.Body).Decode(&itemBody))
+	assert.Equal([]string{"alex", "albert", "alice"}, itemBody.Users)
+
+	halfReq := httptest.NewRequest(http.MethodGet, "/api/v1/repo/gh/acme/widget/comment-autocomplete?trigger=@&q=al&item_number=17", nil)
+	halfRR := httptest.NewRecorder()
+	srv.ServeHTTP(halfRR, halfReq)
+	assert.Equal(http.StatusBadRequest, halfRR.Code, halfRR.Body.String())
+
 	refReq := httptest.NewRequest(http.MethodGet, "/api/v1/repo/gh/acme/widget/comment-autocomplete?trigger=%23&q=1&limit=10", nil)
 	refRR := httptest.NewRecorder()
 	srv.ServeHTTP(refRR, refReq)

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -106,6 +106,10 @@ type commentAutocompleteInput struct {
 	Trigger      string `query:"trigger"`
 	Q            string `query:"q"`
 	Limit        int    `query:"limit"`
+	// ItemType and ItemNumber identify the item the comment is written on so
+	// users already participating in it rank first among @ suggestions.
+	ItemType   string `query:"item_type" enum:"pr,issue" doc:"Optional item the comment targets; requires item_number."`
+	ItemNumber int64  `query:"item_number" doc:"Optional item number the comment targets; requires item_type."`
 }
 
 type commentAutocompleteOutput = httpapi.BodyOutput[commentAutocompleteResponse]
@@ -672,6 +676,21 @@ func (s *Server) getCommentAutocomplete(
 		limit = 25
 	}
 
+	var currentItem *db.CommentAutocompleteItem
+	switch {
+	case input.ItemType != "" && input.ItemNumber > 0:
+		kind := "issue"
+		if input.ItemType == "pr" {
+			kind = "pull"
+		}
+		currentItem = &db.CommentAutocompleteItem{Kind: kind, Number: input.ItemNumber}
+	case input.ItemType != "" || input.ItemNumber != 0:
+		return nil, httpapi.Validation(
+			"query.item_number",
+			"item_type and item_number must be provided together",
+		)
+	}
+
 	switch input.Trigger {
 	case "@":
 		users, err := s.db.ListCommentAutocompleteUsers(
@@ -681,6 +700,7 @@ func (s *Server) getCommentAutocomplete(
 			input.Owner,
 			input.Name,
 			input.Q,
+			currentItem,
 			limit,
 		)
 		if err != nil {


### PR DESCRIPTION
Typing `@` in a pull request or issue comment listed every user who had ever authored something in the repository, ordered only by repository-wide recency. The people already on the item being discussed could sit far down the list, and assignees or requested reviewers who never commented did not appear at all.

- The item's author, assignees, requested reviewers, and comment or review authors now lead the `@` suggestion list in comment boxes, comment edits, and thread replies.
- Below those participants the previous ordering is unchanged: prefix matches first, then recency.
- The new issue form has no item yet and keeps the repository-wide ordering.

The comment editor passes the target item to the autocomplete endpoint through two new optional query parameters, `item_type` and `item_number`, which must be sent together. The assignee and reviewer pickers on the detail pages use the same endpoint and were intentionally left with the old ordering.

🤖 Generated with Claude Code
Co-authored-by: Claude Fable 5.1 <noreply@anthropic.com>
