### PR TITLE
fix: cancel archive waits and list all GitHub App installations

### DIFF
--- a/context/retries-and-backoffs.md
+++ b/context/retries-and-backoffs.md
@@ -72,6 +72,10 @@ The archive worker uses the backoff schedule type only as an idle delay calculat
 not as a retry wrapper: idle passes double up to a five-minute cap and any wake or
 worked pass resets it (`internal/github/sync.go::runArchiveLoop`).
 
+Live provider work waits for preempted archive requests only while its caller is active;
+canceling a waiter must not release the archive request's lease or leak live-work counts.
+(`internal/github/sync.go::beginProviderWork`)
+
 ## Long-lived stream recovery
 
 Hub event-stream recovery is connection lifecycle policy, not a retry

--- a/githubapp/client.go
+++ b/githubapp/client.go
@@ -131,12 +131,17 @@ func (c *Client) GetApp(ctx context.Context, appJWT string) (*App, error) {
 // ListInstallations lists the accounts the app is installed on.
 func (c *Client) ListInstallations(ctx context.Context, appJWT string) ([]Installation, error) {
 	var installs []Installation
-	err := c.do(ctx, http.MethodGet,
-		"/app/installations?per_page=100", appJWT, nil, &installs)
-	if err != nil {
-		return nil, fmt.Errorf("listing app installations: %w", err)
+	for page := 1; ; page++ {
+		var batch []Installation
+		path := fmt.Sprintf("/app/installations?per_page=100&page=%d", page)
+		if err := c.do(ctx, http.MethodGet, path, appJWT, nil, &batch); err != nil {
+			return nil, fmt.Errorf("listing app installations: %w", err)
+		}
+		installs = append(installs, batch...)
+		if len(batch) < 100 {
+			return installs, nil
+		}
 	}
-	return installs, nil
 }
 
 // CreateInstallationToken mints an installation access token. Tokens

--- a/githubapp/client_test.go
+++ b/githubapp/client_test.go
@@ -1,0 +1,65 @@
+package githubapp_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/githubapp"
+)
+
+func TestListInstallationsPaginates(t *testing.T) {
+	for _, count := range []int{0, 1, 100, 101, 200} {
+		t.Run(strconv.Itoa(count), func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal("/api/v3/app/installations", r.URL.Path)
+				assert.Equal("100", r.URL.Query().Get("per_page"))
+				assert.Equal("Bearer app-jwt", r.Header.Get("Authorization"))
+				page, err := strconv.Atoi(r.URL.Query().Get("page"))
+				if err != nil || page < 1 {
+					// GitHub defaults an omitted page to the first page.
+					page = 1
+				}
+				out := make([]githubapp.Installation, 0)
+				for id := (page-1)*100 + 1; id <= min(page*100, count); id++ {
+					out = append(out, githubapp.Installation{ID: int64(id)})
+				}
+				assert.NoError(json.NewEncoder(w).Encode(out))
+			}))
+			defer server.Close()
+			client := githubapp.NewClientWithBase(server.URL + "/api/v3")
+			installs, err := client.ListInstallations(t.Context(), "app-jwt")
+			require.NoError(err)
+			require.Len(installs, count)
+			for i, installation := range installs {
+				require.Equal(int64(i+1), installation.ID)
+			}
+		})
+	}
+}
+
+func TestListInstallationsRejectsIncompleteInventory(t *testing.T) {
+	assert := assert.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("page") == "2" {
+			http.Error(w, "installation listing unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		out := make([]githubapp.Installation, 100)
+		for i := range out {
+			out[i].ID = int64(i + 1)
+		}
+		assert.NoError(json.NewEncoder(w).Encode(out))
+	}))
+	defer server.Close()
+	installs, err := githubapp.NewClientWithBase(server.URL).ListInstallations(t.Context(), "app-jwt")
+	require.Error(t, err)
+	assert.True(githubapp.IsStatus(err, http.StatusServiceUnavailable))
+	assert.Nil(installs, "a failed page must not look like a complete inventory")
+}

--- a/internal/github/archive_lifecycle_test.go
+++ b/internal/github/archive_lifecycle_test.go
@@ -485,7 +485,7 @@ func TestArchivePreemptedItemRecordsNoFailureAndCompletesOnNextPass(t *testing.T
 
 	// beginProviderWork cancels the in-flight archive lease and waits for it to
 	// release; the hydration pass observes preemption and records nothing.
-	releaseLive := syncer.beginProviderWork(key, archive.PriorityActiveDetail)
+	releaseLive := syncer.beginProviderWork(t.Context(), key, archive.PriorityActiveDetail)
 	require.NoError(<-hydrationDone)
 
 	lookup, err := database.GetDatasetProgress(
@@ -1457,7 +1457,7 @@ func TestArchiveAdmissionDefersToNotificationAndActiveDetailWork(t *testing.T) {
 		archive.PriorityNotificationRefresh,
 		archive.PriorityActiveDetail,
 	} {
-		release := syncer.beginProviderWork(key, priority)
+		release := syncer.beginProviderWork(t.Context(), key, priority)
 		denied, err := syncer.Admit(t.Context(), ref, db.ArchiveItemTypeIssue, 1)
 		require.NoError(err)
 		assert.False(denied.Allowed)
@@ -1612,7 +1612,7 @@ func TestLiveProviderWorkCancelsAndWaitsForArchiveRequest(t *testing.T) {
 	liveStarted := make(chan struct{})
 	liveDone := make(chan struct{})
 	go func() {
-		releaseLive := syncer.beginProviderWork(key, archive.PriorityActiveDetail)
+		releaseLive := syncer.beginProviderWork(t.Context(), key, archive.PriorityActiveDetail)
 		close(liveStarted)
 		releaseLive()
 		close(liveDone)

--- a/internal/github/archive_wake_test.go
+++ b/internal/github/archive_wake_test.go
@@ -198,7 +198,7 @@ func TestArchiveLoopWakesOnlyHostsThatDeniedArchiveWork(t *testing.T) {
 		// A normal stream of live work on a host that never turned archive
 		// work away must not wake the worker, or every sync would trigger a
 		// denied pass and a deferral write per release.
-		release := syncer.beginProviderWork(key, archive.PriorityNormalIndex)
+		release := syncer.beginProviderWork(t.Context(), key, archive.PriorityNormalIndex)
 		release()
 		synctest.Wait()
 		require.Empty(runner.offsetsFrom(backedOff), "releasing a host that denied nothing must stay quiet")
@@ -210,13 +210,13 @@ func TestArchiveLoopWakesOnlyHostsThatDeniedArchiveWork(t *testing.T) {
 		started := make(chan struct{})
 		var releaseFirst func()
 		go func() {
-			releaseFirst = syncer.beginProviderWork(key, archive.PriorityActiveDetail)
+			releaseFirst = syncer.beginProviderWork(t.Context(), key, archive.PriorityActiveDetail)
 			close(started)
 		}()
 		synctest.Wait()
 		releaseArchive()
 		<-started
-		releaseSecond := syncer.beginProviderWork(key, archive.PriorityNotificationRefresh)
+		releaseSecond := syncer.beginProviderWork(t.Context(), key, archive.PriorityNotificationRefresh)
 		releaseFirst()
 		synctest.Wait()
 		require.Empty(runner.offsetsFrom(backedOff), "a host still busy must not wake the worker")
@@ -227,9 +227,50 @@ func TestArchiveLoopWakesOnlyHostsThatDeniedArchiveWork(t *testing.T) {
 
 		// The mark is consumed by the wake: the next quiet release stays quiet.
 		quiet := runner.reset()
-		release = syncer.beginProviderWork(key, archive.PriorityNormalIndex)
+		release = syncer.beginProviderWork(t.Context(), key, archive.PriorityNormalIndex)
 		release()
 		synctest.Wait()
 		require.Empty(runner.offsetsFrom(quiet))
+	})
+}
+
+func TestCanceledProviderWorkStopsWaitingForArchive(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		require := require.New(t)
+		syncer := &Syncer{archiveProviderRequests: make(map[string]archiveProviderRequest)}
+		const key = "github\x00github.test"
+		archiveCtx, releaseArchive, allowed := syncer.tryBeginArchiveProviderRequest(t.Context(), key)
+		require.True(allowed)
+		defer releaseArchive()
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		done := make(chan struct{})
+		go func() {
+			release := syncer.beginProviderWork(ctx, key, archive.PriorityActiveDetail)
+			release()
+			release()
+			close(done)
+		}()
+		synctest.Wait()
+		require.ErrorIs(archiveCtx.Err(), context.Canceled)
+		select {
+		case <-done:
+			require.FailNow("active caller must wait for archive release")
+		default:
+		}
+		cancel()
+		synctest.Wait()
+		select {
+		case <-done:
+		default:
+			require.FailNow("canceled caller is still waiting for archive release")
+		}
+		require.False(syncer.higherPriorityProviderWorkActive(key, archive.PriorityFullArchive))
+		_, _, allowed = syncer.tryBeginArchiveProviderRequest(t.Context(), key)
+		require.False(allowed, "canceling a waiter must not free the archive's lease")
+		releaseArchive()
+		_, releaseNext, allowed := syncer.tryBeginArchiveProviderRequest(t.Context(), key)
+		require.True(allowed, "canceled waiter must not leak its work registration")
+		releaseNext()
 	})
 }

--- a/internal/github/notifications_sync.go
+++ b/internal/github/notifications_sync.go
@@ -168,7 +168,7 @@ func (s *Syncer) SyncNotifications(ctx context.Context) error {
 	var errs []error
 	for _, entry := range clients {
 		providerWork := s.beginNotificationProviderWork(
-			entry.platform, entry.host, tracked,
+			ctx, entry.platform, entry.host, tracked,
 		)
 		err := s.syncNotificationsForHost(
 			ctx, entry.platform, entry.host, entry.client, tracked, providerWork,
@@ -185,6 +185,7 @@ func (s *Syncer) SyncNotifications(ctx context.Context) error {
 }
 
 func (s *Syncer) beginNotificationProviderWork(
+	ctx context.Context,
 	kind platform.Kind,
 	host string,
 	tracked map[string]RepoRef,
@@ -199,7 +200,7 @@ func (s *Syncer) beginNotificationProviderWork(
 	// would block healthy siblings from syncing and advancing their
 	// watermarks — the exact coupling per-repository watermarks remove.
 	for _, repo := range notificationTrackedRepos(string(kind), host, tracked) {
-		work.addRepo(repo)
+		work.addRepo(ctx, repo)
 	}
 	return work
 }
@@ -210,7 +211,7 @@ type notificationProviderWork struct {
 	releases []func()
 }
 
-func (w *notificationProviderWork) addRepo(repo RepoRef) {
+func (w *notificationProviderWork) addRepo(ctx context.Context, repo RepoRef) {
 	identityRoutes := []bool{false}
 	if repoPlatform(repo) == platform.KindGitHub {
 		identityRoutes = append(identityRoutes, true)
@@ -225,7 +226,7 @@ func (w *notificationProviderWork) addRepo(repo RepoRef) {
 		}
 		w.seen[bucket] = struct{}{}
 		w.releases = append(w.releases, w.syncer.beginProviderWork(
-			bucket, archive.PriorityNotificationRefresh,
+			ctx, bucket, archive.PriorityNotificationRefresh,
 		))
 	}
 }
@@ -381,7 +382,7 @@ func (s *Syncer) syncNotificationsForRepoAttempt(
 	if !found {
 		return true, nil
 	}
-	providerWork.addRepo(repo)
+	providerWork.addRepo(ctx, repo)
 	if s.afterNotificationRepoIdentityReconciled != nil {
 		s.afterNotificationRepoIdentityReconciled()
 	}
@@ -787,7 +788,7 @@ func (s *Syncer) ProcessQueuedNotificationReads(ctx context.Context, kind platfo
 			continue
 		}
 		seenBuckets[bucket] = struct{}{}
-		defer s.beginProviderWork(bucket, archive.PriorityNotificationRefresh)()
+		defer s.beginProviderWork(ctx, bucket, archive.PriorityNotificationRefresh)()
 	}
 	// A rate limit stops only the credential that hit it. Its remaining rows
 	// are already deferred in the database, so skipping them here avoids

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -1508,7 +1508,7 @@ func archiveLiveFloor(kind platform.Kind) int {
 	return floor
 }
 
-func (s *Syncer) beginProviderWork(key string, priority archive.WorkPriority) func() {
+func (s *Syncer) beginProviderWork(ctx context.Context, key string, priority archive.WorkPriority) func() {
 	s.providerWorkMu.Lock()
 	if s.providerWork == nil {
 		s.providerWork = make(map[string]map[archive.WorkPriority]int)
@@ -1526,7 +1526,10 @@ func (s *Syncer) beginProviderWork(key string, priority archive.WorkPriority) fu
 	}
 	s.providerWorkMu.Unlock()
 	if waitForArchive {
-		<-archiveRequest.done
+		select {
+		case <-archiveRequest.done:
+		case <-ctx.Done():
+		}
 	}
 
 	var once sync.Once
@@ -5017,7 +5020,7 @@ func (s *Syncer) reconcileArchivedRepos(
 		// Register provider work so an admitted archive request on the
 		// same credential is preempted instead of overlapping the
 		// refresh, matching the coordination live repo syncs get.
-		release := s.beginProviderWork(bucket, archive.PriorityNormalIndex)
+		release := s.beginProviderWork(ctx, bucket, archive.PriorityNormalIndex)
 		resolved, _, _, _, _, err := s.reconcileRepoIdentityObservation(ctx, repo)
 		release()
 		if err != nil {
@@ -5439,7 +5442,7 @@ func (s *Syncer) syncRepo(ctx context.Context, repo RepoRef) error {
 	if err != nil {
 		return fmt.Errorf("resolve sync credential route for %s/%s: %w", repo.Owner, repo.Name, err)
 	}
-	releaseProviderWork := s.beginProviderWork(bucket, archive.PriorityNormalIndex)
+	releaseProviderWork := s.beginProviderWork(ctx, bucket, archive.PriorityNormalIndex)
 	defer releaseProviderWork()
 	// Split-auth repository sync also issues a viewer-permission request on
 	// the write identity; register that principal too so an archive sharing
@@ -5450,7 +5453,7 @@ func (s *Syncer) syncRepo(ctx context.Context, repo RepoRef) error {
 			string(repoPlatform(repo)), writeIdentity.Host, writeIdentity.Principal,
 		)
 		if writeBucket != bucket {
-			defer s.beginProviderWork(writeBucket, archive.PriorityNormalIndex)()
+			defer s.beginProviderWork(ctx, writeBucket, archive.PriorityNormalIndex)()
 		}
 	}
 
@@ -7079,7 +7082,7 @@ func (s *Syncer) BackfillMergedActorEventOnProvider(
 			repo.Owner, repo.Name, err,
 		)
 	}
-	releaseProviderWork := s.beginProviderWork(bucket, archive.PriorityActiveDetail)
+	releaseProviderWork := s.beginProviderWork(ctx, bucket, archive.PriorityActiveDetail)
 	defer releaseProviderWork()
 	return s.backfillMergedActorEvent(ctx, repo, repoID, number)
 }
@@ -11449,7 +11452,7 @@ func (s *Syncer) syncMRForRepoResolved(
 		if err != nil {
 			return fmt.Errorf("resolve detail credential route for %s/%s: %w", repo.Owner, repo.Name, err)
 		}
-		releaseProviderWork := s.beginProviderWork(bucket, archive.PriorityActiveDetail)
+		releaseProviderWork := s.beginProviderWork(ctx, bucket, archive.PriorityActiveDetail)
 		defer releaseProviderWork()
 	}
 
@@ -12161,7 +12164,7 @@ func (s *Syncer) syncIssueForRepo(
 		if err != nil {
 			return fmt.Errorf("resolve issue credential route for %s/%s: %w", repo.Owner, repo.Name, err)
 		}
-		releaseProviderWork := s.beginProviderWork(bucket, archive.PriorityActiveDetail)
+		releaseProviderWork := s.beginProviderWork(ctx, bucket, archive.PriorityActiveDetail)
 		defer releaseProviderWork()
 	}
 
@@ -12391,7 +12394,7 @@ func (s *Syncer) SyncItemByNumber(
 	if err != nil {
 		return "", fmt.Errorf("resolve item credential route for %s/%s: %w", owner, name, err)
 	}
-	releaseProviderWork := s.beginProviderWork(bucket, archive.PriorityActiveDetail)
+	releaseProviderWork := s.beginProviderWork(ctx, bucket, archive.PriorityActiveDetail)
 	defer releaseProviderWork()
 
 	if repoPlatform(repo) != platform.KindGitHub {


### PR DESCRIPTION
- Let canceled live operations stop waiting for archive requests, while keeping the archive lease held until that request releases it.
- Include every page when listing GitHub App installations. A later-page failure returns an error instead of a partial inventory.

Regression tests cover cancellation, lease cleanup, multi-page results, and incomplete-list failures.
