### PR TITLE
feat: make PR stacks easier to navigate in the sidebar

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -942,6 +942,9 @@ action, or the two fight and the control renders the inverse of its real state.
 
 Not every visibility control means "remove this entity entirely."
 
+- PR stack trees stay inside the active filters and grouping; a filtered-out root
+  must not reappear as context. Keyboard navigation follows rendered stack rows.
+  (`frontend/src/lib/stores/pulls.svelte.ts::getSidebarRows`)
 - Controls that toggle detail visibility should preserve the parent row unless
   the feature explicitly removes that category from the result set.
 - Activity's Commits filter controls top-level default-branch commits only; it

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -946,6 +946,9 @@ Not every visibility control means "remove this entity entirely."
   must not reappear as context. Stack collapse affects keyboard order; repository
   and status group collapse retain their existing navigation behavior.
   (`frontend/src/lib/stores/pulls.svelte.ts::getSidebarRows`)
+- Stack roots align with ordinary PRs; all children share one shallow indent.
+  Use a shared stack tint and trailing disclosure to avoid implying a parent PR
+  above the root. (`frontend/src/lib/components/sidebar/PullList.svelte::pullRows`)
 - Stack expansion belongs to the stack across status-group fragments; fragment
   counts describe only matching members. (`frontend/src/lib/stores/pulls.svelte.ts::toggleStack`)
 - Collapsing a selected stack child keeps its detail open and anchors keyboard

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -943,8 +943,13 @@ action, or the two fight and the control renders the inverse of its real state.
 Not every visibility control means "remove this entity entirely."
 
 - PR stack trees stay inside the active filters and grouping; a filtered-out root
-  must not reappear as context. Keyboard navigation follows rendered stack rows.
+  must not reappear as context. Stack collapse affects keyboard order; repository
+  and status group collapse retain their existing navigation behavior.
   (`frontend/src/lib/stores/pulls.svelte.ts::getSidebarRows`)
+- Stack expansion belongs to the stack across status-group fragments; fragment
+  counts describe only matching members. (`frontend/src/lib/stores/pulls.svelte.ts::toggleStack`)
+- Collapsing a selected stack child keeps its detail open and anchors keyboard
+  movement at its visible root. (`frontend/src/lib/stores/pulls.svelte.ts::getNavigationIndex`)
 - Controls that toggle detail visibility should preserve the parent row unless
   the feature explicitly removes that category from the result set.
 - Activity's Commits filter controls top-level default-branch commits only; it

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -8460,7 +8460,12 @@ components:
           description: Number of visible pull requests in the stack
           format: int64
           type: integer
+        stack_id:
+          description: Stable local stack identity
+          format: int64
+          type: integer
       required:
+        - stack_id
         - position
         - size
       type: object

--- a/frontend/src/App.pull-stack-tree.browser.svelte.ts
+++ b/frontend/src/App.pull-stack-tree.browser.svelte.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { page } from "vite-plus/test/browser";
+import { mountBrowserApp, resetKeyboardModuleState, type MountedBrowserApp } from "./test/browserAppHarness.js";
+import { createMockApiFetch, jsonResponse, type MockRouteOverride } from "./test/mockApiFetch.js";
+import type { PullRequest } from "./lib/api/types.js";
+
+let mounted: MountedBrowserApp | null = null;
+let routes: MockRouteOverride;
+
+beforeEach(async () => {
+  localStorage.clear();
+  await page.viewport(1280, 900);
+  const api = createMockApiFetch();
+  const response = await api.fetch("/api/v1/pulls");
+  const defaults: PullRequest[] = await response.json();
+  const base = defaults[0]!;
+  const titles = [
+    "Extract request validation",
+    "Add validation to the API",
+    "Show validation errors",
+    "Update release notes",
+  ];
+  const members = titles.map((Title, index) => ({
+    ...base,
+    ID: 800 + index,
+    Number: index + 1,
+    Title,
+    Author: "user-a",
+    AuthorDisplayName: "User A",
+    stack: index < 3 ? { stack_id: 71, position: index + 1, size: 3 } : undefined,
+  }));
+  routes = (req) => {
+    if (req.method !== "GET") return null;
+    if (req.url.pathname === "/api/v1/pulls") return jsonResponse([members[2], members[3], members[1], members[0]]);
+    const number = Number(req.url.pathname.match(/\/pulls\/github\/[^/]+\/[^/]+\/(\d+)$/)?.[1]);
+    const pr = members.find((member) => member.Number === number);
+    if (!pr) return null;
+    return jsonResponse({
+      merge_request: pr,
+      events: [],
+      repo: pr.repo,
+      repo_owner: pr.repo_owner,
+      repo_name: pr.repo_name,
+      platform_host: pr.platform_host,
+      worktree_links: [],
+      detail_loaded: true,
+    });
+  };
+});
+
+afterEach(async () => {
+  mounted?.unmount();
+  mounted = null;
+  localStorage.clear();
+  await resetKeyboardModuleState();
+});
+
+function rowTitles(): string[] {
+  return [...document.querySelectorAll(".pull-list .list-body .pull-item .title-text")].map(
+    (element) => element.textContent?.trim() ?? "",
+  );
+}
+
+describe("PR sidebar stack tree", () => {
+  it("toggles from the filter menu, expands without navigation, and remembers the view", async () => {
+    mounted = await mountBrowserApp("/pulls", { overrides: [routes] });
+    await vi.waitFor(() => expect(rowTitles()).toHaveLength(4));
+    await page.elementLocator(document.querySelector(".pull-list .compact-filter-menu button")!).click();
+    await page.getByRole("button", { name: "Stack tree", exact: true }).click();
+    await vi.waitFor(() => expect(rowTitles()).toEqual(["Extract request validation", "Update release notes"]));
+    const path = window.location.pathname;
+    await page.getByRole("button", { name: "Expand stack at #1: 3 PRs in stack" }).click();
+    await vi.waitFor(() =>
+      expect(rowTitles()).toEqual([
+        "Extract request validation",
+        "Add validation to the API",
+        "Show validation errors",
+        "Update release notes",
+      ]),
+    );
+    expect(window.location.pathname).toBe(path);
+    const sidebar = document.querySelector<HTMLElement>(".pull-list .list-body")!;
+    expect(sidebar.scrollWidth).toBeLessThanOrEqual(sidebar.clientWidth);
+    await page.getByRole("button", { name: "Collapse stack at #1: 3 PRs in stack" }).click();
+    await vi.waitFor(() => expect(rowTitles()).toHaveLength(2));
+    mounted.unmount();
+    mounted = await mountBrowserApp("/pulls", { overrides: [routes] });
+    await expect.element(page.getByRole("button", { name: "Expand stack at #1: 3 PRs in stack" })).toBeVisible();
+  });
+
+  it("reveals a deep-linked member and lets the user collapse it", async () => {
+    localStorage.setItem("kenn-forge:pullStackTree", "1");
+    mounted = await mountBrowserApp("/pulls/github/acme/widgets/2", { overrides: [routes] });
+    await expect.element(page.getByRole("button", { name: "Collapse stack at #1: 3 PRs in stack" })).toBeVisible();
+    await vi.waitFor(() =>
+      expect(document.querySelector(".pull-list .list-body .pull-item.selected .title-text")?.textContent).toBe(
+        "Add validation to the API",
+      ),
+    );
+    await page.getByRole("button", { name: "Collapse stack at #1: 3 PRs in stack" }).click();
+    await vi.waitFor(() => expect(rowTitles()).toEqual(["Extract request validation", "Update release notes"]));
+  });
+});

--- a/frontend/src/App.pull-stack-tree.browser.svelte.ts
+++ b/frontend/src/App.pull-stack-tree.browser.svelte.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import { page } from "vite-plus/test/browser";
 import { mountBrowserApp, resetKeyboardModuleState, type MountedBrowserApp } from "./test/browserAppHarness.js";
 import { createMockApiFetch, jsonResponse, type MockRouteOverride } from "./test/mockApiFetch.js";
+import { navigate } from "./lib/stores/router.svelte.js";
 import type { PullRequest } from "./lib/api/types.js";
 
 let mounted: MountedBrowserApp | null = null;
@@ -88,7 +89,23 @@ describe("PR sidebar stack tree", () => {
     await expect.element(page.getByRole("button", { name: "Expand stack at #1: 3 PRs in stack" })).toBeVisible();
   });
 
-  it("reveals a deep-linked member and lets the user collapse it", async () => {
+  it.each([340, 520])("resets the stack view with a %i-pixel sidebar", async (width) => {
+    localStorage.setItem("kenn-forge-sidebar-width", String(width));
+    localStorage.setItem("kenn-forge:pullStackTree", "1");
+    mounted = await mountBrowserApp("/pulls", { overrides: [routes] });
+    await vi.waitFor(() => expect(rowTitles()).toHaveLength(2));
+    if (width === 340) {
+      await page.elementLocator(document.querySelector(".pull-list .compact-filter-menu button")!).click();
+      await page.getByRole("button", { name: "Reset view", exact: true }).click();
+    } else {
+      await page.getByRole("button", { name: "PR filters", exact: true }).click();
+      await page.getByRole("button", { name: "Clear filters", exact: true }).click();
+    }
+    await vi.waitFor(() => expect(rowTitles()).toHaveLength(4));
+    expect(localStorage.getItem("kenn-forge:pullStackTree")).toBe("0");
+  });
+
+  it("reveals a deep-linked member again after leaving Pulls and returning", async () => {
     localStorage.setItem("kenn-forge:pullStackTree", "1");
     mounted = await mountBrowserApp("/pulls/github/acme/widgets/2", { overrides: [routes] });
     await expect.element(page.getByRole("button", { name: "Collapse stack at #1: 3 PRs in stack" })).toBeVisible();
@@ -99,5 +116,10 @@ describe("PR sidebar stack tree", () => {
     );
     await page.getByRole("button", { name: "Collapse stack at #1: 3 PRs in stack" }).click();
     await vi.waitFor(() => expect(rowTitles()).toEqual(["Extract request validation", "Update release notes"]));
+    navigate("/activity");
+    await vi.waitFor(() => expect(document.querySelector(".pull-list")).toBeNull());
+    window.history.back();
+    await expect.element(page.getByRole("button", { name: "Collapse stack at #1: 3 PRs in stack" })).toBeVisible();
+    await vi.waitFor(() => expect(rowTitles()).toContain("Add validation to the API"));
   });
 });

--- a/frontend/src/App.pull-stack-tree.browser.svelte.ts
+++ b/frontend/src/App.pull-stack-tree.browser.svelte.ts
@@ -80,6 +80,16 @@ describe("PR sidebar stack tree", () => {
       ]),
     );
     expect(window.location.pathname).toBe(path);
+    const rootRow = document.querySelector<HTMLElement>(".stack-row--root .pull-item")!;
+    const childRows = [...document.querySelectorAll<HTMLElement>(".stack-row--member .pull-item")];
+    const ordinaryRow = document.querySelector<HTMLElement>(
+      ".stack-row:not(.stack-row--root):not(.stack-row--member) .pull-item",
+    )!;
+    expect(rootRow.getBoundingClientRect().left).toBe(ordinaryRow.getBoundingClientRect().left);
+    expect(childRows[0]!.getBoundingClientRect().left).toBeGreaterThan(rootRow.getBoundingClientRect().left);
+    expect(childRows[1]!.getBoundingClientRect().left).toBe(childRows[0]!.getBoundingClientRect().left);
+    expect(getComputedStyle(rootRow).backgroundColor).not.toBe(getComputedStyle(ordinaryRow).backgroundColor);
+
     const sidebar = document.querySelector<HTMLElement>(".pull-list .list-body")!;
     expect(sidebar.scrollWidth).toBeLessThanOrEqual(sidebar.clientWidth);
     await page.getByRole("button", { name: "Collapse stack at #1: 3 PRs in stack" }).click();

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -920,6 +920,8 @@
       }
     }
 
+    if (route.page !== "pulls") stores.pulls.clearSelection();
+
     if (route.page === "pulls") {
       if (
         "selected" in route &&

--- a/frontend/src/lib/api/generated/models/stackPlacementResponse.ts
+++ b/frontend/src/lib/api/generated/models/stackPlacementResponse.ts
@@ -7,4 +7,6 @@ export interface StackPlacementResponse {
   position: number;
   /** Number of visible pull requests in the stack */
   size: number;
+  /** Stable local stack identity */
+  stack_id: number;
 }

--- a/frontend/src/lib/app-stores.svelte.ts
+++ b/frontend/src/lib/app-stores.svelte.ts
@@ -96,6 +96,8 @@ export function createAppStores(options: AppStoreOptions): AppStoreComposition {
   pullsOpts.optimisticDetailStarUpdate = (ref, number, starred, envelopeTick) => {
     detailStarProjection.current?.(ref, number, starred, envelopeTick);
   };
+  pullsOpts.getGroupByWorkflow = () => grouping.getGroupingMode() === "byWorkflow";
+  pullsOpts.getUseWorkspaceActivityForRecency = () => activityStore.getUseWorkspaceActivityForRecency();
   const pullsStore = createPullsStore(pullsOpts);
 
   const syncStore = createSyncStore({

--- a/frontend/src/lib/components/sidebar/PullItem.test.ts
+++ b/frontend/src/lib/components/sidebar/PullItem.test.ts
@@ -294,7 +294,7 @@ describe("PullItem kanban status", () => {
   });
 
   it("shows the stack position and size when the PR belongs to a stack", () => {
-    renderItem(mkPR({ stack: { position: 4, size: 7 } }));
+    renderItem(mkPR({ stack: { stack_id: 1, position: 4, size: 7 } }));
 
     const indicator = screen.getByLabelText("Stacked: 4/7");
     expect(indicator.textContent?.trim()).toBe("4/7");

--- a/frontend/src/lib/components/sidebar/PullList.svelte
+++ b/frontend/src/lib/components/sidebar/PullList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
   import { Effect } from "effect";
   import { pollWhileVisible } from "../../effect/poll-while-visible.js";
   import { onDestroy, untrack } from "svelte";
@@ -96,7 +97,7 @@
 
   let searchInput = $state(pulls.getSearchQuery() ?? "");
   let searchExecution: AppExecution<void, never> | null = null;
-  const visiblePulls = $derived(pulls.getDisplayOrderPRs());
+  const visiblePulls = $derived(pulls.getFilteredPulls());
   const repoLabelFormatter = $derived(
     createRepoLabelFormatter(
       visiblePulls.map((pr) => ({
@@ -165,6 +166,7 @@
   function resetCompactView(): void {
     pulls.clearLocalFilters();
     grouping.setGroupingMode("byRepo");
+    pulls.setStackTree(false);
     grouping.setHideOrgName(false);
     if (pulls.getFilterState() !== "open") {
       pulls.setFilterState("open");
@@ -247,8 +249,14 @@
       ],
     },
     {
-      title: "Visibility",
+      title: "View",
       items: [
+        {
+          id: "stack-tree",
+          label: "Stack tree",
+          active: pulls.getStackTree(),
+          onSelect: () => pulls.setStackTree(!pulls.getStackTree()),
+        },
         {
           id: "hide-org-name",
           label: "Hide org name",
@@ -266,7 +274,8 @@
     pulls.getFilterState() !== "open"
       || groupingMode !== "byRepo"
       || pulls.getLocalFilterCount() > 0
-      || grouping.getHideOrgName(),
+      || grouping.getHideOrgName()
+      || pulls.getStackTree(),
   );
   const localViewFilterCount = $derived(
     pulls.getLocalFilterCount() + Number(grouping.getHideOrgName()),
@@ -378,7 +387,8 @@
   const selectedVisiblePR = $derived.by(() => {
     const sel = pulls.getSelectedPR();
     if (sel === null) return null;
-    const pr = visiblePulls.find((p) => pullMatchesSelection(p, sel));
+    const items = selectedPRGroup?.items ?? visiblePulls;
+    const pr = pulls.getSidebarRows(items).find((row) => pullMatchesSelection(row.pr, sel))?.pr;
     if (!pr) return null;
     // Collapsed grouped modes hide the selected PR row, so the files tab
     // renders the fallback file list instead of losing the diff sidebar.
@@ -414,6 +424,67 @@
     return pr.worktree_links.some((l) => l.worktree_key === key);
   });
 </script>
+
+{#snippet pullRows(items: PullRequest[], showRepo: boolean)}
+  {#each pulls.getSidebarRows(items) as row (row.pr.ID)}
+    {@const pr = row.pr}
+    {@const prRef = routeRefForPull(pr)}
+    {@const prSelected = isSelected(prRef)}
+    <div
+      class="stack-row"
+      class:stack-row--member={row.depth > 0}
+      class:stack-row--root={row.memberCount > 0}
+      style:--stack-depth={Math.min(row.depth, 3)}
+    >
+      {#if row.memberCount > 0}
+        {@const countLabel = row.memberCount === pr.stack?.size
+          ? `${row.memberCount} PRs in stack`
+          : `${row.memberCount} of ${pr.stack?.size} PRs in this view`}
+        <div class="stack-control">
+          {#if row.memberCount > 1}
+            <button
+              type="button"
+              class="stack-toggle"
+              aria-expanded={row.expanded}
+              aria-label={`${row.expanded ? "Collapse" : "Expand"} stack at #${pr.Number}: ${countLabel}`}
+              title={countLabel}
+              onclick={() => pulls.toggleStack(row.stackKey, row.expanded)}
+            >
+              <ChevronDownIcon size={12} class={row.expanded ? "" : "stack-chevron--collapsed"} aria-hidden="true" />
+              <span>{row.memberCount}</span>
+            </button>
+          {:else}
+            <span class="stack-partial" title={countLabel} aria-label={countLabel}>1/{pr.stack?.size}</span>
+          {/if}
+        </div>
+      {/if}
+      <div class="stack-row-content">
+        {#if row.memberCount > 0 && pr.stack && (pr.stack.position > 1 || row.memberCount < pr.stack.size)}
+          <span class="stack-context">{row.memberCount} of {pr.stack.size} PRs in this view{pr.stack.position > 1 ? ` · starts at ${pr.stack.position}/${pr.stack.size}` : ""}</span>
+        {/if}
+        <PullItem
+          {pr}
+          repoLabel={repoLabelFormatter.format({
+            provider: pr.repo.provider,
+            platformHost: pr.repo.platform_host,
+            owner: pr.repo.owner,
+            name: pr.repo.name,
+            repoPath: pr.repo.repo_path,
+          })}
+          {showRepo}
+          selected={prSelected}
+          {importAction}
+          onclick={() => handleSelect(prRef)}
+        />
+        {#if showSelectedDiffSidebar && prSelected && _getDetailTab() === "files"}
+          <div class="diff-files-wrap">
+            <DiffSidebar showCommits={false} />
+          </div>
+        {/if}
+      </div>
+    </div>
+  {/each}
+{/snippet}
 
 <div class="pull-list">
   <div class="filter-bar" class:filter-bar--compact={useCompactFilters}>
@@ -457,7 +528,7 @@
       <FilterDropdown
         label="PR filters"
         title="PR filters"
-        active={localViewFilterCount > 0}
+        active={localViewFilterCount > 0 || pulls.getStackTree()}
         badgeCount={localViewFilterCount}
         sections={localFilterSections}
         resetLabel="Clear filters"
@@ -547,55 +618,11 @@
             {collapsed}
             onclick={() => collapsedRepos.toggle("pulls", group.collapseKey)}
           >
-              {#each group.items as pr (pr.ID)}
-                {@const prRef = routeRefForPull(pr)}
-                {@const prSelected = isSelected(prRef)}
-                <PullItem
-                  {pr}
-                  repoLabel={repoLabelFormatter.format({
-                    provider: pr.repo.provider,
-                    platformHost: pr.repo.platform_host,
-                    owner: pr.repo.owner,
-                    name: pr.repo.name,
-                    repoPath: pr.repo.repo_path,
-                  })}
-                  showRepo={group.showRepo}
-                  selected={prSelected}
-                  {importAction}
-                  onclick={() => handleSelect(prRef)}
-                />
-                {#if showSelectedDiffSidebar && prSelected && _getDetailTab() === "files"}
-                  <div class="diff-files-wrap">
-                    <DiffSidebar showCommits={false} />
-                  </div>
-                {/if}
-              {/each}
+            {@render pullRows(group.items, group.showRepo)}
           </GroupedSidebarSection>
         {/each}
       {:else}
-        {#each visiblePulls as pr (pr.ID)}
-          {@const prRef = routeRefForPull(pr)}
-          {@const prSelected = isSelected(prRef)}
-          <PullItem
-            {pr}
-            repoLabel={repoLabelFormatter.format({
-              provider: pr.repo.provider,
-              platformHost: pr.repo.platform_host,
-              owner: pr.repo.owner,
-              name: pr.repo.name,
-              repoPath: pr.repo.repo_path,
-            })}
-            showRepo={true}
-            selected={prSelected}
-            {importAction}
-            onclick={() => handleSelect(prRef)}
-          />
-          {#if showSelectedDiffSidebar && prSelected && _getDetailTab() === "files"}
-            <div class="diff-files-wrap">
-              <DiffSidebar showCommits={false} />
-            </div>
-          {/if}
-        {/each}
+        {@render pullRows(visiblePulls, true)}
       {/if}
     {/if}
   </ScrollBox>
@@ -614,6 +641,71 @@
 </div>
 
 <style>
+  .stack-row {
+    display: flex;
+    min-width: 0;
+  }
+
+  .stack-row-content {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .stack-row--member {
+    margin-left: calc(16px + var(--stack-depth) * 12px);
+    border-left: 1px solid var(--border-default);
+  }
+
+  .stack-control {
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    width: 28px;
+    flex-shrink: 0;
+    padding-top: 8px;
+  }
+
+  .stack-toggle {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-1);
+    width: 28px;
+    min-height: 40px;
+    color: var(--text-secondary);
+    font-size: var(--font-size-2xs);
+    font-variant-numeric: tabular-nums;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+  }
+
+  .stack-toggle:hover {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
+  }
+
+  .stack-toggle:focus-visible {
+    outline: 2px solid var(--accent-blue);
+    outline-offset: -2px;
+  }
+
+  .stack-toggle :global(.stack-chevron--collapsed) {
+    transform: rotate(-90deg);
+  }
+
+  .stack-partial {
+    color: var(--text-muted);
+    font-size: var(--font-size-2xs);
+  }
+
+  .stack-context {
+    display: block;
+    padding: 6px 12px 0;
+    color: var(--text-muted);
+    font-size: var(--font-size-2xs);
+  }
+
   .pull-list {
     display: flex;
     flex-direction: column;
@@ -749,7 +841,7 @@
 
   .state-toggle {
     display: flex;
-    gap: 2px;
+    gap: var(--space-1);
     background: var(--bg-inset);
     border-radius: 6px;
     padding: 2px;
@@ -826,7 +918,7 @@
   }
   .group-toggle {
     display: flex;
-    gap: 2px;
+    gap: var(--space-1);
     background: var(--bg-inset);
     border-radius: 6px;
     padding: 2px;

--- a/frontend/src/lib/components/sidebar/PullList.svelte
+++ b/frontend/src/lib/components/sidebar/PullList.svelte
@@ -176,6 +176,7 @@
 
   function clearLocalViewFilters(): void {
     pulls.clearLocalFilters();
+    pulls.setStackTree(false);
     pulls.loadPulls();
     grouping.setHideOrgName(false);
   }

--- a/frontend/src/lib/components/sidebar/PullList.svelte
+++ b/frontend/src/lib/components/sidebar/PullList.svelte
@@ -435,30 +435,7 @@
       class="stack-row"
       class:stack-row--member={row.depth > 0}
       class:stack-row--root={row.memberCount > 0}
-      style:--stack-depth={Math.min(row.depth, 3)}
     >
-      {#if row.memberCount > 0}
-        {@const countLabel = row.memberCount === pr.stack?.size
-          ? `${row.memberCount} PRs in stack`
-          : `${row.memberCount} of ${pr.stack?.size} PRs in this view`}
-        <div class="stack-control">
-          {#if row.memberCount > 1}
-            <button
-              type="button"
-              class="stack-toggle"
-              aria-expanded={row.expanded}
-              aria-label={`${row.expanded ? "Collapse" : "Expand"} stack at #${pr.Number}: ${countLabel}`}
-              title={countLabel}
-              onclick={() => pulls.toggleStack(row.stackKey, row.expanded)}
-            >
-              <ChevronDownIcon size={12} class={row.expanded ? "" : "stack-chevron--collapsed"} aria-hidden="true" />
-              <span>{row.memberCount}</span>
-            </button>
-          {:else}
-            <span class="stack-partial" title={countLabel} aria-label={countLabel}>1/{pr.stack?.size}</span>
-          {/if}
-        </div>
-      {/if}
       <div class="stack-row-content">
         {#if row.memberCount > 0 && pr.stack && (pr.stack.position > 1 || row.memberCount < pr.stack.size)}
           <span class="stack-context">{row.memberCount} of {pr.stack.size} PRs in this view{pr.stack.position > 1 ? ` · starts at ${pr.stack.position}/${pr.stack.size}` : ""}</span>
@@ -483,6 +460,28 @@
           </div>
         {/if}
       </div>
+      {#if row.memberCount > 0}
+        {@const countLabel = row.memberCount === pr.stack?.size
+          ? `${row.memberCount} PRs in stack`
+          : `${row.memberCount} of ${pr.stack?.size} PRs in this view`}
+        <div class="stack-control">
+          {#if row.memberCount > 1}
+            <button
+              type="button"
+              class="stack-toggle"
+              aria-expanded={row.expanded}
+              aria-label={`${row.expanded ? "Collapse" : "Expand"} stack at #${pr.Number}: ${countLabel}`}
+              title={countLabel}
+              onclick={() => pulls.toggleStack(row.stackKey, row.expanded)}
+            >
+              <span>{row.memberCount}</span>
+              <ChevronDownIcon size={12} class={row.expanded ? "" : "stack-chevron--collapsed"} aria-hidden="true" />
+            </button>
+          {:else}
+            <span class="stack-partial" title={countLabel} aria-label={countLabel}>1/{pr.stack?.size}</span>
+          {/if}
+        </div>
+      {/if}
     </div>
   {/each}
 {/snippet}
@@ -652,27 +651,36 @@
     min-width: 0;
   }
 
+  .stack-row--root,
   .stack-row--member {
-    margin-left: calc(16px + var(--stack-depth) * 12px);
-    border-left: 1px solid var(--border-default);
+    --sidebar-row-bg: color-mix(in srgb, var(--accent-blue) 6%, var(--bg-surface));
+    background: var(--sidebar-row-bg);
+  }
+
+  .stack-row--root {
+    margin-top: var(--space-1);
+    border-top: 1px solid var(--sidebar-list-border-muted, var(--border-muted));
+  }
+
+  .stack-row--member {
+    padding-left: var(--space-4);
   }
 
   .stack-control {
     display: flex;
     align-items: flex-start;
     justify-content: center;
-    width: 28px;
+    width: 44px;
     flex-shrink: 0;
-    padding-top: 8px;
+    padding-top: var(--space-1);
   }
 
   .stack-toggle {
     display: flex;
-    flex-direction: column;
     align-items: center;
     justify-content: center;
     gap: var(--space-1);
-    width: 28px;
+    width: 40px;
     min-height: 40px;
     color: var(--text-secondary);
     font-size: var(--font-size-2xs);

--- a/frontend/src/lib/stores/pulls.svelte.test.ts
+++ b/frontend/src/lib/stores/pulls.svelte.test.ts
@@ -305,6 +305,78 @@ describe("pulls store display order", () => {
     expect(store.getDisplayOrderPRs().map((pr) => pr.ID)).toEqual([1, 3, 2]);
   });
 
+  it("collapses stacks to their root and navigates only rendered rows", async () => {
+    const store = createPullsStore({
+      client: clientWithPulls([
+        pull(3, "api", "2026-05-20T15:00:00Z", { stack: { stack_id: 7, position: 3, size: 3 } }),
+        pull(4, "api", "2026-05-20T14:00:00Z"),
+        pull(1, "api", "2026-05-20T13:00:00Z", { stack: { stack_id: 7, position: 1, size: 3 } }),
+        pull(2, "api", "2026-05-20T12:00:00Z", { stack: { stack_id: 7, position: 2, size: 3 } }),
+      ]),
+    });
+    await loadPulls(store);
+    expect(store.getStackTree()).toBe(false);
+    store.setStackTree(true);
+    expect(localStorage.getItem("kenn-forge:pullStackTree")).toBe("1");
+    expect(store.getDisplayOrderPRs().map((pr) => pr.ID)).toEqual([1, 4]);
+    store.selectNextPR();
+    expect(store.getSelectedPR()?.number).toBe(1);
+    store.selectNextPR();
+    expect(store.getSelectedPR()?.number).toBe(4);
+
+    const root = store.getSidebarRows(store.getFilteredPulls())[0]!;
+    store.toggleStack(root.stackKey, false);
+    expect(store.getDisplayOrderPRs().map((pr) => pr.ID)).toEqual([1, 2, 3, 4]);
+    store.selectPrevPR();
+    expect(store.getSelectedPR()?.number).toBe(3);
+    store.toggleStack(root.stackKey, true);
+    expect(store.getDisplayOrderPRs().map((pr) => pr.ID)).toEqual([1, 4]);
+    // A new selection inside the stack reveals it without changing the view preference.
+    store.selectPR("acme", "api", 2, "github", "github.com", "acme/api");
+    expect(store.getDisplayOrderPRs().map((pr) => pr.ID)).toEqual([1, 2, 3, 4]);
+    store.toggleStack(root.stackKey, true);
+    store.selectPR("acme", "api", 4, "github", "github.com", "acme/api");
+    store.selectPR("acme", "api", 2, "github", "github.com", "acme/api");
+    expect(store.getDisplayOrderPRs().map((pr) => pr.ID)).toEqual([1, 2, 3, 4]);
+    store.setStackTree(false);
+    expect(store.getDisplayOrderPRs().map((pr) => pr.ID)).toEqual([3, 4, 1, 2]);
+  });
+
+  it("keeps filtered and status-grouped stack members within their view", async () => {
+    const store = createPullsStore({
+      getGroupByWorkflow: () => true,
+      client: clientWithPulls([
+        pull(3, "api", "2026-05-20T15:00:00Z", { stack: { stack_id: 7, position: 3, size: 3 }, IsDraft: true }),
+        pull(1, "api", "2026-05-20T13:00:00Z", {
+          stack: { stack_id: 7, position: 1, size: 3 },
+          KanbanStatus: "reviewing",
+        }),
+        pull(2, "api", "2026-05-20T12:00:00Z", { stack: { stack_id: 7, position: 2, size: 3 }, IsDraft: true }),
+      ]),
+    });
+    await loadPulls(store);
+    store.setStackTree(true);
+    expect(store.getDisplayOrderPRs().map((pr) => pr.ID)).toEqual([2, 1]);
+    store.toggleAttributeFilter("draft");
+    const rows = store.getSidebarRows(store.getFilteredPulls());
+    expect(rows.map((row) => [row.pr.ID, row.memberCount])).toEqual([[2, 2]]);
+    store.toggleStack(rows[0]!.stackKey, false);
+    expect(store.getDisplayOrderPRs().map((pr) => pr.ID)).toEqual([2, 3]);
+  });
+
+  it("does not join stacks from different repository identities", async () => {
+    const store = createPullsStore({
+      client: clientWithPulls([
+        pull(1, "api", "2026-05-20T15:00:00Z", { RepoID: 1, stack: { stack_id: 7, position: 1, size: 2 } }),
+        pull(2, "api", "2026-05-20T14:00:00Z", { RepoID: 2, stack: { stack_id: 8, position: 1, size: 2 } }),
+        pull(3, "api", "2026-05-20T13:00:00Z", { RepoID: 1, stack: { stack_id: 7, position: 2, size: 2 } }),
+      ]),
+    });
+    await loadPulls(store);
+    store.setStackTree(true);
+    expect(store.getDisplayOrderPRs().map((pr) => pr.ID)).toEqual([1, 2]);
+  });
+
   it("filters pull requests by review state, readiness, CI, merge conflicts, and multiple kanban statuses", async () => {
     const store = createPullsStore({
       client: clientWithPulls([

--- a/frontend/src/lib/stores/pulls.svelte.test.ts
+++ b/frontend/src/lib/stores/pulls.svelte.test.ts
@@ -342,6 +342,28 @@ describe("pulls store display order", () => {
     expect(store.getDisplayOrderPRs().map((pr) => pr.ID)).toEqual([3, 4, 1, 2]);
   });
 
+  it("uses the collapsed root as the keyboard cursor while a child detail stays selected", async () => {
+    const store = createPullsStore({
+      client: clientWithPulls([
+        pull(9, "api", "2026-05-20T16:00:00Z"),
+        pull(1, "api", "2026-05-20T15:00:00Z", { stack: { stack_id: 7, position: 1, size: 2 } }),
+        pull(2, "api", "2026-05-20T14:00:00Z", { stack: { stack_id: 7, position: 2, size: 2 } }),
+        pull(8, "api", "2026-05-20T13:00:00Z"),
+      ]),
+    });
+    await loadPulls(store);
+    store.setStackTree(true);
+    for (const direction of ["next", "previous"]) {
+      store.selectPR("acme", "api", 2, "github", "github.com", "acme/api");
+      const root = store.getSidebarRows(store.getFilteredPulls()).find((row) => row.pr.ID === 1)!;
+      store.toggleStack(root.stackKey, true);
+      expect(store.getSelectedPR()?.number).toBe(2);
+      if (direction === "next") store.selectNextPR();
+      else store.selectPrevPR();
+      expect(store.getSelectedPR()?.number).toBe(direction === "next" ? 8 : 9);
+    }
+  });
+
   it("keeps filtered and status-grouped stack members within their view", async () => {
     const store = createPullsStore({
       getGroupByWorkflow: () => true,

--- a/frontend/src/lib/stores/pulls.svelte.ts
+++ b/frontend/src/lib/stores/pulls.svelte.ts
@@ -1,3 +1,4 @@
+import { untrack } from "svelte";
 import { Effect } from "effect";
 import { executeGeneratedApiRequest, GeneratedApi } from "../api/generated-api.js";
 import { TransientTransportError, type ApiProblemError } from "../api/effect-errors.js";
@@ -13,7 +14,7 @@ import {
   providerUsesHostRoute,
 } from "../api/provider-routes.js";
 import { bucketCIChecks, parseCIChecks } from "../utils/ci-buckets.js";
-import { normalizeKanbanStatus } from "./workflow.svelte.js";
+import { groupByWorkflow, normalizeKanbanStatus } from "./workflow.svelte.js";
 import { showFlash } from "./flash.svelte.js";
 import { PullsWorkflow, type FetchPullResult } from "./pulls-workflow.js";
 import { ProviderMutations, providerMutationFailureMessage } from "./ordered-mutations.js";
@@ -21,6 +22,8 @@ import { providerItemKey, providerMutationKey } from "./provider-key.js";
 import { nextWorkspaceLifecycleTick } from "./workspace-create-pending.svelte.js";
 import { readInvolvesMeFilter, writeInvolvesMeFilter } from "./involves-me-filter.js";
 import { readUnassignedFilter, writeUnassignedFilter } from "./unassigned-filter.js";
+
+import { groupPullStacks, type PullSidebarRow } from "../utils/pull-stack-tree.js";
 
 export type { FetchPullResult } from "./pulls-workflow.js";
 
@@ -41,6 +44,8 @@ export interface PullsStoreOptions {
   runtime: AppRuntime;
   getGlobalRepo?: () => string | undefined;
   getGroupByRepo?: () => boolean;
+  getGroupByWorkflow?: () => boolean;
+  getUseWorkspaceActivityForRecency?: () => boolean;
   optimisticDetailStarUpdate?: (ref: ProviderRouteRef, number: number, starred: boolean, envelopeTick: number) => void;
 }
 
@@ -59,6 +64,54 @@ export function createPullsStore(opts: PullsStoreOptions) {
   const runtime = opts.runtime;
   const getGlobalRepo = opts.getGlobalRepo ?? (() => undefined);
   const getGroupByRepo = opts.getGroupByRepo ?? (() => false);
+
+  const STACK_TREE_KEY = "kenn-forge:pullStackTree";
+  let stackTree = $state(readStackTree());
+  let selectionVersion = $state(0);
+  let stackExpansion = $state<Record<string, { expanded: boolean; selectionVersion: number }>>({});
+
+  function readStackTree(): boolean {
+    try {
+      return localStorage.getItem(STACK_TREE_KEY) === "1";
+    } catch {
+      return false;
+    }
+  }
+
+  function getStackTree(): boolean {
+    return stackTree;
+  }
+
+  function setStackTree(value: boolean): void {
+    stackTree = value;
+    try {
+      localStorage.setItem(STACK_TREE_KEY, value ? "1" : "0");
+    } catch {
+      // Keep the view usable when browser storage is unavailable.
+    }
+  }
+
+  function toggleStack(key: string, expanded: boolean): void {
+    stackExpansion[key] = { expanded: !expanded, selectionVersion };
+  }
+
+  function getSidebarRows(items: PullRequest[]): PullSidebarRow[] {
+    if (!stackTree) return items.map((pr) => ({ pr, depth: 0, stackKey: "", memberCount: 0, expanded: false }));
+    return groupPullStacks(items).flatMap(({ key, members }) => {
+      const override = stackExpansion[key];
+      const selection = selectedPR;
+      const selectedChild = selection !== null && members.slice(1).some((pr) => pullMatchesSelection(pr, selection));
+      const expanded =
+        override?.expanded === true || (selectedChild && override?.selectionVersion !== selectionVersion);
+      return (expanded ? members : members.slice(0, 1)).map((pr, index) => ({
+        pr,
+        depth: index,
+        stackKey: key,
+        memberCount: index === 0 && pr.stack ? members.length : 0,
+        expanded,
+      }));
+    });
+  }
 
   // --- state ---
 
@@ -205,15 +258,12 @@ export function createPullsStore(opts: PullsStoreOptions) {
 
   /** Returns PRs in display order: grouped by repo or flat chronological. */
   function getDisplayOrderPRs(): PullRequest[] {
-    if (getGroupByRepo()) {
-      const grouped = pullsByRepo();
-      const ordered: PullRequest[] = [];
-      for (const prs of grouped.values()) {
-        ordered.push(...prs);
-      }
-      return ordered;
-    }
-    return getFilteredPulls();
+    const groups = opts.getGroupByWorkflow?.()
+      ? groupByWorkflow(getFilteredPulls(), opts.getUseWorkspaceActivityForRecency?.()).map((group) => group.items)
+      : getGroupByRepo()
+        ? [...pullsByRepo().values()]
+        : [getFilteredPulls()];
+    return groups.flatMap((items) => getSidebarRows(items).map((row) => row.pr));
   }
 
   function selectNextPR(): void {
@@ -291,7 +341,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
     platformHost: string | undefined,
     repoPath: string,
   ): void {
-    selectedPR = {
+    const selection = {
       provider,
       ...(platformHost && { platformHost }),
       owner,
@@ -299,6 +349,11 @@ export function createPullsStore(opts: PullsStoreOptions) {
       repoPath,
       number,
     };
+    // A manual collapse lasts for this visit, not a later navigation back to the same PR.
+    untrack(() => {
+      if (JSON.stringify(selectedPR) !== JSON.stringify(selection)) selectionVersion += 1;
+    });
+    selectedPR = selection;
   }
 
   function selectPRFromPull(pr: PullRequest): void {
@@ -629,6 +684,10 @@ export function createPullsStore(opts: PullsStoreOptions) {
     getFilterState,
     setFilterState,
     getDisplayOrderPRs,
+    getSidebarRows,
+    getStackTree,
+    setStackTree,
+    toggleStack,
     selectNextPR,
     selectPrevPR,
     setFilterKanban,

--- a/frontend/src/lib/stores/pulls.svelte.ts
+++ b/frontend/src/lib/stores/pulls.svelte.ts
@@ -258,12 +258,26 @@ export function createPullsStore(opts: PullsStoreOptions) {
 
   /** Returns PRs in display order: grouped by repo or flat chronological. */
   function getDisplayOrderPRs(): PullRequest[] {
-    const groups = opts.getGroupByWorkflow?.()
+    const groups = getDisplayGroups();
+    return groups.flatMap((items) => getSidebarRows(items).map((row) => row.pr));
+  }
+
+  function getDisplayGroups(): PullRequest[][] {
+    return opts.getGroupByWorkflow?.()
       ? groupByWorkflow(getFilteredPulls(), opts.getUseWorkspaceActivityForRecency?.()).map((group) => group.items)
       : getGroupByRepo()
         ? [...pullsByRepo().values()]
         : [getFilteredPulls()];
-    return groups.flatMap((items) => getSidebarRows(items).map((row) => row.pr));
+  }
+
+  function getNavigationIndex(list: PullRequest[], selection: PullSelection): number {
+    const index = list.findIndex((pr) => pullMatchesSelection(pr, selection));
+    if (index >= 0 || !stackTree) return index;
+    // A manually hidden child keeps its detail open; use its visible root as the cursor.
+    const group = getDisplayGroups().find((items) => items.some((pr) => pullMatchesSelection(pr, selection)));
+    const stack =
+      group && groupPullStacks(group).find(({ members }) => members.some((pr) => pullMatchesSelection(pr, selection)));
+    return stack ? list.findIndex((pr) => pr.ID === stack.members[0]?.ID) : -1;
   }
 
   function selectNextPR(): void {
@@ -277,7 +291,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
       }
       return;
     }
-    const idx = list.findIndex((pr) => pullMatchesSelection(pr, sel));
+    const idx = getNavigationIndex(list, sel);
     const next = list[idx + 1];
     if (next !== undefined) {
       selectPRFromPull(next);
@@ -295,7 +309,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
       }
       return;
     }
-    const idx = list.findIndex((pr) => pullMatchesSelection(pr, sel));
+    const idx = getNavigationIndex(list, sel);
     if (idx > 0) {
       const prev = list[idx - 1];
       if (prev !== undefined) {

--- a/frontend/src/lib/utils/pull-stack-tree.ts
+++ b/frontend/src/lib/utils/pull-stack-tree.ts
@@ -1,0 +1,29 @@
+import type { PullRequest } from "../api/types.js";
+
+export interface PullStackGroup {
+  key: string;
+  members: PullRequest[];
+}
+
+/** Keep each stack at its newest matching row, ordered from its root upward. */
+export function groupPullStacks(items: PullRequest[]): PullStackGroup[] {
+  const groups = new Map<string, PullStackGroup>();
+  for (const pr of items) {
+    const key = pr.stack ? JSON.stringify([pr.RepoID, pr.stack.stack_id]) : `pull:${pr.ID}`;
+    const group = groups.get(key);
+    if (group) group.members.push(pr);
+    else groups.set(key, { key, members: [pr] });
+  }
+  for (const group of groups.values()) {
+    group.members.sort((a, b) => (a.stack?.position ?? 0) - (b.stack?.position ?? 0));
+  }
+  return [...groups.values()];
+}
+
+export interface PullSidebarRow {
+  pr: PullRequest;
+  depth: number;
+  stackKey: string;
+  memberCount: number;
+  expanded: boolean;
+}

--- a/frontend/tests/e2e/pull-list-filters.spec.ts
+++ b/frontend/tests/e2e/pull-list-filters.spec.ts
@@ -107,8 +107,8 @@ test("PR filters stack attributes and allow multiple kanban statuses", async ({ 
     await filterPanel.locator(".kit-filter-dropdown__section-title, .kit-filter-dropdown__item").allTextContents()
   )
     .map((text) => text.trim())
-    .filter((text) => ["Status", "Has workspace", "Visibility"].includes(text));
-  expect(workspaceGrouping).toEqual(["Status", "Has workspace", "Visibility"]);
+    .filter((text) => ["Status", "Has workspace", "View"].includes(text));
+  expect(workspaceGrouping).toEqual(["Status", "Has workspace", "View"]);
 
   await filterPanel.getByRole("button", { name: "Has workspace" }).click();
   await expect(rows).toHaveText([/Approved review queue/, /Ready failed workflow/]);

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -5126,6 +5126,9 @@ type StackPlacementResponse struct {
 
 	// Size Number of visible pull requests in the stack
 	Size int64 `json:"size"`
+
+	// StackId Stable local stack identity
+	StackId int64 `json:"stack_id"`
 }
 
 // StackResponse defines model for StackResponse.

--- a/internal/db/queries_stacks.go
+++ b/internal/db/queries_stacks.go
@@ -399,7 +399,7 @@ func (d *DB) ListStackPlacementsForMRs(ctx context.Context, mrIDs []int64) (map[
 		          AND ai.lifecycle_state = 'removed_upstream'
 		    )
 		)
-		SELECT merge_request_id, position, size
+		SELECT merge_request_id, stack_id, position, size
 		FROM visible
 		WHERE merge_request_id IN (SELECT merge_request_id FROM requested)`,
 		string(payload),
@@ -412,7 +412,7 @@ func (d *DB) ListStackPlacementsForMRs(ctx context.Context, mrIDs []int64) (map[
 	for rows.Next() {
 		var id int64
 		var placement StackPlacement
-		if err := rows.Scan(&id, &placement.Position, &placement.Size); err != nil {
+		if err := rows.Scan(&id, &placement.StackID, &placement.Position, &placement.Size); err != nil {
 			return nil, fmt.Errorf("scan stack placement: %w", err)
 		}
 		placements[id] = placement

--- a/internal/db/queries_stacks_test.go
+++ b/internal/db/queries_stacks_test.go
@@ -226,8 +226,8 @@ func TestListStackPlacementsForMRs(t *testing.T) {
 
 	placements, err := d.ListStackPlacementsForMRs(ctx, []int64{mrID2, mrID4, soloID})
 	require.NoError(err)
-	assert.Equal(StackPlacement{Position: 2, Size: 4}, placements[mrID2])
-	assert.Equal(StackPlacement{Position: 4, Size: 4}, placements[mrID4])
+	assert.Equal(StackPlacement{StackID: stackID, Position: 2, Size: 4}, placements[mrID2])
+	assert.Equal(StackPlacement{StackID: stackID, Position: 4, Size: 4}, placements[mrID4])
 	_, requested := placements[mrID1]
 	assert.False(requested, "unrequested members must not be returned")
 	_, inStack := placements[soloID]
@@ -247,8 +247,8 @@ func TestListStackPlacementsForMRs(t *testing.T) {
 	require.NoError(err)
 	_, hidden := placements[mrID2]
 	assert.False(hidden, "hidden members must not be returned")
-	assert.Equal(StackPlacement{Position: 2, Size: 3}, placements[mrID3])
-	assert.Equal(StackPlacement{Position: 3, Size: 3}, placements[mrID4])
+	assert.Equal(StackPlacement{StackID: stackID, Position: 2, Size: 3}, placements[mrID3])
+	assert.Equal(StackPlacement{StackID: stackID, Position: 3, Size: 3}, placements[mrID4])
 
 	empty, err := d.ListStackPlacementsForMRs(ctx, nil)
 	require.NoError(err)
@@ -264,7 +264,7 @@ func TestListStackPlacementsForMRs(t *testing.T) {
 	placements, err = d.ListStackPlacementsForMRs(ctx, large)
 	require.NoError(err)
 	assert.Len(placements, 2)
-	assert.Equal(StackPlacement{Position: 2, Size: 3}, placements[mrID3])
+	assert.Equal(StackPlacement{StackID: stackID, Position: 2, Size: 3}, placements[mrID3])
 }
 
 func TestDeleteStaleStacks(t *testing.T) {

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -1182,6 +1182,7 @@ type StackMemberWithPR struct {
 // StackPlacement is a merge request's contiguous position within its stack
 // after hidden members are filtered, plus the visible stack size.
 type StackPlacement struct {
+	StackID  int64
 	Position int
 	Size     int
 }

--- a/internal/server/pullapi/handler_test.go
+++ b/internal/server/pullapi/handler_test.go
@@ -198,9 +198,9 @@ func TestListPullsReportsStackPlacementForMultiMemberStacks(t *testing.T) {
 	}
 	require.Len(byNumber, 5)
 	require.NotNil(byNumber[2].Stack)
-	assert.Equal(StackPlacementResponse{Position: 2, Size: 3}, *byNumber[2].Stack)
+	assert.Equal(StackPlacementResponse{StackID: stackID, Position: 2, Size: 3}, *byNumber[2].Stack)
 	require.NotNil(byNumber[3].Stack)
-	assert.Equal(StackPlacementResponse{Position: 3, Size: 3}, *byNumber[3].Stack)
+	assert.Equal(StackPlacementResponse{StackID: stackID, Position: 3, Size: 3}, *byNumber[3].Stack)
 	assert.Nil(byNumber[4].Stack, "pull requests outside a stack carry no placement")
 	assert.Nil(byNumber[5].Stack, "single-member stacks are not shown as stacked")
 }

--- a/internal/server/pullapi/routes.go
+++ b/internal/server/pullapi/routes.go
@@ -500,7 +500,7 @@ func (s *Handler) listPullsRouteCore(ctx context.Context, input *listPullsInput)
 			resp.DetailFetchedAt = formatUTCRFC3339(*mr.DetailFetchedAt)
 		}
 		if placement, ok := stackPlacements[mr.ID]; ok && placement.Size > 1 {
-			resp.Stack = &StackPlacementResponse{Position: placement.Position, Size: placement.Size}
+			resp.Stack = &StackPlacementResponse{StackID: placement.StackID, Position: placement.Position, Size: placement.Size}
 		}
 		out = append(out, resp)
 	}

--- a/internal/server/pullapi/types.go
+++ b/internal/server/pullapi/types.go
@@ -34,8 +34,9 @@ type MergeRequestResponse struct {
 
 // StackPlacementResponse is a pull request's position within its stack.
 type StackPlacementResponse struct {
-	Position int `json:"position" doc:"1-based position of this pull request in its stack"`
-	Size     int `json:"size" doc:"Number of visible pull requests in the stack"`
+	StackID  int64 `json:"stack_id" doc:"Stable local stack identity"`
+	Position int   `json:"position" doc:"1-based position of this pull request in its stack"`
+	Size     int   `json:"size" doc:"Number of visible pull requests in the stack"`
 }
 
 type mergeRequestEventResponse struct {


### PR DESCRIPTION
- Add **Filters → View → Stack tree** to collapse each PR stack to its root, with a count and chevron to reveal dependent PRs in order.
- Remember the view preference and reveal a selected stack member when navigating to it.
- Preserve active filters and repository/status grouping, and make keyboard navigation follow stack expansion and collapse.
