### PR TITLE
fix: keep macOS shell prompts on the correct cursor column

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,6 +433,9 @@ jobs:
       - name: Run Unicode-normalized daemon lifecycle test
         run: go test ./cmd/kenn-forge -run 'TestDaemonRestartTreatsConfigAliasesAsSameIdentityE2E/unicode-normalization' -shuffle=on
 
+      - name: Run macOS PTY owner shell locale test
+        run: go test ./internal/workspace/localruntime -run '^TestManagerPtyOwnerShellCharacterLocale$' -shuffle=on
+
   race:
     name: go test -race
     runs-on: ${{ github.repository == 'kenn-io/forge' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -253,9 +253,9 @@ still exists.
 - Every tmux client attach must force UTF-8; service launchers may omit locale
   variables, causing tmux to replace non-ASCII output before WebSocket transport
   (`internal/workspace/localruntime/tmux_launcher.go::tmuxAttachSessionCommand`).
-- On macOS, a shell pane with no configured `LANG`, `LC_ALL`, or `LC_CTYPE` must
+- On macOS, tmux and PTY-owner shells with no configured `LANG`, `LC_ALL`, or `LC_CTYPE` must
   default `LC_CTYPE` to UTF-8 without overriding an explicit locale; launchd can
-  otherwise leave zsh with incorrect Unicode prompt widths (`internal/workspace/localruntime/tmux_launcher.go::tmuxEnvPolicy.environmentForOS`).
+  otherwise leave zsh with incorrect Unicode prompt widths (`internal/workspace/localruntime/shell_environment.go::shellCharacterLocaleDefault`).
 - Forge's dedicated tmux server owns global passthrough, SIXEL, and mouse mode;
   live changes clear pane overrides, while custom servers receive passthrough
   only on Forge-owned panes and only while graphics are enabled

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -253,6 +253,9 @@ still exists.
 - Every tmux client attach must force UTF-8; service launchers may omit locale
   variables, causing tmux to replace non-ASCII output before WebSocket transport
   (`internal/workspace/localruntime/tmux_launcher.go::tmuxAttachSessionCommand`).
+- On macOS, a shell pane with no configured `LANG`, `LC_ALL`, or `LC_CTYPE` must
+  default `LC_CTYPE` to UTF-8 without overriding an explicit locale; launchd can
+  otherwise leave zsh with incorrect Unicode prompt widths (`internal/workspace/localruntime/tmux_launcher.go::tmuxEnvPolicy.environmentForOS`).
 - Forge's dedicated tmux server owns global passthrough, SIXEL, and mouse mode;
   live changes clear pane overrides, while custom servers receive passthrough
   only on Forge-owned panes and only while graphics are enabled

--- a/internal/ptyowner/runtime/runtime.go
+++ b/internal/ptyowner/runtime/runtime.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -23,6 +24,7 @@ type Owner interface {
 		cwd string,
 		command []string,
 		stripEnvVars []string,
+		extraEnv map[string]string,
 	) (PTY, error)
 	Stop(ctx context.Context, session string) error
 }
@@ -84,6 +86,7 @@ func (o owner) Start(
 	cwd string,
 	command []string,
 	stripEnvVars []string,
+	extraEnv map[string]string,
 ) (PTY, error) {
 	if o.client == nil {
 		return nil, errors.New("pty owner runtime is unavailable")
@@ -106,6 +109,9 @@ func (o owner) Start(
 	)
 	// Build a fresh per-launch client rather than copying o.client: the
 	// shared client carries a mutex guarding its reloadable strip set.
+	env := map[string]string{}
+	maps.Copy(env, extraEnv)
+	env[agentactivity.RuntimeSessionKeyEnv] = session
 	client := ptyowner.Client{
 		Root:        o.client.Root,
 		ExePath:     o.client.ExePath,
@@ -113,9 +119,7 @@ func (o owner) Start(
 		ManagerPath: o.client.ManagerPath,
 		InProcess:   o.client.InProcess,
 		Command:     resolvedCommand,
-		ExtraEnv: map[string]string{
-			agentactivity.RuntimeSessionKeyEnv: session,
-		},
+		ExtraEnv:    env,
 		StripEnvVars: append(
 			o.client.StripEnvVarsSnapshot(), stripEnvVars...,
 		),

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -1761,6 +1761,7 @@ func (m *fakeRuntimeOwner) Start(
 	_ string,
 	_ []string,
 	stripEnvVars []string,
+	_ map[string]string,
 ) (ptyownerruntime.PTY, error) {
 	m.startedStripEnvVars = append([]string(nil), stripEnvVars...)
 	m.pty = &fakeRuntimePTY{

--- a/internal/server/workspaceapi/initial_message_test.go
+++ b/internal/server/workspaceapi/initial_message_test.go
@@ -341,6 +341,7 @@ func (o *initialMessagePTYOwner) Start(
 	_ string,
 	_ []string,
 	_ []string,
+	_ map[string]string,
 ) (ptyownerruntime.PTY, error) {
 	pty := &initialMessagePTY{
 		output: make(chan []byte, 8), done: make(chan struct{}),

--- a/internal/server/workspaceapi/runtime_token_test.go
+++ b/internal/server/workspaceapi/runtime_token_test.go
@@ -82,7 +82,7 @@ func (missingTokenRuntimePtyOwner) Attach(context.Context, string) (ptyownerrunt
 }
 
 func (missingTokenRuntimePtyOwner) Start(
-	context.Context, string, string, []string, []string,
+	context.Context, string, string, []string, []string, map[string]string,
 ) (ptyownerruntime.PTY, error) {
 	return nil, fmt.Errorf("resolve runtime token: %w", tokenauth.ErrMissingToken)
 }

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -1272,6 +1272,44 @@ func TestManagerLaunchPassesStripEnvVarsToPtyOwner(t *testing.T) {
 	assert.Equal([]string{"WORKSPACE_TOKEN"}, backend.startedStripEnvVars)
 }
 
+func TestManagerPtyOwnerShellCharacterLocale(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS shell locale default")
+	}
+	requirePTYAvailable(t)
+	for _, tt := range []struct {
+		name   string
+		kind   LaunchTargetKind
+		locale string
+		want   string
+	}{
+		{name: "shell default", kind: LaunchTargetPlainShell, want: "UTF-8"},
+		{name: "explicit shell locale", kind: LaunchTargetPlainShell, locale: "C", want: "C"},
+		{name: "agent unchanged", kind: LaunchTargetAgent, want: ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("LANG", "")
+			t.Setenv("LC_ALL", "")
+			t.Setenv("LC_CTYPE", tt.locale)
+			cwd := t.TempDir()
+			mgr := NewManager(withTestPtyOwnerRuntime(t, Options{
+				Targets: []LaunchTarget{{
+					Key: "test-shell", Kind: tt.kind, Available: true,
+					Command: []string{"/bin/sh", "-c", `printf '%s' "$LC_CTYPE" > locale; read line`},
+				}},
+			}))
+			t.Cleanup(mgr.Shutdown)
+			info, err := mgr.Launch(t.Context(), "ws-locale", cwd, "test-shell")
+			require.NoError(t, err)
+			assert.Empty(t, info.TmuxSession)
+			require.Eventually(t, func() bool {
+				data, err := os.ReadFile(filepath.Join(cwd, "locale"))
+				return err == nil && string(data) == tt.want
+			}, 2*time.Second, 10*time.Millisecond)
+		})
+	}
+}
+
 func TestManagerUpdateStripEnvVarsPreservesPreviousNamesForFutureLaunches(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -2614,6 +2652,7 @@ func (f *fakeRuntimePtyOwner) Start(
 	cwd string,
 	command []string,
 	stripEnvVars []string,
+	_ map[string]string,
 ) (ptyownerruntime.PTY, error) {
 	f.starts++
 	f.startedSession = session

--- a/internal/workspace/localruntime/ptyowner_runtime.go
+++ b/internal/workspace/localruntime/ptyowner_runtime.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
+	"runtime"
 
 	"github.com/cenkalti/backoff/v7"
 	ptyownerruntime "go.kenn.io/forge/internal/ptyowner/runtime"
@@ -50,7 +52,13 @@ func startPtyOwnerSession(
 	if len(command) == 0 || command[0] == "" {
 		return nil, errors.New("session command is empty")
 	}
-	ptySession, err := owner.Start(ctx, info.Key, cwd, command, extraStripVars)
+	var extraEnv map[string]string
+	if info.Kind == LaunchTargetPlainShell {
+		if locale := shellCharacterLocaleDefault(os.Environ(), runtime.GOOS); locale != "" {
+			extraEnv = map[string]string{"LC_CTYPE": locale}
+		}
+	}
+	ptySession, err := owner.Start(ctx, info.Key, cwd, command, extraStripVars, extraEnv)
 	if err != nil {
 		return nil, fmt.Errorf("start pty owner: %w", err)
 	}

--- a/internal/workspace/localruntime/shell_environment.go
+++ b/internal/workspace/localruntime/shell_environment.go
@@ -1,0 +1,22 @@
+package localruntime
+
+import "strings"
+
+// launchd services can start without a locale. zsh then measures Unicode
+// prompts as US-ASCII and reports the wrong cursor column.
+func shellCharacterLocaleDefault(env []string, goos string) string {
+	if goos != "darwin" {
+		return ""
+	}
+	for _, kv := range env {
+		key, value, _ := strings.Cut(kv, "=")
+		if value == "" {
+			continue
+		}
+		switch key {
+		case "LANG", "LC_ALL", "LC_CTYPE":
+			return ""
+		}
+	}
+	return "UTF-8"
+}

--- a/internal/workspace/localruntime/tmux_launcher.go
+++ b/internal/workspace/localruntime/tmux_launcher.go
@@ -169,10 +169,38 @@ func (p tmuxEnvPolicy) environment(
 	baseEnv []string,
 	extraStripVars []string,
 ) []string {
+	return p.environmentForOS(baseEnv, extraStripVars, runtime.GOOS)
+}
+
+func (p tmuxEnvPolicy) environmentForOS(
+	baseEnv []string,
+	extraStripVars []string,
+	goos string,
+) []string {
 	if p.preserveShellEnv {
-		return sessionEnvironment(baseEnv, extraStripVars)
+		env := sessionEnvironment(baseEnv, extraStripVars)
+		// launchd services can start without a locale. zsh then measures
+		// Unicode prompts as US-ASCII and reports the wrong cursor column.
+		if goos == "darwin" && !hasCharacterLocale(env) {
+			return append(env, "LC_CTYPE=UTF-8")
+		}
+		return env
 	}
 	return tmuxSessionEnvironment(baseEnv, extraStripVars)
+}
+
+func hasCharacterLocale(env []string) bool {
+	for _, kv := range env {
+		key, value, found := strings.Cut(kv, "=")
+		if !found || value == "" {
+			continue
+		}
+		switch key {
+		case "LANG", "LC_ALL", "LC_CTYPE":
+			return true
+		}
+	}
+	return false
 }
 
 type tmuxLauncher struct {

--- a/internal/workspace/localruntime/tmux_launcher.go
+++ b/internal/workspace/localruntime/tmux_launcher.go
@@ -179,28 +179,12 @@ func (p tmuxEnvPolicy) environmentForOS(
 ) []string {
 	if p.preserveShellEnv {
 		env := sessionEnvironment(baseEnv, extraStripVars)
-		// launchd services can start without a locale. zsh then measures
-		// Unicode prompts as US-ASCII and reports the wrong cursor column.
-		if goos == "darwin" && !hasCharacterLocale(env) {
-			return append(env, "LC_CTYPE=UTF-8")
+		if locale := shellCharacterLocaleDefault(env, goos); locale != "" {
+			return append(env, "LC_CTYPE="+locale)
 		}
 		return env
 	}
 	return tmuxSessionEnvironment(baseEnv, extraStripVars)
-}
-
-func hasCharacterLocale(env []string) bool {
-	for _, kv := range env {
-		key, value, found := strings.Cut(kv, "=")
-		if !found || value == "" {
-			continue
-		}
-		switch key {
-		case "LANG", "LC_ALL", "LC_CTYPE":
-			return true
-		}
-	}
-	return false
 }
 
 type tmuxLauncher struct {

--- a/internal/workspace/localruntime/tmux_launcher_test.go
+++ b/internal/workspace/localruntime/tmux_launcher_test.go
@@ -422,6 +422,73 @@ func TestTmuxLauncherShellPolicyPreservesCustomEnvByKey(t *testing.T) {
 	assert.NotContains(paneCommand, "custom-visible-value")
 }
 
+func TestTmuxLauncherShellPolicyDefaultsMacOSCharacterLocale(t *testing.T) {
+	tests := []struct {
+		name    string
+		goos    string
+		env     []string
+		want    string
+		wantSet bool
+	}{
+		{
+			name:    "macOS without a locale",
+			goos:    "darwin",
+			env:     []string{"PATH=/usr/bin"},
+			want:    "LC_CTYPE=UTF-8",
+			wantSet: true,
+		},
+		{
+			name: "macOS with empty locale variables",
+			goos: "darwin",
+			env: []string{
+				"PATH=/usr/bin", "LANG=", "LC_ALL=", "LC_CTYPE=",
+			},
+			want:    "LC_CTYPE=UTF-8",
+			wantSet: true,
+		},
+		{
+			name:    "macOS with LANG",
+			goos:    "darwin",
+			env:     []string{"PATH=/usr/bin", "LANG=en_US.UTF-8"},
+			want:    "LC_CTYPE=UTF-8",
+			wantSet: false,
+		},
+		{
+			name:    "macOS with LC_ALL",
+			goos:    "darwin",
+			env:     []string{"PATH=/usr/bin", "LC_ALL=C"},
+			want:    "LC_CTYPE=UTF-8",
+			wantSet: false,
+		},
+		{
+			name:    "macOS with LC_CTYPE",
+			goos:    "darwin",
+			env:     []string{"PATH=/usr/bin", "LC_CTYPE=C"},
+			want:    "LC_CTYPE=UTF-8",
+			wantSet: false,
+		},
+		{
+			name:    "Linux without a locale",
+			goos:    "linux",
+			env:     []string{"PATH=/usr/bin"},
+			want:    "LC_CTYPE=UTF-8",
+			wantSet: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := tmuxShellEnvPolicy.environmentForOS(tt.env, nil, tt.goos)
+
+			if tt.wantSet {
+				assert.Contains(t, env, tt.want)
+				return
+			}
+			assert.NotContains(t, env, tt.want)
+		})
+	}
+}
+
 func TestTmuxLauncherRejectsUnownedExistingSession(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)


### PR DESCRIPTION
Forge-launched macOS shells now get a UTF-8 character locale when launchd provides no locale. This keeps Unicode prompts such as Starship's `❯` aligned with the terminal cursor in Firefox-based browsers.

- Apply the default to both tmux-backed shells and PTY-owner shells when tmux is unavailable.
- Preserve explicit `LANG`, `LC_ALL`, and `LC_CTYPE` choices and agent environments.
- Leave Linux and other non-macOS shell environments unchanged.
