### PR TITLE
fix: accept stock fork clones as configured worktree bases

### DIFF
--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -668,6 +668,9 @@ silently report nothing when the upstream is not configured. A configured upstre
 whose local tracking ref is missing exposes `branch_upstream_missing`, so the UI can
 offer the push that verifies or creates its remote branch. Every path that creates a
 PR-owned branch should configure its upstream when repository identity is known.
+Passive workspace enrichment never contacts remotes, so the UI offers Push only for a
+missing local tracking ref or commits ahead. A zero-ahead branch deleted remotely remains
+in-sync until local Git state changes (`internal/server/workspaceapi/routes_handlers.go::applyWorktreeDivergence`).
 Issue, Kata, and ad-hoc workspaces create new untracked branches; a
 same-named remote ref is not authority to adopt an upstream
 (`internal/workspace/manager.go::configureFallbackBranchUpstream`). PR upstream

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -664,9 +664,11 @@ The branch's git upstream config (`branch.<name>.remote`/`.merge`) is the
 single source of truth for every sync-derived workspace surface:
 `commits_ahead`/`commits_behind` in the list response, the sidebar
 ahead/behind arrows, push, pull, and unpushed-commit flags. All of them
-silently report nothing when the upstream is missing, so every path that
-creates a PR-owned branch should configure it when repository identity is
-known. Issue, Kata, and ad-hoc workspaces create new untracked branches; a
+silently report nothing when the upstream is not configured. A configured upstream
+whose local tracking ref is missing exposes `branch_upstream_missing`, so the UI can
+offer the push that verifies or creates its remote branch. Every path that creates a
+PR-owned branch should configure its upstream when repository identity is known.
+Issue, Kata, and ad-hoc workspaces create new untracked branches; a
 same-named remote ref is not authority to adopt an upstream
 (`internal/workspace/manager.go::configureFallbackBranchUpstream`). PR upstream
 wiring requires a non-empty head-repository identity whose

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -67,8 +67,10 @@ embedder protocol for arbitrary host state.
   bases do not silently weaken or ignore the configured transport policy
   (`internal/workspace/manager.go::ValidateWorktreeBasePath`).
 - Configured bases resolve and authenticate their read remote by repository identity,
-  rejecting ambiguous matches or tracking-namespace overlap. Branch sync authenticates
-  `origin`'s own repository because it may be a fork (`internal/gitclone/clone.go::RunGitForNamedRemote`).
+  rejecting ambiguous matches or tracking-namespace overlap.
+- Credentialed named-remote operations validate every URL and authenticate `origin`'s
+  repository. A first push may create a missing fork branch but never force-update it
+  (`internal/gitclone/clone.go::RunGitForNamedRemote`, `internal/workspace/branch_sync.go::pushWorktreeBranch`).
 
 ## Endpoint Intent
 

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -66,9 +66,9 @@ embedder protocol for arbitrary host state.
   provider-host cleartext acknowledgement when validating their canonical remote; local
   bases do not silently weaken or ignore the configured transport policy
   (`internal/workspace/manager.go::ValidateWorktreeBasePath`).
-- Configured bases resolve their read remote by repository identity and reject
-  ambiguous matches or tracking-namespace overlap; managed clones and workspace
-  branch upstreams remain `origin`-owned (`internal/workspace/manager.go::resolveWorktreeBaseRemote`).
+- Configured bases resolve and authenticate their read remote by repository identity,
+  rejecting ambiguous matches or tracking-namespace overlap. Branch sync authenticates
+  `origin`'s own repository because it may be a fork (`internal/gitclone/clone.go::RunGitForNamedRemote`).
 
 ## Endpoint Intent
 

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -63,9 +63,12 @@ embedder protocol for arbitrary host state.
   linked worktree; repository tools use the shared value to identify this layout
   (`internal/workspace/manager.go::configureBareLinkedWorktree`).
 - Managed clones and existing local base checkouts use the same exact
-  provider-host cleartext acknowledgement when validating their origin; local
+  provider-host cleartext acknowledgement when validating their canonical remote; local
   bases do not silently weaken or ignore the configured transport policy
   (`internal/workspace/manager.go::ValidateWorktreeBasePath`).
+- Configured bases resolve their read remote by repository identity and reject
+  ambiguous matches or tracking-namespace overlap; managed clones and workspace
+  branch upstreams remain `origin`-owned (`internal/workspace/manager.go::resolveWorktreeBaseRemote`).
 
 ## Endpoint Intent
 

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -6641,6 +6641,8 @@ components:
         associatedPRNumber:
           format: int64
           type: integer
+        branchUpstreamMissing:
+          type: boolean
         commitsAhead:
           format: int64
           type: integer
@@ -9527,6 +9529,9 @@ components:
         associated_pr_number:
           format: int64
           type: integer
+        branch_upstream_missing:
+          description: True when the current branch has an origin upstream configured but its local remote-tracking ref is absent; clients may offer Push so branch sync can verify or create the remote branch.
+          type: boolean
         commits_ahead:
           format: int64
           type: integer
@@ -9686,6 +9691,8 @@ components:
         associated_pr_number:
           format: int64
           type: integer
+        branch_upstream_missing:
+          type: boolean
         commits_ahead:
           format: int64
           type: integer

--- a/frontend/src/lib/api/generated/schema.ts
+++ b/frontend/src/lib/api/generated/schema.ts
@@ -8064,6 +8064,7 @@ export interface components {
             agentStateUpdatedAt?: string;
             /** Format: int64 */
             associatedPRNumber?: number;
+            branchUpstreamMissing?: boolean;
             /** Format: int64 */
             commitsAhead?: number;
             /** Format: int64 */
@@ -9382,6 +9383,8 @@ export interface components {
             agent_state_updated_at?: string;
             /** Format: int64 */
             associated_pr_number?: number;
+            /** @description True when the current branch has an origin upstream configured but its local remote-tracking ref is absent; clients may offer Push so branch sync can verify or create the remote branch. */
+            branch_upstream_missing?: boolean;
             /** Format: int64 */
             commits_ahead?: number;
             /** Format: int64 */
@@ -9455,6 +9458,7 @@ export interface components {
             agent_state_updated_at?: string;
             /** Format: int64 */
             associated_pr_number?: number;
+            branch_upstream_missing?: boolean;
             /** Format: int64 */
             commits_ahead?: number;
             /** Format: int64 */

--- a/frontend/src/lib/components/mobile/MobileWorkspaceList.svelte
+++ b/frontend/src/lib/components/mobile/MobileWorkspaceList.svelte
@@ -357,7 +357,8 @@
   }
 
   function canPush(workspace: WorkspaceListItem): boolean {
-    return (workspace.commits_ahead ?? 0) > 0 && (workspace.commits_behind ?? 0) === 0;
+    return workspace.branch_upstream_missing === true ||
+      ((workspace.commits_ahead ?? 0) > 0 && (workspace.commits_behind ?? 0) === 0);
   }
 
   function canPull(workspace: WorkspaceListItem): boolean {

--- a/frontend/src/lib/components/mobile/MobileWorkspaceList.test.ts
+++ b/frontend/src/lib/components/mobile/MobileWorkspaceList.test.ts
@@ -97,6 +97,22 @@ describe("MobileWorkspaceList", () => {
     expect(onOpen).toHaveBeenCalledWith("ws-1", undefined);
   });
 
+  it("offers the first push when the configured upstream branch is missing", async () => {
+    mockGet.mockImplementation((path: string) => {
+      if (path === "/snapshot") {
+        return Promise.resolve({ data: { hosts: [], workspaces: [{ ...fixture, branch_upstream_missing: true }] } });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    render(MobileWorkspaceList, { props: { onOpen: vi.fn(), onOpenItem: vi.fn() } });
+    await screen.findByText("Build mobile workspaces");
+    await fireEvent.click(screen.getByRole("button", { name: "Workspace actions for Build mobile workspaces" }));
+
+    const actions = await screen.findByRole("dialog", { name: "Workspace actions" });
+    expect(within(actions).getByRole("button", { name: "Push branch" })).toBeTruthy();
+  });
+
   it.each([
     ["working", "Working", "working"],
     ["approval", "Approval", "waiting for approval"],

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -838,7 +838,7 @@
   function canPush(ws: Workspace): boolean {
     const ahead = ws.commits_ahead ?? 0;
     const behind = ws.commits_behind ?? 0;
-    return ahead > 0 && behind === 0;
+    return ws.branch_upstream_missing === true || (ahead > 0 && behind === 0);
   }
 
   function canPull(ws: Workspace): boolean {
@@ -848,6 +848,9 @@
   }
 
   function syncActionDetail(ws: Workspace): string {
+    if (ws.branch_upstream_missing === true) {
+      return "";
+    }
     if (canPush(ws)) {
       return `${ws.commits_ahead ?? 0} ahead`;
     }

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -2495,6 +2495,33 @@ describe("WorkspaceListSidebar", () => {
     });
   });
 
+  it("offers the first push when the configured upstream branch is missing", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [
+          {
+            ...workspaceFixture({
+              id: "ws-first-push",
+              provider: "github",
+              platformHost: "github.com",
+              owner: "acme",
+              name: "widgets",
+              number: 9,
+              title: "First push workspace",
+            }),
+            branch_upstream_missing: true,
+          },
+        ],
+      },
+    });
+
+    const { container } = render(WorkspaceListSidebar, { props: { selectedId: "ws-first-push" } });
+    await screen.findByText("First push workspace");
+    await fireEvent.contextMenu(container.querySelector(".ws-row")!);
+
+    expect(screen.getByRole("menuitem", { name: "Push branch" })).toBeTruthy();
+  });
+
   it("pulls a behind workspace branch and shows a busy state while pending", async () => {
     const pull = deferred<{
       data?: unknown;

--- a/frontend/src/lib/components/terminal/workspace-list-schema.ts
+++ b/frontend/src/lib/components/terminal/workspace-list-schema.ts
@@ -27,6 +27,7 @@ export type WorkspaceListItem = Pick<
     readonly agent_state?: GeneratedWorkspace["agent_state"] | null;
     readonly agent_state_updated_at?: string | null;
     readonly associated_pr_number?: Exclude<GeneratedWorkspace["associated_pr_number"], undefined> | null;
+    readonly branch_upstream_missing?: boolean;
     readonly commits_ahead?: number | null;
     readonly commits_behind?: number | null;
     readonly error_message?: GeneratedWorkspace["error_message"] | null;
@@ -69,6 +70,7 @@ const Workspace = Schema.Struct({
   agent_state: Schema.optionalKey(Schema.NullOr(Schema.Literals(["idle", "working", "input", "approval", "done"]))),
   agent_state_updated_at: Schema.optionalKey(Schema.NullOr(Schema.String)),
   associated_pr_number: Schema.optionalKey(Schema.NullOr(Schema.Number)),
+  branch_upstream_missing: Schema.optionalKey(Schema.Boolean),
   commits_ahead: Schema.optionalKey(Schema.NullOr(Schema.Number)),
   commits_behind: Schema.optionalKey(Schema.NullOr(Schema.Number)),
   created_at: Schema.String,

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -4210,6 +4210,7 @@ type RawWorkspace struct {
 	AgentState            *string            `json:"agentState,omitempty"`
 	AgentStateUpdatedAt   *string            `json:"agentStateUpdatedAt,omitempty"`
 	AssociatedPRNumber    *int64             `json:"associatedPRNumber,omitempty"`
+	BranchUpstreamMissing *bool              `json:"branchUpstreamMissing,omitempty"`
 	CommitsAhead          *int64             `json:"commitsAhead,omitempty"`
 	CommitsBehind         *int64             `json:"commitsBehind,omitempty"`
 	CreatedAt             string             `json:"createdAt"`
@@ -5526,8 +5527,11 @@ type WorkspaceResponse struct {
 	// AgentStateUpdatedAt UTC timestamp of the hook report that produced agent_state.
 	AgentStateUpdatedAt *time.Time `json:"agent_state_updated_at,omitempty"`
 	AssociatedPrNumber  *int64     `json:"associated_pr_number,omitempty"`
-	CommitsAhead        *int64     `json:"commits_ahead,omitempty"`
-	CommitsBehind       *int64     `json:"commits_behind,omitempty"`
+
+	// BranchUpstreamMissing True when the current branch has an origin upstream configured but its local remote-tracking ref is absent; clients may offer Push so branch sync can verify or create the remote branch.
+	BranchUpstreamMissing *bool  `json:"branch_upstream_missing,omitempty"`
+	CommitsAhead          *int64 `json:"commits_ahead,omitempty"`
+	CommitsBehind         *int64 `json:"commits_behind,omitempty"`
 
 	// Created True when this response represents a workspace newly created by this request; absent when an existing workspace was returned or on reads.
 	Created   *bool  `json:"created,omitempty"`
@@ -5608,6 +5612,7 @@ type WorkspaceSummary struct {
 	AgentState            *string                    `json:"agent_state,omitempty"`
 	AgentStateUpdatedAt   *string                    `json:"agent_state_updated_at,omitempty"`
 	AssociatedPrNumber    *int64                     `json:"associated_pr_number,omitempty"`
+	BranchUpstreamMissing *bool                      `json:"branch_upstream_missing,omitempty"`
 	CommitsAhead          *int64                     `json:"commits_ahead,omitempty"`
 	CommitsBehind         *int64                     `json:"commits_behind,omitempty"`
 	CreatedAt             string                     `json:"created_at"`

--- a/internal/fleet/enrich.go
+++ b/internal/fleet/enrich.go
@@ -433,6 +433,7 @@ func buildWorkspaceSummaries(
 			MRReviewDecision: lowerPtr(workspace.MRReviewDecision),
 			MRAdditions:      workspace.MRAdditions, MRDeletions: workspace.MRDeletions,
 			CommitsAhead: workspace.CommitsAhead, CommitsBehind: workspace.CommitsBehind,
+			BranchUpstreamMissing: workspace.BranchUpstreamMissing,
 			WorktreeDirty:         workspace.WorktreeDirty,
 			EnrichmentStatus:      workspace.EnrichmentStatus,
 			EnrichmentRefreshedAt: workspace.EnrichmentRefreshedAt,

--- a/internal/fleet/types.go
+++ b/internal/fleet/types.go
@@ -193,6 +193,7 @@ type RawWorkspace struct {
 	CreatedAt             string             `json:"createdAt"`
 	CommitsAhead          *int               `json:"commitsAhead,omitempty"`
 	CommitsBehind         *int               `json:"commitsBehind,omitempty"`
+	BranchUpstreamMissing *bool              `json:"branchUpstreamMissing,omitempty"`
 	WorktreeDirty         *bool              `json:"worktreeDirty,omitempty"`
 	EnrichmentStatus      string             `json:"enrichmentStatus,omitempty"`
 	EnrichmentRefreshedAt *string            `json:"enrichmentRefreshedAt,omitempty"`
@@ -476,6 +477,7 @@ type WorkspaceSummary struct {
 	MRDeletions           *int                       `json:"mr_deletions,omitempty"`
 	CommitsAhead          *int                       `json:"commits_ahead,omitempty"`
 	CommitsBehind         *int                       `json:"commits_behind,omitempty"`
+	BranchUpstreamMissing *bool                      `json:"branch_upstream_missing,omitempty"`
 	WorktreeDirty         *bool                      `json:"worktree_dirty,omitempty"`
 	EnrichmentStatus      string                     `json:"enrichment_status,omitempty"`
 	EnrichmentRefreshedAt *string                    `json:"enrichment_refreshed_at,omitempty"`

--- a/internal/gitclone/auth_test.go
+++ b/internal/gitclone/auth_test.go
@@ -191,6 +191,69 @@ exit 1
 	assert.Contains(t, err.Error(), "repository-local URL rewrites")
 }
 
+func TestRunGitForRepoRemoteValidatesSelectedRemote(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	gitPath := filepath.Join(dir, "git")
+	require.NoError(os.WriteFile(gitPath, []byte(`#!/bin/sh
+set -eu
+if [ "$1" = "config" ] && [ "$2" = "--local" ]; then exit 1; fi
+if [ "$1" = "config" ] && [ "$2" = "--get-all" ]; then
+	case "$3" in
+	remote.upstream.url) echo "https://github.com/acme/widgets.git"; exit 0 ;;
+	remote.upstream.pushurl) exit 1 ;;
+	esac
+fi
+exit 0
+`), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	source := &mutableTestTokenSource{token: "secret-token"}
+	mgr := New(t.TempDir(), testRouteResolver{repos: map[string]tokenauth.Source{
+		"github.com/acme/widgets": source,
+	}})
+
+	_, err := mgr.RunGitForRepoRemote(
+		t.Context(), "github", "github.com", "acme", "widgets",
+		"upstream", dir, "fetch", "upstream",
+	)
+
+	require.NoError(err)
+	assert.Equal(t, 1, source.resolved)
+}
+
+func TestRunGitForNamedRemoteUsesRemoteRepositoryCredential(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	gitPath := filepath.Join(dir, "git")
+	require.NoError(os.WriteFile(gitPath, []byte(`#!/bin/sh
+set -eu
+if [ "$1" = "config" ] && [ "$2" = "--local" ]; then exit 1; fi
+if [ "$1" = "config" ] && [ "$2" = "--get-all" ]; then
+	case "$3" in
+	remote.origin.url) echo "https://github.com/forker/widgets.git"; exit 0 ;;
+	remote.origin.pushurl) exit 1 ;;
+	esac
+fi
+exit 0
+`), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	canonical := &mutableTestTokenSource{token: "canonical-token"}
+	fork := &mutableTestTokenSource{token: "fork-token"}
+	mgr := New(t.TempDir(), testRouteResolver{repos: map[string]tokenauth.Source{
+		"github.com/acme/widgets":   canonical,
+		"github.com/forker/widgets": fork,
+	}})
+
+	_, err := mgr.RunGitForNamedRemote(
+		t.Context(), "github", "github.com", "acme", "widgets",
+		"origin", dir, "fetch", "origin",
+	)
+
+	require.NoError(err)
+	assert.Zero(t, canonical.resolved)
+	assert.Equal(t, 1, fork.resolved)
+}
+
 func TestRunGitForRemoteRequiresAcknowledgedHTTPTransport(t *testing.T) {
 	require := require.New(t)
 	dir := t.TempDir()

--- a/internal/gitclone/auth_test.go
+++ b/internal/gitclone/auth_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/testutil/gitfake"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 	"go.kenn.io/forge/internal/tokenauth"
 )
 
@@ -252,6 +253,26 @@ exit 0
 	require.NoError(err)
 	assert.Zero(t, canonical.resolved)
 	assert.Equal(t, 1, fork.resolved)
+}
+
+func TestRunGitForNamedRemoteAllowsAnonymousLocalURLRewrite(t *testing.T) {
+	require := require.New(t)
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote.git")
+	repo := filepath.Join(root, "repo")
+	const hostedURL = "https://github.com/acme/widgets.git"
+	gitfixture.Run(t, root, "init", "--bare", remote)
+	gitfixture.Run(t, root, "init", repo)
+	gitfixture.Run(t, repo, "remote", "add", "origin", hostedURL)
+	gitfixture.Run(t, repo, "config", "url."+remote+".insteadOf", hostedURL)
+	mgr := New(t.TempDir(), nil)
+
+	_, err := mgr.RunGitForNamedRemote(
+		t.Context(), "github", "github.com", "acme", "widgets",
+		"origin", repo, "fetch", "origin",
+	)
+
+	require.NoError(err)
 }
 
 func TestRunGitForRemoteRequiresAcknowledgedHTTPTransport(t *testing.T) {

--- a/internal/gitclone/auth_test.go
+++ b/internal/gitclone/auth_test.go
@@ -255,6 +255,36 @@ exit 0
 	assert.Equal(t, 1, fork.resolved)
 }
 
+func TestRunGitForNamedRemoteRejectsInsecurePushURLForLocalFetchURL(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	gitPath := filepath.Join(dir, "git")
+	require.NoError(os.WriteFile(gitPath, []byte(`#!/bin/sh
+set -eu
+if [ "$1" = "config" ] && [ "$2" = "--local" ]; then exit 1; fi
+if [ "$1" = "config" ] && [ "$2" = "--get-all" ]; then
+	case "$3" in
+	remote.origin.url) echo "/tmp/widgets.git"; exit 0 ;;
+	remote.origin.pushurl) echo "http://git.example.test/acme/widgets.git"; exit 0 ;;
+	esac
+fi
+exit 0
+`), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	source := &mutableTestTokenSource{token: "secret-token"}
+	mgr := New(t.TempDir(), testRouteResolver{repos: map[string]tokenauth.Source{
+		"git.example.test/acme/widgets": source,
+	}})
+
+	_, err := mgr.RunGitForNamedRemote(
+		t.Context(), "gitea", "git.example.test", "acme", "widgets",
+		"origin", dir, "push", "origin", "HEAD:feature",
+	)
+
+	require.ErrorContains(err, "allow_insecure = true")
+	require.Zero(source.resolved)
+}
+
 func TestRunGitForNamedRemoteAllowsAnonymousLocalURLRewrite(t *testing.T) {
 	require := require.New(t)
 	root := t.TempDir()

--- a/internal/gitclone/auth_test.go
+++ b/internal/gitclone/auth_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/testutil/gitfake"
-	"go.kenn.io/forge/internal/testutil/gitfixture"
+	"go.kenn.io/forge/internal/testutil/gitsafe"
 	"go.kenn.io/forge/internal/tokenauth"
 )
 
@@ -261,13 +261,18 @@ func TestRunGitForNamedRemoteAllowsAnonymousLocalURLRewrite(t *testing.T) {
 	remote := filepath.Join(root, "remote.git")
 	repo := filepath.Join(root, "repo")
 	const hostedURL = "https://github.com/acme/widgets.git"
-	gitfixture.Run(t, root, "init", "--bare", remote)
-	gitfixture.Run(t, root, "init", repo)
-	gitfixture.Run(t, repo, "remote", "add", "origin", hostedURL)
-	gitfixture.Run(t, repo, "config", "url."+remote+".insteadOf", hostedURL)
+	runner := gitsafe.MutableRunner(t).WithConfig("init.defaultBranch", "main")
+	_, err := runner.Output(t.Context(), root, "init", "--bare", remote)
+	require.NoError(err)
+	_, err = runner.Output(t.Context(), root, "init", repo)
+	require.NoError(err)
+	_, err = runner.Output(t.Context(), repo, "remote", "add", "origin", hostedURL)
+	require.NoError(err)
+	_, err = runner.Output(t.Context(), repo, "config", "url."+remote+".insteadOf", hostedURL)
+	require.NoError(err)
 	mgr := New(t.TempDir(), nil)
 
-	_, err := mgr.RunGitForNamedRemote(
+	_, err = mgr.RunGitForNamedRemote(
 		t.Context(), "github", "github.com", "acme", "widgets",
 		"origin", repo, "fetch", "origin",
 	)

--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -999,13 +999,43 @@ func (m *Manager) git(
 func (m *Manager) RunGitForRepo(
 	ctx context.Context, platform, host, owner, name, dir string, args ...string,
 ) ([]byte, error) {
+	return m.RunGitForRepoRemote(
+		ctx, platform, host, owner, name, "origin", dir, args...,
+	)
+}
+
+// RunGitForRepoRemote runs a networked Git command against a named remote
+// that must match the supplied repository route.
+func (m *Manager) RunGitForRepoRemote(
+	ctx context.Context,
+	platform, host, owner, name, remote, dir string,
+	args ...string,
+) ([]byte, error) {
 	source := m.sourceForRepo(platform, host, owner, name)
 	if source != nil {
-		if err := m.validateOriginIdentity(ctx, dir, host, owner, name); err != nil {
+		if err := m.validateRemoteIdentity(ctx, dir, remote, host, owner, name); err != nil {
 			return nil, err
 		}
 	}
 	return m.gitNetworked(ctx, source, host, dir, nil, args...)
+}
+
+// RunGitForNamedRemote runs a networked Git command with credentials selected
+// from the named remote's validated repository identity.
+func (m *Manager) RunGitForNamedRemote(
+	ctx context.Context,
+	platform, host, routeOwner, routeName, remote, dir string,
+	args ...string,
+) ([]byte, error) {
+	owner, name, err := m.namedRemoteRepository(
+		ctx, platform, host, routeOwner, routeName, remote, dir,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return m.RunGitForRepoRemote(
+		ctx, platform, host, owner, name, remote, dir, args...,
+	)
 }
 
 // RunGitForRemote runs a networked Git command against an explicit hosted
@@ -1041,26 +1071,29 @@ func (m *Manager) RunGitForHost(
 	return m.gitNetworked(ctx, m.fallbackSource(host), host, dir, nil, args...)
 }
 
-func (m *Manager) validateOriginIdentity(
-	ctx context.Context, dir, host, owner, name string,
+func (m *Manager) validateRemoteIdentity(
+	ctx context.Context, dir, remote, host, owner, name string,
 ) error {
 	if strings.TrimSpace(dir) == "" {
 		return nil
+	}
+	if remote == "" || remote[0] == '-' || strings.ContainsAny(remote, " \t\r\n") {
+		return fmt.Errorf("authenticated git rejects unsafe remote name %q", remote)
 	}
 	rewrites, err := m.git(ctx, dir, "config", "--local", "--get-regexp", `^url\..*\.(insteadOf|pushInsteadOf)$`)
 	if err == nil && strings.TrimSpace(string(rewrites)) != "" {
 		return fmt.Errorf("authenticated git rejects repository-local URL rewrites")
 	}
-	for _, key := range []string{"remote.origin.url", "remote.origin.pushurl"} {
+	for _, key := range []string{"remote." + remote + ".url", "remote." + remote + ".pushurl"} {
 		out, err := m.git(ctx, dir, "config", "--get-all", key)
 		if err != nil {
-			if key == "remote.origin.pushurl" {
+			if strings.HasSuffix(key, ".pushurl") {
 				continue
 			}
 			return fmt.Errorf("read %s before authenticated git: %w", key, err)
 		}
 		urls := strings.Fields(string(out))
-		if len(urls) == 0 && key == "remote.origin.pushurl" {
+		if len(urls) == 0 && strings.HasSuffix(key, ".pushurl") {
 			continue
 		}
 		for _, url := range urls {
@@ -1070,6 +1103,61 @@ func (m *Manager) validateOriginIdentity(
 		}
 	}
 	return nil
+}
+
+func (m *Manager) namedRemoteRepository(
+	ctx context.Context,
+	platform, host, routeOwner, routeName, remote, dir string,
+) (string, string, error) {
+	if remote == "" || remote[0] == '-' || strings.ContainsAny(remote, " \t\r\n") {
+		return "", "", fmt.Errorf("authenticated git rejects unsafe remote name %q", remote)
+	}
+	rewrites, err := m.git(ctx, dir, "config", "--local", "--get-regexp", `^url\..*\.(insteadOf|pushInsteadOf)$`)
+	if err == nil && strings.TrimSpace(string(rewrites)) != "" {
+		return "", "", fmt.Errorf("authenticated git rejects repository-local URL rewrites")
+	}
+	var remoteURLs []string
+	for _, key := range []string{"remote." + remote + ".url", "remote." + remote + ".pushurl"} {
+		out, err := m.git(ctx, dir, "config", "--get-all", key)
+		if err != nil {
+			if strings.HasSuffix(key, ".pushurl") {
+				continue
+			}
+			return "", "", fmt.Errorf("read %s before authenticated git: %w", key, err)
+		}
+		remoteURLs = append(remoteURLs, strings.Fields(string(out))...)
+	}
+	if len(remoteURLs) == 0 {
+		return "", "", fmt.Errorf("read remote.%s.url before authenticated git: no URL configured", remote)
+	}
+	repoPath := gitremote.RemoteRepoPath(remoteURLs[0])
+	index := strings.LastIndex(repoPath, "/")
+	if index <= 0 || index == len(repoPath)-1 {
+		owner, name := strings.TrimSpace(routeOwner), strings.TrimSpace(routeName)
+		if owner == "" || name == "" {
+			return "", "", errors.New("remote repository owner and name are required")
+		}
+		for _, remoteURL := range remoteURLs {
+			if err := validateRemoteURLIdentity(host, owner, name, remoteURL); err != nil {
+				return "", "", fmt.Errorf(
+					"validate %q remote before authenticated git: %w", remote, err,
+				)
+			}
+		}
+		return owner, name, nil
+	}
+	owner, name := repoPath[:index], repoPath[index+1:]
+	for _, remoteURL := range remoteURLs {
+		if err := m.validateRemoteTransport(platform, host, remoteURL); err != nil {
+			return "", "", err
+		}
+		if err := validateRemoteURLIdentity(host, owner, name, remoteURL); err != nil {
+			return "", "", fmt.Errorf(
+				"validate %q remote before authenticated git: %w", remote, err,
+			)
+		}
+	}
+	return owner, name, nil
 }
 
 func (m *Manager) gitWithInput(

--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -1112,10 +1112,6 @@ func (m *Manager) namedRemoteRepository(
 	if remote == "" || remote[0] == '-' || strings.ContainsAny(remote, " \t\r\n") {
 		return "", "", fmt.Errorf("authenticated git rejects unsafe remote name %q", remote)
 	}
-	rewrites, err := m.git(ctx, dir, "config", "--local", "--get-regexp", `^url\..*\.(insteadOf|pushInsteadOf)$`)
-	if err == nil && strings.TrimSpace(string(rewrites)) != "" {
-		return "", "", fmt.Errorf("authenticated git rejects repository-local URL rewrites")
-	}
 	var remoteURLs []string
 	for _, key := range []string{"remote." + remote + ".url", "remote." + remote + ".pushurl"} {
 		out, err := m.git(ctx, dir, "config", "--get-all", key)

--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -1134,6 +1134,9 @@ func (m *Manager) namedRemoteRepository(
 			return "", "", errors.New("remote repository owner and name are required")
 		}
 		for _, remoteURL := range remoteURLs {
+			if err := m.validateRemoteTransport(platform, host, remoteURL); err != nil {
+				return "", "", err
+			}
 			if err := validateRemoteURLIdentity(host, owner, name, remoteURL); err != nil {
 				return "", "", fmt.Errorf(
 					"validate %q remote before authenticated git: %w", remote, err,

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -1144,7 +1144,7 @@ func (m *Manager) validateLegacyClone(
 		}
 		return false, err
 	}
-	if err := m.validateOriginIdentity(ctx, legacyPath, host, owner, name); err != nil {
+	if err := m.validateRemoteIdentity(ctx, legacyPath, "origin", host, owner, name); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/internal/server/e2etest/settings_test.go
+++ b/internal/server/e2etest/settings_test.go
@@ -700,6 +700,42 @@ func TestRepoConfigAPIE2EUpdatesWorktreeBasePath(t *testing.T) {
 	assert.Empty(cfgAfterClear.Repos[0].WorktreeBasePath)
 }
 
+func TestRepoConfigAPIE2EAcceptsForkStyleWorktreeBase(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, _, cfgPath := setupTestServerWithConfig(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	localRepo := setupSettingsLocalGitRepoForDefaultHost(t)
+	runSettingsGit(t, localRepo, "remote", "rename", "origin", "upstream")
+	runSettingsGit(
+		t, localRepo, "remote", "add", "origin",
+		"https://github.com/forker/widget.git",
+	)
+
+	updateResp := doServerJSON(
+		t, ts.Client(), http.MethodPut,
+		ts.URL+"/api/v1/repo/github/acme/widget/worktree-base",
+		generated.RepoWorktreeBaseRequest{WorktreeBasePath: localRepo},
+	)
+	defer updateResp.Body.Close()
+	require.Equal(http.StatusOK, updateResp.StatusCode)
+
+	var updated generated.SettingsResponse
+	require.NoError(json.NewDecoder(updateResp.Body).Decode(&updated))
+	require.Len(updated.Repos, 1)
+	require.NotNil(updated.Repos[0].WorktreeBasePath)
+	canonicalLocalRepo, err := filepath.EvalSymlinks(localRepo)
+	require.NoError(err)
+	assert.Equal(canonicalLocalRepo, *updated.Repos[0].WorktreeBasePath)
+
+	cfgAfterUpdate, err := config.Load(cfgPath)
+	require.NoError(err)
+	require.Len(cfgAfterUpdate.Repos, 1)
+	assert.Equal(canonicalLocalRepo, cfgAfterUpdate.Repos[0].WorktreeBasePath)
+}
+
 func TestRepoConfigAPIE2EUpdatesUIVisibility(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -1555,14 +1555,14 @@ func (s *Server) updateConfiguredRepoWorktreeBasePath(
 		allowInsecureHTTP := s.clones != nil && s.clones.AllowsInsecureHTTP(
 			provider, targetRef.PlatformHostOrDefault(),
 		)
-		abs, err := workspace.ValidateWorktreeBasePath(
+		base, err := workspace.ValidateWorktreeBasePath(
 			ctx, worktreeBasePath, targetRef.PlatformHostOrDefault(),
 			targetRef.Owner, targetRef.Name, allowInsecureHTTP,
 		)
 		if err != nil {
 			return nil, httpapi.Validation("body.worktree_base_path", err.Error())
 		}
-		worktreeBasePath = abs
+		worktreeBasePath = base.Path
 	}
 
 	s.configReloadMu.Lock()

--- a/internal/server/workspaceapi/fleet_snapshot.go
+++ b/internal/server/workspaceapi/fleet_snapshot.go
@@ -85,6 +85,7 @@ func rawWorkspaceFromSummary(
 		Status: response.Status, ErrorMessage: response.ErrorMessage,
 		CreatedAt:    response.CreatedAt,
 		CommitsAhead: response.CommitsAhead, CommitsBehind: response.CommitsBehind,
+		BranchUpstreamMissing: response.BranchUpstreamMissing,
 		WorktreeDirty:         response.WorktreeDirty,
 		EnrichmentStatus:      response.EnrichmentStatus,
 		EnrichmentRefreshedAt: response.EnrichmentRefreshedAt,

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -2329,6 +2329,13 @@ func applyWorktreeDivergence(
 		return err
 	}
 	if !ok {
+		missing, missingErr := workspace.WorktreeBranchUpstreamMissing(probeCtx, worktreePath)
+		if missingErr != nil {
+			return missingErr
+		}
+		if missing {
+			resp.BranchUpstreamMissing = &missing
+		}
 		return nil
 	}
 	ahead := div.Ahead

--- a/internal/server/workspaceapi/types.go
+++ b/internal/server/workspaceapi/types.go
@@ -56,6 +56,7 @@ type workspaceResponse struct {
 	MRDeletions           *int                      `json:"mr_deletions,omitempty"`
 	CommitsAhead          *int                      `json:"commits_ahead,omitempty"`
 	CommitsBehind         *int                      `json:"commits_behind,omitempty"`
+	BranchUpstreamMissing *bool                     `json:"branch_upstream_missing,omitempty" doc:"True when the current branch has an origin upstream configured but its local remote-tracking ref is absent; clients may offer Push so branch sync can verify or create the remote branch."`
 	WorktreeDirty         *bool                     `json:"worktree_dirty,omitempty" doc:"True when the worktree has staged, unstaged, or untracked changes; false when clean; omitted until git-state enrichment completes."`
 	EnrichmentStatus      string                    `json:"enrichment_status" enum:"not_applicable,pending,fresh,stale,failed" doc:"Aggregate git-state and tmux-activity reconciliation status. Failed responses retain last-known-good component fields when available."`
 	EnrichmentRefreshedAt *string                   `json:"enrichment_refreshed_at,omitempty" doc:"Oldest successful refresh time across the populated enrichment components."`

--- a/internal/server/workspaceapi/workspace_enrichment.go
+++ b/internal/server/workspaceapi/workspace_enrichment.go
@@ -247,6 +247,7 @@ func applyWorkspaceEnrichmentCacheEntry(
 	if entry.hasDivergence {
 		resp.CommitsAhead = entry.response.CommitsAhead
 		resp.CommitsBehind = entry.response.CommitsBehind
+		resp.BranchUpstreamMissing = entry.response.BranchUpstreamMissing
 		resp.WorktreeDirty = entry.response.WorktreeDirty
 	}
 	if entry.hasTmux {
@@ -544,6 +545,7 @@ func (s *Handler) recordWorkspaceEnrichmentResult(
 	if result.divergenceComplete {
 		entry.response.CommitsAhead = result.response.CommitsAhead
 		entry.response.CommitsBehind = result.response.CommitsBehind
+		entry.response.BranchUpstreamMissing = result.response.BranchUpstreamMissing
 		entry.response.WorktreeDirty = result.response.WorktreeDirty
 		entry.hasDivergence = true
 		entry.divergenceRefreshedAt = now
@@ -597,6 +599,7 @@ func workspaceEnrichmentBroadcastWorthy(prior, next workspaceEnrichmentCacheEntr
 	return next.hasDivergence &&
 		(!intPointerEqual(prior.response.CommitsAhead, next.response.CommitsAhead) ||
 			!intPointerEqual(prior.response.CommitsBehind, next.response.CommitsBehind) ||
+			!boolPointerEqual(prior.response.BranchUpstreamMissing, next.response.BranchUpstreamMissing) ||
 			!boolPointerEqual(prior.response.WorktreeDirty, next.response.WorktreeDirty))
 }
 

--- a/internal/server/workspaceapi/workspace_enrichment_test.go
+++ b/internal/server/workspaceapi/workspace_enrichment_test.go
@@ -16,10 +16,27 @@ import (
 	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/providerplane"
 	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/testutil/gitfixture"
 	"go.kenn.io/forge/internal/workspace"
 	"go.kenn.io/forge/internal/workspace/localruntime"
 	gitcmd "go.kenn.io/kit/git/cmd"
 )
+
+func TestApplyWorktreeDivergenceReportsMissingConfiguredUpstream(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	work := gitfixture.DivergenceWorktree(t)
+	gitfixture.Run(t, work, "update-ref", "-d", "refs/remotes/origin/feature")
+	resp := workspaceResponse{ID: "ws-first-push"}
+
+	err := applyWorktreeDivergence(t.Context(), &resp, work)
+
+	require.NoError(err)
+	require.NotNil(resp.BranchUpstreamMissing)
+	assert.True(*resp.BranchUpstreamMissing)
+	assert.Nil(resp.CommitsAhead)
+	assert.Nil(resp.CommitsBehind)
+}
 
 func newEnrichmentTestHandler(t *testing.T, tmuxScript string) *Handler {
 	t.Helper()

--- a/internal/server/workspacetest/workspace_enrichment_wire_test.go
+++ b/internal/server/workspacetest/workspace_enrichment_wire_test.go
@@ -52,6 +52,34 @@ func TestWorkspaceListReportsCommitsAheadBehindE2E(t *testing.T) {
 			*initial.CommitsBehind == 0 && !*initial.WorktreeDirty
 	}, 10*time.Second, 10*time.Millisecond)
 
+	gitfixture.Run(t, ws.WorktreePath, "update-ref", "-d", "refs/remotes/origin/feature")
+	clockNow.Store(now.Add(workspaceapi.EnrichmentTTL + time.Second).UnixNano())
+	require.Eventually(func() bool {
+		found := workspaceByID()
+		return found != nil && found.BranchUpstreamMissing != nil && *found.BranchUpstreamMissing
+	}, 10*time.Second, 10*time.Millisecond)
+
+	includePeers := false
+	fleetResponse, err := fixture.client.HTTP.GetSnapshotWithResponse(
+		t.Context(), &generated.GetSnapshotParams{IncludePeers: &includePeers},
+	)
+	require.NoError(err)
+	require.NotNil(fleetResponse.JSON200)
+	require.NotNil(fleetResponse.JSON200.Workspaces)
+	var fleetWorkspace *generated.WorkspaceSummary
+	for i := range *fleetResponse.JSON200.Workspaces {
+		candidate := &(*fleetResponse.JSON200.Workspaces)[i]
+		if candidate.Id == ws.Id {
+			fleetWorkspace = candidate
+			break
+		}
+	}
+	require.NotNil(fleetWorkspace)
+	require.NotNil(fleetWorkspace.BranchUpstreamMissing)
+	assert.True(*fleetWorkspace.BranchUpstreamMissing)
+
+	gitfixture.Run(t, ws.WorktreePath, "fetch", "origin")
+
 	gitfixture.Run(t, ws.WorktreePath, "config", "user.email", "test@test.com")
 	gitfixture.Run(t, ws.WorktreePath, "config", "user.name", "Test")
 	for _, name := range []string{"ahead-1.txt", "ahead-2.txt"} {
@@ -60,7 +88,7 @@ func TestWorkspaceListReportsCommitsAheadBehindE2E(t *testing.T) {
 		gitfixture.Run(t, ws.WorktreePath, "commit", "-m", name)
 	}
 	require.NoError(os.WriteFile(filepath.Join(ws.WorktreePath, "uncommitted.txt"), []byte("dirty\n"), 0o644))
-	clockNow.Store(now.Add(workspaceapi.EnrichmentTTL + time.Second).UnixNano())
+	clockNow.Store(now.Add(2*workspaceapi.EnrichmentTTL + 2*time.Second).UnixNano())
 
 	var found *generated.WorkspaceResponse
 	require.Eventually(func() bool {

--- a/internal/workspace/adhoc_test.go
+++ b/internal/workspace/adhoc_test.go
@@ -353,7 +353,7 @@ func TestConfigureFallbackBranchUpstreamIgnoresAdHocWorkspace(t *testing.T) {
 	)
 
 	err := configureFallbackBranchUpstream(
-		t.Context(), localRepo,
+		t.Context(), workspaceGitDir{path: localRepo, remote: originRemoteName},
 		&Workspace{
 			ItemType:     db.WorkspaceItemTypeAdHoc,
 			GitHeadRef:   headBranch,

--- a/internal/workspace/branch_sync.go
+++ b/internal/workspace/branch_sync.go
@@ -23,11 +23,9 @@ type branchUpstream struct {
 }
 
 // networkedBranchGit runs a branch-sync git command that contacts the remote
-// (fetch or push) in the worktree dir. It returns only an error because branch
-// sync never needs the command's stdout, and the managed implementation
-// deliberately discards git's raw output so credential material in a remote
-// error string cannot leak back through the API.
-type networkedBranchGit func(ctx context.Context, dir string, args ...string) error
+// (fetch, push, or ls-remote) in the worktree dir. Successful stdout is used
+// only for explicit read queries and is never returned through the API.
+type networkedBranchGit func(ctx context.Context, dir string, args ...string) (string, error)
 
 // branchSyncGit returns the runner used for the networked steps of branch
 // push/pull. With clone management configured it routes fetch and push through
@@ -40,19 +38,16 @@ func (m *Manager) branchSyncGit(
 	platformName, platformHost, owner, name string,
 ) networkedBranchGit {
 	if m.clones == nil {
-		return func(ctx context.Context, dir string, args ...string) error {
-			_, err := gitCombinedOutput(ctx, dir, args...)
-			return err
+		return func(ctx context.Context, dir string, args ...string) (string, error) {
+			return gitCombinedOutput(ctx, dir, args...)
 		}
 	}
-	return func(ctx context.Context, dir string, args ...string) error {
-		if _, err := m.clones.RunGitForNamedRemote(
+	return func(ctx context.Context, dir string, args ...string) (string, error) {
+		out, err := m.clones.RunGitForNamedRemote(
 			ctx, platformName, platformHost, owner, name,
 			"origin", dir, args...,
-		); err != nil {
-			return err
-		}
-		return nil
+		)
+		return string(out), err
 	}
 }
 
@@ -145,7 +140,11 @@ func (m *Manager) validateBranchSyncLaunchSpec(
 	return workspace, spec != nil && m.requireProviderCredential, err
 }
 
-func pushWorktreeBranch(ctx context.Context, run networkedBranchGit, dir string) error {
+func pushWorktreeBranch(
+	ctx context.Context,
+	run networkedBranchGit,
+	dir string,
+) error {
 	if err := ensureBranchSyncClean(ctx, dir); err != nil {
 		return err
 	}
@@ -153,7 +152,7 @@ func pushWorktreeBranch(ctx context.Context, run networkedBranchGit, dir string)
 	if err != nil {
 		return err
 	}
-	upstreamExists, err := branchUpstreamExists(ctx, dir, upstream)
+	upstreamExists, err := remoteBranchExists(ctx, run, dir, upstream)
 	if err != nil {
 		return err
 	}
@@ -188,6 +187,27 @@ func pushWorktreeBranch(ctx context.Context, run networkedBranchGit, dir string)
 	return nil
 }
 
+func remoteBranchExists(
+	ctx context.Context,
+	run networkedBranchGit,
+	dir string,
+	upstream branchUpstream,
+) (bool, error) {
+	ref := "refs/heads/" + upstream.branch
+	out, err := run(ctx, dir, "ls-remote", "--heads", upstream.remote, ref)
+	if err != nil {
+		return false, fmt.Errorf("check remote branch: %w", err)
+	}
+	if strings.TrimSpace(out) == "" {
+		return false, nil
+	}
+	fields := strings.Fields(out)
+	if len(fields) != 2 || fields[1] != ref {
+		return false, fmt.Errorf("check remote branch: unexpected ls-remote output")
+	}
+	return true, nil
+}
+
 func branchUpstreamExists(ctx context.Context, dir string, upstream branchUpstream) (bool, error) {
 	ref := "refs/remotes/" + upstream.remote + "/" + upstream.branch
 	out, err := gitCombinedOutput(ctx, dir, "for-each-ref", "--format=%(refname)", ref)
@@ -197,10 +217,24 @@ func branchUpstreamExists(ctx context.Context, dir string, upstream branchUpstre
 	return strings.TrimSpace(out) == ref, nil
 }
 
+// WorktreeBranchUpstreamMissing reports whether the current branch has an
+// origin upstream configured but its local remote-tracking ref does not exist.
+func WorktreeBranchUpstreamMissing(ctx context.Context, dir string) (bool, error) {
+	upstream, err := currentBranchUpstream(ctx, dir)
+	if err != nil {
+		if errors.Is(err, ErrWorktreeNoUpstream) {
+			return false, nil
+		}
+		return false, err
+	}
+	exists, err := branchUpstreamExists(ctx, dir, upstream)
+	return !exists, err
+}
+
 func pushBranch(ctx context.Context, run networkedBranchGit, dir string, upstream branchUpstream) error {
 	// Writes stay on the user's own credential chain so the pushed commits
 	// are attributed to the user instead of a GitHub App bot.
-	if err := run(
+	if _, err := run(
 		tokenauth.WithMutationAuth(ctx), dir,
 		"push", upstream.remote, "HEAD:"+upstream.branch,
 	); err != nil {
@@ -285,7 +319,7 @@ func refreshBranchUpstream(
 	ctx context.Context, run networkedBranchGit, dir string, upstream branchUpstream,
 ) error {
 	refspec := "+refs/heads/" + upstream.branch + ":refs/remotes/" + upstream.remote + "/" + upstream.branch
-	if err := run(ctx, dir, "fetch", "--prune", upstream.remote, refspec); err != nil {
+	if _, err := run(ctx, dir, "fetch", "--prune", upstream.remote, refspec); err != nil {
 		return fmt.Errorf("git fetch %s %s: %w", upstream.remote, upstream.branch, err)
 	}
 	return nil

--- a/internal/workspace/branch_sync.go
+++ b/internal/workspace/branch_sync.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os/exec"
 	"strings"
 
 	"go.kenn.io/forge/internal/gitclone"
+	"go.kenn.io/forge/internal/procutil"
 	"go.kenn.io/forge/internal/tokenauth"
 )
 
@@ -39,7 +41,18 @@ func (m *Manager) branchSyncGit(
 ) networkedBranchGit {
 	if m.clones == nil {
 		return func(ctx context.Context, dir string, args ...string) (string, error) {
-			return gitCombinedOutput(ctx, dir, args...)
+			cmd := workspaceGitCommand(ctx, dir, args...)
+			out, err := procutil.Output(ctx, cmd, "git subprocess capacity")
+			if err == nil {
+				return string(out), nil
+			}
+			if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
+				stderr := strings.TrimSpace(string(exitErr.Stderr))
+				if stderr != "" {
+					return string(out), fmt.Errorf("%w: %s", err, stderr)
+				}
+			}
+			return string(out), err
 		}
 	}
 	return func(ctx context.Context, dir string, args ...string) (string, error) {

--- a/internal/workspace/branch_sync.go
+++ b/internal/workspace/branch_sync.go
@@ -46,8 +46,9 @@ func (m *Manager) branchSyncGit(
 		}
 	}
 	return func(ctx context.Context, dir string, args ...string) error {
-		if _, err := m.clones.RunGitForRepo(
-			ctx, platformName, platformHost, owner, name, dir, args...,
+		if _, err := m.clones.RunGitForNamedRemote(
+			ctx, platformName, platformHost, owner, name,
+			"origin", dir, args...,
 		); err != nil {
 			return err
 		}

--- a/internal/workspace/branch_sync.go
+++ b/internal/workspace/branch_sync.go
@@ -153,6 +153,19 @@ func pushWorktreeBranch(ctx context.Context, run networkedBranchGit, dir string)
 	if err != nil {
 		return err
 	}
+	upstreamExists, err := branchUpstreamExists(ctx, dir, upstream)
+	if err != nil {
+		return err
+	}
+	if !upstreamExists {
+		if err := pushBranch(ctx, run, dir, upstream); err != nil {
+			return err
+		}
+		if err := refreshBranchUpstream(ctx, run, dir, upstream); err != nil {
+			return fmt.Errorf("refresh after push: %w", err)
+		}
+		return nil
+	}
 	if err := refreshBranchUpstream(ctx, run, dir, upstream); err != nil {
 		return err
 	}
@@ -166,6 +179,25 @@ func pushWorktreeBranch(ctx context.Context, run networkedBranchGit, dir string)
 	if div.Ahead == 0 {
 		return ErrWorktreeInSync
 	}
+	if err := pushBranch(ctx, run, dir, upstream); err != nil {
+		return err
+	}
+	if err := refreshBranchUpstream(ctx, run, dir, upstream); err != nil {
+		return fmt.Errorf("refresh after push: %w", err)
+	}
+	return nil
+}
+
+func branchUpstreamExists(ctx context.Context, dir string, upstream branchUpstream) (bool, error) {
+	ref := "refs/remotes/" + upstream.remote + "/" + upstream.branch
+	out, err := gitCombinedOutput(ctx, dir, "for-each-ref", "--format=%(refname)", ref)
+	if err != nil {
+		return false, fmt.Errorf("check branch upstream: %w", err)
+	}
+	return strings.TrimSpace(out) == ref, nil
+}
+
+func pushBranch(ctx context.Context, run networkedBranchGit, dir string, upstream branchUpstream) error {
 	// Writes stay on the user's own credential chain so the pushed commits
 	// are attributed to the user instead of a GitHub App bot.
 	if err := run(
@@ -173,9 +205,6 @@ func pushWorktreeBranch(ctx context.Context, run networkedBranchGit, dir string)
 		"push", upstream.remote, "HEAD:"+upstream.branch,
 	); err != nil {
 		return fmt.Errorf("git push: %w", err)
-	}
-	if err := refreshBranchUpstream(ctx, run, dir, upstream); err != nil {
-		return fmt.Errorf("refresh after push: %w", err)
 	}
 	return nil
 }

--- a/internal/workspace/branch_sync_test.go
+++ b/internal/workspace/branch_sync_test.go
@@ -76,6 +76,28 @@ func TestPushWorktreeBranchCreatesMissingRemoteBranch(t *testing.T) {
 	require.Equal(localCommit, remoteCommit)
 }
 
+func TestPushWorktreeBranchRecreatesRemoteBranchWithStaleTrackingRef(t *testing.T) {
+	require := require.New(t)
+	work := gitfixture.DivergenceWorktree(t)
+	remote := filepath.Join(filepath.Dir(work), "remote.git")
+	runWorkspaceTestGit(t, filepath.Dir(work), "--git-dir", remote, "branch", "-D", "feature")
+	require.NoError(os.WriteFile(
+		filepath.Join(work, "f.txt"), []byte("recreated branch\n"), 0o644,
+	))
+	runWorkspaceTestGit(t, work, "add", ".")
+	runWorkspaceTestGit(t, work, "commit", "-m", "recreated branch")
+
+	require.NoError(branchSyncTestManager(t).PushWorktreeBranch(
+		t.Context(), "", "github", "", "", "", work,
+	))
+
+	remoteCommit := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, filepath.Dir(work), "--git-dir", remote, "rev-parse", "refs/heads/feature",
+	)))
+	localCommit := strings.TrimSpace(string(runWorkspaceTestGit(t, work, "rev-parse", "HEAD")))
+	require.Equal(localCommit, remoteCommit)
+}
+
 func TestPushWorktreeBranchDoesNotOverwriteUntrackedRemoteBranch(t *testing.T) {
 	require := require.New(t)
 	work := gitfixture.DivergenceWorktree(t)

--- a/internal/workspace/branch_sync_test.go
+++ b/internal/workspace/branch_sync_test.go
@@ -53,6 +53,61 @@ func TestPushWorktreeBranchPushesAheadCommitsAndRunsHooks(t *testing.T) {
 	assert.FileExists(marker)
 }
 
+func TestPushWorktreeBranchCreatesMissingRemoteBranch(t *testing.T) {
+	require := require.New(t)
+	work := gitfixture.DivergenceWorktree(t)
+	remote := filepath.Join(filepath.Dir(work), "remote.git")
+	runWorkspaceTestGit(t, filepath.Dir(work), "--git-dir", remote, "branch", "-D", "feature")
+	runWorkspaceTestGit(t, work, "update-ref", "-d", "refs/remotes/origin/feature")
+	require.NoError(os.WriteFile(
+		filepath.Join(work, "f.txt"), []byte("first fork commit\n"), 0o644,
+	))
+	runWorkspaceTestGit(t, work, "add", ".")
+	runWorkspaceTestGit(t, work, "commit", "-m", "first fork commit")
+
+	require.NoError(branchSyncTestManager(t).PushWorktreeBranch(
+		t.Context(), "", "github", "", "", "", work,
+	))
+
+	remoteCommit := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, filepath.Dir(work), "--git-dir", remote, "rev-parse", "refs/heads/feature",
+	)))
+	localCommit := strings.TrimSpace(string(runWorkspaceTestGit(t, work, "rev-parse", "HEAD")))
+	require.Equal(localCommit, remoteCommit)
+}
+
+func TestPushWorktreeBranchDoesNotOverwriteUntrackedRemoteBranch(t *testing.T) {
+	require := require.New(t)
+	work := gitfixture.DivergenceWorktree(t)
+	require.NoError(os.WriteFile(filepath.Join(work, "f.txt"), []byte("local\n"), 0o644))
+	runWorkspaceTestGit(t, work, "add", ".")
+	runWorkspaceTestGit(t, work, "commit", "-m", "local")
+
+	other := filepath.Join(filepath.Dir(work), "other")
+	remote := filepath.Join(filepath.Dir(work), "remote.git")
+	runWorkspaceTestGit(t, filepath.Dir(work), "clone", remote, other)
+	runWorkspaceTestGit(t, other, "config", "user.email", "o@test.com")
+	runWorkspaceTestGit(t, other, "config", "user.name", "Other")
+	runWorkspaceTestGit(t, other, "checkout", "-b", "feature", "origin/feature")
+	require.NoError(os.WriteFile(filepath.Join(other, "f.txt"), []byte("remote\n"), 0o644))
+	runWorkspaceTestGit(t, other, "add", ".")
+	runWorkspaceTestGit(t, other, "commit", "-m", "remote")
+	runWorkspaceTestGit(t, other, "push", "origin", "feature")
+	remoteCommit := runWorkspaceTestGit(
+		t, filepath.Dir(work), "--git-dir", remote, "rev-parse", "refs/heads/feature",
+	)
+	runWorkspaceTestGit(t, work, "update-ref", "-d", "refs/remotes/origin/feature")
+
+	err := branchSyncTestManager(t).PushWorktreeBranch(
+		t.Context(), "", "github", "", "", "", work,
+	)
+
+	require.Error(err)
+	require.Equal(remoteCommit, runWorkspaceTestGit(
+		t, filepath.Dir(work), "--git-dir", remote, "rev-parse", "refs/heads/feature",
+	))
+}
+
 func TestPullWorktreeBranchFastForwardsBehindBranch(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/workspace/branch_sync_test.go
+++ b/internal/workspace/branch_sync_test.go
@@ -64,6 +64,18 @@ func TestPushWorktreeBranchCreatesMissingRemoteBranch(t *testing.T) {
 	))
 	runWorkspaceTestGit(t, work, "add", ".")
 	runWorkspaceTestGit(t, work, "commit", "-m", "first fork commit")
+	realGit, err := exec.LookPath("git")
+	require.NoError(err)
+	fakeDir := t.TempDir()
+	require.NoError(os.WriteFile(filepath.Join(fakeDir, "git"), []byte(`#!/bin/sh
+set -eu
+if [ "${1:-}" = "ls-remote" ]; then
+	echo "remote: informational diagnostic" >&2
+fi
+exec "${KENN_FORGE_TEST_REAL_GIT:?}" "$@"
+`), 0o755))
+	t.Setenv("KENN_FORGE_TEST_REAL_GIT", realGit)
+	t.Setenv("PATH", fakeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	require.NoError(branchSyncTestManager(t).PushWorktreeBranch(
 		t.Context(), "", "github", "", "", "", work,

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -2901,8 +2901,8 @@ func fetchRefspecOverlapsNamespace(destination, namespace string) bool {
 		return false
 	}
 	namespaceRoot := strings.TrimSuffix(namespace, "/")
-	if wildcard := strings.IndexByte(destination, '*'); wildcard >= 0 {
-		prefix := strings.TrimSuffix(destination[:wildcard], "/")
+	if prefix, _, wildcard := strings.Cut(destination, "*"); wildcard {
+		prefix = strings.TrimSuffix(prefix, "/")
 		return strings.HasPrefix(namespaceRoot, prefix) ||
 			refPathPrefix(namespaceRoot, prefix)
 	}

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -2904,7 +2904,7 @@ func fetchRefspecOverlapsNamespace(destination, namespace string) bool {
 	if wildcard := strings.IndexByte(destination, '*'); wildcard >= 0 {
 		prefix := strings.TrimSuffix(destination[:wildcard], "/")
 		return strings.HasPrefix(namespaceRoot, prefix) ||
-			strings.HasPrefix(prefix, namespaceRoot)
+			refPathPrefix(namespaceRoot, prefix)
 	}
 	return refPathPrefix(destination, namespaceRoot) ||
 		refPathPrefix(namespaceRoot, destination)

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -2359,10 +2359,10 @@ func (m *Manager) workspaceSetupGitDir(
 				ctx, worktreeBasePath, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
 				m.allowsInsecureHTTP(ws.Platform, ws.PlatformHost),
 			)
-			return workspaceGitDir{path: base.Path, remote: base.Remote, localBase: true}, err
+			return workspaceGitDir{path: base.Path, remote: base.Remote, localBase: err == nil}, err
 		}
 		if base, ok, err := m.localWorktreeBaseDir(ctx, repo); err != nil || ok {
-			return workspaceGitDir{path: base.Path, remote: base.Remote, localBase: true}, err
+			return workspaceGitDir{path: base.Path, remote: base.Remote, localBase: err == nil}, err
 		}
 	}
 
@@ -2854,21 +2854,27 @@ func validateBaseFetchRefspec(ctx context.Context, dir, remote string) error {
 }
 
 func fetchRefspecUpdatesRemote(value, remote string) bool {
-	destination, ok := fetchRefspecDestination(value)
-	return ok && remote != "" && strings.HasPrefix(destination, remoteTrackingRef(remote, ""))
+	source, destination, ok := fetchRefspecParts(value)
+	return ok && strings.HasPrefix(source, "refs/heads/") &&
+		remote != "" && strings.HasPrefix(destination, remoteTrackingRef(remote, ""))
 }
 
 func fetchRefspecDestination(value string) (string, bool) {
+	_, destination, ok := fetchRefspecParts(value)
+	return destination, ok
+}
+
+func fetchRefspecParts(value string) (string, string, bool) {
 	refspec := strings.TrimSpace(value)
 	if refspec == "" || strings.HasPrefix(refspec, "^") {
-		return "", false
+		return "", "", false
 	}
 	refspec = strings.TrimPrefix(refspec, "+")
-	src, dst, ok := strings.Cut(refspec, ":")
-	if !ok || !strings.HasPrefix(src, "refs/heads/") {
-		return "", false
+	source, destination, ok := strings.Cut(refspec, ":")
+	if !ok || destination == "" {
+		return "", "", false
 	}
-	return dst, true
+	return source, destination, true
 }
 
 func gitRemoteNames(ctx context.Context, dir string) ([]string, error) {

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -2669,6 +2669,9 @@ func resolveWorktreeBaseRemote(
 	}
 	var matches []string
 	for _, remote := range names {
+		if !validGitRemoteName(remote) {
+			return "", fmt.Errorf("git remote name %q is unsafe", remote)
+		}
 		remoteURLs, err := gitConfigValues(ctx, dir, "remote."+remote+".url")
 		if err != nil {
 			return "", fmt.Errorf("read %q remote: %w", remote, err)
@@ -2703,6 +2706,11 @@ func remoteMatchesRepositoryIdentity(
 		gitremote.ValidateRemoteIdentity(gitremote.Identity{
 			Host: platformHost, Owner: owner, Name: name,
 		}, remoteURL) == nil
+}
+
+func validGitRemoteName(remote string) bool {
+	return remote != "" && remote[0] != '-' &&
+		!strings.ContainsAny(remote, " \t\r\n")
 }
 
 func validateBaseRemoteURLs(
@@ -2842,7 +2850,9 @@ func validateBaseFetchRefspec(ctx context.Context, dir, remote string) error {
 		}
 		for _, value := range values {
 			destination, ok := fetchRefspecDestination(value)
-			if ok && strings.HasPrefix(destination, remoteTrackingRef(remote, "")) {
+			if ok && fetchRefspecOverlapsNamespace(
+				destination, remoteTrackingRef(remote, ""),
+			) {
 				return fmt.Errorf(
 					"remote %q fetch refspec %q writes into the %q tracking namespace",
 					other, value, remote,
@@ -2875,6 +2885,18 @@ func fetchRefspecParts(value string) (string, string, bool) {
 		return "", "", false
 	}
 	return source, destination, true
+}
+
+func fetchRefspecOverlapsNamespace(destination, namespace string) bool {
+	if destination == "" || namespace == "" {
+		return false
+	}
+	if wildcard := strings.IndexByte(destination, '*'); wildcard >= 0 {
+		prefix := destination[:wildcard]
+		return strings.HasPrefix(namespace, prefix) ||
+			strings.HasPrefix(prefix, namespace)
+	}
+	return strings.HasPrefix(destination, namespace)
 }
 
 func gitRemoteNames(ctx context.Context, dir string) ([]string, error) {
@@ -3172,7 +3194,7 @@ func (m *Manager) addFallbackBranchWorktree(
 	if err != nil {
 		return "", err
 	}
-	if err := configureFallbackBranchUpstreamForGitDir(
+	if err := configureFallbackBranchUpstream(
 		ctx, gitDir, ws, branch,
 	); err != nil {
 		cleanupErr := cleanupOwnedWorktreeAddOnUpstreamFailure(
@@ -3468,20 +3490,6 @@ func cleanupOwnedWorktreeAddOnUpstreamFailure(
 // identity evidence: forks preserve commit IDs. Fork and unknown heads take
 // the merge-request-ref path and remain without an origin upstream.
 func configureFallbackBranchUpstream(
-	ctx context.Context,
-	cloneDir string,
-	ws *Workspace,
-	fallbackBranch string,
-) error {
-	return configureFallbackBranchUpstreamForGitDir(
-		ctx,
-		workspaceGitDir{path: cloneDir, remote: originRemoteName},
-		ws,
-		fallbackBranch,
-	)
-}
-
-func configureFallbackBranchUpstreamForGitDir(
 	ctx context.Context,
 	gitDir workspaceGitDir,
 	ws *Workspace,

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -2891,12 +2891,18 @@ func fetchRefspecOverlapsNamespace(destination, namespace string) bool {
 	if destination == "" || namespace == "" {
 		return false
 	}
+	namespaceRoot := strings.TrimSuffix(namespace, "/")
 	if wildcard := strings.IndexByte(destination, '*'); wildcard >= 0 {
-		prefix := destination[:wildcard]
-		return strings.HasPrefix(namespace, prefix) ||
-			strings.HasPrefix(prefix, namespace)
+		prefix := strings.TrimSuffix(destination[:wildcard], "/")
+		return refPathPrefix(prefix, namespaceRoot) ||
+			refPathPrefix(namespaceRoot, prefix)
 	}
-	return strings.HasPrefix(destination, namespace)
+	return refPathPrefix(destination, namespaceRoot) ||
+		refPathPrefix(namespaceRoot, destination)
+}
+
+func refPathPrefix(prefix, path string) bool {
+	return prefix == path || strings.HasPrefix(path, prefix+"/")
 }
 
 func gitRemoteNames(ctx context.Context, dir string) ([]string, error) {

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -5933,8 +5933,8 @@ func (m *Manager) fetchWorkspaceBase(
 	run := runGitWithoutHooks
 	if m.clones != nil {
 		run = func(ctx context.Context, dir string, args ...string) error {
-			out, err := m.clones.RunGitForRepo(
-				ctx, platformName, platformHost, owner, name, dir, args...,
+			out, err := m.clones.RunGitForRepoRemote(
+				ctx, platformName, platformHost, owner, name, remote, dir, args...,
 			)
 			if err != nil {
 				return fmt.Errorf(
@@ -5958,8 +5958,9 @@ func (m *Manager) fetchWorkspaceMergeRequestHeadRef(
 	runFork := run
 	if m.clones != nil {
 		run = func(ctx context.Context, dir string, args ...string) error {
-			out, err := m.clones.RunGitForRepo(
-				ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName, dir, args...,
+			out, err := m.clones.RunGitForRepoRemote(
+				ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+				remote, dir, args...,
 			)
 			if err != nil {
 				return fmt.Errorf(

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -16,7 +16,6 @@ import (
 	"os/user"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -2668,20 +2667,30 @@ func resolveWorktreeBaseRemote(
 		return "", fmt.Errorf("list git remotes: %w", err)
 	}
 	var matches []string
+	var unsafeMatches []string
 	for _, remote := range names {
-		if !validGitRemoteName(remote) {
-			return "", fmt.Errorf("git remote name %q is unsafe", remote)
-		}
 		remoteURLs, err := gitConfigValues(ctx, dir, "remote."+remote+".url")
 		if err != nil {
 			return "", fmt.Errorf("read %q remote: %w", remote, err)
 		}
+		identityMatch := false
 		for _, remoteURL := range remoteURLs {
 			if remoteMatchesRepositoryIdentity(remoteURL, platformHost, owner, name) {
-				matches = append(matches, remote)
+				identityMatch = true
 				break
 			}
 		}
+		if !identityMatch {
+			continue
+		}
+		if !validGitRemoteName(remote) {
+			unsafeMatches = append(unsafeMatches, remote)
+			continue
+		}
+		matches = append(matches, remote)
+	}
+	if len(unsafeMatches) > 0 {
+		return "", fmt.Errorf("git remote name %q is unsafe", unsafeMatches[0])
 	}
 	if len(matches) == 0 {
 		return "", fmt.Errorf(
@@ -2894,8 +2903,8 @@ func fetchRefspecOverlapsNamespace(destination, namespace string) bool {
 	namespaceRoot := strings.TrimSuffix(namespace, "/")
 	if wildcard := strings.IndexByte(destination, '*'); wildcard >= 0 {
 		prefix := strings.TrimSuffix(destination[:wildcard], "/")
-		return refPathPrefix(prefix, namespaceRoot) ||
-			refPathPrefix(namespaceRoot, prefix)
+		return strings.HasPrefix(namespaceRoot, prefix) ||
+			strings.HasPrefix(prefix, namespaceRoot)
 	}
 	return refPathPrefix(destination, namespaceRoot) ||
 		refPathPrefix(namespaceRoot, destination)
@@ -2916,7 +2925,7 @@ func gitRemoteNames(ctx context.Context, dir string) ([]string, error) {
 			names = append(names, name)
 		}
 	}
-	sort.Strings(names)
+	slices.Sort(names)
 	return names, nil
 }
 

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -16,6 +16,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -767,13 +768,13 @@ func (m *Manager) inspectExistingWorkspaceDirectory(
 			Reason: WorkspaceDirectoryNotLinkedWorktree,
 		}
 	}
-	_, reusable, err := m.existingWorkspaceWorktreeProvenance(
+	prov, err := m.existingWorkspaceWorktreeProvenance(
 		ctx, commonDir, ws,
 	)
 	if err != nil {
 		return "", fmt.Errorf("validate expected workspace provenance: %w", err)
 	}
-	if !reusable {
+	if !prov.reusable {
 		return "", &WorkspaceDirectoryRecoveryError{
 			Reason: WorkspaceDirectoryRepositoryMismatch,
 		}
@@ -1089,8 +1090,8 @@ type workspaceRepoRef struct {
 func (m *Manager) branchInspectionDir(
 	ctx context.Context, repo workspaceRepoRef,
 ) (dir string, ok bool, localBase bool, err error) {
-	if baseDir, ok, err := m.localWorktreeBaseDir(ctx, repo); err != nil || ok {
-		return baseDir, ok, ok, err
+	if base, ok, err := m.localWorktreeBaseDir(ctx, repo); err != nil || ok {
+		return base.Path, ok, ok, err
 	}
 	if m.clones == nil {
 		return "", false, false, nil
@@ -1420,8 +1421,8 @@ func (m *Manager) SetupWithOptions(
 		if err := m.ensureWorkspacePathAvailable(ctx, ws); err != nil {
 			return m.failSetup(ctx, ws.ID, workspaceSetupStageWorktree, err)
 		}
-		var refreshBeforeAdd bool
-		gitDir, refreshBeforeAdd, err = m.workspaceSetupGitDir(
+		var gitSetupDir workspaceGitDir
+		gitSetupDir, err = m.workspaceSetupGitDir(
 			ctx, ws, worktreeBasePath, launchSpec, validateCloneRoute,
 		)
 		if err != nil {
@@ -1431,8 +1432,9 @@ func (m *Manager) SetupWithOptions(
 			)
 		}
 
+		gitDir = gitSetupDir.path
 		branch, err = m.addWorktree(
-			ctx, gitDir, refreshBeforeAdd, ws, workspaceGitFetchOptions{
+			ctx, gitSetupDir, ws, workspaceGitFetchOptions{
 				launchSpec: launchSpec, validateRoute: validateCloneRoute,
 			},
 		)
@@ -1442,8 +1444,8 @@ func (m *Manager) SetupWithOptions(
 				ws.ID, workspaceSetupStageWorktree, err,
 			)
 		}
-		commonDir = gitDir
-		managedClone = !refreshBeforeAdd
+		commonDir = gitSetupDir.path
+		managedClone = !gitSetupDir.localBase
 	}
 	if ws.ItemType == db.WorkspaceItemTypePullRequest && ws.MRHeadRepo != nil {
 		currentBranch, branchErr := worktreeCurrentBranch(ctx, ws.WorktreePath)
@@ -1771,13 +1773,13 @@ func (m *Manager) reuseExistingWorkspaceWorktreeDetails(
 	if !owned {
 		return existingWorkspaceWorktreeResult{}, nil
 	}
-	localBase, reusable, err := m.existingWorkspaceWorktreeProvenance(
+	prov, err := m.existingWorkspaceWorktreeProvenance(
 		ctx, commonDir, ws,
 	)
 	if err != nil {
 		return existingWorkspaceWorktreeResult{}, err
 	}
-	if !reusable {
+	if !prov.reusable {
 		return existingWorkspaceWorktreeResult{}, nil
 	}
 	if m.beforeExistingWorktreeRepoLock != nil {
@@ -1786,12 +1788,12 @@ func (m *Manager) reuseExistingWorkspaceWorktreeDetails(
 	var branch string
 	if err := m.withRepoLockForGitDir(ctx, commonDir, func() error {
 		if err := m.revalidateExistingWorkspaceWorktree(
-			ctx, commonDir, localBase, ws,
+			ctx, commonDir, prov.localBase, ws,
 		); err != nil {
 			return err
 		}
 		var previousOriginURLs []string
-		if !localBase {
+		if !prov.localBase {
 			var originErr error
 			previousOriginURLs, originErr = gitConfigValues(
 				ctx, commonDir, "remote.origin.url",
@@ -1813,10 +1815,10 @@ func (m *Manager) reuseExistingWorkspaceWorktreeDetails(
 			}
 		}
 		useMergeRequestHeadRef, refreshErr := m.refreshExistingWorkspaceWorktree(
-			ctx, commonDir, ws, launchSpec, validateCloneRoute,
+			ctx, commonDir, prov.remote, ws, launchSpec, validateCloneRoute,
 		)
 		if refreshErr != nil {
-			if localBase {
+			if prov.localBase {
 				return refreshErr
 			}
 			restoreErr := restoreGitConfigValues(
@@ -1834,7 +1836,8 @@ func (m *Manager) reuseExistingWorkspaceWorktreeDetails(
 		}
 		var ok bool
 		branch, ok, branchErr = existingWorkspacePersistedBranch(
-			ctx, commonDir, ws, currentBranch, localBase, useMergeRequestHeadRef,
+			ctx, commonDir, prov.remote, ws, currentBranch, prov.localBase,
+			useMergeRequestHeadRef,
 		)
 		if branchErr != nil {
 			return branchErr
@@ -1853,7 +1856,7 @@ func (m *Manager) reuseExistingWorkspaceWorktreeDetails(
 		return existingWorkspaceWorktreeResult{}, err
 	}
 	return existingWorkspaceWorktreeResult{
-		branch: branch, commonDir: commonDir, managedClone: !localBase, reused: true,
+		branch: branch, commonDir: commonDir, managedClone: !prov.localBase, reused: true,
 	}, nil
 }
 
@@ -1908,13 +1911,13 @@ func (m *Manager) revalidateExistingWorkspaceWorktree(
 			Reason: WorkspaceDirectoryNotLinkedWorktree,
 		}
 	}
-	localBase, reusable, err := m.existingWorkspaceWorktreeProvenance(
+	prov, err := m.existingWorkspaceWorktreeProvenance(
 		ctx, currentCommonDir, ws,
 	)
 	if err != nil {
 		return fmt.Errorf("revalidate existing worktree provenance: %w", err)
 	}
-	if !reusable || localBase != expectedLocalBase {
+	if !prov.reusable || prov.localBase != expectedLocalBase {
 		return &WorkspaceDirectoryRecoveryError{
 			Reason: WorkspaceDirectoryRepositoryMismatch,
 		}
@@ -1956,32 +1959,39 @@ func (m *Manager) ensureWorkspacePathAvailable(
 // worktree in place. Cleanup later deletes only branches that the persisted
 // workspace branch proves kenn-forge owns; an empty or unknown branch marker is
 // deliberately treated as user-owned.
+type workspaceWorktreeProvenance struct {
+	remote    string
+	localBase bool
+	reusable  bool
+}
+
 func (m *Manager) existingWorkspaceWorktreeProvenance(
 	ctx context.Context,
 	commonDir string,
 	ws *Workspace,
-) (localBase bool, reusable bool, err error) {
+) (workspaceWorktreeProvenance, error) {
 	usesManagedClone, err := m.existingWorktreeUsesManagedClone(ctx, commonDir, ws)
 	if err != nil {
-		return false, false, err
+		return workspaceWorktreeProvenance{}, err
 	}
 	if usesManagedClone {
-		return false, true, nil
+		return workspaceWorktreeProvenance{remote: originRemoteName, reusable: true}, nil
 	}
 	if ws.MRHeadRepo != nil {
-		return false, false, nil
+		return workspaceWorktreeProvenance{}, nil
 	}
 	usesLocalBase, err := m.workspaceWorktreeUsesLocalBase(ctx, commonDir, ws)
 	if err != nil || !usesLocalBase {
-		return false, false, err
+		return workspaceWorktreeProvenance{}, err
 	}
-	if _, err := ValidateWorktreeBasePath(
+	base, err := ValidateWorktreeBasePath(
 		ctx, ws.WorktreePath, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
 		m.allowsInsecureHTTP(ws.Platform, ws.PlatformHost),
-	); err != nil {
-		return false, false, err
+	)
+	if err != nil {
+		return workspaceWorktreeProvenance{}, err
 	}
-	return true, true, nil
+	return workspaceWorktreeProvenance{remote: base.Remote, localBase: true, reusable: true}, nil
 }
 
 func (m *Manager) existingWorktreeUsesManagedClone(
@@ -2016,8 +2026,8 @@ func (m *Manager) existingWorktreeUsesManagedClone(
 		return false, nil
 	}
 	for _, candidate := range candidates {
-		if validateOriginRemoteURLs(
-			ctx, commonDir, candidate.platformHost,
+		if validateBaseRemoteURLs(
+			ctx, commonDir, originRemoteName, candidate.platformHost,
 			candidate.owner, candidate.name,
 			m.allowsInsecureHTTP(candidate.platform, candidate.platformHost),
 		) == nil {
@@ -2156,8 +2166,8 @@ func (m *Manager) retargetManagedCloneOrigin(
 			return err
 		}
 	}
-	if err := validateOriginRemoteURL(
-		remoteURL, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+	if err := validateBaseRemoteURL(
+		remoteURL, originRemoteName, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
 		m.allowsInsecureHTTP(ws.Platform, ws.PlatformHost),
 	); err != nil {
 		return fmt.Errorf("validate managed clone origin after rename: %w", err)
@@ -2173,6 +2183,7 @@ func (m *Manager) retargetManagedCloneOrigin(
 func (m *Manager) refreshExistingWorkspaceWorktree(
 	ctx context.Context,
 	commonDir string,
+	remote string,
 	ws *Workspace,
 	launchSpec *WorkspaceLaunchSpec,
 	validateCloneRoute func(context.Context) error,
@@ -2182,13 +2193,13 @@ func (m *Manager) refreshExistingWorkspaceWorktree(
 		func() error {
 			return m.fetchWorkspaceBase(
 				ctx, commonDir, ws.Platform, ws.PlatformHost,
-				ws.RepoOwner, ws.RepoName, false,
+				ws.RepoOwner, ws.RepoName, remote, false,
 			)
 		},
 	); err != nil {
 		return false, err
 	}
-	if err := m.syncWorkspaceBaseBranch(ctx, commonDir, ws); err != nil {
+	if err := m.syncWorkspaceBaseBranch(ctx, commonDir, remote, ws); err != nil {
 		return false, err
 	}
 	if ws.ItemType != db.WorkspaceItemTypePullRequest {
@@ -2198,7 +2209,7 @@ func (m *Manager) refreshExistingWorkspaceWorktree(
 		ctx, commonDir, validateCloneRoute,
 		func() error {
 			return m.fetchWorkspaceMergeRequestHeadRef(
-				ctx, commonDir, ws, launchSpec,
+				ctx, commonDir, remote, ws, launchSpec,
 			)
 		},
 	)
@@ -2220,11 +2231,11 @@ func (m *Manager) workspaceWorktreeUsesLocalBase(
 	if err != nil {
 		return false, err
 	}
-	baseDir, ok, err := m.localWorktreeBaseDir(ctx, repo)
+	base, ok, err := m.localWorktreeBaseDir(ctx, repo)
 	if err != nil || !ok {
 		return false, err
 	}
-	baseCommonDir, err := worktreeCommonGitDir(ctx, baseDir)
+	baseCommonDir, err := worktreeCommonGitDir(ctx, base.Path)
 	if err != nil {
 		return false, fmt.Errorf("inspect local worktree base: %w", err)
 	}
@@ -2242,6 +2253,7 @@ func (m *Manager) workspaceWorktreeUsesLocalBase(
 func existingWorkspacePersistedBranch(
 	ctx context.Context,
 	gitDir string,
+	remote string,
 	ws *Workspace,
 	currentBranch string,
 	localBase bool,
@@ -2253,7 +2265,7 @@ func existingWorkspacePersistedBranch(
 	if ws.ItemType == db.WorkspaceItemTypePullRequest &&
 		isSyntheticPRWorktreeBranch(ws.ItemNumber, currentBranch) {
 		ok, err := existingWorkspaceHeadMatchesCurrentHead(
-			ctx, gitDir, ws, currentBranch, useMergeRequestHeadRef,
+			ctx, gitDir, remote, ws, currentBranch, useMergeRequestHeadRef,
 		)
 		return currentBranch, ok, err
 	}
@@ -2263,7 +2275,7 @@ func existingWorkspacePersistedBranch(
 	if currentBranch != "" && currentBranch == ws.GitHeadRef {
 		if ws.ItemType == db.WorkspaceItemTypePullRequest {
 			ok, err := existingWorkspaceHeadMatchesCurrentHead(
-				ctx, gitDir, ws, currentBranch, useMergeRequestHeadRef,
+				ctx, gitDir, remote, ws, currentBranch, useMergeRequestHeadRef,
 			)
 			if err != nil || !ok {
 				return "", false, err
@@ -2277,7 +2289,7 @@ func existingWorkspacePersistedBranch(
 		if err != nil || !ok {
 			return "", false, err
 		}
-		startSHA, ok, err := gitRefSHA(ctx, ws.WorktreePath, workspaceStartRef(ws))
+		startSHA, ok, err := gitRefSHA(ctx, ws.WorktreePath, workspaceStartRef(ws, remote))
 		if err != nil || !ok {
 			return "", false, err
 		}
@@ -2291,7 +2303,7 @@ func existingWorkspacePersistedBranch(
 
 func existingWorkspaceHeadMatchesCurrentHead(
 	ctx context.Context,
-	gitDir string,
+	gitDir, remote string,
 	ws *Workspace,
 	currentBranch string,
 	useMergeRequestHeadRef bool,
@@ -2301,7 +2313,7 @@ func existingWorkspaceHeadMatchesCurrentHead(
 		return false, err
 	}
 	expectedRef, err := workspaceFallbackStartRef(
-		ctx, gitDir, ws, useMergeRequestHeadRef,
+		ctx, gitDir, remote, ws, useMergeRequestHeadRef,
 	)
 	if err != nil {
 		return false, err
@@ -2333,29 +2345,29 @@ func (m *Manager) workspaceSetupGitDir(
 	worktreeBasePath string,
 	launchSpec *WorkspaceLaunchSpec,
 	validateCloneRoute func(context.Context) error,
-) (string, bool, error) {
+) (workspaceGitDir, error) {
 	repo, err := m.workspaceRepositoryRef(ctx, ws)
 	if err != nil {
-		return "", false, err
+		return workspaceGitDir{}, err
 	}
 	if launchSpec != nil {
 		repo.ProviderID = launchSpec.Repository.PlatformRepoID
 	}
 	if ws.MRHeadRepo == nil {
 		if strings.TrimSpace(worktreeBasePath) != "" {
-			baseDir, err := ValidateWorktreeBasePath(
+			base, err := ValidateWorktreeBasePath(
 				ctx, worktreeBasePath, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
 				m.allowsInsecureHTTP(ws.Platform, ws.PlatformHost),
 			)
-			return baseDir, err == nil, err
+			return workspaceGitDir{path: base.Path, remote: base.Remote, localBase: true}, err
 		}
-		if baseDir, ok, err := m.localWorktreeBaseDir(ctx, repo); err != nil || ok {
-			return baseDir, ok, err
+		if base, ok, err := m.localWorktreeBaseDir(ctx, repo); err != nil || ok {
+			return workspaceGitDir{path: base.Path, remote: base.Remote, localBase: true}, err
 		}
 	}
 
 	if m.clones == nil {
-		return "", false, fmt.Errorf("clone manager not set")
+		return workspaceGitDir{}, fmt.Errorf("clone manager not set")
 	}
 
 	remoteURL := ""
@@ -2367,7 +2379,7 @@ func (m *Manager) workspaceSetupGitDir(
 			ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
 		)
 		if err != nil {
-			return "", false, err
+			return workspaceGitDir{}, err
 		}
 	}
 	cloneCtx := gitclone.WithRepositoryIdentity(ctx, repo.ProviderID)
@@ -2375,16 +2387,16 @@ func (m *Manager) workspaceSetupGitDir(
 		cloneCtx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName, remoteURL,
 		validateCloneRoute,
 	); err != nil {
-		return "", false, err
+		return workspaceGitDir{}, err
 	}
 
 	cloneDir, err := m.clones.ClonePathForContext(
 		cloneCtx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
 	)
 	if err != nil {
-		return "", false, err
+		return workspaceGitDir{}, err
 	}
-	return cloneDir, false, nil
+	return workspaceGitDir{path: cloneDir, remote: originRemoteName}, nil
 }
 
 func (m *Manager) workspaceCloneRouteValidator(
@@ -2424,9 +2436,9 @@ func (m *Manager) workspaceSetupRemoteURL(
 
 func (m *Manager) localWorktreeBaseDir(
 	ctx context.Context, repo workspaceRepoRef,
-) (string, bool, error) {
+) (WorktreeBase, bool, error) {
 	if m.worktreeBaseResolver == nil {
-		return "", false, nil
+		return WorktreeBase{}, false, nil
 	}
 	raw, ok, err := m.worktreeBaseResolver(ctx, WorktreeBaseRepository{
 		Platform:       repo.Platform,
@@ -2436,20 +2448,20 @@ func (m *Manager) localWorktreeBaseDir(
 		Name:           repo.Name,
 	})
 	if err != nil {
-		return "", false, err
+		return WorktreeBase{}, false, err
 	}
 	raw = strings.TrimSpace(raw)
 	if !ok || raw == "" {
-		return "", false, nil
+		return WorktreeBase{}, false, nil
 	}
-	abs, err := ValidateWorktreeBasePath(
+	base, err := ValidateWorktreeBasePath(
 		ctx, raw, repo.PlatformHost, repo.Owner, repo.Name,
 		m.allowsInsecureHTTP(repo.Platform, repo.PlatformHost),
 	)
 	if err != nil {
-		return "", false, err
+		return WorktreeBase{}, false, err
 	}
-	return abs, true, nil
+	return base, true, nil
 }
 
 func (m *Manager) workspaceRepositoryRef(
@@ -2486,53 +2498,68 @@ func (m *Manager) localWorktreeBaseLockRoot(path string) string {
 	)
 }
 
+// WorktreeBase is the validated local checkout and the remote resolved from its
+// repository identity. Remote is resolved rather than assumed to be origin.
+type WorktreeBase struct {
+	// Path is the canonical filesystem path of the validated checkout.
+	Path string
+	// Remote is resolved from the checkout rather than assumed to be origin.
+	Remote string
+}
+
 // ValidateWorktreeBasePath verifies that path is an existing local Git
-// worktree whose origin remote matches the tracked repository identity.
+// worktree whose resolved remote matches the tracked repository identity.
 func ValidateWorktreeBasePath(
 	ctx context.Context, path, platformHost, owner, name string,
 	allowInsecureHTTP bool,
-) (string, error) {
+) (WorktreeBase, error) {
 	abs, err := filepath.Abs(strings.TrimSpace(path))
 	if err != nil {
-		return "", fmt.Errorf("resolve path: %w", err)
+		return WorktreeBase{}, fmt.Errorf("resolve path: %w", err)
 	}
 	evaluated, err := filepath.EvalSymlinks(abs)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return "", fmt.Errorf("path does not exist: %s", abs)
+			return WorktreeBase{}, fmt.Errorf("path does not exist: %s", abs)
 		}
-		return "", fmt.Errorf("resolve symbolic links: %w", err)
+		return WorktreeBase{}, fmt.Errorf("resolve symbolic links: %w", err)
 	}
 	abs = evaluated
 	stat, err := os.Stat(abs)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return "", fmt.Errorf("path does not exist: %s", abs)
+			return WorktreeBase{}, fmt.Errorf("path does not exist: %s", abs)
 		}
-		return "", fmt.Errorf("stat path: %w", err)
+		return WorktreeBase{}, fmt.Errorf("stat path: %w", err)
 	}
 	if !stat.IsDir() {
-		return "", fmt.Errorf("path is not a directory: %s", abs)
+		return WorktreeBase{}, fmt.Errorf("path is not a directory: %s", abs)
 	}
 	insideWorkTree, err := gitOutput(ctx, abs, "rev-parse", "--is-inside-work-tree")
 	if err != nil {
-		return "", fmt.Errorf("path is not a git worktree: %w", err)
+		return WorktreeBase{}, fmt.Errorf("path is not a git worktree: %w", err)
 	}
 	if strings.TrimSpace(insideWorkTree) != "true" {
-		return "", fmt.Errorf("path is not a git worktree: %s", abs)
+		return WorktreeBase{}, fmt.Errorf("path is not a git worktree: %s", abs)
 	}
 	if err := validateNoExecutableLocalGitConfig(ctx, abs); err != nil {
-		return "", err
+		return WorktreeBase{}, err
 	}
-	if err := validateOriginFetchRefspec(ctx, abs); err != nil {
-		return "", err
-	}
-	if err := validateOriginRemoteURLs(
+	remote, err := resolveWorktreeBaseRemote(
 		ctx, abs, platformHost, owner, name, allowInsecureHTTP,
-	); err != nil {
-		return "", err
+	)
+	if err != nil {
+		return WorktreeBase{}, err
 	}
-	return abs, nil
+	if err := validateBaseRemoteURLs(
+		ctx, abs, remote, platformHost, owner, name, allowInsecureHTTP,
+	); err != nil {
+		return WorktreeBase{}, err
+	}
+	if err := validateBaseFetchRefspec(ctx, abs, remote); err != nil {
+		return WorktreeBase{}, err
+	}
+	return WorktreeBase{Path: abs, Remote: remote}, nil
 }
 
 func (m *Manager) allowsInsecureHTTP(platform, platformHost string) bool {
@@ -2629,20 +2656,69 @@ func localGitConfigKeyMayExecute(key string) bool {
 			strings.HasSuffix(key, ".allow"))
 }
 
-func validateOriginRemoteURLs(
+// Managed-clone call sites pass the origin remote explicitly.
+const originRemoteName = "origin"
+
+func resolveWorktreeBaseRemote(
 	ctx context.Context, dir, platformHost, owner, name string,
 	allowInsecureHTTP bool,
-) error {
-	remoteURLs, err := gitConfigValues(ctx, dir, "remote.origin.url")
+) (string, error) {
+	names, err := gitRemoteNames(ctx, dir)
 	if err != nil {
-		return fmt.Errorf("read origin remote: %w", err)
+		return "", fmt.Errorf("list git remotes: %w", err)
+	}
+	var matches []string
+	for _, remote := range names {
+		remoteURLs, err := gitConfigValues(ctx, dir, "remote."+remote+".url")
+		if err != nil {
+			return "", fmt.Errorf("read %q remote: %w", remote, err)
+		}
+		for _, remoteURL := range remoteURLs {
+			if remoteMatchesRepositoryIdentity(remoteURL, platformHost, owner, name) {
+				matches = append(matches, remote)
+				break
+			}
+		}
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf(
+			"no git remote matches configured repository %q on host %q; inspected remotes: %s",
+			owner+"/"+name, platformHost, strings.Join(names, ", "),
+		)
+	}
+	if len(matches) > 1 {
+		return "", fmt.Errorf(
+			"git remotes %q and %q both match configured repository %q on host %q",
+			matches[0], matches[1], owner+"/"+name, platformHost,
+		)
+	}
+	return matches[0], nil
+}
+
+func remoteMatchesRepositoryIdentity(
+	remoteURL, platformHost, owner, name string,
+) bool {
+	return gitremote.RemoteHost(remoteURL) != "" &&
+		gitremote.RemoteRepoPath(remoteURL) != "" &&
+		gitremote.ValidateRemoteIdentity(gitremote.Identity{
+			Host: platformHost, Owner: owner, Name: name,
+		}, remoteURL) == nil
+}
+
+func validateBaseRemoteURLs(
+	ctx context.Context, dir, remote, platformHost, owner, name string,
+	allowInsecureHTTP bool,
+) error {
+	remoteURLs, err := gitConfigValues(ctx, dir, "remote."+remote+".url")
+	if err != nil {
+		return fmt.Errorf("read %q remote: %w", remote, err)
 	}
 	if len(remoteURLs) == 0 {
-		return fmt.Errorf("read origin remote: no origin URL configured")
+		return fmt.Errorf("read %q remote: no URL configured", remote)
 	}
 	for _, remoteURL := range remoteURLs {
-		if err := validateOriginRemoteURL(
-			remoteURL, platformHost, owner, name, allowInsecureHTTP,
+		if err := validateBaseRemoteURL(
+			remoteURL, remote, platformHost, owner, name, allowInsecureHTTP,
 		); err != nil {
 			return err
 		}
@@ -2650,14 +2726,14 @@ func validateOriginRemoteURLs(
 	return nil
 }
 
-func validateOriginRemoteURL(
-	remoteURL, platformHost, owner, name string,
+func validateBaseRemoteURL(
+	remoteURL, remote, platformHost, owner, name string,
 	allowInsecureHTTP bool,
 ) error {
 	if gitremote.RemoteHost(remoteURL) == "" ||
 		gitremote.RemoteRepoPath(remoteURL) == "" {
 		return fmt.Errorf(
-			"origin remote must include a forge host and repository path",
+			"%q remote must include a forge host and repository path", remote,
 		)
 	}
 	if !originRemoteSchemeAllowed(remoteURL, allowInsecureHTTP) {
@@ -2665,7 +2741,8 @@ func validateOriginRemoteURL(
 		// (http://oauth2:token@host/...) and this error is persisted as
 		// workspace error state and returned through the API.
 		return fmt.Errorf(
-			"origin remote scheme %q is not allowed (host %q)",
+			"%q remote scheme %q is not allowed (host %q)",
+			remote,
 			remoteURLScheme(remoteURL), gitremote.RemoteHost(remoteURL),
 		)
 	}
@@ -2674,7 +2751,7 @@ func validateOriginRemoteURL(
 		Owner: owner,
 		Name:  name,
 	}, remoteURL); err != nil {
-		return fmt.Errorf("origin remote does not match repository: %w", err)
+		return fmt.Errorf("%q remote does not match repository: %w", remote, err)
 	}
 	return nil
 }
@@ -2720,34 +2797,93 @@ func hostIsLoopback(hostport string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
-func validateOriginFetchRefspec(ctx context.Context, dir string) error {
-	values, err := gitConfigValues(ctx, dir, "remote.origin.fetch")
+func remoteTrackingRef(remote, suffix string) string {
+	if strings.TrimSpace(remote) == "" {
+		return ""
+	}
+	return "refs/remotes/" + remote + "/" + suffix
+}
+
+func remoteTrackingGlob(remote string) string {
+	return remoteTrackingRef(remote, "*")
+}
+
+func remoteBaseFetchRefspec(remote string) string {
+	return "+refs/heads/*:" + remoteTrackingGlob(remote)
+}
+
+func remoteShorthandRef(remote, name string) string {
+	return remote + "/" + name
+}
+
+func validateBaseFetchRefspec(ctx context.Context, dir, remote string) error {
+	values, err := gitConfigValues(ctx, dir, "remote."+remote+".fetch")
 	if err != nil {
-		return fmt.Errorf("read origin fetch refspec: %w", err)
+		return fmt.Errorf("read %q fetch refspec: %w", remote, err)
 	}
 	for _, value := range values {
-		if !originFetchRefspecUpdatesOrigin(value) {
+		if !fetchRefspecUpdatesRemote(value, remote) {
 			return fmt.Errorf(
-				"origin fetch refspec %q may update unsafe refs",
-				value,
+				"%q fetch refspec %q may update unsafe refs", remote, value,
 			)
+		}
+	}
+	remotes, err := gitRemoteNames(ctx, dir)
+	if err != nil {
+		return fmt.Errorf("list git remotes: %w", err)
+	}
+	for _, other := range remotes {
+		if other == remote {
+			continue
+		}
+		values, err := gitConfigValues(ctx, dir, "remote."+other+".fetch")
+		if err != nil {
+			return fmt.Errorf("read %q fetch refspec: %w", other, err)
+		}
+		for _, value := range values {
+			destination, ok := fetchRefspecDestination(value)
+			if ok && strings.HasPrefix(destination, remoteTrackingRef(remote, "")) {
+				return fmt.Errorf(
+					"remote %q fetch refspec %q writes into the %q tracking namespace",
+					other, value, remote,
+				)
+			}
 		}
 	}
 	return nil
 }
 
-func originFetchRefspecUpdatesOrigin(value string) bool {
+func fetchRefspecUpdatesRemote(value, remote string) bool {
+	destination, ok := fetchRefspecDestination(value)
+	return ok && remote != "" && strings.HasPrefix(destination, remoteTrackingRef(remote, ""))
+}
+
+func fetchRefspecDestination(value string) (string, bool) {
 	refspec := strings.TrimSpace(value)
 	if refspec == "" || strings.HasPrefix(refspec, "^") {
-		return false
+		return "", false
 	}
 	refspec = strings.TrimPrefix(refspec, "+")
 	src, dst, ok := strings.Cut(refspec, ":")
-	if !ok {
-		return false
+	if !ok || !strings.HasPrefix(src, "refs/heads/") {
+		return "", false
 	}
-	return strings.HasPrefix(src, "refs/heads/") &&
-		strings.HasPrefix(dst, "refs/remotes/origin/")
+	return dst, true
+}
+
+func gitRemoteNames(ctx context.Context, dir string) ([]string, error) {
+	out, err := gitOutput(ctx, dir, "remote")
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for line := range strings.SplitSeq(out, "\n") {
+		if name := strings.TrimSpace(line); name != "" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names, nil
 }
 
 func gitConfigValues(ctx context.Context, dir, key string) ([]string, error) {
@@ -2839,30 +2975,35 @@ type workspaceGitFetchOptions struct {
 	validateRoute func(context.Context) error
 }
 
+type workspaceGitDir struct {
+	path      string
+	remote    string
+	localBase bool
+}
+
 func (m *Manager) addWorktree(
 	ctx context.Context,
-	cloneDir string,
-	refreshBeforeAdd bool,
+	gitDir workspaceGitDir,
 	ws *Workspace,
 	fetchOptions workspaceGitFetchOptions,
 ) (string, error) {
 	var branch string
-	err := m.withRepoLockForGitDir(ctx, cloneDir, func() error {
-		if refreshBeforeAdd {
+	err := m.withRepoLockForGitDir(ctx, gitDir.path, func() error {
+		if gitDir.localBase {
 			if err := runRouteValidatedFetch(
-				ctx, cloneDir, fetchOptions.validateRoute,
+				ctx, gitDir.path, fetchOptions.validateRoute,
 				func() error {
 					return m.fetchWorkspaceBase(
-						ctx, cloneDir, ws.Platform, ws.PlatformHost,
+						ctx, gitDir.path, ws.Platform, ws.PlatformHost,
 						ws.RepoOwner, ws.RepoName,
-						workspaceUsesOriginHead(ws),
+						gitDir.remote, workspaceUsesOriginHead(ws),
 					)
 				},
 			); err != nil {
 				return err
 			}
 		}
-		if err := m.syncWorkspaceBaseBranch(ctx, cloneDir, ws); err != nil {
+		if err := m.syncWorkspaceBaseBranch(ctx, gitDir.path, gitDir.remote, ws); err != nil {
 			return err
 		}
 		if err := m.ensureWorkspacePathAvailable(ctx, ws); err != nil {
@@ -2870,7 +3011,7 @@ func (m *Manager) addWorktree(
 		}
 		var addErr error
 		branch, addErr = m.addWorktreeLocked(
-			ctx, cloneDir, refreshBeforeAdd, ws, fetchOptions,
+			ctx, gitDir, ws, fetchOptions,
 		)
 		if addErr != nil {
 			return addErr
@@ -2884,21 +3025,20 @@ func (m *Manager) addWorktree(
 // hold the per-repo lock for cloneDir before invoking this function.
 func (m *Manager) addWorktreeLocked(
 	ctx context.Context,
-	cloneDir string,
-	localBase bool,
+	gitDir workspaceGitDir,
 	ws *Workspace,
 	fetchOptions workspaceGitFetchOptions,
 ) (string, error) {
 	if workspaceUsesOriginHead(ws) {
-		return m.addIssueWorktree(ctx, cloneDir, ws)
+		return m.addIssueWorktree(ctx, gitDir, ws)
 	}
 	mergeRequestHeadRefFetched := false
 	if ws.MRHeadRepo != nil {
 		if err := runRouteValidatedFetch(
-			ctx, cloneDir, fetchOptions.validateRoute,
+			ctx, gitDir.path, fetchOptions.validateRoute,
 			func() error {
 				return m.fetchWorkspaceMergeRequestHeadRef(
-					ctx, cloneDir, ws, fetchOptions.launchSpec,
+					ctx, gitDir.path, gitDir.remote, ws, fetchOptions.launchSpec,
 				)
 			},
 		); err != nil {
@@ -2906,7 +3046,7 @@ func (m *Manager) addWorktreeLocked(
 		}
 		mergeRequestHeadRefFetched = true
 	}
-	branch, err := m.addPreferredWorktree(ctx, cloneDir, localBase, ws)
+	branch, err := m.addPreferredWorktree(ctx, gitDir, ws)
 	if err == nil {
 		return branch, nil
 	}
@@ -2921,10 +3061,10 @@ func (m *Manager) addWorktreeLocked(
 	useMergeRequestHeadRef := mergeRequestHeadRefFetched
 	if !useMergeRequestHeadRef {
 		fetchHeadErr = runRouteValidatedFetch(
-			ctx, cloneDir, fetchOptions.validateRoute,
+			ctx, gitDir.path, fetchOptions.validateRoute,
 			func() error {
 				return m.fetchWorkspaceMergeRequestHeadRef(
-					ctx, cloneDir, ws, fetchOptions.launchSpec,
+					ctx, gitDir.path, gitDir.remote, ws, fetchOptions.launchSpec,
 				)
 			},
 		)
@@ -2937,7 +3077,7 @@ func (m *Manager) addWorktreeLocked(
 		)
 	}
 	startRef, startRefErr := workspaceFallbackStartRef(
-		ctx, cloneDir, ws, useMergeRequestHeadRef,
+		ctx, gitDir.path, gitDir.remote, ws, useMergeRequestHeadRef,
 	)
 	if startRefErr != nil {
 		return "", fmt.Errorf(
@@ -2946,7 +3086,7 @@ func (m *Manager) addWorktreeLocked(
 		)
 	}
 	branch, fallbackErr := m.addFallbackWorktree(
-		ctx, cloneDir, ws, fallbackBranch, startRef,
+		ctx, gitDir, ws, fallbackBranch, startRef,
 	)
 	if fallbackErr == nil {
 		return branch, nil
@@ -2968,12 +3108,12 @@ func (m *Manager) addWorktreeLocked(
 // rename by hand always beats a setup error with nothing to retry into.
 func (m *Manager) addFallbackWorktree(
 	ctx context.Context,
-	cloneDir string,
+	gitDir workspaceGitDir,
 	ws *Workspace,
 	fallbackBranch, startRef string,
 ) (string, error) {
 	branch, err := m.addFallbackBranchWorktree(
-		ctx, cloneDir, ws, fallbackBranch, startRef,
+		ctx, gitDir, ws, fallbackBranch, startRef,
 	)
 	if err == nil {
 		return branch, nil
@@ -2986,10 +3126,10 @@ func (m *Manager) addFallbackWorktree(
 	// Uniquifying leaves the colliding branch untouched: it may be a live
 	// workspace's checkout or a user branch kenn-forge never created.
 	if uniqueBranch, nameErr := nextAvailableBranchName(
-		ctx, cloneDir, fallbackBranch,
+		ctx, gitDir.path, fallbackBranch,
 	); nameErr == nil {
 		branch, err = m.addFallbackBranchWorktree(
-			ctx, cloneDir, ws, uniqueBranch, startRef,
+			ctx, gitDir, ws, uniqueBranch, startRef,
 		)
 		if err == nil {
 			return branch, nil
@@ -3000,7 +3140,7 @@ func (m *Manager) addFallbackWorktree(
 	}
 
 	if detachErr := m.runOwnedGitWorktreeAdd(
-		ctx, cloneDir, ws, "--detach", startRef,
+		ctx, gitDir.path, ws, "--detach", startRef,
 	); detachErr != nil {
 		return "", fmt.Errorf(
 			"%w; detached checkout failed: %w", fallbackErr, detachErr,
@@ -3016,21 +3156,21 @@ func (m *Manager) addFallbackWorktree(
 
 func (m *Manager) addFallbackBranchWorktree(
 	ctx context.Context,
-	cloneDir string,
+	gitDir workspaceGitDir,
 	ws *Workspace,
 	branch, startRef string,
 ) (string, error) {
 	branchSHA, err := m.runOwnedGitWorktreeAddCreatingBranch(
-		ctx, cloneDir, ws, branch, startRef,
+		ctx, gitDir.path, ws, branch, startRef,
 	)
 	if err != nil {
 		return "", err
 	}
-	if err := configureFallbackBranchUpstream(
-		ctx, cloneDir, ws, branch,
+	if err := configureFallbackBranchUpstreamForGitDir(
+		ctx, gitDir, ws, branch,
 	); err != nil {
 		cleanupErr := cleanupOwnedWorktreeAddOnUpstreamFailure(
-			ctx, cloneDir, ws, branch, branchSHA,
+			ctx, gitDir.path, ws, branch, branchSHA,
 		)
 		return "", errors.Join(
 			fmt.Errorf("configure branch upstream: %w", err), cleanupErr,
@@ -3040,7 +3180,7 @@ func (m *Manager) addFallbackBranchWorktree(
 }
 
 func (m *Manager) addIssueWorktree(
-	ctx context.Context, cloneDir string, ws *Workspace,
+	ctx context.Context, gitDir workspaceGitDir, ws *Workspace,
 ) (string, error) {
 	workspaceBranch := ws.WorkspaceBranch
 	if workspaceBranch == workspaceBranchUnknown {
@@ -3048,15 +3188,15 @@ func (m *Manager) addIssueWorktree(
 	}
 	if workspaceBranch == "" {
 		if err := m.runOwnedGitWorktreeAdd(
-			ctx, cloneDir, ws, ws.GitHeadRef,
+			ctx, gitDir.path, ws, ws.GitHeadRef,
 		); err != nil {
 			return "", err
 		}
 		return "", nil
 	}
-	startRef := workspaceStartRef(ws)
+	startRef := workspaceStartRef(ws, gitDir.remote)
 	if _, err := m.runOwnedGitWorktreeAddCreatingBranch(
-		ctx, cloneDir, ws, workspaceBranch, startRef,
+		ctx, gitDir.path, ws, workspaceBranch, startRef,
 	); err != nil {
 		return "", err
 	}
@@ -3064,18 +3204,18 @@ func (m *Manager) addIssueWorktree(
 }
 
 func (m *Manager) addPreferredWorktree(
-	ctx context.Context, cloneDir string, localBase bool, ws *Workspace,
+	ctx context.Context, gitDir workspaceGitDir, ws *Workspace,
 ) (string, error) {
 	if err := validateLocalBranchName(
-		ctx, cloneDir, ws.GitHeadRef,
+		ctx, gitDir.path, ws.GitHeadRef,
 	); err != nil {
 		return "", err
 	}
 
 	if ws.MRHeadRepo != nil {
 		_, err := m.runOwnedGitWorktreeAddCreatingBranch(
-			ctx, cloneDir, ws,
-			ws.GitHeadRef, workspaceStartRef(ws),
+			ctx, gitDir.path, ws,
+			ws.GitHeadRef, workspaceStartRef(ws, gitDir.remote),
 		)
 		if err != nil {
 			return "", err
@@ -3083,8 +3223,8 @@ func (m *Manager) addPreferredWorktree(
 		return ws.GitHeadRef, nil
 	}
 
-	startRef := workspaceStartRef(ws)
-	startSHA, ok, err := gitRefSHA(ctx, cloneDir, startRef)
+	startRef := workspaceStartRef(ws, gitDir.remote)
+	startSHA, ok, err := gitRefSHA(ctx, gitDir.path, startRef)
 	if err != nil {
 		return "", err
 	}
@@ -3093,23 +3233,23 @@ func (m *Manager) addPreferredWorktree(
 	}
 
 	branchRef := "refs/heads/" + ws.GitHeadRef
-	branchSHA, exists, err := gitRefSHA(ctx, cloneDir, branchRef)
+	branchSHA, exists, err := gitRefSHA(ctx, gitDir.path, branchRef)
 	if err != nil {
 		return "", err
 	}
 	if !exists {
 		branchSHA, err := m.runOwnedGitWorktreeAddCreatingBranch(
-			ctx, cloneDir, ws, ws.GitHeadRef, startRef,
+			ctx, gitDir.path, ws, ws.GitHeadRef, startRef,
 		)
 		if err != nil {
 			return "", err
 		}
 		if err := setBranchUpstream(
 			ctx, ws.WorktreePath, ws.GitHeadRef,
-			"origin", "refs/heads/"+ws.GitHeadRef,
+			originRemoteName, "refs/heads/"+ws.GitHeadRef,
 		); err != nil {
 			cleanupErr := cleanupOwnedWorktreeAddOnUpstreamFailure(
-				ctx, cloneDir, ws, ws.GitHeadRef, branchSHA,
+				ctx, gitDir.path, ws, ws.GitHeadRef, branchSHA,
 			)
 			return "", errors.Join(
 				fmt.Errorf("configure branch upstream: %w", err), cleanupErr,
@@ -3123,8 +3263,8 @@ func (m *Manager) addPreferredWorktree(
 			ws.GitHeadRef, branchSHA, startSHA,
 		)
 	}
-	if localBase {
-		checkedOut, err := localBranchCheckedOut(ctx, cloneDir, ws.GitHeadRef)
+	if gitDir.localBase {
+		checkedOut, err := localBranchCheckedOut(ctx, gitDir.path, ws.GitHeadRef)
 		if err != nil {
 			return "", fmt.Errorf("inspect checked out branch: %w", err)
 		}
@@ -3137,20 +3277,20 @@ func (m *Manager) addPreferredWorktree(
 	}
 
 	if err := m.runOwnedGitWorktreeAdd(
-		ctx, cloneDir, ws, ws.GitHeadRef,
+		ctx, gitDir.path, ws, ws.GitHeadRef,
 	); err != nil {
 		return "", err
 	}
 
-	if !localBase {
+	if !gitDir.localBase {
 		if err := setBranchUpstream(
 			ctx, ws.WorktreePath, ws.GitHeadRef,
-			"origin", "refs/heads/"+ws.GitHeadRef,
+			originRemoteName, "refs/heads/"+ws.GitHeadRef,
 		); err != nil {
 			// Empty branch: the branch pre-existed this workspace and
 			// stays in place; only the worktree is rolled back.
 			cleanupErr := cleanupOwnedWorktreeAddOnUpstreamFailure(
-				ctx, cloneDir, ws, "", "",
+				ctx, gitDir.path, ws, "", "",
 			)
 			return "", errors.Join(
 				fmt.Errorf("configure branch upstream: %w", err), cleanupErr,
@@ -3164,18 +3304,18 @@ func (m *Manager) addPreferredWorktree(
 	return "", nil
 }
 
-func workspaceStartRef(ws *Workspace) string {
+func workspaceStartRef(ws *Workspace, remote string) string {
 	if workspaceUsesOriginHead(ws) {
-		return "origin/HEAD"
+		return remoteShorthandRef(remote, "HEAD")
 	}
 	if ws.MRHeadRepo != nil {
 		return workspaceMergeRequestHeadRef(ws)
 	}
-	return "origin/" + ws.GitHeadRef
+	return remoteShorthandRef(remote, ws.GitHeadRef)
 }
 
 func workspaceFallbackStartRef(
-	ctx context.Context, cloneDir string, ws *Workspace, useMergeRequestHeadRef bool,
+	ctx context.Context, cloneDir, remote string, ws *Workspace, useMergeRequestHeadRef bool,
 ) (string, error) {
 	if useMergeRequestHeadRef && ws.ItemType == db.WorkspaceItemTypePullRequest {
 		ref := workspaceMergeRequestHeadRef(ws)
@@ -3187,7 +3327,7 @@ func workspaceFallbackStartRef(
 			return ref, nil
 		}
 	}
-	return workspaceStartRef(ws), nil
+	return workspaceStartRef(ws, remote), nil
 }
 
 func workspaceMergeRequestHeadRef(ws *Workspace) string {
@@ -3327,11 +3467,25 @@ func configureFallbackBranchUpstream(
 	ws *Workspace,
 	fallbackBranch string,
 ) error {
+	return configureFallbackBranchUpstreamForGitDir(
+		ctx,
+		workspaceGitDir{path: cloneDir, remote: originRemoteName},
+		ws,
+		fallbackBranch,
+	)
+}
+
+func configureFallbackBranchUpstreamForGitDir(
+	ctx context.Context,
+	gitDir workspaceGitDir,
+	ws *Workspace,
+	fallbackBranch string,
+) error {
 	if ws.ItemType != db.WorkspaceItemTypePullRequest || ws.MRHeadRepo != nil {
 		return nil
 	}
 	trackingSHA, ok, err := gitRefSHA(
-		ctx, cloneDir, "refs/remotes/origin/"+ws.GitHeadRef,
+		ctx, gitDir.path, remoteTrackingRef(gitDir.remote, ws.GitHeadRef),
 	)
 	if err != nil {
 		return err
@@ -3348,7 +3502,7 @@ func configureFallbackBranchUpstream(
 	}
 	return setBranchUpstream(
 		ctx, ws.WorktreePath, fallbackBranch,
-		"origin", "refs/heads/"+ws.GitHeadRef,
+		originRemoteName, "refs/heads/"+ws.GitHeadRef,
 	)
 }
 
@@ -3898,22 +4052,22 @@ func (m *Manager) workspaceCleanupGitDir(
 	if err != nil {
 		return "", false, err
 	}
-	if baseDir, ok, err := m.localWorktreeBaseDir(ctx, repo); err != nil || ok {
+	if base, ok, err := m.localWorktreeBaseDir(ctx, repo); err != nil || ok {
 		if err != nil {
-			baseDir, ok = "", false
+			base, ok = WorktreeBase{}, false
 		}
 		if !ok && m.clones == nil {
-			return baseDir, ok, nil
+			return base.Path, ok, nil
 		}
 		if ok {
 			owned, err := gitDirOwnsCleanupWorktree(
-				ctx, baseDir, ws.WorktreePath, ws.ID,
+				ctx, base.Path, ws.WorktreePath, ws.ID,
 			)
 			if err != nil {
 				return "", false, err
 			}
 			if owned {
-				return baseDir, true, nil
+				return base.Path, true, nil
 			}
 		}
 	}
@@ -3953,15 +4107,15 @@ func (m *Manager) workspaceRegisteredCleanupGitDir(
 	if err != nil {
 		return "", false, err
 	}
-	if baseDir, ok, err := m.localWorktreeBaseDir(ctx, repo); err == nil && ok {
+	if base, ok, err := m.localWorktreeBaseDir(ctx, repo); err == nil && ok {
 		stale, err := gitDirHasStaleWorktreeRegistration(
-			ctx, baseDir, ws.WorktreePath,
+			ctx, base.Path, ws.WorktreePath,
 		)
 		if err != nil {
 			return "", false, err
 		}
 		if stale {
-			return baseDir, true, nil
+			return base.Path, true, nil
 		}
 	}
 
@@ -5744,7 +5898,8 @@ func gitArgsWithoutHooks(args ...string) []string {
 func (m *Manager) fetchWorkspaceBase(
 	ctx context.Context,
 	dir, platformName, platformHost, owner, name string,
-	requireOriginHead bool,
+	remote string,
+	requireRemoteHead bool,
 ) error {
 	run := runGitWithoutHooks
 	if m.clones != nil {
@@ -5760,12 +5915,13 @@ func (m *Manager) fetchWorkspaceBase(
 			return nil
 		}
 	}
-	return fetchWorkspaceBaseWithGit(ctx, run, dir, requireOriginHead)
+	return fetchWorkspaceBaseWithGit(ctx, run, dir, remote, requireRemoteHead)
 }
 
 func (m *Manager) fetchWorkspaceMergeRequestHeadRef(
 	ctx context.Context,
 	dir string,
+	remote string,
 	ws *Workspace,
 	launchSpec *WorkspaceLaunchSpec,
 ) error {
@@ -5797,7 +5953,7 @@ func (m *Manager) fetchWorkspaceMergeRequestHeadRef(
 		}
 	}
 	return fetchWorkspaceMergeRequestHeadRefWithGit(
-		ctx, run, runFork, dir, ws, launchSpec,
+		ctx, run, runFork, dir, remote, ws, launchSpec,
 	)
 }
 
@@ -5806,6 +5962,7 @@ func fetchWorkspaceMergeRequestHeadRefWithGit(
 	runBase func(context.Context, string, ...string) error,
 	runFork func(context.Context, string, ...string) error,
 	dir string,
+	remote string,
 	ws *Workspace,
 	launchSpec *WorkspaceLaunchSpec,
 ) error {
@@ -5818,7 +5975,7 @@ func fetchWorkspaceMergeRequestHeadRefWithGit(
 		return runBase(
 			ctx, dir, gitArgsWithoutHooks(
 				"fetch", "--no-tags", "--recurse-submodules=no",
-				"origin", "+"+targetRef+":"+targetRef,
+				remote, "+"+targetRef+":"+targetRef,
 			)...,
 		)
 	case "fork":
@@ -5827,7 +5984,7 @@ func fetchWorkspaceMergeRequestHeadRefWithGit(
 		if err := runBase(
 			ctx, dir, gitArgsWithoutHooks(
 				"fetch", "--no-tags", "--recurse-submodules=no",
-				"origin", "+"+targetRef+":"+targetRef,
+				remote, "+"+targetRef+":"+targetRef,
 			)...,
 		); err == nil {
 			return nil
@@ -5850,7 +6007,8 @@ func fetchWorkspaceBaseWithGit(
 	ctx context.Context,
 	run func(context.Context, string, ...string) error,
 	dir string,
-	requireOriginHead bool,
+	remote string,
+	requireRemoteHead bool,
 ) error {
 	// The clones-backed run bypasses runGitWithoutHooks, so hook
 	// suppression must be applied here as well; on the runGitWithoutHooks
@@ -5861,13 +6019,15 @@ func fetchWorkspaceBaseWithGit(
 	if err := runWithoutHooks(
 		ctx, dir,
 		"fetch", "--prune", "--no-tags", "--recurse-submodules=no",
-		"--negotiation-tip=refs/remotes/origin/*", "origin",
-		"+refs/heads/*:refs/remotes/origin/*",
+		"--negotiation-tip="+remoteTrackingGlob(remote), remote,
+		remoteBaseFetchRefspec(remote),
 	); err != nil {
 		return fmt.Errorf("fetch configured worktree base: %w", err)
 	}
-	if err := refreshWorkspaceBaseOriginHeadWithGit(ctx, runWithoutHooks, dir); err != nil {
-		if !requireOriginHead {
+	if err := refreshWorkspaceBaseRemoteHeadWithGit(
+		ctx, runWithoutHooks, dir, remote,
+	); err != nil {
+		if !requireRemoteHead {
 			return nil
 		}
 		return err
@@ -5876,7 +6036,7 @@ func fetchWorkspaceBaseWithGit(
 }
 
 func (m *Manager) syncWorkspaceBaseBranch(
-	ctx context.Context, dir string, ws *Workspace,
+	ctx context.Context, dir, remote string, ws *Workspace,
 ) error {
 	if ws == nil || ws.ItemType != db.WorkspaceItemTypePullRequest ||
 		ws.Platform == "" || ws.PlatformHost == "" ||
@@ -5909,14 +6069,14 @@ func (m *Manager) syncWorkspaceBaseBranch(
 	if mr == nil || strings.TrimSpace(mr.BaseBranch) == "" {
 		return nil
 	}
-	return syncLocalBaseBranch(ctx, dir, ws.ID, strings.TrimSpace(mr.BaseBranch))
+	return syncLocalBaseBranch(ctx, dir, remote, ws.ID, strings.TrimSpace(mr.BaseBranch))
 }
 
 func syncLocalBaseBranch(
-	ctx context.Context, dir, workspaceID, branch string,
+	ctx context.Context, dir, remote, workspaceID, branch string,
 ) error {
 	localRef := "refs/heads/" + branch
-	remoteRef := "refs/remotes/origin/" + branch
+	remoteRef := remoteTrackingRef(remote, branch)
 	remoteSHA, exists, err := gitRefSHA(ctx, dir, remoteRef)
 	if err != nil {
 		return fmt.Errorf("inspect remote base branch %q: %w", branch, err)
@@ -6022,40 +6182,40 @@ func gitCommitIsAncestor(
 	return false, err
 }
 
-func refreshWorkspaceBaseOriginHeadWithGit(
+func refreshWorkspaceBaseRemoteHeadWithGit(
 	ctx context.Context,
 	run func(context.Context, string, ...string) error,
-	dir string,
+	dir, remote string,
 ) error {
-	setHeadErr := run(ctx, dir, "remote", "set-head", "origin", "-a")
+	setHeadErr := run(ctx, dir, "remote", "set-head", remote, "-a")
 	if setHeadErr == nil {
 		return nil
 	}
-	if originHeadRefReady(ctx, dir) {
+	if remoteHeadRefReady(ctx, dir, remote) {
 		return nil
 	}
 	for _, branch := range []string{"main", "master"} {
-		ref := "refs/remotes/origin/" + branch
+		ref := remoteTrackingRef(remote, branch)
 		if gitRefExists(ctx, dir, ref) {
 			if err := run(
 				ctx, dir, "symbolic-ref",
-				"refs/remotes/origin/HEAD", ref,
+				remoteTrackingRef(remote, "HEAD"), ref,
 			); err != nil {
 				return fmt.Errorf(
-					"set configured worktree base origin/HEAD: %w", err,
+					"set configured worktree base %s/HEAD: %w", remote, err,
 				)
 			}
 			return nil
 		}
 	}
 	return fmt.Errorf(
-		"refresh configured worktree base origin/HEAD: %w", setHeadErr,
+		"refresh configured worktree base %s/HEAD: %w", remote, setHeadErr,
 	)
 }
 
-func originHeadRefReady(ctx context.Context, dir string) bool {
+func remoteHeadRefReady(ctx context.Context, dir, remote string) bool {
 	out, err := gitOutput(
-		ctx, dir, "symbolic-ref", "--quiet", "refs/remotes/origin/HEAD",
+		ctx, dir, "symbolic-ref", "--quiet", remoteTrackingRef(remote, "HEAD"),
 	)
 	if err != nil {
 		return false

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -2790,6 +2790,7 @@ func TestValidateWorktreeBasePathRejectsForeignRemoteWritingBaseNamespace(t *tes
 		"+refs/tags/*:refs/remotes/upstream/tags/*",
 		"+refs/heads/*:refs/remotes/*",
 		"+refs/heads/*:refs/*",
+		"+refs/heads/main:refs/remotes/upstream",
 	} {
 		t.Run(refspec, func(t *testing.T) {
 			assert := assert.New(t)

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -2815,6 +2815,25 @@ func TestValidateWorktreeBasePathRejectsForeignRemoteWritingBaseNamespace(t *tes
 	}
 }
 
+func TestValidateWorktreeBasePathAllowsForeignRemoteWithSimilarNamespace(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	localRepo, _, platformHost := setupForkStyleHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/thing",
+	)
+	runWorkspaceTestGit(
+		t, localRepo, "config", "--add", "remote.origin.fetch",
+		"+refs/heads/*:refs/remotes/upstreamish/*",
+	)
+
+	base, err := ValidateWorktreeBasePath(
+		t.Context(), localRepo, platformHost, "acme", "widget", false,
+	)
+
+	require.NoError(err)
+	assert.Equal("upstream", base.Remote)
+}
+
 func TestValidateWorktreeBasePathRejectsUnsafeCanonicalRemoteName(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -2791,6 +2791,7 @@ func TestValidateWorktreeBasePathRejectsForeignRemoteWritingBaseNamespace(t *tes
 		"+refs/heads/*:refs/remotes/*",
 		"+refs/heads/*:refs/*",
 		"+refs/heads/main:refs/remotes/upstream",
+		"+refs/heads/*:refs/remotes/upstr*",
 	} {
 		t.Run(refspec, func(t *testing.T) {
 			assert := assert.New(t)
@@ -2832,6 +2833,23 @@ func TestValidateWorktreeBasePathRejectsUnsafeCanonicalRemoteName(t *testing.T) 
 	require.Empty(base.Path)
 	require.Error(err)
 	assert.Contains(err.Error(), `git remote name "-bad" is unsafe`)
+}
+
+func TestValidateWorktreeBasePathAllowsUnsafeUnrelatedRemoteName(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	localRepo := setupLocalWorktreeBaseForWorkspaceGitTest(t, "feature/thing")
+	runWorkspaceTestGit(
+		t, localRepo, "config", "--add", "remote.-bad.url",
+		"https://github.com/other/widget.git",
+	)
+
+	base, err := ValidateWorktreeBasePath(
+		t.Context(), localRepo, "github.com", "acme", "widget", false,
+	)
+
+	require.NoError(err)
+	assert.Equal("origin", base.Remote)
 }
 
 func TestValidateWorktreeBasePathRejectsExecutableLocalConfig(t *testing.T) {

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -2788,6 +2788,8 @@ func TestValidateWorktreeBasePathRejectsForeignRemoteWritingBaseNamespace(t *tes
 	for _, refspec := range []string{
 		"+refs/heads/*:refs/remotes/upstream/*",
 		"+refs/tags/*:refs/remotes/upstream/tags/*",
+		"+refs/heads/*:refs/remotes/*",
+		"+refs/heads/*:refs/*",
 	} {
 		t.Run(refspec, func(t *testing.T) {
 			assert := assert.New(t)
@@ -2809,6 +2811,26 @@ func TestValidateWorktreeBasePathRejectsForeignRemoteWritingBaseNamespace(t *tes
 			assert.Contains(err.Error(), `"upstream" tracking namespace`)
 		})
 	}
+}
+
+func TestValidateWorktreeBasePathRejectsUnsafeCanonicalRemoteName(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	localRepo, _, platformHost := setupForkStyleHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/thing",
+	)
+	runWorkspaceTestGit(
+		t, localRepo, "config", "--add", "remote.-bad.url",
+		"https://"+platformHost+"/acme/widget.git",
+	)
+
+	base, err := ValidateWorktreeBasePath(
+		t.Context(), localRepo, platformHost, "acme", "widget", false,
+	)
+
+	require.Empty(base.Path)
+	require.Error(err)
+	assert.Contains(err.Error(), `git remote name "-bad" is unsafe`)
 }
 
 func TestValidateWorktreeBasePathRejectsExecutableLocalConfig(t *testing.T) {

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -2010,6 +2010,40 @@ func TestSetupUsesConfiguredWorktreeBasePath(t *testing.T) {
 	assert.Empty(status)
 }
 
+func TestSetupCreatesPRWorktreeFromForkStyleWorktreeBase(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	localRepo, _, platformHost := setupForkStyleHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/thing",
+	)
+	repoID := seedRepo(t, d, platformHost, "acme", "widget")
+	seedMR(t, d, repoID, 42, "feature/thing")
+	tmuxScript, _ := writeRecorderScript(t)
+	mgr := newTestManager(t, d, t.TempDir())
+	mgr.SetTmuxCommand([]string{tmuxScript})
+	mgr.SetWorktreeBasePathResolver(staticBaseResolver(localRepo))
+
+	ws, err := mgr.Create(t.Context(), "github", platformHost, "acme", "widget", 42)
+	require.NoError(err)
+	require.NoError(mgr.Setup(t.Context(), ws))
+
+	got, err := d.GetWorkspace(t.Context(), ws.ID)
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal("ready", got.Status)
+	assert.Equal("feature/thing", got.WorkspaceBranch)
+	trackingRef := remoteTrackingRef("upstream", "feature/thing")
+	_, exists, err := gitRefSHA(t.Context(), localRepo, trackingRef)
+	require.NoError(err)
+	assert.True(exists)
+	remote, err := gitConfigValue(
+		t.Context(), ws.WorktreePath, "branch.feature/thing.remote",
+	)
+	require.NoError(err)
+	assert.Equal(originRemoteName, remote)
+}
+
 func TestSetupWithOptionsConfirmsRoborevBeforeTerminal(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -2686,11 +2720,89 @@ func TestValidateWorktreeBasePathRejectsLocalRemotes(t *testing.T) {
 			got, err := ValidateWorktreeBasePath(
 				t.Context(), localRepo, "github.com", "acme", "widget", false)
 
-			require.Empty(got)
+			require.Empty(got.Path)
 			require.Error(err)
-			assert.Contains(err.Error(), "origin remote must include a forge host")
+			assert.Contains(err.Error(), "no git remote matches configured repository")
 		})
 	}
+}
+
+func TestValidateWorktreeBasePathResolvesCanonicalRemoteByIdentity(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	localRepo, _, platformHost := setupForkStyleHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/thing",
+	)
+
+	base, err := ValidateWorktreeBasePath(
+		t.Context(), localRepo, platformHost, "acme", "widget", false,
+	)
+
+	require.NoError(err)
+	canonicalLocalRepo, err := filepath.EvalSymlinks(localRepo)
+	require.NoError(err)
+	assert.Equal(canonicalLocalRepo, base.Path)
+	assert.Equal("upstream", base.Remote)
+}
+
+func TestValidateWorktreeBasePathRejectsAmbiguousCanonicalRemotes(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	localRepo, _, platformHost := setupForkStyleHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/thing",
+	)
+	canonicalURL := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo, "remote", "get-url", "upstream",
+	)))
+	runWorkspaceTestGit(t, localRepo, "remote", "add", "mirror", canonicalURL)
+
+	base, err := ValidateWorktreeBasePath(
+		t.Context(), localRepo, platformHost, "acme", "widget", false,
+	)
+
+	require.Empty(base.Path)
+	require.Error(err)
+	assert.Contains(err.Error(), `git remotes "mirror" and "upstream" both match`)
+	assert.NotContains(err.Error(), canonicalURL)
+}
+
+func TestValidateWorktreeBasePathRejectsMissingCanonicalRemote(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	localRepo, _, platformHost := setupForkStyleHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/thing",
+	)
+	runWorkspaceTestGit(t, localRepo, "remote", "remove", "upstream")
+
+	base, err := ValidateWorktreeBasePath(
+		t.Context(), localRepo, platformHost, "acme", "widget", false,
+	)
+
+	require.Empty(base.Path)
+	require.Error(err)
+	assert.Contains(err.Error(), "no git remote matches configured repository")
+	assert.Contains(err.Error(), "origin")
+}
+
+func TestValidateWorktreeBasePathRejectsForeignRemoteWritingBaseNamespace(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	localRepo, _, platformHost := setupForkStyleHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/thing",
+	)
+	runWorkspaceTestGit(
+		t, localRepo, "config", "--add", "remote.origin.fetch",
+		"+refs/heads/*:refs/remotes/upstream/*",
+	)
+
+	base, err := ValidateWorktreeBasePath(
+		t.Context(), localRepo, platformHost, "acme", "widget", false,
+	)
+
+	require.Empty(base.Path)
+	require.Error(err)
+	assert.Contains(err.Error(), `remote "origin" fetch refspec`)
+	assert.Contains(err.Error(), `"upstream" tracking namespace`)
 }
 
 func TestValidateWorktreeBasePathRejectsExecutableLocalConfig(t *testing.T) {
@@ -2735,7 +2847,7 @@ func TestValidateWorktreeBasePathRejectsExecutableLocalConfig(t *testing.T) {
 			got, err := ValidateWorktreeBasePath(
 				t.Context(), localRepo, "github.com", "acme", "widget", false)
 
-			require.Empty(got)
+			require.Empty(got.Path)
 			require.Error(err)
 			assert.Contains(
 				strings.ToLower(err.Error()), strings.ToLower(tt.key),
@@ -2764,10 +2876,10 @@ func TestValidateWorktreeBasePathAcceptsConfiguredHooksPath(t *testing.T) {
 	require.NoError(err)
 	canonicalLocalRepo, err := filepath.EvalSymlinks(localRepo)
 	require.NoError(err)
-	assert.Equal(canonicalLocalRepo, got)
+	assert.Equal(canonicalLocalRepo, got.Path)
 }
 
-func TestValidateWorktreeBasePathRejectsUnsafeOriginSchemes(t *testing.T) {
+func TestValidateWorktreeBasePathRejectsUnsafeBaseRemoteSchemes(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -2802,12 +2914,12 @@ func TestValidateWorktreeBasePathRejectsUnsafeOriginSchemes(t *testing.T) {
 			got, err := ValidateWorktreeBasePath(
 				t.Context(), localRepo, "github.com", "acme", "widget", false)
 
-			require.Empty(got)
+			require.Empty(got.Path)
 			require.Error(err)
 			assert.Contains(
 				err.Error(),
 				fmt.Sprintf(
-					"origin remote scheme %q is not allowed (host %q)",
+					"\"origin\" remote scheme %q is not allowed (host %q)",
 					tt.wantScheme, "github.com",
 				),
 			)
@@ -2834,7 +2946,7 @@ func TestValidateWorktreeBasePathAcceptsLoopbackHTTPOrigin(t *testing.T) {
 	require.NoError(err)
 	canonicalLocalRepo, err := filepath.EvalSymlinks(localRepo)
 	require.NoError(err)
-	require.Equal(canonicalLocalRepo, got)
+	require.Equal(canonicalLocalRepo, got.Path)
 }
 
 func TestValidateWorktreeBasePathAcceptsExplicitlyAllowedHTTPOrigin(t *testing.T) {
@@ -2853,7 +2965,7 @@ func TestValidateWorktreeBasePathAcceptsExplicitlyAllowedHTTPOrigin(t *testing.T
 	require.NoError(err)
 	canonicalLocalRepo, err := filepath.EvalSymlinks(localRepo)
 	require.NoError(err)
-	require.Equal(canonicalLocalRepo, got)
+	require.Equal(canonicalLocalRepo, got.Path)
 }
 
 func TestValidateWorktreeBasePathAcceptsSCPStyleSSHOrigin(t *testing.T) {
@@ -2871,7 +2983,7 @@ func TestValidateWorktreeBasePathAcceptsSCPStyleSSHOrigin(t *testing.T) {
 	require.NoError(err)
 	canonicalLocalRepo, err := filepath.EvalSymlinks(localRepo)
 	require.NoError(err)
-	require.Equal(canonicalLocalRepo, got)
+	require.Equal(canonicalLocalRepo, got.Path)
 }
 
 func TestValidateWorktreeBasePathCanonicalizesSymlinkPath(t *testing.T) {
@@ -2906,12 +3018,12 @@ func TestValidateWorktreeBasePathCanonicalizesSymlinkPath(t *testing.T) {
 				t.Context(), tt.path, "github.com", "acme", "widget", false)
 
 			require.NoError(err)
-			assert.Equal(canonicalLocalRepo, got)
+			assert.Equal(canonicalLocalRepo, got.Path)
 		})
 	}
 }
 
-func TestValidateWorktreeBasePathRejectsAdditionalOriginURLs(t *testing.T) {
+func TestValidateWorktreeBasePathRejectsAdditionalBaseRemoteURLs(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -2924,12 +3036,12 @@ func TestValidateWorktreeBasePathRejectsAdditionalOriginURLs(t *testing.T) {
 	got, err := ValidateWorktreeBasePath(
 		t.Context(), localRepo, "github.com", "acme", "widget", false)
 
-	require.Empty(got)
+	require.Empty(got.Path)
 	require.Error(err)
-	assert.Contains(err.Error(), "origin remote does not match repository")
+	assert.Contains(err.Error(), `"origin" remote does not match repository`)
 }
 
-func TestValidateWorktreeBasePathRejectsUnsafeOriginFetchRefspec(t *testing.T) {
+func TestValidateWorktreeBasePathRejectsUnsafeBaseFetchRefspec(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -2947,13 +3059,13 @@ func TestValidateWorktreeBasePathRejectsUnsafeOriginFetchRefspec(t *testing.T) {
 	got, err := ValidateWorktreeBasePath(
 		t.Context(), localRepo, "github.com", "acme", "widget", false)
 
-	require.Empty(got)
+	require.Empty(got.Path)
 	require.Error(err)
-	assert.Contains(err.Error(), "origin fetch refspec")
+	assert.Contains(err.Error(), "\"origin\" fetch refspec")
 	assert.Contains(err.Error(), "may update unsafe refs")
 }
 
-func TestValidateWorktreeBasePathAcceptsSingleBranchOriginFetchRefspec(t *testing.T) {
+func TestValidateWorktreeBasePathAcceptsSingleBranchBaseFetchRefspec(t *testing.T) {
 	require := require.New(t)
 
 	localRepo := setupLocalWorktreeBaseForWorkspaceGitTest(t, "feature/thing")
@@ -2973,7 +3085,7 @@ func TestValidateWorktreeBasePathAcceptsSingleBranchOriginFetchRefspec(t *testin
 	require.NoError(err)
 	canonicalLocalRepo, err := filepath.EvalSymlinks(localRepo)
 	require.NoError(err)
-	require.Equal(canonicalLocalRepo, got)
+	require.Equal(canonicalLocalRepo, got.Path)
 }
 
 func TestValidateWorktreeBasePathRejectsBareRepositories(t *testing.T) {
@@ -2991,7 +3103,7 @@ func TestValidateWorktreeBasePathRejectsBareRepositories(t *testing.T) {
 	got, err := ValidateWorktreeBasePath(
 		t.Context(), bareRepo, "github.com", "acme", "widget", false)
 
-	require.Empty(got)
+	require.Empty(got.Path)
 	require.Error(err)
 	assert.Contains(err.Error(), "path is not a git worktree")
 }
@@ -3010,7 +3122,7 @@ func TestValidateWorktreeBasePathRejectsExecutableWorktreeConfig(t *testing.T) {
 	got, err := ValidateWorktreeBasePath(
 		t.Context(), localRepo, "github.com", "acme", "widget", false)
 
-	require.Empty(got)
+	require.Empty(got.Path)
 	require.Error(err)
 	assert.Contains(err.Error(), "filter.demo.clean")
 	assert.Contains(err.Error(), "may execute or rewrite git commands")
@@ -3206,7 +3318,7 @@ func TestWorkspaceSetupGitDirRemovesCloneWhenRouteChangesDuringClone(t *testing.
 	routeChanged := errors.New("repository route changed")
 	validations := 0
 
-	_, _, err := manager.workspaceSetupGitDir(
+	_, err := manager.workspaceSetupGitDir(
 		t.Context(), workspace, "", nil,
 		func(context.Context) error {
 			validations++
@@ -3468,8 +3580,8 @@ func TestFetchWorkspaceBaseRequiresOriginHeadOnlyForIssueWorkspaces(t *testing.T
 		"update-ref", "--no-deref", "-d", "refs/remotes/origin/HEAD",
 	)
 
-	require.NoError(fetchWorkspaceBaseWithGit(t.Context(), runGitWithoutHooks, localRepo, false))
-	require.Error(fetchWorkspaceBaseWithGit(t.Context(), runGitWithoutHooks, localRepo, true))
+	require.NoError(fetchWorkspaceBaseWithGit(t.Context(), runGitWithoutHooks, localRepo, "origin", false))
+	require.Error(fetchWorkspaceBaseWithGit(t.Context(), runGitWithoutHooks, localRepo, "origin", true))
 }
 
 func TestAddAndRefreshPRWorktreeFastForwardLocalBaseBranch(t *testing.T) {
@@ -3501,7 +3613,9 @@ func TestAddAndRefreshPRWorktreeFastForwardLocalBaseBranch(t *testing.T) {
 	launchSpec, err := mgr.RequireWorkspaceLaunchSpec(t.Context(), ws)
 	require.NoError(err)
 
-	_, err = mgr.addWorktree(t.Context(), localRepo, true, ws, workspaceGitFetchOptions{
+	_, err = mgr.addWorktree(t.Context(), workspaceGitDir{
+		path: localRepo, remote: originRemoteName, localBase: true,
+	}, ws, workspaceGitFetchOptions{
 		launchSpec: launchSpec,
 	})
 	require.NoError(err)
@@ -3518,7 +3632,7 @@ func TestAddAndRefreshPRWorktreeFastForwardLocalBaseBranch(t *testing.T) {
 	runWorkspaceTestGit(t, remote, "update-server-info")
 
 	_, err = mgr.refreshExistingWorkspaceWorktree(
-		t.Context(), localRepo, ws, launchSpec, nil,
+		t.Context(), localRepo, originRemoteName, ws, launchSpec, nil,
 	)
 	require.NoError(err)
 	localBaseSHA = strings.TrimSpace(string(runWorkspaceTestGit(
@@ -3563,7 +3677,9 @@ func TestAddWorktreeRestoresBaseRefsWhenRouteChangesDuringFetch(t *testing.T) {
 	mgr := newTestManager(t, openTestDB(t), t.TempDir())
 
 	_, err = mgr.addWorktree(
-		t.Context(), localRepo, true, ws, workspaceGitFetchOptions{
+		t.Context(), workspaceGitDir{
+			path: localRepo, remote: originRemoteName, localBase: true,
+		}, ws, workspaceGitFetchOptions{
 			validateRoute: validateRoute,
 		},
 	)
@@ -3612,7 +3728,9 @@ func TestAddWorktreeRestoresPullRefWhenRouteChangesDuringFetch(t *testing.T) {
 	mgr := newTestManager(t, openTestDB(t), t.TempDir())
 
 	_, err = mgr.addWorktreeLocked(
-		t.Context(), localRepo, true, ws, workspaceGitFetchOptions{
+		t.Context(), workspaceGitDir{
+			path: localRepo, remote: originRemoteName, localBase: true,
+		}, ws, workspaceGitFetchOptions{
 			launchSpec:    pullLaunchSpecForWorkspace(ws, "same_repo", ""),
 			validateRoute: validateRoute,
 		},
@@ -3645,7 +3763,7 @@ func TestSyncLocalBaseBranchSkipsCheckedOutAndDivergedBranches(t *testing.T) {
 	runWorkspaceTestGit(t, localRepo, "checkout", "--detach")
 
 	require.NoError(syncLocalBaseBranch(
-		t.Context(), localRepo, "ws-base-sync-safety", branch,
+		t.Context(), localRepo, "origin", "ws-base-sync-safety", branch,
 	))
 	assert.Equal(firstRemoteSHA, strings.TrimSpace(string(runWorkspaceTestGit(
 		t, localRepo, "rev-parse", "refs/heads/main",
@@ -3660,7 +3778,7 @@ func TestSyncLocalBaseBranchSkipsCheckedOutAndDivergedBranches(t *testing.T) {
 	)
 	runWorkspaceTestGit(t, localRepo, "checkout", branch)
 	require.NoError(syncLocalBaseBranch(
-		t.Context(), localRepo, "ws-base-sync-safety", branch,
+		t.Context(), localRepo, "origin", "ws-base-sync-safety", branch,
 	))
 	assert.Equal(firstRemoteSHA, strings.TrimSpace(string(runWorkspaceTestGit(
 		t, localRepo, "rev-parse", "refs/heads/main",
@@ -3682,7 +3800,7 @@ func TestSyncLocalBaseBranchSkipsCheckedOutAndDivergedBranches(t *testing.T) {
 		t, localRepo, "update-ref", "refs/remotes/origin/main", thirdRemoteSHA,
 	)
 	require.NoError(syncLocalBaseBranch(
-		t.Context(), localRepo, "ws-base-sync-safety", branch,
+		t.Context(), localRepo, "origin", "ws-base-sync-safety", branch,
 	))
 	assert.Equal(divergentSHA, strings.TrimSpace(string(runWorkspaceTestGit(
 		t, localRepo, "rev-parse", "refs/heads/main",
@@ -3702,7 +3820,7 @@ func TestSyncLocalBaseBranchSkipsOccupiedRefNamespace(t *testing.T) {
 	runWorkspaceTestGit(t, localRepo, "branch", "main/topic", mainSHA)
 
 	require.NoError(syncLocalBaseBranch(
-		t.Context(), localRepo, "ws-base-sync-namespace", "main",
+		t.Context(), localRepo, "origin", "ws-base-sync-namespace", "main",
 	))
 	_, mainExists, err := gitRefSHA(t.Context(), localRepo, "refs/heads/main")
 	require.NoError(err)
@@ -3754,7 +3872,7 @@ func TestSyncWorkspaceBaseBranchRejectsReplacedRepositoryRoute(t *testing.T) {
 		ItemNumber:   968,
 	}
 
-	err = mgr.syncWorkspaceBaseBranch(t.Context(), localRepo, ws)
+	err = mgr.syncWorkspaceBaseBranch(t.Context(), localRepo, originRemoteName, ws)
 	require.ErrorContains(err, "historical occupants")
 	assert.Equal(localMainSHA, strings.TrimSpace(string(runWorkspaceTestGit(
 		t, localRepo, "rev-parse", "refs/heads/main",
@@ -3772,7 +3890,7 @@ func TestFetchWorkspaceBaseConstrainsNegotiationTips(t *testing.T) {
 	}
 
 	require.NoError(fetchWorkspaceBaseWithGit(
-		t.Context(), run, t.TempDir(), false,
+		t.Context(), run, t.TempDir(), originRemoteName, false,
 	))
 	require.NotEmpty(calls)
 	fetchArgs := calls[0]
@@ -3792,7 +3910,7 @@ func TestFetchWorkspaceBaseDisablesGitHooks(t *testing.T) {
 	}
 
 	require.NoError(fetchWorkspaceBaseWithGit(
-		t.Context(), run, t.TempDir(), false,
+		t.Context(), run, t.TempDir(), originRemoteName, false,
 	))
 	require.Len(calls, 2)
 	for _, args := range calls {
@@ -3803,6 +3921,25 @@ func TestFetchWorkspaceBaseDisablesGitHooks(t *testing.T) {
 	assert.Contains(calls[0], "fetch")
 	assert.Contains(calls[1], "remote")
 	assert.Contains(calls[1], "set-head")
+}
+
+func TestFetchWorkspaceBaseUsesResolvedRemoteNamespace(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var calls [][]string
+	run := func(_ context.Context, _ string, args ...string) error {
+		calls = append(calls, slices.Clone(args))
+		return nil
+	}
+
+	require.NoError(fetchWorkspaceBaseWithGit(
+		t.Context(), run, t.TempDir(), "upstream", true,
+	))
+	require.Len(calls, 2)
+	assert.Contains(calls[0], "--negotiation-tip=refs/remotes/upstream/*")
+	assert.Contains(calls[0], "upstream")
+	assert.Contains(calls[0], "+refs/heads/*:refs/remotes/upstream/*")
+	assert.Equal([]string{"remote", "set-head", "upstream", "-a"}, calls[1][2:])
 }
 
 func TestCleanupPreservesExistingWorktreeWhenConfiguredBaseChanges(t *testing.T) {
@@ -4508,7 +4645,7 @@ func TestAddPreferredWorktreeRejectsUnsafeBranchName(t *testing.T) {
 	}
 
 	_, err := mgr.addPreferredWorktree(
-		t.Context(), cloneDir, false, ws,
+		t.Context(), workspaceGitDir{path: cloneDir, remote: originRemoteName}, ws,
 	)
 	require.Error(err)
 	require.Contains(err.Error(), "invalid branch name")
@@ -4565,7 +4702,7 @@ func TestAddWorktreeUsesFallbackWhenLocalBasePreferredBranchCheckedOut(t *testin
 	}
 
 	gotBranch, err := mgr.addWorktreeLocked(
-		t.Context(), localRepo, true, ws, workspaceGitFetchOptions{},
+		t.Context(), workspaceGitDir{path: localRepo, remote: originRemoteName, localBase: true}, ws, workspaceGitFetchOptions{},
 	)
 
 	require.NoError(err)
@@ -4627,7 +4764,7 @@ func TestAddWorktreeFallbackBranchTracksPRHeadBranch(t *testing.T) {
 	mgr := newTestManager(t, openTestDB(t), t.TempDir())
 
 	branch, err := mgr.addWorktreeLocked(
-		t.Context(), cloneDir, false, ws, workspaceGitFetchOptions{},
+		t.Context(), workspaceGitDir{path: cloneDir, remote: originRemoteName}, ws, workspaceGitFetchOptions{},
 	)
 
 	require.NoError(err)
@@ -4672,7 +4809,7 @@ func TestAddWorktreeLockedRecordsOwnershipBeforeReturning(t *testing.T) {
 	mgr := newTestManager(t, openTestDB(t), t.TempDir())
 
 	_, err := mgr.addWorktreeLocked(
-		t.Context(), cloneDir, false, ws, workspaceGitFetchOptions{},
+		t.Context(), workspaceGitDir{path: cloneDir, remote: originRemoteName}, ws, workspaceGitFetchOptions{},
 	)
 	require.NoError(err)
 	owned, err := workspaceRegistrationMatches(
@@ -4773,7 +4910,7 @@ func TestAddWorktreeUniquifiesFallbackBranchWhenSyntheticNameTaken(t *testing.T)
 	mgr := newTestManager(t, openTestDB(t), t.TempDir())
 
 	branch, err := mgr.addWorktreeLocked(
-		t.Context(), cloneDir, false, ws, workspaceGitFetchOptions{},
+		t.Context(), workspaceGitDir{path: cloneDir, remote: originRemoteName}, ws, workspaceGitFetchOptions{},
 	)
 
 	require.NoError(err)
@@ -4850,7 +4987,7 @@ func TestAddWorktreeFallsBackToDetachedWorktreeWhenBranchNamesExhausted(
 	mgr := newTestManager(t, openTestDB(t), t.TempDir())
 
 	branch, err := mgr.addWorktreeLocked(
-		t.Context(), cloneDir, false, ws, workspaceGitFetchOptions{},
+		t.Context(), workspaceGitDir{path: cloneDir, remote: originRemoteName}, ws, workspaceGitFetchOptions{},
 	)
 
 	require.NoError(err)
@@ -4897,7 +5034,7 @@ func TestAddWorktreeUnknownHeadRepoDoesNotTrackMatchingOriginBranch(t *testing.T
 	require.NoError(err)
 
 	_, err = mgr.addWorktreeLocked(
-		t.Context(), cloneDir, false, ws, workspaceGitFetchOptions{
+		t.Context(), workspaceGitDir{path: cloneDir, remote: originRemoteName}, ws, workspaceGitFetchOptions{
 			launchSpec: pullLaunchSpecForWorkspace(ws, "unknown", ""),
 		},
 	)
@@ -4948,7 +5085,7 @@ func TestAddWorktreeLocalBaseFetchesPullRefWhenHeadBranchDeleted(t *testing.T) {
 	}
 
 	gotBranch, err := mgr.addWorktree(
-		t.Context(), localRepo, true, ws, workspaceGitFetchOptions{
+		t.Context(), workspaceGitDir{path: localRepo, remote: originRemoteName, localBase: true}, ws, workspaceGitFetchOptions{
 			launchSpec: pullLaunchSpecForWorkspace(ws, "same_repo", ""),
 		},
 	)
@@ -5001,7 +5138,7 @@ func TestAddWorktreeLocalBaseIgnoresStalePullRefWhenFetchFails(t *testing.T) {
 	}
 
 	gotBranch, err := mgr.addWorktree(
-		t.Context(), localRepo, true, ws, workspaceGitFetchOptions{
+		t.Context(), workspaceGitDir{path: localRepo, remote: originRemoteName, localBase: true}, ws, workspaceGitFetchOptions{
 			launchSpec: pullLaunchSpecForWorkspace(ws, "same_repo", ""),
 		},
 	)
@@ -5037,7 +5174,7 @@ func TestLocalBaseExistingPRBranchIsNotDeletedOnCleanup(t *testing.T) {
 	}
 
 	managedBranch, err := mgr.addWorktreeLocked(
-		t.Context(), localRepo, true, ws, workspaceGitFetchOptions{},
+		t.Context(), workspaceGitDir{path: localRepo, remote: originRemoteName, localBase: true}, ws, workspaceGitFetchOptions{},
 	)
 	require.NoError(err)
 	require.Empty(managedBranch)
@@ -5076,7 +5213,7 @@ func TestLocalBaseExistingPRBranchPreservesUpstream(t *testing.T) {
 	}
 
 	managedBranch, err := mgr.addWorktreeLocked(
-		t.Context(), localRepo, true, ws, workspaceGitFetchOptions{},
+		t.Context(), workspaceGitDir{path: localRepo, remote: originRemoteName, localBase: true}, ws, workspaceGitFetchOptions{},
 	)
 
 	require.NoError(err)
@@ -5171,7 +5308,7 @@ func TestAddPreferredWorktreeHeadRepoRouting(t *testing.T) {
 			)
 			require.NoError(err)
 
-			branch, err := mgr.addPreferredWorktree(t.Context(), cloneDir, false, ws)
+			branch, err := mgr.addPreferredWorktree(t.Context(), workspaceGitDir{path: cloneDir, remote: originRemoteName}, ws)
 			require.NoError(err)
 			assert.Equal(tt.headBranch, branch)
 
@@ -5241,7 +5378,7 @@ func TestAddWorktreeGitLabForkMRFetchesHeadBeforePreferredBranch(t *testing.T) {
 	mgr := newTestManager(t, openTestDB(t), t.TempDir())
 
 	branch, err := mgr.addWorktreeLocked(
-		t.Context(), cloneDir, false, ws, workspaceGitFetchOptions{
+		t.Context(), workspaceGitDir{path: cloneDir, remote: originRemoteName}, ws, workspaceGitFetchOptions{
 			launchSpec: pullLaunchSpecForWorkspace(ws, "fork", forkRemote),
 		},
 	)
@@ -5289,7 +5426,7 @@ func TestAddWorktreeMergedSameRepoPRUsesPullRefWhenHeadBranchDeleted(
 	mgr := newTestManager(t, openTestDB(t), t.TempDir())
 
 	branch, err := mgr.addWorktreeLocked(
-		t.Context(), cloneDir, false, ws, workspaceGitFetchOptions{
+		t.Context(), workspaceGitDir{path: cloneDir, remote: originRemoteName}, ws, workspaceGitFetchOptions{
 			launchSpec: pullLaunchSpecForWorkspace(ws, "same_repo", ""),
 		},
 	)
@@ -5343,7 +5480,7 @@ func TestAddWorktreeGitLabMRUsesMergeRequestRefWhenHeadBranchDeleted(
 	mgr := newTestManager(t, openTestDB(t), t.TempDir())
 
 	branch, err := mgr.addWorktreeLocked(
-		t.Context(), cloneDir, false, ws, workspaceGitFetchOptions{
+		t.Context(), workspaceGitDir{path: cloneDir, remote: originRemoteName}, ws, workspaceGitFetchOptions{
 			launchSpec: pullLaunchSpecForWorkspace(ws, "same_repo", ""),
 		},
 	)
@@ -5391,7 +5528,7 @@ func TestAddWorktreeGitLabMRFetchesSpecificMergeRequestRef(t *testing.T) {
 	mgr := newTestManager(t, openTestDB(t), t.TempDir())
 
 	branch, err := mgr.addWorktreeLocked(
-		t.Context(), cloneDir, false, ws, workspaceGitFetchOptions{
+		t.Context(), workspaceGitDir{path: cloneDir, remote: originRemoteName}, ws, workspaceGitFetchOptions{
 			launchSpec: pullLaunchSpecForWorkspace(ws, "same_repo", ""),
 		},
 	)
@@ -5676,6 +5813,19 @@ func setupHTTPWorktreeBaseForWorkspaceGitTest(
 	runWorkspaceTestGit(
 		t, repo, "symbolic-ref",
 		"refs/remotes/origin/HEAD", "refs/remotes/origin/main",
+	)
+	return repo, remote, platformHost
+}
+
+func setupForkStyleHTTPWorktreeBaseForWorkspaceGitTest(
+	t *testing.T, branch string,
+) (repo, remote, platformHost string) {
+	t.Helper()
+	repo, remote, platformHost = setupHTTPWorktreeBaseForWorkspaceGitTest(t, branch)
+	runWorkspaceTestGit(t, repo, "remote", "rename", "origin", "upstream")
+	runWorkspaceTestGit(
+		t, repo, "remote", "add", "origin",
+		"https://"+platformHost+"/forker/widget.git",
 	)
 	return repo, remote, platformHost
 }
@@ -7517,7 +7667,7 @@ func TestIssueRetryCleansLeakedUnknownBranchAndUsesIssueBranch(t *testing.T) {
 	require.NoError(err)
 	assert.False(exists)
 
-	branch, err := mgr.addIssueWorktree(t.Context(), cloneDir, ws)
+	branch, err := mgr.addIssueWorktree(t.Context(), workspaceGitDir{path: cloneDir, remote: originRemoteName}, ws)
 	require.NoError(err)
 	assert.Equal(ws.GitHeadRef, branch)
 
@@ -8242,7 +8392,7 @@ func TestManagerAddWorktreeAcquiresRepoLock(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		_, err := mgr.addWorktree(
-			t.Context(), cloneDir, false, ws, workspaceGitFetchOptions{},
+			t.Context(), workspaceGitDir{path: cloneDir, remote: originRemoteName}, ws, workspaceGitFetchOptions{},
 		)
 		done <- err
 	}()
@@ -8285,7 +8435,7 @@ func TestManagerAddWorktreeRechecksOccupiedPathAfterWaitingForLock(t *testing.T)
 	done := make(chan error, 1)
 	go func() {
 		_, err := mgr.addWorktree(
-			t.Context(), cloneDir, false, ws, workspaceGitFetchOptions{},
+			t.Context(), workspaceGitDir{path: cloneDir, remote: originRemoteName}, ws, workspaceGitFetchOptions{},
 		)
 		done <- err
 	}()
@@ -8344,7 +8494,7 @@ func TestAddPreferredWorktreeRemovesBranchCreatedByFailedAdd(t *testing.T) {
 	))
 	mgr := newTestManager(t, openTestDB(t), t.TempDir())
 
-	_, err := mgr.addPreferredWorktree(t.Context(), cloneDir, false, ws)
+	_, err := mgr.addPreferredWorktree(t.Context(), workspaceGitDir{path: cloneDir, remote: originRemoteName}, ws)
 
 	require.Error(err)
 	contents, err := os.ReadFile(filepath.Join(ws.WorktreePath, "keep.txt"))
@@ -8800,7 +8950,7 @@ func TestSyncWorkspaceBaseBranchSurvivesQueuedReconciliationWriter(t *testing.T)
 	mgr := NewManager(d, t.TempDir())
 	go func() {
 		syncDone <- mgr.syncWorkspaceBaseBranch(
-			context.Background(), ws.WorktreePath, ws,
+			context.Background(), ws.WorktreePath, originRemoteName, ws,
 		)
 	}()
 	deadline := time.Now().Add(5 * time.Second)

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -2785,24 +2785,30 @@ func TestValidateWorktreeBasePathRejectsMissingCanonicalRemote(t *testing.T) {
 }
 
 func TestValidateWorktreeBasePathRejectsForeignRemoteWritingBaseNamespace(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	localRepo, _, platformHost := setupForkStyleHTTPWorktreeBaseForWorkspaceGitTest(
-		t, "feature/thing",
-	)
-	runWorkspaceTestGit(
-		t, localRepo, "config", "--add", "remote.origin.fetch",
+	for _, refspec := range []string{
 		"+refs/heads/*:refs/remotes/upstream/*",
-	)
+		"+refs/tags/*:refs/remotes/upstream/tags/*",
+	} {
+		t.Run(refspec, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			localRepo, _, platformHost := setupForkStyleHTTPWorktreeBaseForWorkspaceGitTest(
+				t, "feature/thing",
+			)
+			runWorkspaceTestGit(
+				t, localRepo, "config", "--add", "remote.origin.fetch", refspec,
+			)
 
-	base, err := ValidateWorktreeBasePath(
-		t.Context(), localRepo, platformHost, "acme", "widget", false,
-	)
+			base, err := ValidateWorktreeBasePath(
+				t.Context(), localRepo, platformHost, "acme", "widget", false,
+			)
 
-	require.Empty(base.Path)
-	require.Error(err)
-	assert.Contains(err.Error(), `remote "origin" fetch refspec`)
-	assert.Contains(err.Error(), `"upstream" tracking namespace`)
+			require.Empty(base.Path)
+			require.Error(err)
+			assert.Contains(err.Error(), `remote "origin" fetch refspec`)
+			assert.Contains(err.Error(), `"upstream" tracking namespace`)
+		})
+	}
 }
 
 func TestValidateWorktreeBasePathRejectsExecutableLocalConfig(t *testing.T) {


### PR DESCRIPTION
A checkout created by `gh repo fork --clone` can now be used as `worktree_base_path`. Forge resolves the canonical fetch remote by repository URL identity, threads that remote through validation and synchronization, and keeps workspace branch upstreams on `origin` so contributor pushes retain the stock fork workflow.

Ambiguous canonical remotes and fetch refspecs that overlap the canonical tracking namespace still fail closed. Managed clones remain origin-only.

This brings [rodboev/forge#8](https://github.com/rodboev/forge/pull/8) into forge proper with the contributor commits preserved.

Refs #681
