### PR TITLE
fix: resume branch activity after a clone loses saved history

### DIFF
--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -212,6 +212,9 @@ review suggestion application, or ready-for-review.
 
 ## Sync Capabilities
 
+- Saved branch tips may outlive objects in rebuilt or pruned clones; resume bounded activity indexing without inferring a force push from missing history.
+  (`internal/github/sync.go::Syncer.syncDefaultBranchActivity`)
+
 kenn-forge reads repositories, merge requests, issues, releases, tags, CI, and
 timeline/comment-like events through provider capability interfaces in
 `platform`. Providers implement only supported optional interfaces;

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5689,15 +5689,22 @@ func (s *Syncer) syncDefaultBranchActivity(
 				previousTip.TipSHA,
 				currentTip,
 			)
-			if err != nil {
+			switch {
+			case errors.Is(err, gitclone.ErrNotFound):
+				// SQLite can retain a tip after its object disappears from a
+				// rebuilt or pruned clone. Resume bounded history indexing;
+				// missing history does not prove a force push.
+				afterSHA = ""
+			case err != nil:
 				slog.Warn("check default branch ancestry failed",
 					"repo", repo.Owner+"/"+repo.Name,
 					"branch", branch,
 					"err", err,
 				)
 				return
+			default:
+				forcePush = !ancestor
 			}
-			forcePush = !ancestor
 		}
 	}
 

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -690,6 +690,48 @@ func TestSyncRepoRecordsDefaultBranchForcePushBeforeUpdatingTip(t *testing.T) {
 	assert.Equal(afterSHA, tip.TipSHA)
 }
 
+func TestSyncRepoResumesDefaultBranchActivityAfterCloneReplacement(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := setupSyncBranchActivityFixture(t, "main")
+	t.Cleanup(fixture.Syncer.Stop)
+	beforeSHA := syncActivityCommitAndPush(t, fixture.Work,
+		"before.txt", "before\n", "before rewrite", "main")
+	require.NoError(fixture.Syncer.syncRepo(t.Context(), fixture.Repo))
+
+	syncActivityGitRun(t, fixture.Work, "checkout", "--orphan", "rewrite")
+	syncActivityGitRun(t, fixture.Work, "rm", "-r", "--cached", ".")
+	afterSHA := syncActivityCommit(t, fixture.Work, "after.txt", "after\n", "after rewrite")
+	syncActivityGitRun(t, fixture.Work, "push", "--force", "origin", "HEAD:main")
+	// A rebuilt clone no longer has the unreachable tip retained in SQLite.
+	syncActivityGitRun(t, fixture.Remote, "reflog", "expire", "--expire=now", "--all")
+	syncActivityGitRun(t, fixture.Remote, "gc", "--prune=now")
+	fixture.Syncer.clones = gitclone.New(t.TempDir(), nil)
+
+	require.NoError(fixture.Syncer.syncRepo(t.Context(), fixture.Repo))
+	repoRow := requireSyncActivityRepoRow(t, fixture.DB)
+	tip, err := fixture.DB.GetBranchTip(t.Context(), repoRow.ID, "main")
+	require.NoError(err)
+	require.NotNil(tip)
+	assert.Equal(afterSHA, tip.TipSHA, "missing old objects must not stall branch activity")
+	var shas []string
+	for _, item := range syncActivityBranchCommits(t, fixture.DB) {
+		shas = append(shas, item.CommitSHA)
+	}
+	assert.Contains(shas, beforeSHA, "keep previously recorded activity")
+	assert.Contains(shas, afterSHA, "index the current history")
+	assert.Empty(syncActivityForcePushes(t, fixture.DB), "missing history cannot prove a force push")
+
+	nextSHA := syncActivityCommitAndPush(t, fixture.Work,
+		"next.txt", "next\n", "next commit", "main")
+	require.NoError(fixture.Syncer.syncRepo(t.Context(), fixture.Repo))
+	tip, err = fixture.DB.GetBranchTip(t.Context(), repoRow.ID, "main")
+	require.NoError(err)
+	require.NotNil(tip)
+	assert.Equal(nextSHA, tip.TipSHA)
+	assert.Empty(syncActivityForcePushes(t, fixture.DB))
+}
+
 func TestSyncRepoSkipsBranchActivityWhenCloneFetchFails(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)


### PR DESCRIPTION
Resume default-branch activity indexing when a rebuilt or pruned clone no longer contains the branch tip saved in SQLite. Preserve recorded activity and avoid reporting a force push solely because old history is missing.

Draft pending regression-test verification: local Git fixtures stop at a git-safe executable configuration error. Non-mutating lint and commit hooks passed.
