### PR TITLE
feat: add direct diff navigation and collapse controls

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -833,6 +833,9 @@ Diff file navigation and collapse/expand-all are direct header and toolbar
 actions, not menu-only actions. File arrows follow the filtered file order
 (`frontend/src/lib/components/diff/DiffView.svelte`); bulk collapse affects only
 visible files (`frontend/src/lib/components/diff/DiffToolbar.svelte`).
+Commit diffs have no PR number. Individual and bulk collapse must share a key
+scoped by provider, host, repository path, and commit SHA
+(`frontend/src/lib/stores/diff.svelte.ts::collapseKeyFor`).
 
 Rows that contain buttons, links, or toggles need clear event ownership.
 

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -829,6 +829,11 @@ the user's current item identity and deep link.
 
 ## Nested Interaction Rules
 
+Diff file navigation and collapse/expand-all are direct header and toolbar
+actions, not menu-only actions. File arrows follow the filtered file order
+(`frontend/src/lib/components/diff/DiffView.svelte`); bulk collapse affects only
+visible files (`frontend/src/lib/components/diff/DiffToolbar.svelte`).
+
 Rows that contain buttons, links, or toggles need clear event ownership.
 
 - Activating a nested control inside a clickable row must not also trigger the

--- a/frontend/src/lib/components/diff/DiffFile.svelte
+++ b/frontend/src/lib/components/diff/DiffFile.svelte
@@ -16,7 +16,8 @@
   import DiffReviewThreadInlineComment from "./DiffReviewThreadInlineComment.svelte";
   import DiffRichPreview from "./DiffRichPreview.svelte";
   import { CopyButton, DiffStats, IconButton } from "@kenn-io/kit-ui";
-  import { ArrowDown, ArrowUp } from "@lucide/svelte";
+  import ArrowDown from "@lucide/svelte/icons/arrow-down";
+  import ArrowUp from "@lucide/svelte/icons/arrow-up";
   import {
     reviewThreadSnapshotState,
     reviewThreadTargetLine,

--- a/frontend/src/lib/components/diff/DiffFile.svelte
+++ b/frontend/src/lib/components/diff/DiffFile.svelte
@@ -15,7 +15,8 @@
   import DiffReviewDraftInlineComment from "./DiffReviewDraftInlineComment.svelte";
   import DiffReviewThreadInlineComment from "./DiffReviewThreadInlineComment.svelte";
   import DiffRichPreview from "./DiffRichPreview.svelte";
-  import { CopyButton, DiffStats } from "@kenn-io/kit-ui";
+  import { CopyButton, DiffStats, IconButton } from "@kenn-io/kit-ui";
+  import { ArrowDown, ArrowUp } from "@lucide/svelte";
   import {
     reviewThreadSnapshotState,
     reviewThreadTargetLine,
@@ -32,6 +33,8 @@
 
   interface Props {
     file: DiffFileType;
+    previousFilePath?: string | undefined;
+    nextFilePath?: string | undefined;
     contextPrefetchIdentity?: string | undefined;
     provider: string;
     platformHost?: string | undefined;
@@ -51,6 +54,8 @@
 
   const {
     file,
+    previousFilePath,
+    nextFilePath,
     contextPrefetchIdentity = "",
     provider,
     platformHost,
@@ -601,6 +606,26 @@
     >
       {displayPath(file)}
     </span>
+    <div class="file-navigation">
+      <IconButton
+        ariaLabel="Previous file"
+        title="Previous file"
+        size="sm"
+        disabled={previousFilePath === undefined}
+        onclick={() => previousFilePath !== undefined && diffStore.requestScrollToFile(previousFilePath)}
+      >
+        <ArrowUp size={14} />
+      </IconButton>
+      <IconButton
+        ariaLabel="Next file"
+        title="Next file"
+        size="sm"
+        disabled={nextFilePath === undefined}
+        onclick={() => nextFilePath !== undefined && diffStore.requestScrollToFile(nextFilePath)}
+      >
+        <ArrowDown size={14} />
+      </IconButton>
+    </div>
     <!--
       Copying repository metadata is not code execution or a security boundary.
       Preserve the provider's filename exactly; interpretation after paste belongs
@@ -759,6 +784,11 @@
     flex-shrink: 0;
     font-size: var(--font-size-xs);
     font-weight: 600;
+  }
+
+  .file-navigation {
+    display: flex;
+    flex-shrink: 0;
   }
 
   .file-content {

--- a/frontend/src/lib/components/diff/DiffFile.test.ts
+++ b/frontend/src/lib/components/diff/DiffFile.test.ts
@@ -283,6 +283,8 @@ function uniqueOwner(): string {
 function renderDiffFile(
   file: DiffFileType,
   options: {
+    previousFilePath?: string;
+    nextFilePath?: string;
     richPreview?: boolean;
     richPreviewEnabled?: boolean;
     contextExpansionEnabled?: boolean;
@@ -324,6 +326,8 @@ function renderDiffFile(
     props: {
       runtime,
       file,
+      previousFilePath: options.previousFilePath,
+      nextFilePath: options.nextFilePath,
       provider: "github",
       platformHost: "github.com",
       owner,
@@ -2793,5 +2797,17 @@ describe("DiffFile", () => {
     renderDiffFile(file);
 
     await expectPierreDiffText(/@@ -17,3 \+17,3 @@ usefulContext/);
+  });
+
+  it("header arrows request the adjacent file without collapsing the current file", async () => {
+    const { diff } = renderDiffFile(makeFile(), {
+      previousFilePath: "src/before.ts",
+      nextFilePath: "src/after.ts",
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Next file" }));
+    expect(diff.getScrollTarget()).toEqual({ path: "src/after.ts" });
+    await fireEvent.click(screen.getByRole("button", { name: "Previous file" }));
+    expect(diff.getScrollTarget()).toEqual({ path: "src/before.ts" });
+    expect(screen.getByRole("button", { name: "Collapse file" }).getAttribute("aria-expanded")).toBe("true");
   });
 });

--- a/frontend/src/lib/components/diff/DiffToolbar.svelte
+++ b/frontend/src/lib/components/diff/DiffToolbar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { IconButton, SidebarToggle, Toggle } from "@kenn-io/kit-ui";
-  import { ChevronsDownUp, ChevronsUpDown } from "@lucide/svelte";
+  import ChevronsDownUp from "@lucide/svelte/icons/chevrons-down-up";
+  import ChevronsUpDown from "@lucide/svelte/icons/chevrons-up-down";
   import MoreHorizontalIcon from "@lucide/svelte/icons/more-horizontal";
   import { getStores } from "../../context.js";
   import {

--- a/frontend/src/lib/components/diff/DiffToolbar.svelte
+++ b/frontend/src/lib/components/diff/DiffToolbar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { SidebarToggle, Toggle } from "@kenn-io/kit-ui";
+  import { IconButton, SidebarToggle, Toggle } from "@kenn-io/kit-ui";
+  import { ChevronsDownUp, ChevronsUpDown } from "@lucide/svelte";
   import MoreHorizontalIcon from "@lucide/svelte/icons/more-horizontal";
   import { getStores } from "../../context.js";
   import {
@@ -94,16 +95,6 @@
       </div>
     </div>
   {/if}
-  <div class="compact-menu-section">
-    <button
-      class="compact-menu-action"
-      type="button"
-      disabled={disabled}
-      onclick={() => diff.setAllVisibleFilesCollapsed(!allVisibleFilesCollapsed)}
-    >
-      {collapseAllLabel}
-    </button>
-  </div>
   <div class="compact-menu-section">
     <div class="compact-menu-title">Tab width</div>
     <div class="compact-menu-grid" role="group" aria-label="Tab width">
@@ -216,6 +207,19 @@
     <DiffScopePicker {disabled} />
   {/if}
   <div class="toolbar-actions">
+    <IconButton
+      size="sm"
+      ariaLabel={collapseAllLabel}
+      title={collapseAllLabel}
+      disabled={disabled || visibleFileCount === 0}
+      onclick={() => diff.setAllVisibleFilesCollapsed(!allVisibleFilesCollapsed)}
+    >
+      {#if allVisibleFilesCollapsed}
+        <ChevronsUpDown size={16} aria-hidden="true" />
+      {:else}
+        <ChevronsDownUp size={16} aria-hidden="true" />
+      {/if}
+    </IconButton>
     {#if shouldShowFileJump}
       <FileJumpPicker {disabled} />
     {/if}
@@ -365,8 +369,7 @@
     gap: 4px;
   }
 
-  .compact-menu-item,
-  .compact-menu-action {
+  .compact-menu-item {
     display: flex;
     align-items: center;
     gap: 8px;
@@ -386,7 +389,6 @@
   }
 
   .compact-menu-item:hover,
-  .compact-menu-action:hover,
   :global(.compact-switch-row:hover) {
     background: var(--bg-surface-hover);
     color: var(--text-primary);

--- a/frontend/src/lib/components/diff/DiffView.svelte
+++ b/frontend/src/lib/components/diff/DiffView.svelte
@@ -662,9 +662,11 @@
                 <p class="diff-state-msg">No changed files match this category.</p>
               </div>
             {/if}
-            {#each visibleFiles as file (file.path)}
+            {#each visibleFiles as file, index (file.path)}
               <DiffFileComponent
                 {file}
+                previousFilePath={visibleFiles[index - 1]?.path}
+                nextFilePath={visibleFiles[index + 1]?.path}
                 contextPrefetchIdentity={nextContextPrefetchIdentity}
                 {provider}
                 {platformHost}

--- a/frontend/src/lib/stores/diff.svelte.test.ts
+++ b/frontend/src/lib/stores/diff.svelte.test.ts
@@ -222,6 +222,40 @@ describe("createDiffStore loadDiff", () => {
     expect(calls.filter((url) => url.includes("/files"))).toHaveLength(2);
   });
 
+  it("shares individual and bulk collapse state within each repository commit", async () => {
+    const diff = makeDiffResult(["src/app.go", "src/app_test.go"]);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => Response.json(diff));
+    const store = createDiffStore({ client: testClient() });
+    const first = Promise.withResolvers<void>();
+    store.loadCommitDiff(ownerRepoRef, "abc123", { onSettled: first.resolve });
+    await first.promise;
+
+    store.setAllVisibleFilesCollapsed(true);
+    expect(store.areAllVisibleFilesCollapsed()).toBe(true);
+    expect(store.isFileCollapsed("owner", "repo", 0, "src/app.go")).toBe(true);
+    store.toggleFileCollapsed("owner", "repo", 0, "src/app.go");
+    expect(store.areAllVisibleFilesCollapsed()).toBe(false);
+    store.setFileCategoryFilter("tests");
+    store.setAllVisibleFilesCollapsed(false);
+    expect(store.isFileCollapsed("owner", "repo", 0, "src/app_test.go")).toBe(false);
+    store.setAllVisibleFilesCollapsed(true);
+
+    for (const [identity, sha] of [
+      [ownerRepoRef, "def456"],
+      [{ ...ownerRepoRef, platformHost: "forge.example.com" }, "abc123"],
+      [{ ...ownerRepoRef, repoPath: "other/repo" }, "abc123"],
+    ] as const) {
+      const next = Promise.withResolvers<void>();
+      store.loadCommitDiff(identity, sha, { onSettled: next.resolve });
+      await next.promise;
+      expect(store.isFileCollapsed("owner", "repo", 0, "src/app_test.go")).toBe(false);
+    }
+    const restored = Promise.withResolvers<void>();
+    store.loadCommitDiff(ownerRepoRef, "abc123", { onSettled: restored.resolve });
+    await restored.promise;
+    expect(store.isFileCollapsed("owner", "repo", 0, "src/app_test.go")).toBe(true);
+  });
+
   it("loads default branch commit diffs through the repo route", async () => {
     const calls: string[] = [];
     const diff = makeDiffResult(["internal/cache.go"]);

--- a/frontend/src/lib/stores/diff.svelte.ts
+++ b/frontend/src/lib/stores/diff.svelte.ts
@@ -452,8 +452,8 @@ export function createDiffStore(opts: DiffStoreOptions) {
   }
 
   function currentCollapseKey(): string | null {
-    if (currentWorkspaceID) {
-      return `workspace:${currentWorkspaceHostKey ?? "self"}:${currentWorkspaceID}:${currentWorkspaceBase}`;
+    if (currentWorkspaceID || currentCommitSHA) {
+      return collapseKeyFor(currentOwner, currentName, currentNumber);
     }
     if (!currentOwner || !currentName || !currentNumber) return null;
     return collapseKeyFor(currentOwner, currentName, currentNumber);
@@ -462,6 +462,9 @@ export function createDiffStore(opts: DiffStoreOptions) {
   function collapseKeyFor(owner: string, name: string, number: number): string {
     if (currentWorkspaceID) {
       return `workspace:${currentWorkspaceHostKey ?? "self"}:${currentWorkspaceID}:${currentWorkspaceBase}`;
+    }
+    if (currentCommitSHA) {
+      return JSON.stringify(["commit", currentProvider, currentPlatformHost ?? "", currentRepoPath, currentCommitSHA]);
     }
     return `${owner}/${name}#${number}`;
   }

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -2054,6 +2054,34 @@ test.describe("diff view", () => {
     await expect(secondRow).toHaveAttribute("aria-selected", "true");
   });
 
+  test("file header arrows jump between adjacent files", async ({ page }) => {
+    await mockDiffApi(page, largeDiff);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+    await waitForSidebarFilesLoaded(page);
+
+    const files = page.locator(".diff-file");
+    const first = files.first();
+    const second = files.nth(1);
+    const secondPath = await second.getAttribute("data-file-path");
+    await expect(first.getByRole("button", { name: "Previous file" })).toBeDisabled();
+    await expect(files.last().getByRole("button", { name: "Next file" })).toBeDisabled();
+    await first.getByRole("button", { name: "Next file" }).click();
+    await expect(treeFileItem(page, secondPath!)).toHaveAttribute("aria-selected", "true");
+    const diffArea = page.locator(".diff-area .kit-scrollbox__viewport");
+    await expect
+      .poll(() =>
+        second.evaluate((el) => {
+          const area = el.closest(".kit-scrollbox__viewport")!;
+          return Math.abs(el.getBoundingClientRect().top - area.getBoundingClientRect().top);
+        }),
+      )
+      .toBeLessThan(4);
+
+    await second.getByRole("button", { name: "Previous file" }).click();
+    await expect.poll(() => diffArea.evaluate((el) => Math.round(el.scrollTop))).toBe(0);
+  });
+
   test("sidebar file jumps keep the outer detail frame pinned", async ({ page }) => {
     await mockDiffApi(page, largeDiff);
     await navigateToDiff(page);
@@ -2271,14 +2299,13 @@ test.describe("diff view", () => {
     await expect.poll(decorations).toContain("line-through");
   });
 
-  test("more menu collapses and expands all visible diffs", async ({ page }) => {
+  test("toolbar collapses and expands all visible diffs", async ({ page }) => {
     await mockDiffApi(page, smallDiff);
     await navigateToDiff(page);
     await waitForDiffLoaded(page);
 
     await expect(page.locator(".diff-file .file-content")).toHaveCount(4);
 
-    await openDiffFilterMenu(page);
     await page.getByRole("button", { name: "Collapse all diffs" }).click();
 
     await expect(page.locator(".diff-file .file-content")).toHaveCount(0);


### PR DESCRIPTION
Add previous/next file arrows beside each diff file's copy button, and expose collapse/expand-all directly in the toolbar. Both pull request and workspace diffs use these controls, with navigation and bulk collapse respecting the current file filter.

![diff-controls-1.jpeg](https://github.com/user-attachments/assets/47e7c39f-8d3c-4004-8900-aaf50ea7af56)
