### PR TITLE
fix: stabilize Firefox e2e CI and navigation tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -682,7 +682,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: e2e-report-${{ matrix.browser }}
-          path: frontend/playwright-report/
+          path: frontend/test-results/
           retention-days: 7
 
       - name: Upload GitHub App setup UI Playwright report

--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -2651,7 +2651,7 @@ func buildAppState(
 		}
 		if r.Method == http.MethodPost &&
 			r.URL.Path == "/__e2e/pr-ci-state/mixed" {
-			mixedPayload, err := json.Marshal([]db.CICheck{
+			checks := []db.CICheck{
 				{
 					Name:       "build-darwin",
 					Status:     "completed",
@@ -2683,18 +2683,16 @@ func buildAppState(
 					Conclusion: "skipped",
 					App:        "GitHub Actions",
 				},
-			})
+			}
+			mixedPayload, err := json.Marshal(checks)
 			if err != nil {
 				http.Error(w, "marshal mixed checks", http.StatusInternalServerError)
 				return
 			}
 			setPR1CIState(w, r, database, fc, "mixed", ciFixtureOptions{
-				statusName: "failure",
-				checksJSON: string(mixedPayload),
-				pinProviderTo: &struct {
-					Status     string
-					Conclusion string
-				}{Status: "completed", Conclusion: "failure"},
+				statusName:        "failure",
+				checksJSON:        string(mixedPayload),
+				providerCheckRuns: ciChecksToCheckRuns(checks),
 			})
 			return
 		}

--- a/cmd/e2e-server/main_test.go
+++ b/cmd/e2e-server/main_test.go
@@ -483,6 +483,42 @@ func TestDefaultRoborevEndpointIsUnbindable(t *testing.T) {
 	assert.Positive(port)
 }
 
+func TestMixedCIFixtureSurvivesRefresh(t *testing.T) {
+	require := require.New(t)
+	assets, err := web.Assets()
+	require.NoError(err)
+	state, err := buildAppState(t.Context(), assets, appOptions{roborevEndpoint: defaultRoborevEndpoint})
+	require.NoError(err)
+	t.Cleanup(state.close)
+
+	seed := httptest.NewRecorder()
+	state.handler.ServeHTTP(seed, httptest.NewRequest(http.MethodPost, "http://127.0.0.1/__e2e/pr-ci-state/mixed", nil))
+	require.Equal(http.StatusOK, seed.Code, seed.Body.String())
+
+	refresh := httptest.NewRecorder()
+	state.handler.ServeHTTP(refresh, httptest.NewRequest(http.MethodPost, "http://127.0.0.1/api/v1/pulls/github/acme/widgets/1/ci-refresh", nil))
+	require.Equal(http.StatusOK, refresh.Code, refresh.Body.String())
+	var detail struct {
+		MergeRequest struct {
+			CIChecksJSON string
+		} `json:"merge_request"`
+	}
+	require.NoError(json.Unmarshal(refresh.Body.Bytes(), &detail))
+	var checks []db.CICheck
+	require.NoError(json.Unmarshal([]byte(detail.MergeRequest.CIChecksJSON), &checks))
+	conclusions := make(map[string]string, len(checks))
+	for _, check := range checks {
+		conclusions[check.Name] = check.Conclusion
+	}
+	assert.Equal(t, map[string]string{
+		"build-darwin":   "failure",
+		"build-linux":    "success",
+		"test-linux":     "success",
+		"deploy-staging": "",
+		"build-windows":  "skipped",
+	}, conclusions)
+}
+
 func TestBuildAppStateSeedsReviewedHeadsForUTCMergeTargets(t *testing.T) {
 	assets, err := web.Assets()
 	require.NoError(t, err)

--- a/frontend/tests/e2e-full/ci-dropdown.spec.ts
+++ b/frontend/tests/e2e-full/ci-dropdown.spec.ts
@@ -285,7 +285,16 @@ test.describe("CI dropdown", () => {
       const seed = await page.request.post(`${server.info.base_url}/__e2e/pr-ci-state/dropdown-mixed`);
       expect(seed.ok()).toBe(true);
 
+      const backgroundSync = page.waitForResponse(
+        (response) =>
+          response.request().method() === "POST" &&
+          new URL(response.url()).pathname === "/api/v1/pulls/github/acme/widgets/1/sync/async",
+      );
       await page.goto(`${server.info.base_url}/pulls/github/acme/widgets/1`);
+      await backgroundSync;
+      await expect(page.locator(".pull-detail")).toBeVisible();
+      // The initial detail refresh can replace the chip during the click.
+      await expect(page.locator(".pull-detail .sync-indicator")).toHaveCount(0);
 
       const chip = page.locator(".pull-detail [data-testid='ci-chip']");
       await chip.click();

--- a/frontend/tests/e2e-full/description-task-list.spec.ts
+++ b/frontend/tests/e2e-full/description-task-list.spec.ts
@@ -104,8 +104,13 @@ test.describe("PR description task list", () => {
   });
 
   test("checkbox clicks persist when navigation happens before the debounce", async ({ page }) => {
+    await page.setViewportSize({ width: 900, height: 720 });
     const server = await openPullDetail(page);
     try {
+      // Keep the 400ms save debounce pending until navigation flushes it.
+      const now = Date.now();
+      await page.clock.install({ time: now });
+      await page.clock.pauseAt(now + 1_000);
       const body = page.locator(".body-section .markdown-body");
       const cb0 = body.locator('input[type="checkbox"][data-task-index="0"]');
       const cb1 = body.locator('input[type="checkbox"][data-task-index="1"]');
@@ -132,8 +137,10 @@ test.describe("PR description task list", () => {
       await cb1.click();
       await expect(cb1).toBeChecked({ checked: cb1Expected });
 
-      await page.getByRole("button", { name: "Activity", exact: true }).click();
+      await page.getByRole("combobox", { name: "Page: PRs", exact: true }).click();
+      await page.getByRole("option", { name: "Activity", exact: true }).click();
       await expect(page).toHaveURL(/\/$/);
+      await page.clock.resume();
       await persisted;
       await page.goto(`${server.info.base_url}/pulls/github/acme/widgets/1`);
       const reloadedBody = page.locator(".body-section .markdown-body");


### PR DESCRIPTION
- Keep mixed CI fixture results intact after a provider refresh.
- Wait for initial detail sync before opening CI checks, and make checkbox navigation independent of responsive tabs and debounce timing.
- Preserve Playwright failure traces in CI artifacts.

The four originally failing cases passed 40 repeated Firefox runs. The full local Firefox suite still reported 25 other failures, including layout failures also observed before this change.
