### PR TITLE
feat: prove merge and squash landing boundaries

### DIFF
--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -43,6 +43,8 @@ remain gaps, never empty complete inventories (`landedwork/prepare.go::Prepare`)
 Unsupported landing methods remain unresolved, and unowned commits are not
 direct-push claims; generic squash proof does not establish any provider's
 squash capability (`landedwork/analyze.go::Analyze`).
+Git's commit-graph can outlive commit objects; verify required commits physically,
+including the squash parent (`landedwork/git.go::parents`, `landedwork/proof.go::prove`).
 
 Minimum provider checklist:
 

--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -40,6 +40,9 @@ cache policy and admission remain internal
 Landing preparation uses local objects only; callers own collection and supply
 evidence for the exact prepared interval. Missing history and exhausted budgets
 remain gaps, never empty complete inventories (`landedwork/prepare.go::Prepare`).
+Unsupported landing methods remain unresolved, and unowned commits are not
+direct-push claims; generic squash proof does not establish any provider's
+squash capability (`landedwork/analyze.go::Analyze`).
 
 Minimum provider checklist:
 

--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -37,14 +37,14 @@ cache policy and admission remain internal
 
 ## Adding A Provider
 
-Landing preparation uses local objects only; callers own collection and supply
+The public landing API uses local objects only; callers own collection and supply
 evidence for the exact prepared interval. Missing history and exhausted budgets
 remain gaps, never empty complete inventories (`landedwork/prepare.go::Prepare`).
 Unsupported landing methods remain unresolved, and unowned commits are not
 direct-push claims; generic squash proof does not establish any provider's
 squash capability (`landedwork/analyze.go::Analyze`).
 Git's commit-graph can outlive commit objects; verify required commits physically,
-including the squash parent (`landedwork/git.go::parents`, `landedwork/proof.go::prove`).
+including each landing's first parent (`landedwork/git.go::parents`, `landedwork/proof.go::prove`).
 
 Minimum provider checklist:
 

--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -37,6 +37,10 @@ cache policy and admission remain internal
 
 ## Adding A Provider
 
+Landing preparation uses local objects only; callers own collection and supply
+evidence for the exact prepared interval. Missing history and exhausted budgets
+remain gaps, never empty complete inventories (`landedwork/prepare.go::Prepare`).
+
 Minimum provider checklist:
 
 - Add provider metadata in `platform/metadata.go`: kind, label, default

--- a/landedwork/accounting.go
+++ b/landedwork/accounting.go
@@ -1,0 +1,42 @@
+package landedwork
+
+func repositoryBytes(r Repository) int64 { return int64(len(r.Provider) + len(r.Host) + len(r.ID)) }
+func gapBytes(g Gap) int64               { return int64(len(g.CandidateID) + len(g.ObjectID) + len(g.Reason)) }
+func stringBytes(ids []string) int64 {
+	var n int64
+	for _, id := range ids {
+		n += int64(len(id))
+	}
+	return n
+}
+func inventoryBytes(i Inventory) int64 {
+	return int64(len(i.Reason) + len(i.NextCommit) + len(i.NextPage))
+}
+func candidateBytes(c Candidate) int64 {
+	return repositoryBytes(c.Repository) + int64(len(c.ID)+len(c.Terminal)+len(c.SourceHead)+len(c.Method)+len(c.MethodEvidence)+len(c.TerminalEvidence)) + stringBytes(c.Source)
+}
+func queryBytes(q Query) int64 {
+	n := repositoryBytes(q.Bounds.Repository) + int64(len(q.Bounds.Base)+len(q.Bounds.Head)) + stringBytes(q.Commits)
+	for _, gap := range q.Gaps {
+		n += gapBytes(gap)
+	}
+	return n
+}
+
+func checkResultOutput(r Result, l Limits) error {
+	c := r.Coverage
+	n := repositoryBytes(c.Bounds.Repository) + int64(len(c.Bounds.Base)+len(c.Bounds.Head)+len(c.CertifiedHead)) + inventoryBytes(c.Inventory)
+	records := int64(len(c.Gaps) + len(r.Landings) + len(r.Unattributed))
+	for _, gap := range c.Gaps {
+		n += gapBytes(gap)
+	}
+	n += stringBytes(r.Unattributed)
+	for _, landing := range r.Landings {
+		n += int64(len(landing.CandidateID)+len(landing.Method)+len(landing.Before)+len(landing.Terminal)) + stringBytes(landing.Source) + stringBytes(landing.Introduced)
+		records += int64(len(landing.Source) + len(landing.Introduced))
+	}
+	if n > l.OutputBytes || records > l.Records {
+		return ErrOutputBudget
+	}
+	return nil
+}

--- a/landedwork/analyze.go
+++ b/landedwork/analyze.go
@@ -24,6 +24,9 @@ func Analyze(ctx context.Context, p *Interval, e Evidence, limits Limits) (r Res
 			err = ctx.Err()
 		}
 		if err == nil {
+			if p.query.Complete {
+				finishCoverage(&r, p)
+			}
 			err = checkResultOutput(r, limits)
 		}
 		if err != nil {
@@ -59,7 +62,9 @@ func Analyze(ctx context.Context, p *Interval, e Evidence, limits Limits) (r Res
 		return r, nil
 	}
 	terminals, ids := candidateCounts(e.Candidates)
-	for _, c := range e.Candidates {
+	candidates := slices.Clone(e.Candidates)
+	slices.SortFunc(candidates, func(a, b Candidate) int { return cmp.Compare(a.ID, b.ID) })
+	for _, c := range candidates {
 		if terminals[c.Terminal] > 1 || ids[c.ID] > 1 {
 			r.Coverage.Gaps = append(r.Coverage.Gaps, Gap{CandidateID: c.ID, ObjectID: c.Terminal, Reason: "candidate_conflict"})
 			continue
@@ -71,7 +76,6 @@ func Analyze(ctx context.Context, p *Interval, e Evidence, limits Limits) (r Res
 			r.Landings = append(r.Landings, landing)
 		}
 	}
-	finishCoverage(&r, p)
 	return r, nil
 }
 

--- a/landedwork/analyze.go
+++ b/landedwork/analyze.go
@@ -17,7 +17,8 @@ func Analyze(ctx context.Context, p *Interval, e Evidence, limits Limits) (r Res
 	if err = validate(ctx, p.query.Bounds, limits); err != nil {
 		return r, err
 	}
-	r.Coverage = Coverage{Bounds: p.query.Bounds, Inventory: e.Inventory, CertifiedHead: p.query.Bounds.Base}
+	r.Coverage = Coverage{Bounds: p.query.Bounds, Inventory: e.Inventory, CertifiedHead: p.query.Bounds.Base,
+		Gaps: slices.Clone(p.query.Gaps)}
 	m := &meter{limits: limits}
 	defer func() {
 		if ctx.Err() != nil {
@@ -35,12 +36,11 @@ func Analyze(ctx context.Context, p *Interval, e Evidence, limits Limits) (r Res
 	}()
 	if err = validateEvidence(p, e, m); err != nil {
 		if errors.Is(err, ErrInputBudget) {
-			r.Coverage.Gaps = []Gap{{Reason: "input_budget_exhausted"}}
+			r.Coverage.Gaps = append(r.Coverage.Gaps, Gap{Reason: "input_budget_exhausted"})
 			return r, nil
 		}
 		return r, err
 	}
-	r.Coverage.Gaps = slices.Clone(p.query.Gaps)
 	if !p.query.Complete {
 		return r, nil
 	}

--- a/landedwork/analyze.go
+++ b/landedwork/analyze.go
@@ -1,0 +1,116 @@
+package landedwork
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"slices"
+)
+
+// Analyze accepts only evidence for p.Query(). Missing proof returns a named
+// coverage gap; malformed inputs, cancellation and unrepresentable output return
+// errors. Callers must never publish a result returned with an error.
+func Analyze(ctx context.Context, p *Interval, e Evidence, limits Limits) (r Result, err error) {
+	if p == nil {
+		return r, errors.New("prepared interval required")
+	}
+	if err = validate(ctx, p.query.Bounds, limits); err != nil {
+		return r, err
+	}
+	r.Coverage = Coverage{Bounds: p.query.Bounds, Inventory: e.Inventory, CertifiedHead: p.query.Bounds.Base}
+	m := &meter{limits: limits}
+	defer func() {
+		if ctx.Err() != nil {
+			err = ctx.Err()
+		}
+		if err == nil {
+			err = checkResultOutput(r, limits)
+		}
+		if err != nil {
+			r = Result{}
+		}
+	}()
+	if err = validateEvidence(p, e, m); err != nil {
+		if errors.Is(err, ErrInputBudget) {
+			r.Coverage.Gaps = []Gap{{Reason: "input_budget_exhausted"}}
+			return r, nil
+		}
+		return r, err
+	}
+	r.Coverage.Gaps = slices.Clone(p.query.Gaps)
+	if !p.query.Complete {
+		return r, nil
+	}
+	if !e.Inventory.Supported || !e.Inventory.Complete {
+		reason := e.Inventory.Reason
+		if reason == "" {
+			reason = "inventory_unknown"
+		}
+		r.Coverage.Gaps = append(r.Coverage.Gaps, Gap{ObjectID: e.Inventory.NextCommit, Reason: reason})
+	}
+	v, openErr := openView(ctx, p.path, m)
+	if openErr != nil {
+		r.Coverage.Gaps = append(r.Coverage.Gaps, Gap{Reason: graphReason(openErr)})
+		return r, nil
+	}
+	defer func() { err = errors.Join(err, v.close()) }()
+	if shallowErr := v.checkShallow(ctx, p.query.Bounds); shallowErr != nil {
+		r.Coverage.Gaps = append(r.Coverage.Gaps, Gap{Reason: graphReason(shallowErr)})
+		return r, nil
+	}
+	terminals, ids := candidateCounts(e.Candidates)
+	for _, c := range e.Candidates {
+		if terminals[c.Terminal] > 1 || ids[c.ID] > 1 {
+			r.Coverage.Gaps = append(r.Coverage.Gaps, Gap{CandidateID: c.ID, ObjectID: c.Terminal, Reason: "candidate_conflict"})
+			continue
+		}
+		landing, gap := prove(ctx, v, p, c, e.Capabilities)
+		if gap.Reason != "" {
+			r.Coverage.Gaps = append(r.Coverage.Gaps, gap)
+		} else {
+			r.Landings = append(r.Landings, landing)
+		}
+	}
+	finishCoverage(&r, p)
+	return r, nil
+}
+
+func candidateCounts(candidates []Candidate) (map[string]int, map[string]int) {
+	terminals, ids := map[string]int{}, map[string]int{}
+	for _, c := range candidates {
+		if c.Terminal != "" {
+			terminals[c.Terminal]++
+		}
+		ids[c.ID]++
+	}
+	return terminals, ids
+}
+
+func finishCoverage(r *Result, p *Interval) {
+	owners, positions := map[string]bool{}, map[string]int{}
+	for _, landing := range r.Landings {
+		owners[landing.Terminal] = true
+	}
+	complete := len(r.Coverage.Gaps) == 0
+	for index, id := range p.spine {
+		positions[id] = index
+		if !owners[id] {
+			r.Unattributed = append(r.Unattributed, id)
+			complete = false
+		}
+		if complete {
+			r.Coverage.CertifiedHead = id
+		}
+	}
+	r.Coverage.Complete = complete
+	slices.SortFunc(r.Landings, func(a, b Landing) int { return cmp.Compare(positions[a.Terminal], positions[b.Terminal]) })
+	slices.SortFunc(r.Coverage.Gaps, func(a, b Gap) int {
+		if n := cmp.Compare(a.CandidateID, b.CandidateID); n != 0 {
+			return n
+		}
+		if n := cmp.Compare(a.Reason, b.Reason); n != 0 {
+			return n
+		}
+		return cmp.Compare(a.ObjectID, b.ObjectID)
+	})
+}

--- a/landedwork/budget.go
+++ b/landedwork/budget.go
@@ -1,0 +1,68 @@
+package landedwork
+
+import (
+	"bytes"
+	"sync"
+)
+
+type meter struct {
+	mu     sync.Mutex
+	limits Limits
+	failed bool
+}
+
+func (m *meter) input(n int64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if n > m.limits.InputBytes {
+		m.failed = true
+		return ErrInputBudget
+	}
+	m.limits.InputBytes -= n
+	return nil
+}
+
+func (m *meter) records(n int64) error {
+	if n > m.limits.Records {
+		return ErrInputBudget
+	}
+	m.limits.Records -= n
+	return nil
+}
+
+func (m *meter) node() error {
+	if m.limits.Nodes == 0 {
+		return ErrInputBudget
+	}
+	m.limits.Nodes--
+	return nil
+}
+
+// The process owns one writer per stream; the shared byte meter is synchronized.
+type boundedBuffer struct {
+	buf   bytes.Buffer
+	meter *meter
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	if err := b.meter.input(int64(len(p))); err != nil {
+		return 0, err
+	}
+	return b.buf.Write(p)
+}
+
+func (b *boundedBuffer) Bytes() []byte { return b.buf.Bytes() }
+
+func checkQueryOutput(q Query, l Limits) error {
+	n := int64(len(q.Bounds.Base) + len(q.Bounds.Head) + len(q.Bounds.Repository.Host) + len(q.Bounds.Repository.ID) + len(q.Bounds.Repository.Provider))
+	for _, id := range q.Commits {
+		n += int64(len(id))
+	}
+	for _, g := range q.Gaps {
+		n += int64(len(g.Reason) + len(g.ObjectID) + len(g.CandidateID))
+	}
+	if n > l.OutputBytes || int64(len(q.Commits)+len(q.Gaps)) > l.Records {
+		return ErrOutputBudget
+	}
+	return nil
+}

--- a/landedwork/budget.go
+++ b/landedwork/budget.go
@@ -23,7 +23,10 @@ func (m *meter) input(n int64) error {
 }
 
 func (m *meter) records(n int64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if n > m.limits.Records {
+		m.failed = true
 		return ErrInputBudget
 	}
 	m.limits.Records -= n
@@ -31,7 +34,10 @@ func (m *meter) records(n int64) error {
 }
 
 func (m *meter) node() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.limits.Nodes == 0 {
+		m.failed = true
 		return ErrInputBudget
 	}
 	m.limits.Nodes--
@@ -54,14 +60,7 @@ func (b *boundedBuffer) Write(p []byte) (int, error) {
 func (b *boundedBuffer) Bytes() []byte { return b.buf.Bytes() }
 
 func checkQueryOutput(q Query, l Limits) error {
-	n := int64(len(q.Bounds.Base) + len(q.Bounds.Head) + len(q.Bounds.Repository.Host) + len(q.Bounds.Repository.ID) + len(q.Bounds.Repository.Provider))
-	for _, id := range q.Commits {
-		n += int64(len(id))
-	}
-	for _, g := range q.Gaps {
-		n += int64(len(g.Reason) + len(g.ObjectID) + len(g.CandidateID))
-	}
-	if n > l.OutputBytes || int64(len(q.Commits)+len(q.Gaps)) > l.Records {
+	if queryBytes(q) > l.OutputBytes || int64(len(q.Commits)+len(q.Gaps)) > l.Records {
 		return ErrOutputBudget
 	}
 	return nil

--- a/landedwork/budget_test.go
+++ b/landedwork/budget_test.go
@@ -1,0 +1,18 @@
+package landedwork
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A ReaderFrom promoted from an embedded buffer would bypass the byte meter.
+func TestBufferMetersCopy(t *testing.T) {
+	b := &boundedBuffer{meter: &meter{limits: Limits{InputBytes: 3}}}
+	_, err := io.Copy(b, struct{ io.Reader }{strings.NewReader("oversized")})
+	require.ErrorIs(t, err, ErrInputBudget)
+	assert.Empty(t, b.Bytes())
+}

--- a/landedwork/budget_test.go
+++ b/landedwork/budget_test.go
@@ -16,3 +16,11 @@ func TestBufferMetersCopy(t *testing.T) {
 	require.ErrorIs(t, err, ErrInputBudget)
 	assert.Empty(t, b.Bytes())
 }
+
+func TestCommitStreamStopsBeforeRetainingOverBudgetRecord(t *testing.T) {
+	stream := &commitStream{meter: &meter{limits: Limits{InputBytes: 1024, Records: 1, Nodes: 10}}}
+	first, second := strings.Repeat("a", 40), strings.Repeat("b", 40)
+	_, err := stream.Write([]byte(first + "\n" + second + "\n"))
+	require.ErrorIs(t, err, ErrInputBudget)
+	assert.Equal(t, []string{first}, stream.ids)
+}

--- a/landedwork/coverage_test.go
+++ b/landedwork/coverage_test.go
@@ -1,0 +1,133 @@
+package landedwork_test
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/landedwork"
+)
+
+func TestAnalyzeCoverage(t *testing.T) {
+	cases := []struct {
+		name, reason string
+		change       func(*landedwork.Evidence)
+		proven       bool
+	}{
+		{"partial source", "source_incomplete", func(e *landedwork.Evidence) { e.Candidates[0].SourceComplete = false }, false},
+		{"rebase", "method_unsupported", func(e *landedwork.Evidence) { e.Candidates[0].Method = "rebase" }, false},
+		{"fast forward", "method_unsupported", func(e *landedwork.Evidence) { e.Candidates[0].Method = "fast_forward" }, false},
+		{"missing method evidence", "method_unproven", func(e *landedwork.Evidence) { e.Candidates[0].MethodEvidence = "" }, false},
+		{"missing terminal evidence", "terminal_unproven", func(e *landedwork.Evidence) { e.Candidates[0].TerminalEvidence = "" }, false},
+		{"missing object", "objects_unavailable", func(e *landedwork.Evidence) {
+			e.Candidates[0].Source = append(slices.Clone(e.Candidates[0].Source), strings.Repeat("a", 40))
+		}, false},
+		{"duplicate source", "source_invalid", func(e *landedwork.Evidence) {
+			e.Candidates[0].Source = append(slices.Clone(e.Candidates[0].Source), e.Candidates[0].Source[0])
+		}, false},
+		{"wrong head", "source_head_mismatch", func(e *landedwork.Evidence) { e.Candidates[0].SourceHead = e.Query.Bounds.Base }, false},
+		{"incomplete correspondence", "source_correspondence_unproven", func(e *landedwork.Evidence) { e.Candidates[0].Source = e.Candidates[0].Source[1:] }, false},
+		{"unsupported capability", "method_unsupported", func(e *landedwork.Evidence) { e.Capabilities.Merge = false }, false},
+		{"unknown inventory", "inventory_unknown", func(e *landedwork.Evidence) { e.Inventory = landedwork.Inventory{} }, true},
+		{"partial sweep", "association_sweep_incomplete", func(e *landedwork.Evidence) {
+			e.Inventory.Complete = false
+			e.Inventory.Reason = "association_sweep_incomplete"
+			e.Inventory.NextCommit = e.Query.Commits[0]
+			e.Inventory.NextPage = "next-page"
+		}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := buildFixture(t, false)
+			ctx, p := f.prepare(t)
+			e := fixtureEvidence(f, p, "merge")
+			tc.change(&e)
+			r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+			require := require.New(t)
+			assert := assert.New(t)
+			require.NoError(err)
+			require.Len(r.Coverage.Gaps, 1)
+			assert.Equal(tc.reason, r.Coverage.Gaps[0].Reason)
+			assert.Equal(f.bounds(), r.Coverage.Bounds)
+			assert.Equal(e.Inventory, r.Coverage.Inventory)
+			assert.False(r.Coverage.Complete)
+			assert.Equal(f.base, r.Coverage.CertifiedHead)
+			if tc.proven {
+				assert.Len(r.Landings, 1)
+				assert.Empty(r.Unattributed)
+			} else {
+				assert.Empty(r.Landings)
+				assert.Equal([]string{f.head}, r.Unattributed)
+				assert.Equal("7", r.Coverage.Gaps[0].CandidateID)
+			}
+		})
+	}
+}
+
+func TestAnalyzeCoverageNoCandidateAndConflict(t *testing.T) {
+	for _, name := range []string{"unattributed", "conflict", "rebase with merge"} {
+		t.Run(name, func(t *testing.T) {
+			f := buildSideFixture(t)
+			ctx, p := f.prepare(t)
+			e := fixtureEvidence(f, p, "merge")
+			switch name {
+			case "unattributed":
+				e.Candidates = nil
+			case "conflict":
+				c := e.Candidates[0]
+				c.ID = "8"
+				e.Candidates = append(e.Candidates, c)
+			case "rebase with merge":
+				e.Candidates[0].Method = "rebase"
+			}
+			r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+			require.NoError(t, err)
+			assert := assert.New(t)
+			assert.Empty(r.Landings)
+			assert.Equal([]string{f.head}, r.Unattributed)
+			assert.Equal(f.bounds(), r.Coverage.Bounds)
+			assert.False(r.Coverage.Complete)
+			assert.Equal(f.base, r.Coverage.CertifiedHead)
+			switch name {
+			case "unattributed":
+				assert.Empty(r.Coverage.Gaps)
+			case "conflict":
+				assert.Equal([]landedwork.Gap{{CandidateID: "7", ObjectID: f.head, Reason: "candidate_conflict"}, {CandidateID: "8", ObjectID: f.head, Reason: "candidate_conflict"}}, r.Coverage.Gaps)
+			case "rebase with merge":
+				assert.Equal([]landedwork.Gap{{CandidateID: "7", ObjectID: f.head, Reason: "method_unsupported"}}, r.Coverage.Gaps)
+			}
+		})
+	}
+}
+
+func TestAnalyzeCoverageInputBudget(t *testing.T) {
+	for _, name := range []string{"records", "bytes", "nodes"} {
+		t.Run(name, func(t *testing.T) {
+			f := buildFixture(t, false)
+			ctx, p := f.prepare(t)
+			limits := fixtureLimits()
+			switch name {
+			case "records":
+				limits.Records = 1
+			case "bytes":
+				limits.InputBytes = 1
+			case "nodes":
+				limits.Nodes = 1
+			}
+			r, err := landedwork.Analyze(ctx, p, fixtureEvidence(f, p, "merge"), limits)
+			if err != nil {
+				require.ErrorIs(t, err, landedwork.ErrOutputBudget)
+				return
+			}
+			assert := assert.New(t)
+			assert.False(r.Coverage.Complete)
+			assert.Equal(f.base, r.Coverage.CertifiedHead)
+			assert.Equal([]string{f.head}, r.Unattributed)
+			assert.Equal(f.bounds(), r.Coverage.Bounds)
+			require.NotEmpty(t, r.Coverage.Gaps)
+			assert.Equal("input_budget_exhausted", r.Coverage.Gaps[0].Reason)
+		})
+	}
+}

--- a/landedwork/evidence.go
+++ b/landedwork/evidence.go
@@ -1,0 +1,87 @@
+package landedwork
+
+import (
+	"errors"
+	"slices"
+)
+
+// Inventory separates provider capability from observed collection coverage.
+// Continuations identify where an incomplete collection stopped.
+type Inventory struct {
+	Supported, Complete          bool
+	Reason, NextCommit, NextPage string
+}
+
+// Capabilities authorize generic proof paths, not inferred provider support.
+type Capabilities struct{ Merge, Squash bool }
+
+// Candidate contains provider facts bound to a stable target repository.
+// Evidence labels name the facts establishing method and terminal, not guesses
+// from subjects, current settings, or patch similarity. Source is complete only
+// after every required source page was collected; order is preserved.
+type Candidate struct {
+	Repository                               Repository
+	ID, Terminal, SourceHead                 string
+	Source                                   []string
+	SourceComplete                           bool
+	Method, MethodEvidence, TerminalEvidence string
+}
+
+type Evidence struct {
+	Query        Query
+	Inventory    Inventory
+	Capabilities Capabilities
+	Candidates   []Candidate
+}
+
+type Landing struct {
+	CandidateID, Method, Before, Terminal string
+	Source, Introduced                    []string
+}
+
+type Coverage struct {
+	Bounds        Bounds
+	Inventory     Inventory
+	Complete      bool
+	CertifiedHead string
+	Gaps          []Gap
+}
+
+// Result is evidence, never a total when Coverage.Complete is false.
+type Result struct {
+	Landings     []Landing
+	Unattributed []string
+	Coverage     Coverage
+}
+
+func validateEvidence(p *Interval, e Evidence, m *meter) error {
+	if e.Query.Bounds != p.query.Bounds || e.Query.Complete != p.query.Complete ||
+		!slices.Equal(e.Query.Commits, p.query.Commits) || !slices.Equal(e.Query.Gaps, p.query.Gaps) {
+		return errors.New("evidence does not match the prepared query")
+	}
+	if err := m.records(int64(len(e.Candidates) + len(e.Query.Commits) + len(e.Query.Gaps))); err != nil {
+		return err
+	}
+	for _, c := range e.Candidates {
+		if err := m.records(int64(len(c.Source))); err != nil {
+			return err
+		}
+		if err := m.input(candidateBytes(c)); err != nil {
+			return err
+		}
+		if c.Repository != p.query.Bounds.Repository || c.ID == "" {
+			return errors.New("candidate identity mismatch")
+		}
+		for _, id := range append([]string{c.Terminal, c.SourceHead}, c.Source...) {
+			if id != "" && (!objectID(id) || len(id) != len(p.query.Bounds.Head)) {
+				return errors.New("invalid candidate object ID")
+			}
+		}
+		switch c.Method {
+		case "", "merge", "squash", "rebase", "fast_forward":
+		default:
+			return errors.New("invalid landing method")
+		}
+	}
+	return m.input(queryBytes(e.Query) + inventoryBytes(e.Inventory))
+}

--- a/landedwork/fixtures_test.go
+++ b/landedwork/fixtures_test.go
@@ -1,0 +1,58 @@
+package landedwork_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/testutil/gitsafe"
+	"go.kenn.io/forge/landedwork"
+	"go.kenn.io/forge/platform"
+	gittest "go.kenn.io/kit/git/test"
+)
+
+func TestMain(m *testing.M) { os.Exit(gitsafe.RunIsolatedMain(m)) }
+
+type fixture struct {
+	repo       *gittest.Repo
+	base, head string
+	source     []string
+}
+
+// Scripted edits deliberately have a hand-counted net diff of +3/-1.
+func buildFixture(t *testing.T, squash bool) fixture {
+	t.Helper()
+	r := gittest.NewRepo(t, gittest.Options{InitArgs: []string{"init", "-b", "main"}, ConfigureUser: true})
+	r.Runner = gitsafe.Runner()
+	base := r.CommitFile("work.txt", "old\nkeep\n", "base")
+	r.Checkout("-b", "topic")
+	a := r.CommitFile("work.txt", "new\nkeep\n", "replace")
+	b := r.CommitFile("work.txt", "new\nkeep\none\ntwo\n", "append")
+	r.Checkout("main")
+	if squash {
+		r.Run("merge", "--squash", "topic")
+		r.Run("commit", "-m", "squash")
+	} else {
+		r.Run("merge", "--no-ff", "topic", "-m", "merge")
+	}
+	return fixture{r, base, r.Head(), []string{a, b}}
+}
+
+func fixtureLimits() landedwork.Limits {
+	return landedwork.Limits{Records: 1000, Nodes: 1000, InputBytes: 1 << 20, OutputBytes: 1 << 20}
+}
+
+func (f fixture) bounds() landedwork.Bounds {
+	return landedwork.Bounds{Repository: landedwork.Repository{Provider: platform.KindGitHub, Host: "github.com", ID: "101"}, Base: f.base, Head: f.head}
+}
+
+func (f fixture) prepare(t *testing.T) (context.Context, *landedwork.Interval) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	t.Cleanup(cancel)
+	p, err := landedwork.Prepare(ctx, f.repo.Root, f.bounds(), fixtureLimits())
+	require.NoError(t, err)
+	return ctx, p
+}

--- a/landedwork/fixtures_test.go
+++ b/landedwork/fixtures_test.go
@@ -56,3 +56,21 @@ func (f fixture) prepare(t *testing.T) (context.Context, *landedwork.Interval) {
 	require.NoError(t, err)
 	return ctx, p
 }
+
+func buildSideFixture(t *testing.T) fixture {
+	t.Helper()
+	r := gittest.NewRepo(t, gittest.Options{InitArgs: []string{"init", "-b", "main"}, ConfigureUser: true})
+	r.Runner = gitsafe.Runner()
+	r.CommitFile("work.txt", "old\nkeep\n", "base")
+	r.Checkout("-b", "topic")
+	a := r.CommitFile("work.txt", "new\nkeep\n", "replace")
+	r.Checkout("main")
+	base := r.CommitFile("other.txt", "already present\n", "main advances")
+	r.Checkout("topic")
+	r.Run("merge", "--no-ff", "main", "-m", "merge main")
+	internalMerge := r.Head()
+	b := r.CommitFile("work.txt", "new\nkeep\none\ntwo\n", "append")
+	r.Checkout("main")
+	r.Run("merge", "--no-ff", "topic", "-m", "merge topic")
+	return fixture{r, base, r.Head(), []string{a, base, internalMerge, b}}
+}

--- a/landedwork/git.go
+++ b/landedwork/git.go
@@ -118,6 +118,10 @@ func (v *objectView) parents(ctx context.Context, id string) ([]string, error) {
 	if err := v.meter.node(); err != nil {
 		return nil, err
 	}
+	// rev-list can serve cached ancestry even after the commit object disappears.
+	if _, err := v.run(ctx, "cat-file", "-e", id+"^{commit}"); err != nil {
+		return nil, err
+	}
 	data, err := v.run(ctx, "rev-list", "--parents", "-n", "1", id, "--")
 	if err != nil {
 		return nil, err

--- a/landedwork/git.go
+++ b/landedwork/git.go
@@ -1,0 +1,137 @@
+package landedwork
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	gitcmd "go.kenn.io/kit/git/cmd"
+	gitenv "go.kenn.io/kit/git/env"
+)
+
+type objectView struct {
+	dir    string
+	runner gitcmd.Runner
+	meter  *meter
+}
+
+func (v *objectView) command(ctx context.Context, args ...string) *exec.Cmd {
+	return v.runner.Command(ctx, v.dir, args...)
+}
+
+func (v *objectView) run(ctx context.Context, args ...string) ([]byte, error) {
+	cmd := v.command(ctx, args...)
+	out, stderr := &boundedBuffer{meter: v.meter}, &boundedBuffer{meter: v.meter}
+	cmd.Stdout, cmd.Stderr = out, stderr
+	err := cmd.Run()
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	if v.meter.failed {
+		return nil, ErrInputBudget
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read Git objects: %w", err)
+	}
+	return out.Bytes(), nil
+}
+
+func openView(ctx context.Context, path string, m *meter) (_ *objectView, err error) {
+	if path == "" {
+		return nil, errors.New("explicit repository path required")
+	}
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	runner := gitcmd.New()
+	runner.DisableSafeDirectoryForward = true
+	source := &objectView{dir: path, runner: runner, meter: m}
+	objects, err := source.run(ctx, "rev-parse", "--path-format=absolute", "--git-path", "objects")
+	if err != nil {
+		return nil, err
+	}
+	format, err := source.run(ctx, "rev-parse", "--show-object-format")
+	if err != nil {
+		return nil, err
+	}
+	fmtName := strings.TrimSpace(string(format))
+	if fmtName != "sha1" && fmtName != "sha256" {
+		return nil, errors.New("unknown Git object format")
+	}
+	dir, err := os.MkdirTemp("", "forge-object-view-*")
+	if err != nil {
+		return nil, err
+	}
+	v := &objectView{dir: dir, runner: runner, meter: m}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, os.RemoveAll(dir))
+		}
+	}()
+	if _, err = v.run(ctx, "init", "--bare", "--template=", "--object-format="+fmtName); err != nil {
+		return nil, err
+	}
+	shallowPath, err := source.run(ctx, "rev-parse", "--path-format=absolute", "--git-path", "shallow")
+	if err != nil {
+		return nil, err
+	}
+	if err = copyShallow(strings.TrimSpace(string(shallowPath)), dir, m); err != nil {
+		return nil, err
+	}
+	v.runner.Env = append(gitenv.StripAll(os.Environ()),
+		"GIT_OBJECT_DIRECTORY="+strings.TrimSpace(string(objects)), "GIT_NO_LAZY_FETCH=1",
+		"GIT_NO_REPLACE_OBJECTS=1", "GIT_OPTIONAL_LOCKS=0")
+	v.runner.StripEnv = false
+	return v, nil
+}
+
+func (v *objectView) close() error { return os.RemoveAll(v.dir) }
+
+func (v *objectView) parents(ctx context.Context, id string) ([]string, error) {
+	if err := v.meter.node(); err != nil {
+		return nil, err
+	}
+	data, err := v.run(ctx, "cat-file", "commit", id)
+	if err != nil {
+		return nil, err
+	}
+	var parents []string
+	for line := range strings.SplitSeq(string(data), "\n") {
+		if line == "" {
+			break
+		}
+		if parent, ok := strings.CutPrefix(line, "parent "); ok {
+			if !objectID(parent) {
+				return nil, errors.New("invalid parent object ID")
+			}
+			parents = append(parents, parent)
+		}
+	}
+	return parents, nil
+}
+
+func (v *objectView) introduced(ctx context.Context, base, head string) ([]string, error) {
+	data, err := v.run(ctx, "rev-list", "--topo-order", "--reverse", head, "^"+base, "--")
+	if err != nil {
+		return nil, err
+	}
+	var ids []string
+	for id := range strings.FieldsSeq(string(data)) {
+		if err := v.meter.node(); err != nil {
+			return nil, err
+		}
+		if err := v.meter.records(1); err != nil {
+			return nil, err
+		}
+		if !objectID(id) {
+			return nil, errors.New("invalid revision object ID")
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}

--- a/landedwork/git.go
+++ b/landedwork/git.go
@@ -96,23 +96,20 @@ func (v *objectView) parents(ctx context.Context, id string) ([]string, error) {
 	if err := v.meter.node(); err != nil {
 		return nil, err
 	}
-	data, err := v.run(ctx, "cat-file", "commit", id)
+	data, err := v.run(ctx, "rev-list", "--parents", "-n", "1", id, "--")
 	if err != nil {
 		return nil, err
 	}
-	var parents []string
-	for line := range strings.SplitSeq(string(data), "\n") {
-		if line == "" {
-			break
-		}
-		if parent, ok := strings.CutPrefix(line, "parent "); ok {
-			if !objectID(parent) {
-				return nil, errors.New("invalid parent object ID")
-			}
-			parents = append(parents, parent)
+	ids := strings.Fields(string(data))
+	if len(ids) == 0 || ids[0] != id {
+		return nil, errors.New("missing commit object")
+	}
+	for _, parent := range ids[1:] {
+		if !objectID(parent) {
+			return nil, errors.New("invalid parent object ID")
 		}
 	}
-	return parents, nil
+	return ids[1:], nil
 }
 
 func (v *objectView) introduced(ctx context.Context, base, head string) ([]string, error) {

--- a/landedwork/git.go
+++ b/landedwork/git.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -24,20 +25,25 @@ func (v *objectView) command(ctx context.Context, args ...string) *exec.Cmd {
 }
 
 func (v *objectView) run(ctx context.Context, args ...string) ([]byte, error) {
+	out := &boundedBuffer{meter: v.meter}
+	err := v.runTo(ctx, out, args...)
+	return out.Bytes(), err
+}
+
+func (v *objectView) runTo(ctx context.Context, out io.Writer, args ...string) error {
 	cmd := v.command(ctx, args...)
-	out, stderr := &boundedBuffer{meter: v.meter}, &boundedBuffer{meter: v.meter}
-	cmd.Stdout, cmd.Stderr = out, stderr
+	cmd.Stdout, cmd.Stderr = out, &boundedBuffer{meter: v.meter}
 	err := cmd.Run()
 	if ctx.Err() != nil {
-		return nil, ctx.Err()
+		return ctx.Err()
 	}
 	if v.meter.failed {
-		return nil, ErrInputBudget
+		return ErrInputBudget
 	}
 	if err != nil {
-		return nil, fmt.Errorf("read Git objects: %w", err)
+		return fmt.Errorf("read Git objects: %w", err)
 	}
-	return out.Bytes(), nil
+	return nil
 }
 
 func openView(ctx context.Context, path string, m *meter) (_ *objectView, err error) {
@@ -113,22 +119,13 @@ func (v *objectView) parents(ctx context.Context, id string) ([]string, error) {
 }
 
 func (v *objectView) introduced(ctx context.Context, base, head string) ([]string, error) {
-	data, err := v.run(ctx, "rev-list", "--topo-order", "--reverse", head, "^"+base, "--")
+	out := &commitStream{meter: v.meter}
+	err := v.runTo(ctx, out, "rev-list", "--topo-order", "--reverse", head, "^"+base, "--")
 	if err != nil {
 		return nil, err
 	}
-	var ids []string
-	for id := range strings.FieldsSeq(string(data)) {
-		if err := v.meter.node(); err != nil {
-			return nil, err
-		}
-		if err := v.meter.records(1); err != nil {
-			return nil, err
-		}
-		if !objectID(id) {
-			return nil, errors.New("invalid revision object ID")
-		}
-		ids = append(ids, id)
+	if out.pending != "" {
+		return nil, errors.New("incomplete revision object ID")
 	}
-	return ids, nil
+	return out.ids, nil
 }

--- a/landedwork/git.go
+++ b/landedwork/git.go
@@ -57,6 +57,9 @@ func openView(ctx context.Context, path string, m *meter) (_ *objectView, err er
 	runner := gitcmd.New()
 	runner.DisableSafeDirectoryForward = true
 	source := &objectView{dir: path, runner: runner, meter: m}
+	if err := source.requireRepositoryRoot(ctx); err != nil {
+		return nil, err
+	}
 	objects, err := source.run(ctx, "rev-parse", "--path-format=absolute", "--git-path", "objects")
 	if err != nil {
 		return nil, err
@@ -94,6 +97,19 @@ func openView(ctx context.Context, path string, m *meter) (_ *objectView, err er
 		"GIT_NO_REPLACE_OBJECTS=1", "GIT_OPTIONAL_LOCKS=0")
 	v.runner.StripEnv = false
 	return v, nil
+}
+
+// Resolve only metadata at the supplied path, never Git's parent discovery.
+// Worktrees have a .git directory or gitfile; bare repositories are git dirs.
+func (v *objectView) requireRepositoryRoot(ctx context.Context) error {
+	gitDir := filepath.Join(v.dir, ".git")
+	if _, err := os.Stat(gitDir); errors.Is(err, os.ErrNotExist) {
+		gitDir = v.dir
+	} else if err != nil {
+		return err
+	}
+	_, err := v.run(ctx, "rev-parse", "--resolve-git-dir", gitDir)
+	return err
 }
 
 func (v *objectView) close() error { return os.RemoveAll(v.dir) }

--- a/landedwork/git_test.go
+++ b/landedwork/git_test.go
@@ -1,0 +1,60 @@
+package landedwork
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gittest "go.kenn.io/kit/git/test"
+)
+
+func TestObjectCommandReapsCanceledProcess(t *testing.T) {
+	r := gittest.NewRepoWithCommit(t)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+	m := &meter{limits: Limits{Records: 1000, Nodes: 1000, InputBytes: 1 << 20, OutputBytes: 1 << 20}}
+	v, err := openView(ctx, r.Root, m)
+	require := require.New(t)
+	require.NoError(err)
+	defer func() { require.NoError(v.close()) }()
+	input, writer, err := os.Pipe()
+	require.NoError(err)
+	defer input.Close()
+	defer writer.Close()
+	cmd := v.command(ctx, "cat-file", "--batch")
+	cmd.Stdin = input
+	out, err := cmd.StdoutPipe()
+	require.NoError(err)
+	require.NoError(cmd.Start())
+	defer func() {
+		cancel()
+		if cmd.ProcessState == nil {
+			_ = cmd.Wait()
+		}
+	}()
+	_, err = fmt.Fprintln(writer, r.Head())
+	require.NoError(err)
+	reader := bufio.NewReader(out)
+	header, err := reader.ReadString('\n')
+	require.NoError(err)
+	var id, kind string
+	var size int64
+	_, err = fmt.Sscanf(header, "%s %s %d", &id, &kind, &size)
+	require.NoError(err)
+	require.Equal(r.Head(), id)
+	require.Equal("commit", kind)
+	_, err = io.CopyN(io.Discard, reader, size+1)
+	require.NoError(err)
+	// The input stays open: cancellation, not EOF, must stop and reap Git.
+	cancel()
+	require.Error(cmd.Wait())
+	require.NotNil(cmd.ProcessState)
+	assert.False(t, cmd.ProcessState.Success())
+	require.ErrorIs(ctx.Err(), context.Canceled)
+}

--- a/landedwork/git_test.go
+++ b/landedwork/git_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -57,4 +59,36 @@ func TestObjectCommandReapsCanceledProcess(t *testing.T) {
 	require.NotNil(cmd.ProcessState)
 	assert.False(t, cmd.ProcessState.Success())
 	require.ErrorIs(ctx.Err(), context.Canceled)
+}
+
+func TestObjectViewIgnoresGlobalAndSystemConfig(t *testing.T) {
+	r := gittest.NewRepoWithCommit(t)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+	// Config discovery is the subject: all candidate files are test-owned.
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(root, "xdg"))
+	system := filepath.Join(root, "system.gitconfig")
+	require := require.New(t)
+	require.NoError(os.WriteFile(filepath.Join(root, ".gitconfig"), []byte("[landingprobe]\n global = visible\n"), 0600))
+	require.NoError(os.WriteFile(system, []byte("[landingprobe]\n system = visible\n"), 0600))
+	m := &meter{limits: Limits{Records: 1000, Nodes: 1000, InputBytes: 1 << 20, OutputBytes: 1 << 20}}
+	v, err := openView(ctx, r.Root, m)
+	require.NoError(err)
+	defer func() { require.NoError(v.close()) }()
+	v.runner.Env = append(v.runner.Env, "GIT_CONFIG_SYSTEM="+system)
+	// Prove that Git can read both files when the existing protections are off.
+	control := v.runner
+	control.NullGlobalConfig, control.NoSystemConfig = false, false
+	out, err := control.Command(ctx, v.dir, "config", "--get-regexp", "^landingprobe\\.").Output()
+	require.NoError(err)
+	require.ElementsMatch([]string{"landingprobe.system visible", "landingprobe.global visible"}, strings.Split(strings.TrimSpace(string(out)), "\n"))
+	out, err = v.run(ctx, "config", "--get-regexp", "^landingprobe\\.")
+	require.Error(err)
+	require.Empty(out)
+	// The object view remains usable, rather than merely failing every command.
+	parents, err := v.parents(ctx, r.Head())
+	require.NoError(err)
+	require.Empty(parents)
 }

--- a/landedwork/interval_test.go
+++ b/landedwork/interval_test.go
@@ -2,6 +2,7 @@ package landedwork_test
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -126,4 +127,25 @@ func TestAnalyzeIncompletePreparation(t *testing.T) {
 	assert.Equal(p.Query().Gaps, r.Coverage.Gaps)
 	assert.Equal(f.bounds(), r.Coverage.Bounds)
 	assert.Empty(r.Landings)
+}
+
+func TestAnalyzeBudgetPreservesPreparedGaps(t *testing.T) {
+	f := buildFixture(t, false)
+	ctx, _ := f.prepare(t)
+	bounds := f.bounds()
+	bounds.Head = strings.Repeat("a", 40)
+	p, err := landedwork.Prepare(ctx, f.repo.Root, bounds, fixtureLimits())
+	require := require.New(t)
+	require.NoError(err)
+	expected := []landedwork.Gap{{ObjectID: bounds.Head, Reason: "objects_unavailable"}}
+	require.Equal(expected, p.Query().Gaps)
+	limits := fixtureLimits()
+	limits.InputBytes = 1
+	r, err := landedwork.Analyze(ctx, p, fixtureEvidence(f, p, "merge"), limits)
+	require.NoError(err)
+	assert := assert.New(t)
+	assert.Equal(append(expected, landedwork.Gap{Reason: "input_budget_exhausted"}), r.Coverage.Gaps)
+	assert.False(r.Coverage.Complete)
+	assert.Equal(bounds, r.Coverage.Bounds)
+	assert.Equal(bounds.Base, r.Coverage.CertifiedHead)
 }

--- a/landedwork/interval_test.go
+++ b/landedwork/interval_test.go
@@ -1,0 +1,129 @@
+package landedwork_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/landedwork"
+)
+
+func twoLandings(t *testing.T) (fixture, []landedwork.Candidate) {
+	t.Helper()
+	f := buildFixture(t, false)
+	first := landedwork.Candidate{Repository: f.bounds().Repository, ID: "7", Terminal: f.head,
+		SourceHead: f.source[1], Source: f.source, SourceComplete: true, Method: "merge",
+		MethodEvidence: "fixture-method", TerminalEvidence: "fixture-terminal"}
+	f.repo.Checkout("-b", "second")
+	id := f.repo.CommitFile("second.txt", "second\n", "second change")
+	f.repo.Checkout("main")
+	f.repo.Run("merge", "--no-ff", "second", "-m", "second merge")
+	f.head = f.repo.Head()
+	second := first
+	second.ID, second.Terminal, second.SourceHead, second.Source = "8", f.head, id, []string{id}
+	return f, []landedwork.Candidate{first, second}
+}
+
+func TestAnalyzeMixedCoverage(t *testing.T) {
+	for _, name := range []string{"complete", "unresolved", "unattributed"} {
+		t.Run(name, func(t *testing.T) {
+			f, candidates := twoLandings(t)
+			ctx, p := f.prepare(t)
+			e := fixtureEvidence(f, p, "merge")
+			e.Candidates = candidates
+			switch name {
+			case "unresolved":
+				e.Candidates[1].SourceComplete = false
+			case "unattributed":
+				e.Candidates = e.Candidates[:1]
+			}
+			r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+			require := require.New(t)
+			assert := assert.New(t)
+			require.NoError(err)
+			require.NotEmpty(r.Landings)
+			assert.Equal("7", r.Landings[0].CandidateID)
+			assert.Equal(f.bounds(), r.Coverage.Bounds)
+			switch name {
+			case "complete":
+				assert.Len(r.Landings, 2)
+				assert.True(r.Coverage.Complete)
+				assert.Equal(f.head, r.Coverage.CertifiedHead)
+				assert.Empty(r.Unattributed)
+				assert.Empty(r.Coverage.Gaps)
+			case "unresolved":
+				assert.Len(r.Landings, 1)
+				assert.False(r.Coverage.Complete)
+				assert.Equal(f.base, r.Coverage.CertifiedHead)
+				assert.Equal([]string{f.head}, r.Unattributed)
+				assert.Equal([]landedwork.Gap{{CandidateID: "8", ObjectID: f.head, Reason: "source_incomplete"}}, r.Coverage.Gaps)
+			case "unattributed":
+				assert.Len(r.Landings, 1)
+				assert.False(r.Coverage.Complete)
+				assert.Equal(candidates[0].Terminal, r.Coverage.CertifiedHead)
+				assert.Equal([]string{f.head}, r.Unattributed)
+				assert.Empty(r.Coverage.Gaps)
+			}
+		})
+	}
+}
+
+func TestAnalyzeOrderIndependentUnderExhaustion(t *testing.T) {
+	f, candidates := twoLandings(t)
+	ctx, p := f.prepare(t)
+	e := fixtureEvidence(f, p, "merge")
+	e.Candidates = candidates
+	limits := fixtureLimits()
+	limits.Nodes = 12 // Enough for the first proof, not both; candidate order must not select the winner.
+	r, err := landedwork.Analyze(ctx, p, e, limits)
+	require.NoError(t, err)
+	e.Candidates = slices.Clone(e.Candidates)
+	slices.Reverse(e.Candidates)
+	reversed, err := landedwork.Analyze(ctx, p, e, limits)
+	require.NoError(t, err)
+	assert.Equal(t, r, reversed)
+}
+
+func TestAnalyzeQueryBinding(t *testing.T) {
+	for _, name := range []string{"repository", "pin", "commits", "coverage", "candidate identity"} {
+		t.Run(name, func(t *testing.T) {
+			f := buildFixture(t, false)
+			ctx, p := f.prepare(t)
+			e := fixtureEvidence(f, p, "merge")
+			switch name {
+			case "repository":
+				e.Query.Bounds.Repository.ID = "202"
+			case "pin":
+				e.Query.Bounds.Head = f.base
+			case "commits":
+				e.Query.Commits = e.Query.Commits[:1]
+			case "coverage":
+				e.Query.Complete = false
+			case "candidate identity":
+				e.Candidates[0].Repository.ID = "202"
+			}
+			r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+			require.Error(t, err)
+			assert.Equal(t, landedwork.Result{}, r)
+		})
+	}
+}
+
+func TestAnalyzeIncompletePreparation(t *testing.T) {
+	f := buildFixture(t, false)
+	ctx, _ := f.prepare(t)
+	limits := fixtureLimits()
+	limits.Nodes = 1
+	p, err := landedwork.Prepare(ctx, f.repo.Root, f.bounds(), limits)
+	require := require.New(t)
+	require.NoError(err)
+	r, err := landedwork.Analyze(ctx, p, fixtureEvidence(f, p, "merge"), fixtureLimits())
+	require.NoError(err)
+	assert := assert.New(t)
+	assert.False(r.Coverage.Complete)
+	assert.Equal(f.base, r.Coverage.CertifiedHead)
+	assert.Equal(p.Query().Gaps, r.Coverage.Gaps)
+	assert.Equal(f.bounds(), r.Coverage.Bounds)
+	assert.Empty(r.Landings)
+}

--- a/landedwork/model.go
+++ b/landedwork/model.go
@@ -23,7 +23,11 @@ type Bounds struct {
 	Base, Head string
 }
 
-// Limits are per-operation positive maxima, not production defaults.
+// Limits are per-operation positive maxima, not production defaults. Records
+// bounds collection entries; Nodes charges commit reads and reachability probes.
+// InputBytes charges supplied evidence and Git stdout/stderr. OutputBytes is
+// the sum of returned string bytes, counting every occurrence, not a wire size.
+// Git's internal traversal work is bounded by the required context deadline.
 type Limits struct{ Records, Nodes, InputBytes, OutputBytes int64 }
 
 type Gap struct{ CandidateID, ObjectID, Reason string }

--- a/landedwork/model.go
+++ b/landedwork/model.go
@@ -1,0 +1,90 @@
+// Package landedwork proves landing boundaries from pinned Git objects and
+// caller-supplied provider evidence. It neither collects nor resolves identities.
+package landedwork
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"slices"
+	"strings"
+
+	"go.kenn.io/forge/platform"
+)
+
+// Repository is a provider-verified identity, never an owner/name route.
+type Repository struct {
+	Provider platform.Kind
+	Host, ID string
+}
+
+type Bounds struct {
+	Repository Repository
+	Base, Head string
+}
+
+// Limits are per-operation positive maxima, not production defaults.
+type Limits struct{ Records, Nodes, InputBytes, OutputBytes int64 }
+
+type Gap struct{ CandidateID, ObjectID, Reason string }
+
+// Query is the exact newly reachable set to collect, including side ancestry.
+type Query struct {
+	Bounds   Bounds
+	Commits  []string
+	Complete bool
+	Gaps     []Gap
+}
+
+// Interval retains private preparation state. Query returns independent copies.
+type Interval struct {
+	path  string
+	query Query
+	spine []string
+}
+
+func (p *Interval) Query() Query {
+	q := p.query
+	q.Commits = slices.Clone(q.Commits)
+	q.Gaps = slices.Clone(q.Gaps)
+	return q
+}
+
+// ErrInputBudget and ErrOutputBudget distinguish finite work from empty work.
+var (
+	ErrInputBudget  = errors.New("landing input budget exhausted")
+	ErrOutputBudget = errors.New("landing output budget exhausted")
+)
+
+func validate(ctx context.Context, b Bounds, l Limits) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		return errors.New("landing analysis requires a deadline")
+	}
+	if l.Records <= 0 || l.Nodes <= 0 || l.InputBytes <= 0 || l.OutputBytes <= 0 {
+		return errors.New("landing limits must be positive")
+	}
+	if !validRepository(b.Repository) || !objectID(b.Base) || !objectID(b.Head) || len(b.Base) != len(b.Head) {
+		return errors.New("landing analysis requires repository identity and full object IDs")
+	}
+	return nil
+}
+
+func validRepository(r Repository) bool {
+	switch r.Provider {
+	case platform.KindGitHub, platform.KindGitLab, platform.KindForgejo, platform.KindGitea:
+	default:
+		return false
+	}
+	return r.ID != "" && r.Host != "" && !strings.ContainsAny(r.Host, " /\t\r\n") && strings.ToLower(r.Host) == r.Host
+}
+
+func objectID(id string) bool {
+	if len(id) != 40 && len(id) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(id)
+	return err == nil && strings.ToLower(id) == id
+}

--- a/landedwork/prepare.go
+++ b/landedwork/prepare.go
@@ -1,0 +1,84 @@
+package landedwork
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"slices"
+)
+
+// Prepare enumerates the pinned interval without fetching or selecting a remote.
+// Valid input with missing graph evidence returns an incomplete Interval.
+func Prepare(ctx context.Context, path string, bounds Bounds, limits Limits) (p *Interval, err error) {
+	if err = validate(ctx, bounds, limits); err != nil {
+		return nil, err
+	}
+	if path == "" {
+		return nil, errors.New("explicit repository path required")
+	}
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	p = &Interval{path: path, query: Query{Bounds: bounds}}
+	m := &meter{limits: limits}
+	defer func() {
+		if ctx.Err() != nil {
+			p, err = nil, ctx.Err()
+			return
+		}
+		if err != nil {
+			return
+		}
+		if err = checkQueryOutput(p.query, limits); err != nil {
+			p = nil
+		}
+	}()
+	v, openErr := openView(ctx, path, m)
+	if openErr != nil {
+		p.query.Gaps = []Gap{{Reason: graphReason(openErr)}}
+		return p, nil
+	}
+	defer func() { err = errors.Join(err, v.close()) }()
+	if shallowErr := v.checkShallow(ctx, bounds); shallowErr != nil {
+		p.query.Gaps = []Gap{{Reason: graphReason(shallowErr)}}
+		return p, nil
+	}
+	if _, readErr := v.parents(ctx, bounds.Base); readErr != nil {
+		p.query.Gaps = []Gap{{ObjectID: bounds.Base, Reason: graphReason(readErr)}}
+		return p, nil
+	}
+	current := bounds.Head
+	for current != bounds.Base {
+		parents, readErr := v.parents(ctx, current)
+		if readErr != nil {
+			p.query.Gaps = []Gap{{ObjectID: current, Reason: graphReason(readErr)}}
+			return p, nil
+		}
+		if len(parents) == 0 {
+			p.query.Gaps = []Gap{{Reason: "base_not_first_parent"}}
+			return p, nil
+		}
+		p.spine = append(p.spine, current)
+		current = parents[0]
+	}
+	slices.Reverse(p.spine)
+	ids, readErr := v.introduced(ctx, bounds.Base, bounds.Head)
+	if readErr != nil {
+		p.query.Gaps = []Gap{{Reason: graphReason(readErr)}}
+		return p, nil
+	}
+	slices.Sort(ids)
+	p.query.Commits, p.query.Complete = ids, true
+	return p, nil
+}
+
+func graphReason(err error) string {
+	if errors.Is(err, ErrInputBudget) {
+		return "input_budget_exhausted"
+	}
+	if errors.Is(err, errShallow) {
+		return "shallow_boundary"
+	}
+	return "objects_unavailable"
+}

--- a/landedwork/prepare_test.go
+++ b/landedwork/prepare_test.go
@@ -1,0 +1,71 @@
+package landedwork_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/landedwork"
+)
+
+func TestPrepareIncludesSideAncestry(t *testing.T) {
+	for _, squash := range []bool{false, true} {
+		t.Run(map[bool]string{false: "merge", true: "squash"}[squash], func(t *testing.T) {
+			f := buildFixture(t, squash)
+			_, p := f.prepare(t)
+			q := p.Query()
+			want := []string{f.head}
+			if !squash {
+				want = append(want, f.source...)
+			}
+			assert := assert.New(t)
+			assert.True(q.Complete)
+			assert.Equal(f.bounds(), q.Bounds)
+			assert.ElementsMatch(want, q.Commits)
+			assert.Empty(q.Gaps)
+		})
+	}
+}
+
+func TestPrepareGraphGaps(t *testing.T) {
+	for _, name := range []string{"missing", "divergent", "side-base", "budget"} {
+		t.Run(name, func(t *testing.T) {
+			f := buildFixture(t, false)
+			bounds, limits := f.bounds(), fixtureLimits()
+			reason := "base_not_first_parent"
+			switch name {
+			case "missing":
+				bounds.Head = strings.Repeat("a", 40)
+				reason = "objects_unavailable"
+			case "divergent":
+				f.repo.Checkout("-b", "other", f.base)
+				bounds.Base = f.repo.CommitFile("other.txt", "other\n", "other")
+			case "side-base":
+				bounds.Base = f.source[1]
+			case "budget":
+				limits.Nodes = 1
+				reason = "input_budget_exhausted"
+			}
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+			defer cancel()
+			p, err := landedwork.Prepare(ctx, f.repo.Root, bounds, limits)
+			require := require.New(t)
+			assert := assert.New(t)
+			require.NoError(err)
+			assert.False(p.Query().Complete)
+			require.NotEmpty(p.Query().Gaps)
+			assert.Equal(reason, p.Query().Gaps[0].Reason)
+		})
+	}
+}
+
+func TestPrepareCanceled(t *testing.T) {
+	f := buildFixture(t, false)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	cancel()
+	_, err := landedwork.Prepare(ctx, f.repo.Root, f.bounds(), fixtureLimits())
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/landedwork/prepare_test.go
+++ b/landedwork/prepare_test.go
@@ -2,12 +2,16 @@ package landedwork_test
 
 import (
 	"context"
+	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/testutil/gitsafe"
 	"go.kenn.io/forge/landedwork"
 )
 
@@ -30,8 +34,75 @@ func TestPrepareIncludesSideAncestry(t *testing.T) {
 	}
 }
 
+func TestAnalyzeMissingBoundaryAfterPreparation(t *testing.T) {
+	f := buildFixture(t, true)
+	ctx, p := f.prepare(t)
+	// Remove only a loose object from this test-owned repository after preparing.
+	require.NoError(t, os.Remove(filepath.Join(f.repo.GitDir, "objects", f.base[:2], f.base[2:])))
+	r, err := landedwork.Analyze(ctx, p, fixtureEvidence(f, p, "squash"), fixtureLimits())
+	require := require.New(t)
+	assert := assert.New(t)
+	require.NoError(err)
+	assert.Empty(r.Landings)
+	assert.False(r.Coverage.Complete)
+	assert.Equal(f.base, r.Coverage.CertifiedHead)
+	assert.Equal(f.bounds(), r.Coverage.Bounds)
+	require.NotEmpty(r.Coverage.Gaps)
+	assert.Equal("objects_unavailable", r.Coverage.Gaps[0].Reason)
+}
+
+func TestObjectSourceIgnoresWorkingFilesAndReplacementRefs(t *testing.T) {
+	f := buildFixture(t, false)
+	f.repo.WriteFile("work.txt", "uncommitted\n")
+	f.repo.Run("replace", f.head, f.base)
+	f.repo.Run("remote", "add", "upstream", "https://unavailable.example/repository.git")
+	refs, status := f.repo.Run("show-ref"), f.repo.Run("status", "--porcelain")
+	ctx, p := f.prepare(t)
+	r, err := landedwork.Analyze(ctx, p, fixtureEvidence(f, p, "merge"), fixtureLimits())
+	require.NoError(t, err)
+	assert := assert.New(t)
+	assert.ElementsMatch([]string{f.source[0], f.source[1], f.head}, p.Query().Commits)
+	assert.True(r.Coverage.Complete)
+	assert.Equal(f.bounds(), r.Coverage.Bounds)
+	assert.Equal(f.head, r.Coverage.CertifiedHead)
+	assert.Empty(r.Coverage.Gaps)
+	assert.Empty(r.Unattributed)
+	assert.Len(r.Landings, 1)
+	assert.Equal(refs, f.repo.Run("show-ref"))
+	assert.Equal(status, f.repo.Run("status", "--porcelain"))
+}
+
+func TestPrepareShallowSourceDoesNotFetch(t *testing.T) {
+	f := buildFixture(t, false)
+	clone := filepath.Join(t.TempDir(), "shallow")
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+	runner := gitsafe.Runner()
+	source := (&url.URL{Scheme: "file", Path: filepath.ToSlash(f.repo.Root)}).String()
+	_, _, err := runner.Run(ctx, "", nil, "clone", "--depth=1", "--no-local", source, clone)
+	require := require.New(t)
+	require.NoError(err)
+	_, _, err = runner.Run(ctx, clone, nil, "remote", "set-url", "origin", "https://unavailable.example/repository.git")
+	require.NoError(err)
+	p, err := landedwork.Prepare(ctx, clone, f.bounds(), fixtureLimits())
+	require.NoError(err)
+	assert := assert.New(t)
+	assert.False(p.Query().Complete)
+	assert.Equal(f.bounds(), p.Query().Bounds)
+	require.NotEmpty(p.Query().Gaps)
+	// Base is missing in this depth-one clone; the gap must not be repaired by fetch.
+	_, _, err = runner.Run(ctx, clone, nil, "cat-file", "-e", f.base)
+	require.Error(err)
+	r, err := landedwork.Analyze(ctx, p, fixtureEvidence(f, p, "merge"), fixtureLimits())
+	require.NoError(err)
+	assert.False(r.Coverage.Complete)
+	assert.Equal(f.base, r.Coverage.CertifiedHead)
+	assert.Equal(p.Query().Gaps, r.Coverage.Gaps)
+	assert.Empty(r.Landings)
+}
+
 func TestPrepareGraphGaps(t *testing.T) {
-	for _, name := range []string{"missing", "divergent", "side-base", "budget"} {
+	for _, name := range []string{"missing", "divergent", "side-base", "budget", "records", "bytes"} {
 		t.Run(name, func(t *testing.T) {
 			f := buildFixture(t, false)
 			bounds, limits := f.bounds(), fixtureLimits()
@@ -47,6 +118,12 @@ func TestPrepareGraphGaps(t *testing.T) {
 				bounds.Base = f.source[1]
 			case "budget":
 				limits.Nodes = 1
+				reason = "input_budget_exhausted"
+			case "records":
+				limits.Records = 1
+				reason = "input_budget_exhausted"
+			case "bytes":
+				limits.InputBytes = 1
 				reason = "input_budget_exhausted"
 			}
 			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)

--- a/landedwork/prepare_test.go
+++ b/landedwork/prepare_test.go
@@ -35,20 +35,53 @@ func TestPrepareIncludesSideAncestry(t *testing.T) {
 }
 
 func TestAnalyzeMissingBoundaryAfterPreparation(t *testing.T) {
-	f := buildFixture(t, true)
-	ctx, p := f.prepare(t)
-	// Remove only a loose object from this test-owned repository after preparing.
-	require.NoError(t, os.Remove(filepath.Join(f.repo.GitDir, "objects", f.base[:2], f.base[2:])))
-	r, err := landedwork.Analyze(ctx, p, fixtureEvidence(f, p, "squash"), fixtureLimits())
-	require := require.New(t)
-	assert := assert.New(t)
-	require.NoError(err)
-	assert.Empty(r.Landings)
-	assert.False(r.Coverage.Complete)
-	assert.Equal(f.base, r.Coverage.CertifiedHead)
-	assert.Equal(f.bounds(), r.Coverage.Bounds)
-	require.NotEmpty(r.Coverage.Gaps)
-	assert.Equal("objects_unavailable", r.Coverage.Gaps[0].Reason)
+	for _, mode := range []string{"loose", "commit-graph"} {
+		t.Run(mode, func(t *testing.T) {
+			f := buildFixture(t, true)
+			if mode == "commit-graph" {
+				f.repo.Run("commit-graph", "write", "--reachable")
+			}
+			ctx, p := f.prepare(t)
+			// Remove only a loose object from this test-owned repository after preparing.
+			require.NoError(t, os.Remove(filepath.Join(f.repo.GitDir, "objects", f.base[:2], f.base[2:])))
+			r, err := landedwork.Analyze(ctx, p, fixtureEvidence(f, p, "squash"), fixtureLimits())
+			require := require.New(t)
+			assert := assert.New(t)
+			require.NoError(err)
+			assert.Empty(r.Landings)
+			assert.False(r.Coverage.Complete)
+			assert.Equal(f.base, r.Coverage.CertifiedHead)
+			assert.Equal(f.bounds(), r.Coverage.Bounds)
+			require.NotEmpty(r.Coverage.Gaps)
+			assert.Equal("objects_unavailable", r.Coverage.Gaps[0].Reason)
+			if mode == "commit-graph" {
+				assert.Equal(f.base, r.Coverage.Gaps[0].ObjectID)
+			}
+		})
+	}
+}
+
+func TestAnalyzeCachedMissingSourceOrTerminal(t *testing.T) {
+	for _, target := range []string{"source", "terminal"} {
+		t.Run(target, func(t *testing.T) {
+			f := buildFixture(t, true)
+			f.repo.Run("commit-graph", "write", "--reachable")
+			ctx, p := f.prepare(t)
+			missing := f.head
+			if target == "source" {
+				missing = f.source[0]
+			}
+			require := require.New(t)
+			require.NoError(os.Remove(filepath.Join(f.repo.GitDir, "objects", missing[:2], missing[2:])))
+			r, err := landedwork.Analyze(ctx, p, fixtureEvidence(f, p, "squash"), fixtureLimits())
+			require.NoError(err)
+			assert := assert.New(t)
+			assert.Empty(r.Landings)
+			assert.False(r.Coverage.Complete)
+			assert.Equal(f.base, r.Coverage.CertifiedHead)
+			assert.Equal([]landedwork.Gap{{CandidateID: "7", ObjectID: missing, Reason: "objects_unavailable"}}, r.Coverage.Gaps)
+		})
+	}
 }
 
 func TestObjectSourceIgnoresWorkingFilesAndReplacementRefs(t *testing.T) {

--- a/landedwork/prepare_test.go
+++ b/landedwork/prepare_test.go
@@ -146,3 +146,31 @@ func TestPrepareCanceled(t *testing.T) {
 	_, err := landedwork.Prepare(ctx, f.repo.Root, f.bounds(), fixtureLimits())
 	require.ErrorIs(t, err, context.Canceled)
 }
+
+func TestPrepareRequiresRepositoryRoot(t *testing.T) {
+	f := buildFixture(t, false)
+	ctx, _ := f.prepare(t)
+	nested := filepath.Join(f.repo.Root, "nested")
+	require := require.New(t)
+	require.NoError(os.Mkdir(nested, 0700))
+	p, err := landedwork.Prepare(ctx, nested, f.bounds(), fixtureLimits())
+	require.NoError(err)
+	assert := assert.New(t)
+	assert.False(p.Query().Complete)
+	assert.Empty(p.Query().Commits)
+	assert.Equal([]landedwork.Gap{{Reason: "objects_unavailable"}}, p.Query().Gaps)
+}
+
+func TestPrepareBareAndLinkedRepositories(t *testing.T) {
+	f := buildFixture(t, false)
+	ctx, _ := f.prepare(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	f.repo.Run("clone", "--bare", "--no-local", f.repo.Root, bare)
+	linked := f.repo.AddWorktree("linked")
+	for _, path := range []string{bare, linked} {
+		p, err := landedwork.Prepare(ctx, path, f.bounds(), fixtureLimits())
+		require.NoError(t, err)
+		assert.True(t, p.Query().Complete)
+		assert.Empty(t, p.Query().Gaps)
+	}
+}

--- a/landedwork/prepare_test.go
+++ b/landedwork/prepare_test.go
@@ -35,16 +35,24 @@ func TestPrepareIncludesSideAncestry(t *testing.T) {
 }
 
 func TestAnalyzeMissingBoundaryAfterPreparation(t *testing.T) {
-	for _, mode := range []string{"loose", "commit-graph"} {
-		t.Run(mode, func(t *testing.T) {
-			f := buildFixture(t, true)
-			if mode == "commit-graph" {
+	for _, tc := range []struct {
+		method string
+		mode   string
+	}{
+		{"squash", "loose"},
+		{"squash", "commit-graph"},
+		{"merge", "loose"},
+		{"merge", "commit-graph"},
+	} {
+		t.Run(tc.method+"/"+tc.mode, func(t *testing.T) {
+			f := buildFixture(t, tc.method == "squash")
+			if tc.mode == "commit-graph" {
 				f.repo.Run("commit-graph", "write", "--reachable")
 			}
 			ctx, p := f.prepare(t)
 			// Remove only a loose object from this test-owned repository after preparing.
 			require.NoError(t, os.Remove(filepath.Join(f.repo.GitDir, "objects", f.base[:2], f.base[2:])))
-			r, err := landedwork.Analyze(ctx, p, fixtureEvidence(f, p, "squash"), fixtureLimits())
+			r, err := landedwork.Analyze(ctx, p, fixtureEvidence(f, p, tc.method), fixtureLimits())
 			require := require.New(t)
 			assert := assert.New(t)
 			require.NoError(err)
@@ -54,7 +62,7 @@ func TestAnalyzeMissingBoundaryAfterPreparation(t *testing.T) {
 			assert.Equal(f.bounds(), r.Coverage.Bounds)
 			require.NotEmpty(r.Coverage.Gaps)
 			assert.Equal("objects_unavailable", r.Coverage.Gaps[0].Reason)
-			if mode == "commit-graph" {
+			if tc.mode == "commit-graph" {
 				assert.Equal(f.base, r.Coverage.Gaps[0].ObjectID)
 			}
 		})

--- a/landedwork/proof.go
+++ b/landedwork/proof.go
@@ -1,0 +1,106 @@
+package landedwork
+
+import (
+	"context"
+	"errors"
+	"slices"
+)
+
+func prove(ctx context.Context, v *objectView, p *Interval, c Candidate, caps Capabilities) (Landing, Gap) {
+	gap := Gap{CandidateID: c.ID, ObjectID: c.Terminal}
+	reject := func(reason string) (Landing, Gap) { gap.Reason = reason; return Landing{}, gap }
+	if c.Method == "rebase" || c.Method == "fast_forward" {
+		return reject("method_unsupported")
+	}
+	if c.Terminal == "" || c.TerminalEvidence == "" {
+		return reject("terminal_unproven")
+	}
+	if !slices.Contains(p.spine, c.Terminal) {
+		return reject("terminal_outside_spine")
+	}
+	if c.Method != "" && c.MethodEvidence == "" {
+		return reject("method_unproven")
+	}
+	if !c.SourceComplete || len(c.Source) == 0 || c.SourceHead == "" {
+		return reject("source_incomplete")
+	}
+	parents, err := v.parents(ctx, c.Terminal)
+	if err != nil {
+		return reject(graphReason(err))
+	}
+	method := c.Method
+	if method == "" && len(parents) == 2 {
+		method = "merge"
+	}
+	if method == "" {
+		return reject("method_unproven")
+	}
+	if (method == "merge" && !caps.Merge) || (method == "squash" && !caps.Squash) {
+		return reject("method_unsupported")
+	}
+	if (method == "merge" && len(parents) != 2) || (method == "squash" && len(parents) != 1) {
+		return reject("topology_unproven")
+	}
+	if method == "merge" && parents[1] != c.SourceHead {
+		return reject("source_head_mismatch")
+	}
+	if reason, object := checkSources(ctx, v, c); reason != "" {
+		gap.ObjectID = object
+		return reject(reason)
+	}
+	introduced := []string{c.Terminal}
+	if method == "merge" {
+		introduced, err = mergeCorrespondence(ctx, v, c, parents[0])
+		if err != nil {
+			if errors.Is(err, errCorrespondence) {
+				return reject("source_correspondence_unproven")
+			}
+			return reject(graphReason(err))
+		}
+	}
+	return Landing{CandidateID: c.ID, Method: method, Before: parents[0], Terminal: c.Terminal,
+		Source: slices.Clone(c.Source), Introduced: introduced}, Gap{}
+}
+
+func checkSources(ctx context.Context, v *objectView, c Candidate) (string, string) {
+	seen := make(map[string]bool, len(c.Source))
+	for _, id := range c.Source {
+		if id == "" || seen[id] {
+			return "source_invalid", id
+		}
+		seen[id] = true
+		if _, err := v.parents(ctx, id); err != nil {
+			return graphReason(err), id
+		}
+	}
+	if !seen[c.SourceHead] {
+		return "source_incomplete", c.SourceHead
+	}
+	return "", ""
+}
+
+var errCorrespondence = errors.New("source correspondence unproven")
+
+func mergeCorrespondence(ctx context.Context, v *objectView, c Candidate, before string) ([]string, error) {
+	ids, err := v.introduced(ctx, before, c.Terminal)
+	if err != nil {
+		return nil, err
+	}
+	ids = slices.DeleteFunc(ids, func(id string) bool { return id == c.Terminal })
+	expected := make([]string, 0, len(c.Source))
+	for _, id := range c.Source {
+		present, err := v.ancestor(ctx, id, before)
+		if err != nil {
+			return nil, err
+		}
+		if !present {
+			expected = append(expected, id)
+		}
+	}
+	slices.Sort(ids)
+	slices.Sort(expected)
+	if !slices.Equal(ids, expected) {
+		return nil, errCorrespondence
+	}
+	return ids, nil
+}

--- a/landedwork/proof.go
+++ b/landedwork/proof.go
@@ -48,6 +48,16 @@ func prove(ctx context.Context, v *objectView, p *Interval, c Candidate, caps Ca
 		gap.ObjectID = object
 		return reject(reason)
 	}
+	if method == "squash" {
+		// Cached ancestry can outlive the object needed for the boundary diff.
+		gap.ObjectID = parents[0]
+		if err := v.meter.node(); err != nil {
+			return reject(graphReason(err))
+		}
+		if _, err := v.run(ctx, "cat-file", "-e", parents[0]+"^{commit}"); err != nil {
+			return reject(graphReason(err))
+		}
+	}
 	introduced := []string{c.Terminal}
 	if method == "merge" {
 		introduced, err = mergeCorrespondence(ctx, v, c, parents[0])

--- a/landedwork/proof.go
+++ b/landedwork/proof.go
@@ -48,15 +48,14 @@ func prove(ctx context.Context, v *objectView, p *Interval, c Candidate, caps Ca
 		gap.ObjectID = object
 		return reject(reason)
 	}
-	if method == "squash" {
-		// Cached ancestry can outlive the object needed for the boundary diff.
+	// Cached ancestry can outlive the object needed for the boundary diff.
+	if err := v.meter.node(); err != nil {
 		gap.ObjectID = parents[0]
-		if err := v.meter.node(); err != nil {
-			return reject(graphReason(err))
-		}
-		if _, err := v.run(ctx, "cat-file", "-e", parents[0]+"^{commit}"); err != nil {
-			return reject(graphReason(err))
-		}
+		return reject(graphReason(err))
+	}
+	if _, err := v.run(ctx, "cat-file", "-e", parents[0]+"^{commit}"); err != nil {
+		gap.ObjectID = parents[0]
+		return reject(graphReason(err))
 	}
 	introduced := []string{c.Terminal}
 	if method == "merge" {

--- a/landedwork/proof_test.go
+++ b/landedwork/proof_test.go
@@ -1,0 +1,112 @@
+package landedwork_test
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/landedwork"
+)
+
+func fixtureEvidence(f fixture, p *landedwork.Interval, method string) landedwork.Evidence {
+	return landedwork.Evidence{
+		Query: p.Query(), Inventory: landedwork.Inventory{Supported: true, Complete: true},
+		Capabilities: landedwork.Capabilities{Merge: true, Squash: true},
+		Candidates: []landedwork.Candidate{{Repository: f.bounds().Repository, ID: "7",
+			Terminal: f.head, SourceHead: f.source[len(f.source)-1], Source: f.source,
+			SourceComplete: true, Method: method,
+			MethodEvidence: "fixture-method", TerminalEvidence: "fixture-terminal"}},
+	}
+}
+
+func TestAnalyzeProofSideAncestry(t *testing.T) {
+	f := buildSideFixture(t)
+	ctx, p := f.prepare(t)
+	r, err := landedwork.Analyze(ctx, p, fixtureEvidence(f, p, "merge"), fixtureLimits())
+	require := require.New(t)
+	require.NoError(err)
+	require.Len(r.Landings, 1)
+	a := assert.New(t)
+	l := r.Landings[0]
+	a.Equal(f.source, l.Source)
+	a.ElementsMatch([]string{f.source[0], f.source[2], f.source[3]}, l.Introduced)
+	var authored []string
+	for _, id := range l.Introduced {
+		if len(strings.Fields(f.repo.Run("rev-list", "--parents", "-n", "1", id))) <= 2 {
+			authored = append(authored, id)
+		}
+	}
+	a.ElementsMatch([]string{f.source[0], f.source[3]}, authored)
+	a.Equal("3\t1\twork.txt", f.repo.Run("diff", "--numstat", l.Before, l.Terminal, "--", "work.txt"))
+	a.Equal(f.bounds(), r.Coverage.Bounds)
+	a.True(r.Coverage.Complete)
+	a.Equal(f.head, r.Coverage.CertifiedHead)
+	a.Empty(r.Coverage.Gaps)
+	a.Empty(r.Unattributed)
+}
+
+func TestAnalyzeProofIntermediateEditsDoNotChangeBoundary(t *testing.T) {
+	for _, method := range []string{"merge", "squash"} {
+		t.Run(method, func(t *testing.T) {
+			f := buildFixture(t, method == "squash")
+			f.repo.Checkout("topic")
+			a := f.repo.CommitFile("work.txt", "new\nkeep\none\ntwo\ntemporary\n", "insert temporary")
+			b := f.repo.CommitFile("work.txt", "new\nkeep\none\ntwo\n", "remove temporary")
+			f.source = append(slices.Clone(f.source), a, b)
+			f.repo.Checkout("-b", "target", f.base)
+			if method == "squash" {
+				f.repo.Run("merge", "--squash", "topic")
+				f.repo.Run("commit", "-m", "squash topic")
+			} else {
+				f.repo.Run("merge", "--no-ff", "topic", "-m", "merge topic")
+			}
+			f.head = f.repo.Head()
+			ctx, p := f.prepare(t)
+			r, err := landedwork.Analyze(ctx, p, fixtureEvidence(f, p, method), fixtureLimits())
+			require := require.New(t)
+			assert := assert.New(t)
+			require.NoError(err)
+			require.Len(r.Landings, 1)
+			l := r.Landings[0]
+			assert.Equal("3\t1\twork.txt", f.repo.Run("diff", "--numstat", l.Before, l.Terminal, "--", "work.txt"))
+			assert.Equal(f.bounds(), r.Coverage.Bounds)
+			assert.True(r.Coverage.Complete)
+			assert.Equal(f.head, r.Coverage.CertifiedHead)
+			assert.Empty(r.Coverage.Gaps)
+			assert.Empty(r.Unattributed)
+		})
+	}
+}
+
+func TestAnalyzeProof(t *testing.T) {
+	for _, method := range []string{"merge", "squash", ""} {
+		t.Run(method, func(t *testing.T) {
+			f := buildFixture(t, method == "squash")
+			ctx, p := f.prepare(t)
+			e := fixtureEvidence(f, p, method)
+			result, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+			require := require.New(t)
+			require.NoError(err)
+			require.Len(result.Landings, 1)
+			assert := assert.New(t)
+			landing := result.Landings[0]
+			assert.Equal("7", landing.CandidateID)
+			assert.Equal(f.base, landing.Before)
+			assert.Equal(f.head, landing.Terminal)
+			assert.Equal(f.source, landing.Source)
+			assert.Equal(f.bounds(), result.Coverage.Bounds)
+			assert.True(result.Coverage.Complete)
+			assert.Equal(f.head, result.Coverage.CertifiedHead)
+			assert.Empty(result.Coverage.Gaps)
+			assert.Empty(result.Unattributed)
+			introduced := f.source
+			if method == "squash" {
+				introduced = []string{f.head}
+			}
+			assert.ElementsMatch(introduced, landing.Introduced)
+			assert.Equal("3\t1\twork.txt", f.repo.Run("diff", "--no-ext-diff", "--no-textconv", "--no-renames", "--numstat", landing.Before, landing.Terminal, "--", "work.txt"))
+		})
+	}
+}

--- a/landedwork/shallow.go
+++ b/landedwork/shallow.go
@@ -1,0 +1,77 @@
+package landedwork
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+var errShallow = errors.New("required shallow boundary")
+
+func copyShallow(source, dir string, m *meter) (err error) {
+	f, err := os.Open(source)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(err, f.Close()) }()
+	b := &boundedBuffer{meter: m}
+	if _, err = io.Copy(b, f); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "shallow"), b.Bytes(), 0600)
+}
+
+// A reachable shallow root can hide either introduced or excluded ancestry.
+// Unrelated shallow branches do not affect this interval.
+func (v *objectView) checkShallow(ctx context.Context, b Bounds) error {
+	data, err := v.run(ctx, "rev-parse", "--is-shallow-repository")
+	if err != nil || strings.TrimSpace(string(data)) == "false" {
+		return err
+	}
+	f, err := os.Open(filepath.Join(v.dir, "shallow"))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	buf := &boundedBuffer{meter: v.meter}
+	if _, err = io.Copy(buf, f); err != nil {
+		return err
+	}
+	for id := range strings.FieldsSeq(string(buf.Bytes())) {
+		if !objectID(id) {
+			return errShallow
+		}
+		for _, head := range []string{b.Base, b.Head} {
+			found, err := v.ancestor(ctx, id, head)
+			if err != nil {
+				return err
+			}
+			if found {
+				return errShallow
+			}
+		}
+	}
+	return nil
+}
+
+func (v *objectView) ancestor(ctx context.Context, base, head string) (bool, error) {
+	if err := v.meter.node(); err != nil {
+		return false, err
+	}
+	_, err := v.run(ctx, "merge-base", "--is-ancestor", base, head)
+	if err == nil {
+		return true, nil
+	}
+	var exit *exec.ExitError
+	if errors.As(err, &exit) && exit.ExitCode() == 1 {
+		return false, nil
+	}
+	return false, err
+}

--- a/landedwork/stream.go
+++ b/landedwork/stream.go
@@ -1,0 +1,48 @@
+package landedwork
+
+import (
+	"bytes"
+	"errors"
+)
+
+// Git writes arbitrary chunks. Retain an ID only after charging its record and
+// node, and retain at most one unfinished ID between writes.
+type commitStream struct {
+	meter   *meter
+	ids     []string
+	pending string
+}
+
+func (s *commitStream) Write(p []byte) (int, error) {
+	if err := s.meter.input(int64(len(p))); err != nil {
+		return 0, err
+	}
+	n := len(p)
+	for len(p) > 0 {
+		end := bytes.IndexByte(p, '\n')
+		if end < 0 {
+			if len(s.pending)+len(p) > 64 {
+				return 0, errors.New("invalid revision object ID")
+			}
+			s.pending += string(p)
+			break
+		}
+		if len(s.pending)+end > 64 {
+			return 0, errors.New("invalid revision object ID")
+		}
+		if err := s.meter.node(); err != nil {
+			return 0, err
+		}
+		if err := s.meter.records(1); err != nil {
+			return 0, err
+		}
+		id := s.pending + string(p[:end])
+		if !objectID(id) {
+			return 0, errors.New("invalid revision object ID")
+		}
+		s.ids = append(s.ids, id)
+		s.pending = ""
+		p = p[end+1:]
+	}
+	return n, nil
+}

--- a/landedwork/validation_test.go
+++ b/landedwork/validation_test.go
@@ -1,0 +1,74 @@
+package landedwork_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/landedwork"
+)
+
+func TestAnalyzeSquashRequiresIndependentProof(t *testing.T) {
+	for _, name := range []string{"unknown method", "no method evidence", "unsupported", "merge topology"} {
+		t.Run(name, func(t *testing.T) {
+			f := buildFixture(t, true)
+			ctx, p := f.prepare(t)
+			e := fixtureEvidence(f, p, "squash")
+			reason := "method_unproven"
+			switch name {
+			case "unknown method":
+				e.Candidates[0].Method = ""
+			case "no method evidence":
+				e.Candidates[0].MethodEvidence = ""
+			case "unsupported":
+				e.Capabilities.Squash = false
+				reason = "method_unsupported"
+			case "merge topology":
+				e.Candidates[0].Method = "merge"
+				reason = "topology_unproven"
+			}
+			r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+			require.NoError(t, err)
+			assert := assert.New(t)
+			assert.Empty(r.Landings)
+			assert.Equal(f.bounds(), r.Coverage.Bounds)
+			assert.Equal([]landedwork.Gap{{CandidateID: "7", ObjectID: f.head, Reason: reason}}, r.Coverage.Gaps)
+			assert.Equal([]string{f.head}, r.Unattributed)
+			assert.False(r.Coverage.Complete)
+			assert.Equal(f.base, r.Coverage.CertifiedHead)
+		})
+	}
+}
+
+func TestInvalidInputsAndOutputLimits(t *testing.T) {
+	f := buildFixture(t, false)
+	ctx, p := f.prepare(t)
+	for _, name := range []string{"deadline", "zero limit", "short SHA", "path", "output"} {
+		t.Run(name, func(t *testing.T) {
+			callCtx, path, bounds, limits := ctx, f.repo.Root, f.bounds(), fixtureLimits()
+			switch name {
+			case "deadline":
+				callCtx = context.Background()
+			case "zero limit":
+				limits.Records = 0
+			case "short SHA":
+				bounds.Head = "123abc"
+			case "path":
+				path = ""
+			case "output":
+				limits.OutputBytes = 1
+			}
+			_, err := landedwork.Prepare(callCtx, path, bounds, limits)
+			require.Error(t, err)
+			if name == "output" {
+				require.ErrorIs(t, err, landedwork.ErrOutputBudget)
+			}
+		})
+	}
+	limits := fixtureLimits()
+	limits.OutputBytes = 1
+	r, err := landedwork.Analyze(ctx, p, fixtureEvidence(f, p, "merge"), limits)
+	require.ErrorIs(t, err, landedwork.ErrOutputBudget)
+	assert.Equal(t, landedwork.Result{}, r)
+}


### PR DESCRIPTION
Adds a standalone public `landedwork` library for proving which Git commits landed through ordinary merges or squashes.

- Prepare a pinned interval from local objects, then analyze caller-supplied provider evidence for that exact commit set. No fetching or source-repository writes.
- Preserve internal merge commits during source correspondence. Require independent method evidence for squash; one-parent topology is not enough.
- Return proven boundaries alongside mandatory coverage. Incomplete inventories or unresolved candidates keep certification at the base, and unowned commits remain unattributed.

Real-Git fixtures check hand-counted +3/−1 boundary diffs, side ancestry, conflicting claims, incomplete history, resource limits, and active cancellation.

No collectors, production churn engine, identity mapping, rebase/direct-push claims, API, or UI changes. The generic squash proof does not enable any live provider's squash capability.
