### PR TITLE
fix: allow MCP handoffs to custom agent targets

### DIFF
--- a/context/mcp-server.md
+++ b/context/mcp-server.md
@@ -103,6 +103,9 @@
   receives a bounded, cancellation-independent read
   (`internal/mcpserver/tools_agent_spawn.go::Server.resolveOrCreatePRWorkspace`,
   `internal/mcpserver/tools_agent_spawn.go::Server.recoverInitialMessageStatus`).
+- Configured agent target keys are not hook agent identities; custom targets
+  must remain launchable and handoffs match the live runtime and target key
+  (`internal/mcpserver/tools_agent_spawn.go::Server.waitForCodingSession`).
 - Agent-session inspection returns live agent runtimes separately from
   hook-authoritative sessions. `hook_observed=false` distinguishes a launched
   runtime awaiting its first hook from a workspace with no agent runtime

--- a/docs/kenn-forge-mcp.md
+++ b/docs/kenn-forge-mcp.md
@@ -103,8 +103,12 @@ deleted before daemon shutdown.
 
 ## Coding-agent handoff
 
-Call `kenn_forge_list_agent_targets` to discover available coding agents. Then
-call `kenn_forge_spawn_workspace_with_agent` with one source:
+Call `kenn_forge_list_agent_targets` to discover configured coding agents,
+including custom targets. Use the returned target key as `agent_target`; it
+does not need to match the agent name reported by hooks. The launched agent
+must report a supported hook session for the handoff to complete.
+
+Call `kenn_forge_spawn_workspace_with_agent` with one source:
 
 - a provider-aware pull request or issue; or
 - a provider-aware repository with an optional ad-hoc branch.

--- a/internal/mcpserver/tools_agent.go
+++ b/internal/mcpserver/tools_agent.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"go.kenn.io/kit/agenthook"
 )
 
 type listAgentTargetsInput struct{}
@@ -74,8 +73,9 @@ type workspaceAgentRuntimeRow struct {
 func (s *Server) registerAgentTools() {
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name: "kenn_forge_list_agent_targets",
-		Description: "List configured launch targets that can report supported coding-agent hook sessions. " +
-			"Unavailable targets remain visible, but command arguments are never returned.",
+		Description: "List configured coding-agent launch targets, including custom targets. " +
+			"Unavailable targets remain visible, but command arguments are never returned. " +
+			"Handoff completion requires the launched runtime to report a supported coding-agent hook session.",
 	}, wrapTool(s.listAgentTargets))
 	mcp.AddTool(s.mcp, &mcp.Tool{
 		Name: "kenn_forge_list_workspace_agent_sessions",
@@ -123,17 +123,10 @@ func (s *Server) listAgentTargets(
 	if err != nil {
 		return listAgentTargetsOutput{}, err
 	}
-	supported := make(map[string]struct{})
-	for _, profile := range agenthook.Profiles() {
-		supported[string(profile.Agent)] = struct{}{}
-	}
 	out := listAgentTargetsOutput{Targets: make([]agentTargetRow, 0)}
 	for index, target := range targets {
 		key := strings.ToLower(strings.TrimSpace(target.Key))
 		if target.Kind != "agent" {
-			continue
-		}
-		if _, ok := supported[key]; !ok {
 			continue
 		}
 		out.Targets = append(out.Targets, agentTargetRow{

--- a/internal/mcpserver/tools_agent_spawn.go
+++ b/internal/mcpserver/tools_agent_spawn.go
@@ -206,7 +206,7 @@ func (s *Server) prepareAgentHandoff(
 	target, ok := findAgentTarget(targets.Targets, in.AgentTarget)
 	if !ok {
 		return Workspace{}, RuntimeSession{}, fmt.Errorf(
-			"agent_target %q is not a supported coding-agent target", in.AgentTarget,
+			"agent_target %q is not a configured coding-agent target", in.AgentTarget,
 		)
 	}
 	if !target.Available {
@@ -575,7 +575,7 @@ func (s *Server) waitForCodingSession(
 		}
 		for _, session := range response.Sessions {
 			if session.RuntimeSessionKey == runtimeSessionKey &&
-				session.TargetKey == targetKey && session.Agent == targetKey {
+				session.TargetKey == targetKey {
 				return session, nil
 			}
 		}

--- a/internal/mcpserver/tools_agent_spawn_test.go
+++ b/internal/mcpserver/tools_agent_spawn_test.go
@@ -63,6 +63,51 @@ func TestSpawnWorkspaceWithAgentCallsDirectServicesAndUsesAuthoritativeEvidence(
 	assert.NotContains(string(raw), `"message_delivered":`)
 }
 
+func TestSpawnWorkspaceWithAgentCustomTargetObservesCanonicalHookAgent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	backend := successfulSpawnBackend("ws-custom", "runtime-custom", "coding-custom")
+	backend.listLaunchTargetsFn = func(context.Context) ([]LaunchTarget, error) {
+		return []LaunchTarget{{Key: "custom-worker", Kind: "agent", Available: true}}, nil
+	}
+	backend.launchWorkspaceRuntimeFn = func(_ context.Context, workspaceID, target string) (RuntimeSession, error) {
+		assert.Equal("ws-custom", workspaceID)
+		assert.Equal("custom-worker", target)
+		return RuntimeSession{Key: "runtime-custom", TargetKey: target, Kind: "agent", Status: "running"}, nil
+	}
+	backend.getWorkspaceRuntimeFn = func(context.Context, string) (WorkspaceRuntime, error) {
+		return WorkspaceRuntime{Sessions: []RuntimeSession{{
+			Key: "runtime-custom", TargetKey: "custom-worker", Kind: "agent", Status: "running",
+		}}}, nil
+	}
+	backend.listWorkspaceAgentSessionsFn = func(context.Context, string) ([]WorkspaceAgentSession, error) {
+		return []WorkspaceAgentSession{
+			{Agent: "codex", SessionID: "a-other-runtime", RuntimeSessionKey: "runtime-other", TargetKey: "custom-worker"},
+			{Agent: "codex", SessionID: "b-other-target", RuntimeSessionKey: "runtime-custom", TargetKey: "other-worker"},
+			{Agent: "codex", SessionID: "coding-custom", RuntimeSessionKey: "runtime-custom", TargetKey: "custom-worker"},
+		}, nil
+	}
+	submissions := 0
+	backend.submitInitialMessageFn = func(_ context.Context, req InitialMessageRequest) (InitialMessageStatus, error) {
+		submissions++
+		assert.Equal("custom-worker", req.TargetKey)
+		return InitialMessageStatus{State: "delivered", MessageBytes: len(req.Message)}, nil
+	}
+	s := newMCPTestServer(t, backend)
+	input := prSpawnInput("start")
+	input.AgentTarget = "custom-worker"
+
+	out, err := s.spawnWorkspaceWithAgent(t.Context(), input)
+
+	require.NoError(err)
+	assert.Equal(1, submissions)
+	assert.Equal("coding_session_observed", out.Stage)
+	require.NotNil(out.CodingSession)
+	assert.Equal("coding-custom", out.CodingSession.SessionID)
+	assert.Equal("codex", out.CodingSession.Agent)
+	assert.Equal("custom-worker", out.CodingSession.TargetKey)
+}
+
 func TestSpawnWorkspaceWithAgentSubmitsPromptBeforeHookObservation(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/mcpserver/tools_agent_test.go
+++ b/internal/mcpserver/tools_agent_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestListAgentTargetsFiltersSupportedHookAgentsWithoutCommands(t *testing.T) {
+func TestListAgentTargetsIncludesCustomAgentsWithoutCommands(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	backend := &fakeBackend{listLaunchTargetsFn: func(context.Context) ([]LaunchTarget, error) {
@@ -27,10 +27,12 @@ func TestListAgentTargetsFiltersSupportedHookAgentsWithoutCommands(t *testing.T)
 	out, err := s.listAgentTargets(t.Context(), listAgentTargetsInput{})
 
 	require.NoError(err)
-	require.Len(out.Targets, 2)
+	require.Len(out.Targets, 4)
 	assert.Equal("codex", out.Targets[0].Key)
 	assert.False(out.Targets[0].Available)
-	assert.Equal("gemini", out.Targets[1].Key)
+	assert.Equal("custom", out.Targets[1].Key)
+	assert.Equal("gemini", out.Targets[2].Key)
+	assert.Equal("opencode", out.Targets[3].Key)
 	raw, err := json.Marshal(out)
 	require.NoError(err)
 	assert.NotContains(string(raw), "command")

--- a/internal/server/workspaceapi/agent_sessions.go
+++ b/internal/server/workspaceapi/agent_sessions.go
@@ -109,7 +109,7 @@ func (s *Handler) ListWorkspaceAgentSessionsService(
 		}
 		if attempt, found := s.initialMessageAttempt(
 			summary.ID, report.RuntimeSessionKey,
-		); found && attempt.TargetKey == live.TargetKey && report.Agent == live.TargetKey {
+		); found && attempt.TargetKey == live.TargetKey {
 			message := initialMessageAttemptResult(attempt)
 			result.InitialMessage = &message
 		}

--- a/internal/server/workspaceapi/agent_sessions_test.go
+++ b/internal/server/workspaceapi/agent_sessions_test.go
@@ -52,7 +52,7 @@ func TestListWorkspaceAgentSessionsProjectsOnlySupportedLiveAgentReports(t *test
 	runtime := localruntime.NewManager(localruntime.Options{
 		Targets: []localruntime.LaunchTarget{
 			{
-				Key: "codex", Label: "Codex", Kind: localruntime.LaunchTargetAgent,
+				Key: "custom-worker", Label: "Custom worker", Kind: localruntime.LaunchTargetAgent,
 				Source: "test", Command: helperCommand, Available: true,
 			},
 			{
@@ -68,7 +68,7 @@ func TestListWorkspaceAgentSessionsProjectsOnlySupportedLiveAgentReports(t *test
 		runtime.StopWorkspace(t.Context(), workspaceID)
 		runtime.Shutdown()
 	})
-	agentRuntime, err := runtime.Launch(ctx, workspaceID, worktree, "codex")
+	agentRuntime, err := runtime.Launch(ctx, workspaceID, worktree, "custom-worker")
 	require.NoError(err)
 	shellRuntime, err := runtime.Launch(ctx, workspaceID, worktree, "shell")
 	require.NoError(err)
@@ -101,7 +101,7 @@ func TestListWorkspaceAgentSessionsProjectsOnlySupportedLiveAgentReports(t *test
 
 	require.NoError(database.UpsertWorkspaceRuntimeSession(ctx, &db.WorkspaceRuntimeSession{
 		WorkspaceID: workspaceID, SessionKey: agentRuntime.Key,
-		TargetKey: "codex", Label: "Codex", Kind: "agent", Scope: "session",
+		TargetKey: "custom-worker", Label: "Custom worker", Kind: "agent", Scope: "session",
 		CreatedAt: agentRuntime.CreatedAt,
 	}))
 	handler := New(Deps{
@@ -110,7 +110,7 @@ func TestListWorkspaceAgentSessionsProjectsOnlySupportedLiveAgentReports(t *test
 	})
 	_, reserved := handler.reserveInitialMessageAttempt(
 		workspaceID, agentRuntime.Key,
-		initialMessageAttempt{TargetKey: "codex", Message: "review this!"},
+		initialMessageAttempt{TargetKey: "custom-worker", Message: "review this!"},
 	)
 	require.True(reserved)
 	handler.finishInitialMessageAttempt(workspaceID, agentRuntime.Key, initialMessageDelivered)
@@ -143,11 +143,12 @@ func TestListWorkspaceAgentSessionsProjectsOnlySupportedLiveAgentReports(t *test
 	require.Len(response.Sessions, 2)
 	assert.Equal("claude", response.Sessions[0].Agent)
 	assert.Equal(agentactivity.StateDone, response.Sessions[0].State)
-	assert.Nil(response.Sessions[0].InitialMessage)
+	require.NotNil(response.Sessions[0].InitialMessage)
+	assert.Equal(initialMessageDelivered, response.Sessions[0].InitialMessage.State)
 	assert.Equal("codex", response.Sessions[1].Agent)
 	assert.Equal("shared-session", response.Sessions[1].SessionID)
 	assert.Equal(agentRuntime.Key, response.Sessions[1].RuntimeSessionKey)
-	assert.Equal("codex", response.Sessions[1].TargetKey)
+	assert.Equal("custom-worker", response.Sessions[1].TargetKey)
 	assert.Equal(agentactivity.StateWorking, response.Sessions[1].State)
 	assert.Equal(time.UTC, response.Sessions[1].UpdatedAt.Location())
 	require.NotNil(response.Sessions[1].InitialMessage)

--- a/internal/server/workspacetest/workspace_agent_activity_test.go
+++ b/internal/server/workspacetest/workspace_agent_activity_test.go
@@ -102,7 +102,10 @@ func TestWorkspaceAgentActivityFlowsThroughHTTPResponsesE2E(t *testing.T) {
 	require.NotNil(sessionsResponse.JSON200)
 	require.NotNil(sessionsResponse.JSON200.Sessions)
 	require.Len(sessionsResponse.JSON200.Sessions, 1)
-	assert.Nil(sessionsResponse.JSON200.Sessions[0].InitialMessage)
+	require.NotNil(sessionsResponse.JSON200.Sessions[0].InitialMessage)
+	assert.Equal("delivered", sessionsResponse.JSON200.Sessions[0].InitialMessage.State)
+	assert.Equal("hook-agent", sessionsResponse.JSON200.Sessions[0].InitialMessage.TargetKey)
+	assert.Equal(int64(11), sessionsResponse.JSON200.Sessions[0].InitialMessage.MessageBytes)
 
 	getResponse, err := fixture.client.HTTP.GetWorkspaceWithResponse(ctx, ws.Id)
 	require.NoError(err)


### PR DESCRIPTION
MCP can now launch custom agent targets configured in Forge. Previously, it only accepted target keys that matched a built-in hook agent name.

Handoffs and initial-message status now match the live runtime and configured target, allowing a custom target to report its underlying agent name, such as `codex`. Handoff completion still requires a supported hook report from that runtime.
