### PR TITLE
fix: preserve enrolled fleets across the protocol 4 upgrade

### DIFF
--- a/cmd/kenn-forge/fleet_cli.go
+++ b/cmd/kenn-forge/fleet_cli.go
@@ -109,6 +109,7 @@ func newFleetCommand(options fleetCLIOptions) *cobra.Command {
 		newFleetPrepareSpokeCommand(options),
 		newFleetAbortPreparationCommand(options),
 		newFleetRevokeCommand(options),
+		newFleetMigrateProtocolCommand(options),
 	)
 	return cmd
 }

--- a/cmd/kenn-forge/fleet_migrate.go
+++ b/cmd/kenn-forge/fleet_migrate.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/forge/internal/config"
+	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/federation"
+	"go.kenn.io/forge/internal/runtimelock"
+)
+
+func newFleetMigrateProtocolCommand(options fleetCLIOptions) *cobra.Command {
+	var configPath string
+	cmd := &cobra.Command{
+		Use: "migrate-protocol", Short: "Migrate stopped fleet enrollment to the current protocol",
+		Long: "Migrate durable federation protocol 3 to 4. Stop the daemon and retain a matching " +
+			"backup of its database, enrollment, credentials, config, and binary first. " +
+			"Existing protocol-4 and unenrolled installations need no changes. " +
+			"An interrupted migration can be resumed with the same command.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := migrateFleetProtocol(cmd.Context(), configPath); err != nil {
+				return err
+			}
+			_, err := fmt.Fprintln(options.Stdout, "Fleet enrollment is ready for protocol 4.")
+			return err
+		},
+	}
+	cmd.Flags().StringVar(&configPath, "config", config.DefaultConfigPath(), "path to config file")
+	return cmd
+}
+
+func migrateFleetProtocol(ctx context.Context, configPath string) (err error) {
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return err
+	}
+	lock, err := runtimelock.Acquire(cfg.DataDir)
+	if err != nil {
+		return fmt.Errorf("stop the Forge daemon before migrating its fleet protocol: %w", err)
+	}
+	defer func() { err = errors.Join(err, lock.Release()) }()
+	return federation.MigrateProtocol3To4(federation.DefaultStorePath(cfg.DataDir),
+		func(local *federation.LocalEnrollment) (digest string, err error) {
+			database, err := db.Open(cfg.DBPath())
+			if err != nil {
+				return "", err
+			}
+			defer func() { err = errors.Join(err, database.Close()) }()
+			var binding *db.SpokePreparationBinding
+			seal := ""
+			if local != nil {
+				binding = &db.SpokePreparationBinding{
+					EnrollmentID: local.EnrollmentID, LocalNodeID: local.NodeID,
+					HubNodeID: local.HubID, ProtocolVersion: local.ProtocolVersion,
+				}
+				if local.Preparation != nil {
+					digest, seal = local.Preparation.PreparationDigest, local.Preparation.Seal
+				}
+			}
+			return database.MigrateFleetProtocol3To4(ctx, binding, digest, seal)
+		})
+}

--- a/cmd/kenn-forge/fleet_migrate_activation_test.go
+++ b/cmd/kenn-forge/fleet_migrate_activation_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/config"
+	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/federation"
+	"go.kenn.io/forge/internal/federationauth"
+	"go.kenn.io/forge/internal/server"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/testutil/servertest"
+)
+
+func TestFleetMigrateProtocolRestoresAuthenticatedActivation(t *testing.T) {
+	for _, state := range []federation.EnrollmentState{federation.EnrollmentPending, federation.EnrollmentActive} {
+		t.Run(string(state), func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			hub := httptest.NewUnstartedServer(nil)
+			t.Cleanup(hub.Close)
+			hubURL := "https://" + hub.Listener.Addr().String()
+			hubDir, spokeDir := t.TempDir(), t.TempDir()
+			hubConfig := &config.Config{DataDir: hubDir, BasePath: "/", Host: "127.0.0.1", Port: 8091,
+				Fleet: config.Fleet{Enabled: true, Role: config.FleetRoleHub, BaseURL: hubURL}}
+			hubConfig.Tmux.Command = []string{"kenn-forge-no-such-tmux"}
+			spokeConfig := &config.Config{DataDir: spokeDir, BasePath: "/", Host: "127.0.0.1", Port: 8091,
+				Fleet: config.Fleet{Enabled: true, Role: config.FleetRoleSpoke, BaseURL: "https://spoke.example",
+					Hub: &config.FleetHub{NodeID: startupHubID, BaseURL: hubURL}}}
+			hubConfig.API.RequireAuth = true
+			spokeConfig.API.RequireAuth = true
+			member := config.FleetMember{NodeID: startupNodeID, Name: "Spoke", BaseURL: spokeConfig.Fleet.BaseURL, State: federation.EnrollmentActive}
+			if state == federation.EnrollmentActive {
+				hubConfig.Fleet.Members = []config.FleetMember{member}
+			}
+			hubPath, spokePath := filepath.Join(hubDir, "config.toml"), filepath.Join(spokeDir, "config.toml")
+			require.NoError(hubConfig.Save(hubPath))
+			require.NoError(spokeConfig.Save(spokePath))
+			hubConfig, err := config.Load(hubPath)
+			require.NoError(err)
+			spokeConfig, err = config.Load(spokePath)
+			require.NoError(err)
+			hubDB, spokeDB := dbtest.OpenAt(t, hubConfig.DBPath()), dbtest.OpenAt(t, spokeConfig.DBPath())
+			binding := db.SpokePreparationBinding{EnrollmentID: startupEnrollmentID, HubNodeID: startupHubID, LocalNodeID: startupNodeID, ProtocolVersion: 3}
+			_, err = spokeDB.BeginSpokePreparation(t.Context(), binding)
+			require.NoError(err)
+			generation, err := spokeDB.FreezeSpokePreparationAckGeneration(t.Context())
+			require.NoError(err)
+			emptyReceipts := sha256.Sum256([]byte("[]"))
+			sealRequest := db.SpokePreparationSealRequest{EnrollmentID: startupEnrollmentID, NodeID: startupNodeID,
+				HubNodeID: startupHubID, ProtocolVersion: 3, MigrationVersion: db.WorkspaceLaunchSpecMigrationVersion,
+				ReceiptsDigest: hex.EncodeToString(emptyReceipts[:]), DrainedAckGeneration: generation}
+			sealRequest.PreparationDigest, err = db.SpokePreparationSealDigest(sealRequest)
+			require.NoError(err)
+			seal, err := hubDB.IssueSpokePreparationSeal(t.Context(), sealRequest)
+			require.NoError(err)
+			require.NoError(spokeDB.StoreLocalSpokePreparationSeal(t.Context(), seal.PreparationDigest, seal.Seal))
+			now := time.Now().UTC()
+			enrollment := federation.Enrollment{ID: startupEnrollmentID, NodeID: startupNodeID,
+				SpokeName: "Spoke", SpokePlatform: "linux", SpokeBaseURL: spokeConfig.Fleet.BaseURL,
+				HubID: startupHubID, HubURL: hubURL, ProtocolVersion: 3, State: state,
+				ExpiresAt: now.Add(time.Hour), CreatedAt: now, UpdatedAt: now, PreparationStarted: true}
+			local := federation.LocalEnrollment{EnrollmentID: enrollment.ID, NodeID: enrollment.NodeID,
+				SpokeName: enrollment.SpokeName, SpokePlatform: enrollment.SpokePlatform, SpokeBaseURL: enrollment.SpokeBaseURL,
+				HubID: enrollment.HubID, HubURL: hubURL, ProtocolVersion: 3, State: state,
+				ExpiresAt: enrollment.ExpiresAt, PreparationStarted: true, PreparationRequired: state == federation.EnrollmentPending,
+				Preparation: &federation.LocalPreparationSeal{EnrollmentID: enrollment.ID, NodeID: enrollment.NodeID,
+					HubID: enrollment.HubID, ProtocolVersion: 3, PreparationDigest: seal.PreparationDigest, Seal: seal.Seal}}
+			for dir, record := range map[string]any{
+				hubDir:   map[string]any{"version": 1, "tokens": []any{}, "enrollments": []federation.Enrollment{enrollment}},
+				spokeDir: map[string]any{"version": 1, "tokens": []any{}, "enrollments": []any{}, "local": local},
+			} {
+				encoded, err := json.Marshal(record)
+				require.NoError(err)
+				require.NoError(os.WriteFile(federation.DefaultStorePath(dir), encoded, 0o600))
+			}
+			hubCredentials, err := federationauth.Open(federationauth.DefaultStorePath(hubDir))
+			require.NoError(err)
+			spokeCredentials, err := federationauth.Open(federationauth.DefaultStorePath(spokeDir))
+			require.NoError(err)
+			require.NoError(hubCredentials.StoreInbound(startupNodeID, "spoke-to-hub", federationauth.PendingSpokeToHubScopes()))
+			require.NoError(hubCredentials.StoreOutbound(startupNodeID, "hub-to-spoke", federationauth.PendingHubToSpokeScopes()))
+			require.NoError(spokeCredentials.StoreInbound(startupHubID, "hub-to-spoke", federationauth.PendingHubToSpokeScopes()))
+			require.NoError(spokeCredentials.StoreOutbound(startupHubID, "spoke-to-hub", federationauth.PendingSpokeToHubScopes()))
+			require.NoError(hubDB.Close())
+			require.NoError(spokeDB.Close())
+
+			for _, path := range []string{hubPath, spokePath, hubPath, spokePath} {
+				require.NoError(migrateFleetProtocol(t.Context(), path))
+			}
+			hubDB = dbtest.OpenPreparedAt(t, hubConfig.DBPath())
+			spokeDB = dbtest.OpenPreparedAt(t, spokeConfig.DBPath())
+			hubCredentials, err = federationauth.Open(federationauth.DefaultStorePath(hubDir))
+			require.NoError(err)
+			spokeCredentials, err = federationauth.Open(federationauth.DefaultStorePath(spokeDir))
+			require.NoError(err)
+			hubEnrollments, err := federation.Open(federation.DefaultStorePath(hubDir), federation.StoreOptions{})
+			require.NoError(err)
+			spokeEnrollments, err := federation.Open(federation.DefaultStorePath(spokeDir), federation.StoreOptions{})
+			require.NoError(err)
+			hub.Config.Handler = servertest.NewWithConfig(t, hubDB, nil, nil, nil, hubConfig, hubPath, server.ServerOptions{
+				DaemonAccess:          server.DaemonAccessOptions{Token: "local-secret", RequireAPIAuth: true},
+				FederationCredentials: hubCredentials, FederationEnrollments: hubEnrollments, FederationSpokeID: startupHubID,
+				WorktreeDir: t.TempDir(), DisableWorkspaceBackgroundMonitors: true, HostCheckAllowLoopbackAnyPort: true,
+			})
+			hub.StartTLS()
+			for range 2 {
+				status := activateFederationSpokeAtStartup(t.Context(), spokeDB, spokeConfig, startupNodeID,
+					spokeEnrollments, spokeCredentials, hub.Client())
+				require.Equal(federationStartupActive, status.State, status.Reason)
+			}
+			migrated, ok := spokeEnrollments.Local()
+			require.True(ok)
+			assert.Equal(seal.Seal, migrated.Preparation.Seal)
+			assert.True(migrated.ActivationValidUntil.After(time.Now()))
+			persisted, err := config.Load(hubPath)
+			require.NoError(err)
+			assert.Equal([]config.FleetMember{member}, persisted.Fleet.Members)
+			principal, ok := hubCredentials.Authenticate("spoke-to-hub")
+			require.True(ok)
+			assert.Equal(startupNodeID, principal.NodeID)
+			outbound, ok := spokeCredentials.Outbound(startupHubID)
+			require.True(ok)
+			assert.Equal("spoke-to-hub", outbound.Token)
+		})
+	}
+}

--- a/cmd/kenn-forge/fleet_migrate_test.go
+++ b/cmd/kenn-forge/fleet_migrate_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/config"
+	"go.kenn.io/forge/internal/federation"
+	"go.kenn.io/forge/internal/runtimelock"
+)
+
+func TestFleetMigrateProtocolHelpDoesNotLoadConfig(t *testing.T) {
+	var output bytes.Buffer
+	command := newFleetCommand(fleetCLIOptions{Stdout: &output})
+	command.SetOut(&output)
+	command.SetArgs([]string{"migrate-protocol", "--config", filepath.Join(t.TempDir(), "missing", "config.toml"), "--help"})
+	require.NoError(t, command.Execute())
+}
+
+func TestFleetMigrateProtocolUnenrolledNeedsNoDatabaseAndRefusesRunningDaemon(t *testing.T) {
+	require := require.New(t)
+	directory := t.TempDir()
+	path := filepath.Join(directory, "config.toml")
+	require.NoError(os.WriteFile(path, []byte("data_dir = "+strconv.Quote(directory)+"\n"), 0o600))
+	cfg, err := config.Load(path)
+	require.NoError(err)
+	cfg.DataDir = directory
+	require.NoError(cfg.Save(path))
+	require.NoError(migrateFleetProtocol(t.Context(), path))
+	_, err = os.Stat(cfg.DBPath())
+	require.ErrorIs(err, os.ErrNotExist)
+	_, err = federation.Open(federation.DefaultStorePath(directory), federation.StoreOptions{})
+	require.NoError(err)
+	require.NoError(migrateFleetProtocol(t.Context(), path))
+	lock, err := runtimelock.Acquire(directory)
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(lock.Release()) })
+	err = migrateFleetProtocol(t.Context(), path)
+	var collision *runtimelock.CollisionError
+	assert.ErrorAs(t, err, &collision)
+}

--- a/context/fleet-architecture.md
+++ b/context/fleet-architecture.md
@@ -54,6 +54,10 @@ or remote workspace and session operations.
 
 ## Snapshot And Routing Contracts
 
+- Protocol-3 enrollment upgrades require the offline native migration, not wire
+  compatibility; keep its transition only until maintained fleets migrate and
+  protocol-3 rollback retention closes (`cmd/kenn-forge/fleet_migrate.go::migrateFleetProtocol`).
+
 - Snapshots use the shared federation protocol version, not a separate schema
   version; protocol version and node ID must match exactly
   (`internal/server/fleetapi/fleet_hub.go::Handler.fetchRawSnapshot`).

--- a/docs/federated-fleet.md
+++ b/docs/federated-fleet.md
@@ -691,6 +691,30 @@ Database rollback can discard changes made after the backup. Do not overwrite
 new worktree contents as part of restoring Forge state. Revoking a new
 enrollment alone does not restore the old enrollment or provider ownership.
 
+## Upgrade federation protocol 3 to 4
+
+A protocol-3 fleet needs a one-time data migration before protocol-4 binaries
+can use its enrollment. Keep a matching rollback backup of every host's
+database, enrollment and credential stores, configuration, and binary.
+
+1. Stop the Forge service on every fleet member. Keep its worktrees and tmux
+   sessions in place.
+2. On each host, run the new binary against that host's existing configuration:
+
+   ```sh
+   /path/to/new/kenn-forge fleet migrate-protocol --config ~/.kenn/forge/config.toml
+   ```
+
+3. Install the new binary, start the hub, then start its spokes. Verify the
+   fleet workspace list and terminal access on each member.
+
+The migration retains node identities, enrollment, credentials, preparation
+seals, local workspaces, and provider data. It does not enable communication
+between protocol-3 and protocol-4 peers. Repeating the command after an
+interruption resumes the migration; already migrated and unenrolled hosts need
+no changes. To roll back, stop the affected services and restore every host's
+matching pre-migration state and binary together.
+
 ## Replace an older fleet
 
 Older key-based and shell-relay entries are not accepted. Before starting the

--- a/internal/db/protocol_migration.go
+++ b/internal/db/protocol_migration.go
@@ -1,0 +1,129 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// MigrateFleetProtocol3To4 updates preparation bindings in one transaction.
+// The caller holds the daemon lock and publishes enrollment JSON afterward.
+// Retrying with the old enrollment after a committed transaction is supported.
+// Remove this transition after maintained fleets and their rollback snapshots
+// no longer contain protocol 3.
+func (d *DB) MigrateFleetProtocol3To4(
+	ctx context.Context,
+	binding *SpokePreparationBinding,
+	digest, seal string,
+) (string, error) {
+	local, err := d.GetSpokePreparation(ctx)
+	if err != nil {
+		return "", err
+	}
+	updatedDigest := ""
+	if local.Phase != SpokePreparationOpen {
+		if binding == nil || local.EnrollmentID != binding.EnrollmentID ||
+			local.HubNodeID != binding.HubNodeID || local.LocalNodeID != binding.LocalNodeID ||
+			(local.ProtocolVersion != 3 && local.ProtocolVersion != 4) {
+			return "", ErrSpokePreparationConflict
+		}
+		if local.Phase == SpokePreparationSealed {
+			if local.DrainAckGeneration == nil || seal != local.PreparationSeal {
+				return "", ErrSpokePreparationConflict
+			}
+			receipts, err := d.ListSpokePreparationReceipts(ctx)
+			if err != nil {
+				return "", err
+			}
+			receiptsDigest, err := SpokePreparationReceiptsDigest(receipts)
+			if err != nil {
+				return "", err
+			}
+			request := SpokePreparationSealRequest{
+				EnrollmentID: local.EnrollmentID, NodeID: local.LocalNodeID,
+				HubNodeID: local.HubNodeID, ProtocolVersion: local.ProtocolVersion,
+				MigrationVersion: local.MigrationVersion, ReceiptsDigest: receiptsDigest,
+				DrainedAckGeneration: *local.DrainAckGeneration,
+			}
+			storedDigest, err := SpokePreparationSealDigest(request)
+			if err != nil || storedDigest != local.PreparationDigest {
+				return "", ErrSpokePreparationConflict
+			}
+			request.ProtocolVersion = binding.ProtocolVersion
+			enrollmentDigest, err := SpokePreparationSealDigest(request)
+			if err != nil || enrollmentDigest != digest {
+				return "", ErrSpokePreparationConflict
+			}
+			request.ProtocolVersion = 4
+			updatedDigest, err = SpokePreparationSealDigest(request)
+			if err != nil {
+				return "", err
+			}
+		} else if digest != "" || seal != "" {
+			return "", ErrSpokePreparationConflict
+		}
+	} else if digest != "" || seal != "" {
+		return "", ErrSpokePreparationConflict
+	}
+	err = d.Tx(ctx, func(tx *sql.Tx) error {
+		rows, err := tx.QueryContext(ctx, `
+			SELECT enrollment_id, node_id, hub_node_id, protocol_version,
+			       migration_version, receipts_digest, drained_ack_generation,
+			       preparation_digest
+			FROM forge_spoke_preparation_seals`)
+		if err != nil {
+			return err
+		}
+		var updates []SpokePreparationSealRequest
+		for rows.Next() {
+			var request SpokePreparationSealRequest
+			if err := rows.Scan(&request.EnrollmentID, &request.NodeID, &request.HubNodeID,
+				&request.ProtocolVersion, &request.MigrationVersion, &request.ReceiptsDigest,
+				&request.DrainedAckGeneration, &request.PreparationDigest); err != nil {
+				_ = rows.Close()
+				return err
+			}
+			if request.ProtocolVersion != 3 && request.ProtocolVersion != 4 {
+				_ = rows.Close()
+				return fmt.Errorf("cannot migrate preparation protocol %d to 4", request.ProtocolVersion)
+			}
+			if err := validateSpokePreparationSealRequest(request); err != nil {
+				_ = rows.Close()
+				return err
+			}
+			if request.ProtocolVersion == 3 {
+				request.ProtocolVersion = 4
+				request.PreparationDigest, err = SpokePreparationSealDigest(request)
+				if err != nil {
+					_ = rows.Close()
+					return err
+				}
+				updates = append(updates, request)
+			}
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+		for _, request := range updates {
+			if _, err := tx.ExecContext(ctx, `
+				UPDATE forge_spoke_preparation_seals
+				SET protocol_version = 4, preparation_digest = ?
+				WHERE enrollment_id = ?`, request.PreparationDigest, request.EnrollmentID); err != nil {
+				return err
+			}
+		}
+		if local.Phase != SpokePreparationOpen {
+			_, err := tx.ExecContext(ctx, `
+				UPDATE forge_spoke_preparation
+				SET protocol_version = 4, preparation_digest = ?
+				WHERE singleton_id = 1`, updatedDigest)
+			return err
+		}
+		return nil
+	})
+	return updatedDigest, err
+}

--- a/internal/db/protocol_migration_test.go
+++ b/internal/db/protocol_migration_test.go
@@ -1,0 +1,97 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFleetProtocolMigrationPreservesSealsAndResumesBeforeEnrollmentPublish(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	database := openTestDB(t)
+	require.NoError(database.InsertWorkspace(t.Context(), &Workspace{
+		ID: "workspace-1", PlatformHost: "github.com", RepoOwner: "acme", RepoName: "widget",
+		ItemType: WorkspaceItemTypePullRequest, ItemNumber: 42,
+		GitHeadRef: "feature", WorkspaceBranch: "feature", WorktreePath: t.TempDir(),
+		TmuxSession: "workspace-1", Status: "ready",
+	}))
+	require.NoError(database.RecordWorkspaceRuntimeSession(t.Context(), &WorkspaceRuntimeSession{
+		WorkspaceID: "workspace-1", SessionKey: "agent-1", TargetKey: "agent",
+		Label: "Agent", Kind: "agent", Scope: "session", CreatedAt: time.Now().UTC(),
+	}))
+	workspace, err := database.GetWorkspace(t.Context(), "workspace-1")
+	require.NoError(err)
+	runtimes, err := database.ListWorkspaceRuntimeSessions(t.Context(), "workspace-1")
+	require.NoError(err)
+	binding := spokePreparationBindingForTest()
+	_, err = database.BeginSpokePreparation(t.Context(), binding)
+	require.NoError(err)
+	_, err = database.FreezeSpokePreparationAckGeneration(t.Context())
+	require.NoError(err)
+	receipt := SpokePreparationReceipt{StateKind: "review_draft", SourceKey: "draft-1", ContentDigest: "content", HubReceipt: "receipt"}
+	require.NoError(database.RecordSpokePreparationReceipt(t.Context(), receipt))
+	receipts, err := database.ListSpokePreparationReceipts(t.Context())
+	require.NoError(err)
+	digest, err := SpokePreparationReceiptsDigest(receipts)
+	require.NoError(err)
+	request := spokePreparationSealRequestForTest()
+	request.ReceiptsDigest = digest
+	request.DrainedAckGeneration = 0
+	request.PreparationDigest, err = SpokePreparationSealDigest(request)
+	require.NoError(err)
+	seal, err := database.IssueSpokePreparationSeal(t.Context(), request)
+	require.NoError(err)
+	require.NoError(database.StoreLocalSpokePreparationSeal(t.Context(), request.PreparationDigest, seal.Seal))
+
+	updated, err := database.MigrateFleetProtocol3To4(t.Context(), &binding, request.PreparationDigest, seal.Seal)
+	require.NoError(err)
+	repeated, err := database.MigrateFleetProtocol3To4(t.Context(), &binding, request.PreparationDigest, seal.Seal)
+	require.NoError(err)
+	assert.Equal(updated, repeated)
+	request.ProtocolVersion = 4
+	expected, err := SpokePreparationSealDigest(request)
+	require.NoError(err)
+	assert.Equal(expected, updated)
+	current, err := database.GetSpokePreparation(t.Context())
+	require.NoError(err)
+	assert.Equal(4, current.ProtocolVersion)
+	assert.Equal(seal.Seal, current.PreparationSeal)
+	assert.Equal(updated, current.PreparationDigest)
+	hubSeal, err := database.GetSpokePreparationSeal(t.Context(), request.EnrollmentID)
+	require.NoError(err)
+	seal.ProtocolVersion = 4
+	seal.PreparationDigest = updated
+	assert.Equal(seal, *hubSeal)
+	remaining, err := database.ListSpokePreparationReceipts(t.Context())
+	require.NoError(err)
+	assert.Equal(receipts, remaining)
+	retained, err := database.GetWorkspace(t.Context(), "workspace-1")
+	require.NoError(err)
+	assert.Equal(workspace, retained)
+	retainedRuntimes, err := database.ListWorkspaceRuntimeSessions(t.Context(), "workspace-1")
+	require.NoError(err)
+	assert.Equal(runtimes, retainedRuntimes)
+	assertDatabaseIntegrityForTest(t, database.ReadDB())
+}
+
+func TestFleetProtocolMigrationRejectsUnsupportedSealWithoutPartialWrites(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	request := spokePreparationSealRequestForTest()
+	original, err := database.IssueSpokePreparationSeal(t.Context(), request)
+	require.NoError(err)
+	request.EnrollmentID = "future-enrollment"
+	request.ProtocolVersion = 5
+	request.PreparationDigest, err = SpokePreparationSealDigest(request)
+	require.NoError(err)
+	_, err = database.IssueSpokePreparationSeal(t.Context(), request)
+	require.NoError(err)
+	_, err = database.MigrateFleetProtocol3To4(t.Context(), nil, "", "")
+	require.Error(err)
+	actual, err := database.GetSpokePreparationSeal(t.Context(), original.EnrollmentID)
+	require.NoError(err)
+	assert.Equal(t, original, *actual)
+}

--- a/internal/db/queries_spoke_preparation.go
+++ b/internal/db/queries_spoke_preparation.go
@@ -478,3 +478,29 @@ func (d *DB) StoreLocalSpokePreparationSeal(
 	}
 	return nil
 }
+
+// SpokePreparationReceiptsDigest covers receipt identity and content, excluding local timestamps.
+func SpokePreparationReceiptsDigest(
+	receipts []SpokePreparationReceipt,
+) (string, error) {
+	type semanticReceipt struct {
+		StateKind     string `json:"state_kind"`
+		SourceKey     string `json:"source_key"`
+		ContentDigest string `json:"content_digest"`
+		HubReceipt    string `json:"hub_receipt"`
+	}
+	semantic := make([]semanticReceipt, 0, len(receipts))
+	for _, receipt := range receipts {
+		semantic = append(semantic, semanticReceipt{
+			StateKind: receipt.StateKind, SourceKey: receipt.SourceKey,
+			ContentDigest: receipt.ContentDigest,
+			HubReceipt:    receipt.HubReceipt,
+		})
+	}
+	encoded, err := json.Marshal(semantic)
+	if err != nil {
+		return "", fmt.Errorf("encode spoke preparation receipts: %w", err)
+	}
+	digest := sha256.Sum256(encoded)
+	return hex.EncodeToString(digest[:]), nil
+}

--- a/internal/federation/enrollment_store.go
+++ b/internal/federation/enrollment_store.go
@@ -729,6 +729,17 @@ func enrollmentIndexByID(enrollments []Enrollment, enrollmentID string) int {
 }
 
 func readEnrollmentStore(path string) (persistedEnrollmentStore, bool, error) {
+	state, exists, err := decodeEnrollmentStore(path)
+	if err != nil || !exists {
+		return state, exists, err
+	}
+	if err := validateEnrollmentStore(&state); err != nil {
+		return persistedEnrollmentStore{}, false, err
+	}
+	return state, true, nil
+}
+
+func decodeEnrollmentStore(path string) (persistedEnrollmentStore, bool, error) {
 	file, err := os.Open(path)
 	if errors.Is(err, os.ErrNotExist) {
 		return persistedEnrollmentStore{}, false, nil
@@ -749,9 +760,6 @@ func readEnrollmentStore(path string) (persistedEnrollmentStore, bool, error) {
 			return persistedEnrollmentStore{}, false, errors.New("decode federation enrollment store: multiple JSON values")
 		}
 		return persistedEnrollmentStore{}, false, fmt.Errorf("decode federation enrollment store trailer: %w", err)
-	}
-	if err := validateEnrollmentStore(&state); err != nil {
-		return persistedEnrollmentStore{}, false, err
 	}
 	return state, true, nil
 }

--- a/internal/federation/protocol_migration.go
+++ b/internal/federation/protocol_migration.go
@@ -1,0 +1,68 @@
+package federation
+
+import "fmt"
+
+// MigrateProtocol3To4 advances durable enrollment after preparation storage is
+// migrated by prepare. The caller must hold the daemon runtime lock. Runtime
+// loading and peer authentication continue to require the current protocol.
+// Remove this transition once all maintained fleets have completed it and their
+// protocol-3 rollback retention windows have closed.
+func MigrateProtocol3To4(
+	path string,
+	prepare func(local *LocalEnrollment) (string, error),
+) error {
+	state, exists, err := decodeEnrollmentStore(path)
+	if err != nil || !exists {
+		return err
+	}
+	changed := false
+	advance := func(version *int) error {
+		switch *version {
+		case 3:
+			*version = 4
+			changed = true
+		case 4:
+		default:
+			return fmt.Errorf("cannot migrate federation protocol %d to 4: %w", *version, ErrProtocolMismatch)
+		}
+		return nil
+	}
+	for index := range state.Enrollments {
+		if err := advance(&state.Enrollments[index].ProtocolVersion); err != nil {
+			return err
+		}
+	}
+	var original *LocalEnrollment
+	if state.Local != nil {
+		local, err := normalizePersistedLocalEnrollment(*state.Local)
+		if err != nil {
+			return err
+		}
+		original = &local
+		if err := advance(&state.Local.ProtocolVersion); err != nil {
+			return err
+		}
+		if state.Local.Preparation != nil {
+			if err := advance(&state.Local.Preparation.ProtocolVersion); err != nil {
+				return err
+			}
+		}
+	}
+	if err := validateEnrollmentStore(&state); err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+	digest, err := prepare(original)
+	if err != nil {
+		return fmt.Errorf("migrate federation preparation: %w", err)
+	}
+	if state.Local != nil && state.Local.Preparation != nil {
+		state.Local.Preparation.PreparationDigest = digest
+	}
+	if err := validateEnrollmentStore(&state); err != nil {
+		return err
+	}
+	return writeEnrollmentStore(path, state)
+}

--- a/internal/federation/protocol_migration_test.go
+++ b/internal/federation/protocol_migration_test.go
@@ -1,0 +1,73 @@
+package federation
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProtocolMigrationPreservesHubEnrollmentAndRevocation(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	path := filepath.Join(t.TempDir(), "enrollments.json")
+	now := time.Now().UTC()
+	state := persistedEnrollmentStore{Version: 1, Enrollments: []Enrollment{{
+		ID: testEnrollmentID, NodeID: testNodeID, HubID: testHubID,
+		HubURL: "https://hub.example", SpokeBaseURL: "https://spoke.example",
+		ProtocolVersion: 3, State: EnrollmentRevoked, ExpiresAt: now,
+		CreatedAt: now, UpdatedAt: now, RevokedAt: now,
+	}}}
+	raw, err := json.Marshal(state)
+	require.NoError(err)
+	require.NoError(os.WriteFile(path, raw, 0o600))
+	_, err = Open(path, StoreOptions{})
+	require.ErrorIs(err, ErrProtocolMismatch)
+	prepared := 0
+	require.NoError(MigrateProtocol3To4(path, func(local *LocalEnrollment) (string, error) {
+		assert.Nil(local)
+		prepared++
+		return "", nil
+	}))
+	store, err := Open(path, StoreOptions{})
+	require.NoError(err)
+	actual, err := store.Get(t.Context(), testEnrollmentID)
+	require.NoError(err)
+	expected := state.Enrollments[0]
+	expected.ProtocolVersion = 4
+	assert.Equal(expected, actual)
+	require.NoError(MigrateProtocol3To4(path, func(*LocalEnrollment) (string, error) {
+		prepared++
+		return "", nil
+	}))
+	assert.Equal(1, prepared)
+}
+
+func TestProtocolMigrationRejectsFutureAndDoesNotPublishAfterPreparationFailure(t *testing.T) {
+	for _, protocol := range []int{3, 5} {
+		t.Run(string(rune('0'+protocol)), func(t *testing.T) {
+			require := require.New(t)
+			path := filepath.Join(t.TempDir(), "enrollments.json")
+			state := persistedEnrollmentStore{Version: 1, Local: &LocalEnrollment{
+				EnrollmentID: testEnrollmentID, NodeID: testNodeID,
+				SpokeBaseURL: "https://spoke.example", HubURL: "https://hub.example",
+				ProtocolVersion: protocol, State: EnrollmentPending,
+			}}
+			raw, err := json.Marshal(state)
+			require.NoError(err)
+			require.NoError(os.WriteFile(path, raw, 0o600))
+			err = MigrateProtocol3To4(path, func(*LocalEnrollment) (string, error) {
+				return "", errors.New("preparation failed")
+			})
+			require.Error(err)
+			actual, err := os.ReadFile(path)
+			require.NoError(err)
+			assert.Equal(t, raw, actual)
+		})
+	}
+}

--- a/internal/server/spoke_preparation.go
+++ b/internal/server/spoke_preparation.go
@@ -3,8 +3,6 @@ package server
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -226,7 +224,7 @@ func (s *Server) prepareFederationSpoke(
 	if err != nil {
 		return nil, httpapi.Internal("list provider state receipts: " + err.Error())
 	}
-	receiptsDigest, err := spokePreparationReceiptsDigest(receipts)
+	receiptsDigest, err := db.SpokePreparationReceiptsDigest(receipts)
 	if err != nil {
 		return nil, httpapi.Internal(err.Error())
 	}
@@ -658,29 +656,4 @@ func spokePreparationHubProblem(err error) error {
 		return problem
 	}
 	return httpapi.Internal("begin hub spoke preparation: " + err.Error())
-}
-
-func spokePreparationReceiptsDigest(
-	receipts []db.SpokePreparationReceipt,
-) (string, error) {
-	type semanticReceipt struct {
-		StateKind     string `json:"state_kind"`
-		SourceKey     string `json:"source_key"`
-		ContentDigest string `json:"content_digest"`
-		HubReceipt    string `json:"hub_receipt"`
-	}
-	semantic := make([]semanticReceipt, 0, len(receipts))
-	for _, receipt := range receipts {
-		semantic = append(semantic, semanticReceipt{
-			StateKind: receipt.StateKind, SourceKey: receipt.SourceKey,
-			ContentDigest: receipt.ContentDigest,
-			HubReceipt:    receipt.HubReceipt,
-		})
-	}
-	encoded, err := json.Marshal(semantic)
-	if err != nil {
-		return "", fmt.Errorf("encode spoke preparation receipts: %w", err)
-	}
-	digest := sha256.Sum256(encoded)
-	return hex.EncodeToString(digest[:]), nil
 }


### PR DESCRIPTION
Protocol-4 binaries could not reuse existing protocol-3 fleet enrollment: hubs failed to start and spokes could not activate.

- Add `fleet migrate-protocol --config FILE` for stopped daemons. Preserve enrollment identities, credentials, preparation seals, workspaces, and provider data while advancing durable bindings to protocol 4.
- Resume an interrupted migration safely; leave already migrated and unenrolled hosts unchanged. Keep exact protocol matching for running peers.
- Document coordinated migration and rollback. Remove the protocol-3 transformation after maintained fleets migrate and their protocol-3 rollback retention windows close.
