### PR TITLE
feat: configure faster refresh for recently active pull requests

### DIFF
--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -1737,6 +1737,7 @@ func buildAppState(
 	})
 	syncer.SetWatchInterval(cfg.ActivePRRefreshDuration())
 	syncer.SetActiveMRWindow(cfg.ActivePRWindowDuration())
+	syncer.SetActiveMRRefreshPolicy(cfg.ActivePRHotWindowDuration(), cfg.ActivePRWarmRefreshDuration())
 
 	serverSyncer := syncer
 	serverOptions := server.ServerOptions{

--- a/cmd/kenn-forge/main.go
+++ b/cmd/kenn-forge/main.go
@@ -706,6 +706,7 @@ func run(opts serve.Options) error {
 		)
 		syncer.SetWatchInterval(cfg.ActivePRRefreshDuration())
 		syncer.SetActiveMRWindow(cfg.ActivePRWindowDuration())
+		syncer.SetActiveMRRefreshPolicy(cfg.ActivePRHotWindowDuration(), cfg.ActivePRWarmRefreshDuration())
 		syncer.SetPreferGitHubNativeStacks(cfg.PullRequests.PreferGitHubNativeStacks)
 		syncer.SetFetchers(controlPlane.fetchers)
 		syncer.SetGitHubRouters(controlPlane.githubRouters)

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -84,7 +84,7 @@ For pull requests, that means:
   restarts. Hot and explicit workspace-linked PRs use the configured watched cadence;
   terminal PRs are evicted immediately (`internal/db/queries_hot_merge_requests.go::RecordHotMergeRequestView`).
 - Recency-hot admission includes every open PR within `active_pr_hot_window`
-  (zero disables it); remaining active PRs use `active_pr_warm_refresh_interval`
+  (zero disables it; it must not exceed `active_pr_window`); remaining active PRs use `active_pr_warm_refresh_interval`
   (default 10m). Never-fetched PRs are due (`internal/github/sync.go::hotAndWarmOpenMRs`).
 - Linked PR notifications may advance fast-sync scheduling through
   `source_updated_at`, but that timestamp is only a staleness hint. Combine it

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -83,12 +83,12 @@ For pull requests, that means:
 - The hot set is the last 10 unique open PR details viewed and persists across
   restarts. Hot and explicit workspace-linked PRs use the configured watched cadence;
   terminal PRs are evicted immediately (`internal/db/queries_hot_merge_requests.go::RecordHotMergeRequestView`).
-- Other recently active PRs are warm and detail-age gated at 10 minutes;
-  never-fetched hot or warm PRs are immediately due
-  (`internal/github/sync.go::hotAndWarmOpenMRs`).
+- Recency-hot admission includes every open PR within `active_pr_hot_window`
+  (zero disables it); remaining active PRs use `active_pr_warm_refresh_interval`
+  (default 10m). Never-fetched PRs are due (`internal/github/sync.go::hotAndWarmOpenMRs`).
 - Linked PR notifications may advance fast-sync scheduling through
   `source_updated_at`, but that timestamp is only a staleness hint. Combine it
-  with authoritative PR activity for warm admission; never persist it as
+  with authoritative PR activity for hot/warm admission; never persist it as
   `last_activity_at` (`internal/github/sync.go::hotAndWarmOpenMRs`).
 - Scheduled and immediate watched-MR passes are serialized for the full pass so
   provider work and host cadence state have one owner

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1504,6 +1504,8 @@ func (c *Config) validate() error {
 		return fmt.Errorf("config: invalid active_pr_hot_window %q: %w", c.ActivePRHotWindow, err)
 	} else if d < 0 {
 		return fmt.Errorf("config: active_pr_hot_window must be nonnegative, got %q", c.ActivePRHotWindow)
+	} else if d > c.ActivePRWindowDuration() {
+		return fmt.Errorf("config: active_pr_hot_window must not exceed active_pr_window (%s), got %q", c.ActivePRWindow, c.ActivePRHotWindow)
 	}
 	if d, err := time.ParseDuration(c.ActivePRWarmRefreshInterval); err != nil {
 		return fmt.Errorf("config: invalid active_pr_warm_refresh_interval %q: %w", c.ActivePRWarmRefreshInterval, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,8 @@ const (
 	defaultGiteaTokenEnv                   = "KENN_FORGE_GITEA_TOKEN"
 	defaultSyncInterval                    = "5m"
 	defaultActivePRRefreshInterval         = "2m"
+	defaultActivePRHotWindow               = "0s"
+	defaultActivePRWarmRefreshInterval     = "10m"
 	defaultActivePRWindow                  = "4h"
 	defaultNotificationSyncInterval        = "2m"
 	defaultNotificationPropagationInterval = "1m"
@@ -916,18 +918,20 @@ type MCP struct {
 }
 
 type Config struct {
-	SyncInterval              string `toml:"sync_interval"`
-	ActivePRRefreshInterval   string `toml:"active_pr_refresh_interval"`
-	ActivePRWindow            string `toml:"active_pr_window"`
-	GitHubTokenEnv            string `toml:"github_token_env"`
-	DefaultPlatformHost       string `toml:"default_platform_host"`
-	Host                      string `toml:"host"`
-	Port                      int    `toml:"port"`
-	BasePath                  string `toml:"base_path"`
-	DataDir                   string `toml:"data_dir"`
-	SyncBudgetPerHour         int    `toml:"sync_budget_per_hour"`
-	SSEBufferSize             int    `toml:"sse_buffer_size"`
-	IssueWorkspaceBranchStyle string `toml:"issue_workspace_branch_style"`
+	SyncInterval                string `toml:"sync_interval"`
+	ActivePRRefreshInterval     string `toml:"active_pr_refresh_interval"`
+	ActivePRHotWindow           string `toml:"active_pr_hot_window"`
+	ActivePRWarmRefreshInterval string `toml:"active_pr_warm_refresh_interval"`
+	ActivePRWindow              string `toml:"active_pr_window"`
+	GitHubTokenEnv              string `toml:"github_token_env"`
+	DefaultPlatformHost         string `toml:"default_platform_host"`
+	Host                        string `toml:"host"`
+	Port                        int    `toml:"port"`
+	BasePath                    string `toml:"base_path"`
+	DataDir                     string `toml:"data_dir"`
+	SyncBudgetPerHour           int    `toml:"sync_budget_per_hour"`
+	SSEBufferSize               int    `toml:"sse_buffer_size"`
+	IssueWorkspaceBranchStyle   string `toml:"issue_workspace_branch_style"`
 	// AllowedHosts is an exact-match allowlist of Host header values
 	// beyond the bind address that the Host validation middleware
 	// should accept. Loopback synonyms (127.0.0.1 / localhost /
@@ -1218,13 +1222,15 @@ func Load(path string) (*Config, error) {
 // load reads and normalizes path without running validation.
 func load(path string) (*Config, error) {
 	cfg := &Config{
-		SyncInterval:            defaultSyncInterval,
-		ActivePRRefreshInterval: defaultActivePRRefreshInterval,
-		ActivePRWindow:          defaultActivePRWindow,
-		GitHubTokenEnv:          defaultGitHubTokenEnv,
-		DefaultPlatformHost:     defaultPlatformHost,
-		Host:                    defaultHost,
-		Port:                    defaultPort,
+		SyncInterval:                defaultSyncInterval,
+		ActivePRRefreshInterval:     defaultActivePRRefreshInterval,
+		ActivePRHotWindow:           defaultActivePRHotWindow,
+		ActivePRWarmRefreshInterval: defaultActivePRWarmRefreshInterval,
+		ActivePRWindow:              defaultActivePRWindow,
+		GitHubTokenEnv:              defaultGitHubTokenEnv,
+		DefaultPlatformHost:         defaultPlatformHost,
+		Host:                        defaultHost,
+		Port:                        defaultPort,
 		Activity: Activity{
 			CollapseThreads: true,
 		},
@@ -1472,6 +1478,12 @@ func (c *Config) validate() error {
 	if _, err := time.ParseDuration(c.SyncInterval); err != nil {
 		return fmt.Errorf("config: invalid sync_interval %q: %w", c.SyncInterval, err)
 	}
+	if c.ActivePRHotWindow == "" {
+		c.ActivePRHotWindow = defaultActivePRHotWindow
+	}
+	if c.ActivePRWarmRefreshInterval == "" {
+		c.ActivePRWarmRefreshInterval = defaultActivePRWarmRefreshInterval
+	}
 	if c.ActivePRRefreshInterval == "" {
 		c.ActivePRRefreshInterval = defaultActivePRRefreshInterval
 	}
@@ -1487,6 +1499,16 @@ func (c *Config) validate() error {
 		return fmt.Errorf("config: invalid active_pr_window %q: %w", c.ActivePRWindow, err)
 	} else if d <= 0 {
 		return fmt.Errorf("config: active_pr_window must be positive, got %q", c.ActivePRWindow)
+	}
+	if d, err := time.ParseDuration(c.ActivePRHotWindow); err != nil {
+		return fmt.Errorf("config: invalid active_pr_hot_window %q: %w", c.ActivePRHotWindow, err)
+	} else if d < 0 {
+		return fmt.Errorf("config: active_pr_hot_window must be nonnegative, got %q", c.ActivePRHotWindow)
+	}
+	if d, err := time.ParseDuration(c.ActivePRWarmRefreshInterval); err != nil {
+		return fmt.Errorf("config: invalid active_pr_warm_refresh_interval %q: %w", c.ActivePRWarmRefreshInterval, err)
+	} else if d <= 0 {
+		return fmt.Errorf("config: active_pr_warm_refresh_interval must be positive, got %q", c.ActivePRWarmRefreshInterval)
 	}
 	if c.Notifications.SyncInterval == "" {
 		c.Notifications.SyncInterval = defaultNotificationSyncInterval
@@ -2319,6 +2341,23 @@ func (c *Config) ActivePRRefreshDuration() time.Duration {
 		return d
 	}
 	d, _ := time.ParseDuration(c.ActivePRRefreshInterval)
+	return d
+}
+
+func (c *Config) ActivePRHotWindowDuration() time.Duration {
+	if c == nil || c.ActivePRHotWindow == "" {
+		return 0
+	}
+	d, _ := time.ParseDuration(c.ActivePRHotWindow)
+	return d
+}
+
+func (c *Config) ActivePRWarmRefreshDuration() time.Duration {
+	if c == nil || c.ActivePRWarmRefreshInterval == "" {
+		d, _ := time.ParseDuration(defaultActivePRWarmRefreshInterval)
+		return d
+	}
+	d, _ := time.ParseDuration(c.ActivePRWarmRefreshInterval)
 	return d
 }
 
@@ -3424,42 +3463,44 @@ func reposForSave(repos []Repo) []Repo {
 
 // configFile is the subset of Config written to disk.
 type configFile struct {
-	SyncInterval              string                   `toml:"sync_interval"`
-	ActivePRRefreshInterval   string                   `toml:"active_pr_refresh_interval"`
-	ActivePRWindow            string                   `toml:"active_pr_window"`
-	GitHubTokenEnv            string                   `toml:"github_token_env"`
-	DefaultPlatformHost       string                   `toml:"default_platform_host,omitempty"`
-	Host                      string                   `toml:"host"`
-	Port                      int                      `toml:"port"`
-	SyncBudgetPerHour         int                      `toml:"sync_budget_per_hour,omitempty"`
-	SSEBufferSize             int                      `toml:"sse_buffer_size,omitempty"`
-	BasePath                  string                   `toml:"base_path,omitempty"`
-	DataDir                   string                   `toml:"data_dir,omitempty"`
-	IssueWorkspaceBranchStyle string                   `toml:"issue_workspace_branch_style,omitempty"`
-	AllowedHosts              []string                 `toml:"allowed_hosts,omitempty"`
-	TrustReverseProxy         bool                     `toml:"trust_reverse_proxy,omitempty"`
-	Repos                     []Repo                   `toml:"repos"`
-	RepoPresets               []RepoPreset             `toml:"repo_presets,omitempty"`
-	KataProjects              []KataProjectRepoMapping `toml:"kata_projects,omitempty"`
-	Platforms                 []PlatformConfig         `toml:"platforms,omitempty"`
-	GitHubOwnerTokens         []GitHubOwnerTokenConfig `toml:"github_owner_tokens,omitempty"`
-	GitHubApps                []GitHubAppConfig        `toml:"github_apps,omitempty"`
-	Activity                  Activity                 `toml:"activity"`
-	Notifications             Notifications            `toml:"notifications,omitempty"`
-	Terminal                  Terminal                 `toml:"terminal,omitempty"`
-	Modes                     ModeVisibility           `toml:"modes,omitempty"`
-	Agents                    []Agent                  `toml:"agents,omitempty"`
-	DocFolders                []DocFolder              `toml:"doc_folders,omitempty"`
-	Roborev                   Roborev                  `toml:"roborev,omitempty"`
-	PullRequests              PullRequests             `toml:"pull_requests,omitempty"`
-	Detail                    Detail                   `toml:"detail,omitempty"`
-	Workspaces                Workspaces               `toml:"workspaces,omitempty"`
-	Issues                    Issues                   `toml:"issues,omitempty"`
-	Tmux                      Tmux                     `toml:"tmux,omitempty"`
-	Shell                     Shell                    `toml:"shell,omitempty"`
-	Fleet                     Fleet                    `toml:"fleet,omitempty"`
-	API                       API                      `toml:"api,omitempty"`
-	MCP                       MCP                      `toml:"mcp,omitempty"`
+	SyncInterval                string                   `toml:"sync_interval"`
+	ActivePRRefreshInterval     string                   `toml:"active_pr_refresh_interval"`
+	ActivePRHotWindow           string                   `toml:"active_pr_hot_window"`
+	ActivePRWarmRefreshInterval string                   `toml:"active_pr_warm_refresh_interval"`
+	ActivePRWindow              string                   `toml:"active_pr_window"`
+	GitHubTokenEnv              string                   `toml:"github_token_env"`
+	DefaultPlatformHost         string                   `toml:"default_platform_host,omitempty"`
+	Host                        string                   `toml:"host"`
+	Port                        int                      `toml:"port"`
+	SyncBudgetPerHour           int                      `toml:"sync_budget_per_hour,omitempty"`
+	SSEBufferSize               int                      `toml:"sse_buffer_size,omitempty"`
+	BasePath                    string                   `toml:"base_path,omitempty"`
+	DataDir                     string                   `toml:"data_dir,omitempty"`
+	IssueWorkspaceBranchStyle   string                   `toml:"issue_workspace_branch_style,omitempty"`
+	AllowedHosts                []string                 `toml:"allowed_hosts,omitempty"`
+	TrustReverseProxy           bool                     `toml:"trust_reverse_proxy,omitempty"`
+	Repos                       []Repo                   `toml:"repos"`
+	RepoPresets                 []RepoPreset             `toml:"repo_presets,omitempty"`
+	KataProjects                []KataProjectRepoMapping `toml:"kata_projects,omitempty"`
+	Platforms                   []PlatformConfig         `toml:"platforms,omitempty"`
+	GitHubOwnerTokens           []GitHubOwnerTokenConfig `toml:"github_owner_tokens,omitempty"`
+	GitHubApps                  []GitHubAppConfig        `toml:"github_apps,omitempty"`
+	Activity                    Activity                 `toml:"activity"`
+	Notifications               Notifications            `toml:"notifications,omitempty"`
+	Terminal                    Terminal                 `toml:"terminal,omitempty"`
+	Modes                       ModeVisibility           `toml:"modes,omitempty"`
+	Agents                      []Agent                  `toml:"agents,omitempty"`
+	DocFolders                  []DocFolder              `toml:"doc_folders,omitempty"`
+	Roborev                     Roborev                  `toml:"roborev,omitempty"`
+	PullRequests                PullRequests             `toml:"pull_requests,omitempty"`
+	Detail                      Detail                   `toml:"detail,omitempty"`
+	Workspaces                  Workspaces               `toml:"workspaces,omitempty"`
+	Issues                      Issues                   `toml:"issues,omitempty"`
+	Tmux                        Tmux                     `toml:"tmux,omitempty"`
+	Shell                       Shell                    `toml:"shell,omitempty"`
+	Fleet                       Fleet                    `toml:"fleet,omitempty"`
+	API                         API                      `toml:"api,omitempty"`
+	MCP                         MCP                      `toml:"mcp,omitempty"`
 }
 
 // Save writes the current config to the given path.
@@ -3469,37 +3510,39 @@ func (c *Config) Save(path string) error {
 		return fmt.Errorf("validating config: %w", err)
 	}
 	f := configFile{
-		SyncInterval:            cfg.SyncInterval,
-		ActivePRRefreshInterval: cfg.ActivePRRefreshInterval,
-		ActivePRWindow:          cfg.ActivePRWindow,
-		GitHubTokenEnv:          cfg.GitHubTokenEnv,
-		DefaultPlatformHost:     cfg.DefaultPlatformHost,
-		Host:                    cfg.Host,
-		Port:                    cfg.Port,
-		AllowedHosts:            slices.Clone(cfg.AllowedHosts),
-		TrustReverseProxy:       cfg.TrustReverseProxy,
-		Repos:                   reposForSave(cfg.Repos),
-		RepoPresets:             cloneRepoPresets(cfg.RepoPresets),
-		KataProjects:            slices.Clone(cfg.KataProjects),
-		Platforms:               cfg.Platforms,
-		GitHubOwnerTokens:       cfg.GitHubOwnerTokens,
-		GitHubApps:              cfg.GitHubApps,
-		Activity:                cfg.Activity,
-		Notifications:           cfg.Notifications,
-		Terminal:                cfg.Terminal,
-		Modes:                   cfg.Modes,
-		Agents:                  cfg.Agents,
-		DocFolders:              cfg.DocFolders,
-		Roborev:                 cfg.Roborev,
-		PullRequests:            cfg.PullRequests,
-		Detail:                  cfg.Detail,
-		Workspaces:              cfg.Workspaces,
-		Issues:                  cfg.Issues,
-		Tmux:                    cfg.Tmux,
-		Shell:                   cfg.Shell,
-		Fleet:                   cfg.Fleet,
-		API:                     cfg.API,
-		MCP:                     cfg.MCP,
+		SyncInterval:                cfg.SyncInterval,
+		ActivePRRefreshInterval:     cfg.ActivePRRefreshInterval,
+		ActivePRHotWindow:           cfg.ActivePRHotWindow,
+		ActivePRWarmRefreshInterval: cfg.ActivePRWarmRefreshInterval,
+		ActivePRWindow:              cfg.ActivePRWindow,
+		GitHubTokenEnv:              cfg.GitHubTokenEnv,
+		DefaultPlatformHost:         cfg.DefaultPlatformHost,
+		Host:                        cfg.Host,
+		Port:                        cfg.Port,
+		AllowedHosts:                slices.Clone(cfg.AllowedHosts),
+		TrustReverseProxy:           cfg.TrustReverseProxy,
+		Repos:                       reposForSave(cfg.Repos),
+		RepoPresets:                 cloneRepoPresets(cfg.RepoPresets),
+		KataProjects:                slices.Clone(cfg.KataProjects),
+		Platforms:                   cfg.Platforms,
+		GitHubOwnerTokens:           cfg.GitHubOwnerTokens,
+		GitHubApps:                  cfg.GitHubApps,
+		Activity:                    cfg.Activity,
+		Notifications:               cfg.Notifications,
+		Terminal:                    cfg.Terminal,
+		Modes:                       cfg.Modes,
+		Agents:                      cfg.Agents,
+		DocFolders:                  cfg.DocFolders,
+		Roborev:                     cfg.Roborev,
+		PullRequests:                cfg.PullRequests,
+		Detail:                      cfg.Detail,
+		Workspaces:                  cfg.Workspaces,
+		Issues:                      cfg.Issues,
+		Tmux:                        cfg.Tmux,
+		Shell:                       cfg.Shell,
+		Fleet:                       cfg.Fleet,
+		API:                         cfg.API,
+		MCP:                         cfg.MCP,
 	}
 	if cfg.DefaultPlatformHost == defaultPlatformHost {
 		f.DefaultPlatformHost = ""
@@ -3588,6 +3631,12 @@ func (c *Config) copyForSave() Config {
 	cfg.Fleet.Members = slices.Clone(c.Fleet.Members)
 	if cfg.SyncInterval == "" {
 		cfg.SyncInterval = defaultSyncInterval
+	}
+	if cfg.ActivePRHotWindow == "" {
+		cfg.ActivePRHotWindow = defaultActivePRHotWindow
+	}
+	if cfg.ActivePRWarmRefreshInterval == "" {
+		cfg.ActivePRWarmRefreshInterval = defaultActivePRWarmRefreshInterval
 	}
 	if cfg.ActivePRRefreshInterval == "" {
 		cfg.ActivePRRefreshInterval = defaultActivePRRefreshInterval

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4559,6 +4559,9 @@ func TestLoadValidatesActivePRRefreshPolicy(t *testing.T) {
 	for _, content := range []string{
 		`active_pr_hot_window = "-1s"`,
 		`active_pr_hot_window = "invalid"`,
+		`active_pr_hot_window = "5h"`,
+		`active_pr_hot_window = "3h"
+active_pr_window = "2h"`,
 		`active_pr_warm_refresh_interval = "0s"`,
 		`active_pr_warm_refresh_interval = "-1m"`,
 		`active_pr_warm_refresh_interval = "invalid"`,
@@ -4571,4 +4574,7 @@ func TestLoadValidatesActivePRRefreshPolicy(t *testing.T) {
 	cfg, err := Load(writeConfig(t, `active_pr_hot_window = "0s"`))
 	require.NoError(t, err)
 	assert.Zero(t, cfg.ActivePRHotWindowDuration())
+	_, err = Load(writeConfig(t, `active_pr_hot_window = "2h"
+active_pr_window = "2h"`))
+	require.NoError(t, err)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -258,6 +258,8 @@ func TestLoadAppliesActivePRRefreshDefaults(t *testing.T) {
 	assert.Equal(defaultActivePRWindow, cfg.ActivePRWindow)
 	assert.Equal(2*time.Minute, cfg.ActivePRRefreshDuration())
 	assert.Equal(4*time.Hour, cfg.ActivePRWindowDuration())
+	assert.Zero(cfg.ActivePRHotWindowDuration())
+	assert.Equal(10*time.Minute, cfg.ActivePRWarmRefreshDuration())
 }
 
 func TestLoadRejectsNonPositiveActivePRRefreshDurations(t *testing.T) {
@@ -4532,4 +4534,41 @@ func TestValidateHostBinding(t *testing.T) {
 			require.Contains(err.Error(), tc.wantErr)
 		})
 	}
+}
+
+func TestActivePRRefreshPolicyRoundTrip(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	path := writeConfig(t, `active_pr_hot_window = "30m"
+active_pr_warm_refresh_interval = "5m"
+active_pr_refresh_interval = "1m"
+active_pr_window = "2h"
+`)
+	cfg, err := Load(path)
+	require.NoError(err)
+	require.NoError(cfg.Save(path))
+	loaded, err := Load(path)
+	require.NoError(err)
+	assert.Equal(30*time.Minute, loaded.ActivePRHotWindowDuration())
+	assert.Equal(5*time.Minute, loaded.ActivePRWarmRefreshDuration())
+	assert.Equal(time.Minute, loaded.ActivePRRefreshDuration())
+	assert.Equal(2*time.Hour, loaded.ActivePRWindowDuration())
+}
+
+func TestLoadValidatesActivePRRefreshPolicy(t *testing.T) {
+	for _, content := range []string{
+		`active_pr_hot_window = "-1s"`,
+		`active_pr_hot_window = "invalid"`,
+		`active_pr_warm_refresh_interval = "0s"`,
+		`active_pr_warm_refresh_interval = "-1m"`,
+		`active_pr_warm_refresh_interval = "invalid"`,
+	} {
+		t.Run(content, func(t *testing.T) {
+			_, err := Load(writeConfig(t, content))
+			require.Error(t, err)
+		})
+	}
+	cfg, err := Load(writeConfig(t, `active_pr_hot_window = "0s"`))
+	require.NoError(t, err)
+	assert.Zero(t, cfg.ActivePRHotWindowDuration())
 }

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -811,6 +811,8 @@ type Syncer struct {
 	watchInterval            time.Duration
 	watchedMRs               []WatchedMR
 	activeMRWindow           time.Duration
+	activeMRHotWindow        time.Duration
+	activeMRWarmInterval     time.Duration
 	watchMu                  sync.Mutex
 	watchSyncMu              sync.Mutex
 	branchActivityMu         sync.RWMutex
@@ -2055,6 +2057,15 @@ func (s *Syncer) SetActiveMRWindow(d time.Duration) {
 	s.watchMu.Lock()
 	defer s.watchMu.Unlock()
 	s.activeMRWindow = d
+}
+
+// SetActiveMRRefreshPolicy configures recency-based hot admission and warm cadence.
+// A zero hot window preserves view-only hot admission.
+func (s *Syncer) SetActiveMRRefreshPolicy(hotWindow, warmInterval time.Duration) {
+	s.watchMu.Lock()
+	defer s.watchMu.Unlock()
+	s.activeMRHotWindow = hotWindow
+	s.activeMRWarmInterval = warmInterval
 }
 
 // SetPreferGitHubNativeStacks enables GitHub's read-only preview metadata for
@@ -3771,6 +3782,12 @@ func (s *Syncer) hotAndWarmOpenMRs(
 	window time.Duration,
 	hotInterval time.Duration,
 ) []WatchedMR {
+	s.watchMu.Lock()
+	hotWindow, warmInterval := s.activeMRHotWindow, s.activeMRWarmInterval
+	s.watchMu.Unlock()
+	if warmInterval <= 0 {
+		warmInterval = activeMRWarmRefreshInterval
+	}
 	prs, err := s.db.ListMergeRequests(ctx, db.ListMergeRequestsOpts{State: "open"})
 	if err != nil {
 		slog.Warn("fast-sync active MR selection failed", "err", err)
@@ -3813,7 +3830,10 @@ func (s *Syncer) hotAndWarmOpenMRs(
 			if effectiveActivityAt.Before(cutoff) {
 				continue
 			}
-			refreshInterval = activeMRWarmRefreshInterval
+			refreshInterval = warmInterval
+			if hotWindow > 0 && !effectiveActivityAt.Before(now.Add(-hotWindow)) {
+				refreshInterval = hotInterval
+			}
 		}
 		if !mergeRequestDetailDue(pr, now, refreshInterval) {
 			continue

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -11086,6 +11086,124 @@ func TestWatchedMRsUsePersistedHotAndWarmCadences(t *testing.T) {
 	}, got)
 }
 
+func TestWatchedMRsUseConfiguredActivityTiers(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	now := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	repoID, err := d.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-acme-app",
+		Owner:          "acme",
+		Name:           "app",
+	})
+	require.NoError(err)
+	cases := []struct {
+		activityAge     time.Duration
+		detailAge       time.Duration
+		viewed          bool
+		notificationAge time.Duration
+		due             bool
+	}{
+		{29 * time.Minute, time.Minute, false, 0, true},
+		{30 * time.Minute, time.Minute, false, 0, true},
+		{30*time.Minute + time.Second, time.Minute, false, 0, false},
+		{time.Hour, 5 * time.Minute, false, 0, true},
+		{time.Hour, 5*time.Minute - time.Second, false, 0, false},
+		{2 * time.Hour, 5 * time.Minute, false, 0, true},
+		{2*time.Hour + time.Second, 5 * time.Minute, false, 0, false},
+		{3 * time.Hour, time.Minute, true, 0, true},
+		{3 * time.Hour, time.Minute - time.Second, true, 0, false},
+		{3 * time.Hour, time.Minute, false, 10 * time.Minute, true},
+		{3 * time.Hour, time.Minute - time.Second, false, 10 * time.Minute, false},
+	}
+	var want []int
+	for i, tc := range cases {
+		number := i + 1
+		activity := now.Add(-tc.activityAge)
+		detail := now.Add(-tc.detailAge)
+		id, err := d.UpsertMergeRequest(ctx, &db.MergeRequest{
+			RepoID:          repoID,
+			PlatformID:      int64(number),
+			Number:          number,
+			Title:           "PR",
+			Author:          "octo",
+			State:           db.MergeRequestStateOpen,
+			HeadBranch:      "feature",
+			BaseBranch:      "main",
+			CreatedAt:       now.Add(-24 * time.Hour),
+			UpdatedAt:       activity,
+			LastActivityAt:  activity,
+			DetailFetchedAt: &detail,
+		})
+		require.NoError(err)
+		if tc.viewed {
+			require.NoError(d.RecordHotMergeRequestView(ctx, id, now))
+		}
+		if tc.notificationAge > 0 {
+			require.NoError(d.UpsertNotifications(ctx, []db.Notification{{
+				Platform:               "github",
+				PlatformHost:           "github.com",
+				PlatformNotificationID: fmt.Sprint(number),
+				RepoID:                 &repoID,
+				RepoOwner:              "acme",
+				RepoName:               "app",
+				SubjectType:            "PullRequest",
+				SubjectTitle:           "PR activity",
+				ItemNumber:             &number,
+				ItemType:               "pr",
+				Reason:                 "comment",
+				SourceUpdatedAt:        now.Add(-tc.notificationAge),
+				SyncedAt:               now,
+			}}))
+		}
+		if tc.due {
+			want = append(want, number)
+		}
+	}
+	// More recent PRs than the persisted view-hot limit must all be selected.
+	for i := range db.HotMergeRequestLimit + 1 {
+		number := 100 + i
+		_, err := d.UpsertMergeRequest(ctx, &db.MergeRequest{
+			RepoID:          repoID,
+			PlatformID:      int64(number),
+			Number:          number,
+			Title:           "PR",
+			Author:          "octo",
+			State:           db.MergeRequestStateOpen,
+			HeadBranch:      "feature",
+			BaseBranch:      "main",
+			CreatedAt:       now.Add(-time.Hour),
+			UpdatedAt:       now,
+			LastActivityAt:  now,
+			DetailFetchedAt: new(now.Add(-time.Minute)),
+		})
+		require.NoError(err)
+		want = append(want, number)
+	}
+	syncer := NewSyncer(map[string]Client{}, d, nil, []RepoRef{{Platform: platform.KindGitHub,
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "app"}}, time.Hour, nil, nil)
+	syncer.SetWatchInterval(time.Minute)
+	syncer.SetActiveMRWindow(2 * time.Hour)
+	syncer.SetActiveMRRefreshPolicy(30*time.Minute, 5*time.Minute)
+	var got []int
+	for _, mr := range syncer.watchedMRsForFastSync(ctx, now) {
+		got = append(got, mr.Number)
+	}
+	assert.ElementsMatch(want, got)
+	stored, err := d.ListMergeRequests(ctx, db.ListMergeRequestsOpts{State: "open"})
+	require.NoError(err)
+	for _, mr := range stored {
+		if mr.Number <= len(cases) {
+			assert.True(mr.LastActivityAt.Equal(now.Add(-cases[mr.Number-1].activityAge)))
+		}
+	}
+}
+
 func TestWatchedMRsUseNotificationActivityForWarmPRCadence(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/config_reload.go
+++ b/internal/server/config_reload.go
@@ -554,6 +554,7 @@ func (s *Server) applyConfigChange(ctx context.Context) configChangedEvent {
 		)
 		s.syncer.SetWatchInterval(newCfg.ActivePRRefreshDuration())
 		s.syncer.SetActiveMRWindow(newCfg.ActivePRWindowDuration())
+		s.syncer.SetActiveMRRefreshPolicy(newCfg.ActivePRHotWindowDuration(), newCfg.ActivePRWarmRefreshDuration())
 	}
 
 	if s.docsAPI != nil {

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -2570,6 +2570,14 @@ func TestRestartRequiredForNotificationIntervals(t *testing.T) {
 	require.False(snap.restartRequiredFor(activeRefreshChanged),
 		"active PR refresh interval is hot-reloadable by the syncer")
 
+	activeHotWindowChanged := base()
+	activeHotWindowChanged.ActivePRHotWindow = "30m"
+	require.False(snap.restartRequiredFor(activeHotWindowChanged))
+
+	activeWarmRefreshChanged := base()
+	activeWarmRefreshChanged.ActivePRWarmRefreshInterval = "5m"
+	require.False(snap.restartRequiredFor(activeWarmRefreshChanged))
+
 	activeWindowChanged := base()
 	activeWindowChanged.ActivePRWindow = "8h"
 	require.False(snap.restartRequiredFor(activeWindowChanged),


### PR DESCRIPTION
Operators can refresh every recently active open PR at the fast cadence, even if its details have never been viewed. Configure `active_pr_hot_window` and `active_pr_warm_refresh_interval` alongside the existing refresh interval and activity window.

Existing defaults and viewed/workspace-linked priority remain unchanged. Notification activity can promote refresh scheduling without changing the PR’s stored provider activity time. The settings reload without a restart.
