### PR TITLE
fix: show spoke workspace indicators in hub Activity

### DIFF
--- a/context/fleet-architecture.md
+++ b/context/fleet-architecture.md
@@ -73,6 +73,9 @@ or remote workspace and session operations.
 - Hubs show the fleet-wide workspace surface. Spokes retain the full host
   directory for navigation but project only their own actionable workspace data
   (`internal/fleet/enrich.go::ProjectForObserver`).
+- Hub Activity workspace indicators include the fleet; peer provider responses
+  omit them so spokes can apply their local workspace ownership
+  (`internal/server/huma_routes.go::Server.listActivityService`).
 - Workspace lists consume inline projected summaries without per-host fan-out;
   remote actions require the owning host's projected operation availability.
   Explicitly incomplete aggregates retain absent-host rows; authoritative views

--- a/internal/server/e2etest/federation_e2e_test.go
+++ b/internal/server/e2etest/federation_e2e_test.go
@@ -619,3 +619,37 @@ func mcpRepositoryIdentity(item mcpserver.ItemIdentity) mcpserver.RepositoryIden
 		PlatformRepoID: item.PlatformRepoID, Owner: item.Owner, Name: item.Name,
 	}
 }
+
+func TestFederatedActivityWorkspaceIndicators(t *testing.T) {
+	fixture := newFederatedForgesFixture(t)
+	for _, tc := range []struct {
+		daemon *federatedDaemonFixture
+		want   map[int]string
+	}{
+		{fixture.Hub, map[int]string{1: "ws-spoke-a", 2: "ws-spoke-b"}},
+		{fixture.NodeA, map[int]string{1: "ws-spoke-a", 2: ""}},
+	} {
+		t.Run(tc.daemon.Name, func(t *testing.T) {
+			response := fixture.request(t, tc.daemon, http.MethodGet, "/api/v1/activity?projection=collapsed", nil)
+			defer response.Body.Close()
+			require.Equal(t, http.StatusOK, response.StatusCode)
+			var body struct {
+				Subjects []struct {
+					Number    int `json:"item_number"`
+					Workspace *struct {
+						ID string `json:"id"`
+					} `json:"workspace"`
+				} `json:"item_activity"`
+			}
+			require.NoError(t, json.NewDecoder(response.Body).Decode(&body))
+			got := map[int]string{}
+			for _, subject := range body.Subjects {
+				got[subject.Number] = ""
+				if subject.Workspace != nil {
+					got[subject.Number] = subject.Workspace.ID
+				}
+			}
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/server/fleet_activity.go
+++ b/internal/server/fleet_activity.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/fleet"
+	"go.kenn.io/forge/internal/providerplane"
+	"go.kenn.io/forge/internal/server/workspaceapi"
+)
+
+func overlayFleetActivityWorkspaces(response *activityResponse, workspaces []fleet.WorkspaceSummary) {
+	overlays := make(map[providerplane.ItemIdentity]workspaceapi.WorkspaceRef)
+	for _, workspace := range workspaces {
+		if !workspace.Visible || workspace.FleetHostKey == "" {
+			continue
+		}
+		identity := providerplane.ItemIdentity{
+			Repository: providerplane.RepositoryIdentity{
+				Provider: workspace.Repo.Provider, PlatformHost: workspace.Repo.PlatformHost,
+				PlatformRepoID: workspace.Repo.PlatformRepoID,
+			},
+			ItemType: workspace.ItemType, ItemNumber: workspace.ItemNumber,
+		}.Canonical()
+		switch workspace.ItemType {
+		case db.WorkspaceItemTypePullRequest:
+			identity.ItemType = "pr"
+		case db.WorkspaceItemTypeIssue:
+			identity.ItemType = "issue"
+		default:
+			identity.ItemType = ""
+		}
+		ref := workspaceapi.WorkspaceRef{ID: workspace.ID, Status: workspace.Status}
+		if workspace.SourceItemVisible && identity.Valid() {
+			if _, exists := overlays[identity]; !exists {
+				overlays[identity] = ref
+			}
+		}
+		if workspace.AssociatedPRNumber != nil {
+			identity.ItemType = "pr"
+			identity.ItemNumber = *workspace.AssociatedPRNumber
+			if identity.Valid() {
+				if _, exists := overlays[identity]; !exists {
+					overlays[identity] = ref
+				}
+			}
+		}
+	}
+	for i := range response.Items {
+		item := &response.Items[i]
+		if ref, ok := overlays[activityItemIdentity(*item)]; ok && item.Workspace == nil {
+			item.Workspace = &ref
+		}
+	}
+	for i := range response.ItemActivity {
+		item := &response.ItemActivity[i]
+		if ref, ok := overlays[activitySubjectIdentity(*item)]; ok && item.Workspace == nil {
+			item.Workspace = &ref
+		}
+	}
+}

--- a/internal/server/fleet_activity_test.go
+++ b/internal/server/fleet_activity_test.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/fleet"
+	"go.kenn.io/forge/internal/server/workspaceapi"
+)
+
+func TestFleetActivityWorkspaceMatching(t *testing.T) {
+	repo := activityRepoRefResponse{
+		Provider: "gitlab", PlatformHost: "git.example.test", PlatformRepoID: "42",
+		Owner: "acme", Name: "renamed",
+	}
+	workspace := fleet.WorkspaceSummary{
+		ID: "remote", Status: "ready", FleetHostKey: "spoke", Visible: true,
+		SourceItemVisible: true, ItemType: db.WorkspaceItemTypeIssue, ItemNumber: 7,
+		AssociatedPRNumber: new(8),
+		Repo: fleet.WorkspaceRepositorySummary{
+			Provider: repo.Provider, PlatformHost: repo.PlatformHost, PlatformRepoID: repo.PlatformRepoID,
+			Owner: "acme", Name: "original",
+		},
+	}
+	remote := &workspaceapi.WorkspaceRef{ID: "remote", Status: "ready"}
+	local := &workspaceapi.WorkspaceRef{ID: "local", Status: "creating"}
+	for _, tc := range []struct {
+		name     string
+		repo     activityRepoRefResponse
+		itemType string
+		number   int
+		local    *workspaceapi.WorkspaceRef
+		want     *workspaceapi.WorkspaceRef
+	}{
+		{"issue after rename", repo, "issue", 7, nil, remote},
+		{"associated pull", repo, "pr", 8, nil, remote},
+		{"different item type", repo, "pr", 7, nil, nil},
+		{"different number", repo, "issue", 9, nil, nil},
+		{"local takes precedence", repo, "issue", 7, local, local},
+		{"reused route", activityRepoRefResponse{Provider: repo.Provider, PlatformHost: repo.PlatformHost, PlatformRepoID: "43", Owner: repo.Owner, Name: repo.Name}, "issue", 7, nil, nil},
+		{"different provider", activityRepoRefResponse{Provider: "gitea", PlatformHost: repo.PlatformHost, PlatformRepoID: "42"}, "issue", 7, nil, nil},
+		{"different host", activityRepoRefResponse{Provider: repo.Provider, PlatformHost: "other.example.test", PlatformRepoID: "42"}, "issue", 7, nil, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			response := activityResponse{
+				Items:        []activityItemResponse{{Repo: tc.repo, ItemType: tc.itemType, ItemNumber: tc.number, Workspace: tc.local}},
+				ItemActivity: []activitySubjectResponse{{Repo: tc.repo, ItemType: tc.itemType, ItemNumber: tc.number, Workspace: tc.local}},
+			}
+			overlayFleetActivityWorkspaces(&response, []fleet.WorkspaceSummary{workspace})
+			assert.Equal(t, tc.want, response.Items[0].Workspace)
+			assert.Equal(t, tc.want, response.ItemActivity[0].Workspace)
+		})
+	}
+}

--- a/internal/server/fleetapi/activity_workspaces.go
+++ b/internal/server/fleetapi/activity_workspaces.go
@@ -1,0 +1,23 @@
+package fleetapi
+
+import (
+	"context"
+
+	"go.kenn.io/forge/internal/config"
+	"go.kenn.io/forge/internal/fleet"
+)
+
+// ActivityWorkspaces supplies the hub's Activity indicators from the same
+// observer projection as the Workspaces tab. Spokes keep local indicators.
+func (s *Handler) ActivityWorkspaces(ctx context.Context) ([]fleet.WorkspaceSummary, error) {
+	cfg := s.configSnapshot().Fleet
+	if !cfg.Enabled || cfg.RoleOrDefault() != config.FleetRoleHub {
+		return nil, nil
+	}
+	s.noteSnapshotDemand()
+	snapshot, err := s.buildFleetSnapshot(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	return snapshot.Workspaces, nil
+}

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1433,6 +1433,14 @@ func (s *Server) listActivityService(
 	if _, federationRequest := federationauth.PrincipalFromContext(ctx); federationRequest {
 		return providerActivityResponse(output.Body), nil
 	}
+	if s.fleetAPI != nil {
+		workspaces, err := s.fleetAPI.ActivityWorkspaces(ctx)
+		if err != nil {
+			slog.Warn("list fleet activity workspaces failed", "err", err)
+		} else {
+			overlayFleetActivityWorkspaces(&output.Body, workspaces)
+		}
+	}
 	return output.Body, nil
 }
 


### PR DESCRIPTION
The hub Activity sidebar now shows workspace indicators for PRs and issues with workspaces on a spoke. Previously, it only marked hub-local workspaces, making items already being worked on elsewhere in the fleet appear to need a workspace.

Spokes keep their local indicators, and existing local workspace references take precedence.
