### PR TITLE
fix: complete fleet upgrades with historical preparation seals

### DIFF
--- a/cmd/kenn-forge/fleet_migrate_activation_test.go
+++ b/cmd/kenn-forge/fleet_migrate_activation_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -22,8 +23,18 @@ import (
 )
 
 func TestFleetMigrateProtocolRestoresAuthenticatedActivation(t *testing.T) {
-	for _, state := range []federation.EnrollmentState{federation.EnrollmentPending, federation.EnrollmentActive} {
-		t.Run(string(state), func(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		state      federation.EnrollmentState
+		historical bool
+	}{
+		{name: "pending", state: federation.EnrollmentPending},
+		{name: "active", state: federation.EnrollmentActive},
+		{name: "historical pending", state: federation.EnrollmentPending, historical: true},
+		{name: "historical active resume", state: federation.EnrollmentActive, historical: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			state := test.state
 			assert := assert.New(t)
 			require := require.New(t)
 			hub := httptest.NewUnstartedServer(nil)
@@ -63,6 +74,16 @@ func TestFleetMigrateProtocolRestoresAuthenticatedActivation(t *testing.T) {
 			require.NoError(err)
 			seal, err := hubDB.IssueSpokePreparationSeal(t.Context(), sealRequest)
 			require.NoError(err)
+			if test.historical {
+				encoded := fmt.Sprintf(`{"enrollment_id":%q,"node_id":%q,"coordinator_node_id":%q,"protocol_version":3,"migration_version":54,"receipts_digest":%q,"drained_ack_generation":%d,"preparation_digest":""}`,
+					startupEnrollmentID, startupNodeID, startupHubID, sealRequest.ReceiptsDigest, generation)
+				digest := sha256.Sum256([]byte(encoded))
+				seal.PreparationDigest = hex.EncodeToString(digest[:])
+				_, err := hubDB.WriteDB().ExecContext(t.Context(),
+					`UPDATE forge_spoke_preparation_seals SET preparation_digest = ? WHERE enrollment_id = ?`,
+					seal.PreparationDigest, startupEnrollmentID)
+				require.NoError(err)
+			}
 			require.NoError(spokeDB.StoreLocalSpokePreparationSeal(t.Context(), seal.PreparationDigest, seal.Seal))
 			now := time.Now().UTC()
 			enrollment := federation.Enrollment{ID: startupEnrollmentID, NodeID: startupNodeID,
@@ -91,6 +112,11 @@ func TestFleetMigrateProtocolRestoresAuthenticatedActivation(t *testing.T) {
 			require.NoError(hubCredentials.StoreOutbound(startupNodeID, "hub-to-spoke", federationauth.PendingHubToSpokeScopes()))
 			require.NoError(spokeCredentials.StoreInbound(startupHubID, "hub-to-spoke", federationauth.PendingHubToSpokeScopes()))
 			require.NoError(spokeCredentials.StoreOutbound(startupHubID, "spoke-to-hub", federationauth.PendingSpokeToHubScopes()))
+			if test.historical && state == federation.EnrollmentActive {
+				// Resume after SQLite commits while enrollment still has its old digest.
+				_, err := spokeDB.MigrateFleetProtocol3To4(t.Context(), &binding, seal.PreparationDigest, seal.Seal)
+				require.NoError(err)
+			}
 			require.NoError(hubDB.Close())
 			require.NoError(spokeDB.Close())
 

--- a/context/fleet-architecture.md
+++ b/context/fleet-architecture.md
@@ -57,6 +57,9 @@ or remote workspace and session operations.
 - Protocol-3 enrollment upgrades require the offline native migration, not wire
   compatibility; keep its transition only until maintained fleets migrate and
   protocol-3 rollback retention closes (`cmd/kenn-forge/fleet_migrate.go::migrateFleetProtocol`).
+- Protocol-3 seals may hash `coordinator_node_id`; accept that historical encoding
+  only during offline migration, preserving strict current-protocol validation
+  (`internal/db/protocol_migration.go::validateMigratingSpokePreparationSeal`).
 
 - Snapshots use the shared federation protocol version, not a separate schema
   version; protocol version and node ID must match exactly

--- a/internal/db/protocol_migration.go
+++ b/internal/db/protocol_migration.go
@@ -1,8 +1,12 @@
 package db
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -87,7 +91,7 @@ func (d *DB) MigrateFleetProtocol3To4(
 				_ = rows.Close()
 				return fmt.Errorf("cannot migrate preparation protocol %d to 4", request.ProtocolVersion)
 			}
-			if err := validateSpokePreparationSealRequest(request); err != nil {
+			if err := validateMigratingSpokePreparationSeal(request); err != nil {
 				_ = rows.Close()
 				return err
 			}
@@ -126,4 +130,25 @@ func (d *DB) MigrateFleetProtocol3To4(
 		return nil
 	})
 	return updatedDigest, err
+}
+
+// Historical protocol-3 seals used coordinator_node_id in the hashed JSON.
+// Accept that exact binding only inside the one-time migration, which rewrites
+// it to the canonical protocol-4 digest before publishing enrollment state.
+func validateMigratingSpokePreparationSeal(request SpokePreparationSealRequest) error {
+	err := validateSpokePreparationSealRequest(request)
+	if err == nil || request.ProtocolVersion != 3 || !errors.Is(err, ErrSpokePreparationConflict) {
+		return err
+	}
+	expected := request.PreparationDigest
+	request.PreparationDigest = ""
+	encoded, encodeErr := json.Marshal(request)
+	if encodeErr != nil {
+		return encodeErr
+	}
+	encoded = bytes.Replace(encoded, []byte(`"hub_node_id":`), []byte(`"coordinator_node_id":`), 1)
+	if fmt.Sprintf("%x", sha256.Sum256(encoded)) != expected {
+		return err
+	}
+	return nil
 }

--- a/internal/db/protocol_migration.go
+++ b/internal/db/protocol_migration.go
@@ -49,14 +49,14 @@ func (d *DB) MigrateFleetProtocol3To4(
 				MigrationVersion: local.MigrationVersion, ReceiptsDigest: receiptsDigest,
 				DrainedAckGeneration: *local.DrainAckGeneration,
 			}
-			storedDigest, err := SpokePreparationSealDigest(request)
-			if err != nil || storedDigest != local.PreparationDigest {
-				return "", ErrSpokePreparationConflict
+			request.PreparationDigest = local.PreparationDigest
+			if err := validateMigratingSpokePreparationSeal(request); err != nil {
+				return "", err
 			}
 			request.ProtocolVersion = binding.ProtocolVersion
-			enrollmentDigest, err := SpokePreparationSealDigest(request)
-			if err != nil || enrollmentDigest != digest {
-				return "", ErrSpokePreparationConflict
+			request.PreparationDigest = digest
+			if err := validateMigratingSpokePreparationSeal(request); err != nil {
+				return "", err
 			}
 			request.ProtocolVersion = 4
 			updatedDigest, err = SpokePreparationSealDigest(request)

--- a/internal/db/protocol_migration_test.go
+++ b/internal/db/protocol_migration_test.go
@@ -1,12 +1,71 @@
 package db
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestFleetProtocolMigrationConvertsHistoricalCoordinatorSealDigest(t *testing.T) {
+	// This is the shipped protocol-3 encoding, before coordinator_node_id
+	// became hub_node_id. Keep the fixture independent of the current encoder.
+	historical := `{"enrollment_id":"historical-enrollment","node_id":"spoke-1","coordinator_node_id":"hub-1","protocol_version":%d,"migration_version":54,"receipts_digest":"receipts-digest","drained_ack_generation":4,"preparation_digest":""}`
+	for _, test := range []struct {
+		name     string
+		protocol int
+		hubID    string
+		valid    bool
+	}{
+		{name: "historical protocol 3", protocol: 3, hubID: "hub-1", valid: true},
+		{name: "changed identity", protocol: 3, hubID: "other-hub"},
+		{name: "historical digest on protocol 4", protocol: 4, hubID: "hub-1"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			database := openTestDB(t)
+			canonical, err := database.IssueSpokePreparationSeal(t.Context(), spokePreparationSealRequestForTest())
+			require.NoError(err)
+			_, err = database.WriteDB().ExecContext(t.Context(), `
+				INSERT INTO forge_spoke_preparation_seals (
+				    enrollment_id, node_id, hub_node_id, protocol_version,
+				    migration_version, receipts_digest, drained_ack_generation,
+				    preparation_digest, preparation_seal, created_at
+				) VALUES ('historical-enrollment', 'spoke-1', ?, ?, 54,
+				          'receipts-digest', 4, ?, 'historical-seal', '2026-08-01T00:00:00Z')`,
+				test.hubID, test.protocol, fmt.Sprintf("%x", sha256.Sum256([]byte(fmt.Sprintf(historical, test.protocol)))))
+			require.NoError(err)
+			before, err := database.GetSpokePreparationSeal(t.Context(), "historical-enrollment")
+			require.NoError(err)
+			_, err = database.MigrateFleetProtocol3To4(t.Context(), nil, "", "")
+			if !test.valid {
+				require.ErrorIs(err, ErrSpokePreparationConflict)
+				after, err := database.GetSpokePreparationSeal(t.Context(), before.EnrollmentID)
+				require.NoError(err)
+				assert.Equal(before, after)
+				unchanged, err := database.GetSpokePreparationSeal(t.Context(), canonical.EnrollmentID)
+				require.NoError(err)
+				assert.Equal(canonical, *unchanged)
+				return
+			}
+			require.NoError(err)
+			_, err = database.MigrateFleetProtocol3To4(t.Context(), nil, "", "")
+			require.NoError(err)
+			after, err := database.GetSpokePreparationSeal(t.Context(), before.EnrollmentID)
+			require.NoError(err)
+			before.ProtocolVersion = 4
+			before.PreparationDigest, err = SpokePreparationSealDigest(before.SpokePreparationSealRequest)
+			require.NoError(err)
+			assert.Equal(before, after)
+			require.NoError(validateSpokePreparationSealRequest(after.SpokePreparationSealRequest))
+			assertDatabaseIntegrityForTest(t, database.ReadDB())
+		})
+	}
+}
 
 func TestFleetProtocolMigrationPreservesSealsAndResumesBeforeEnrollmentPublish(t *testing.T) {
 	require := require.New(t)


### PR DESCRIPTION
Complete protocol-3 migrations for databases retaining preparation seals whose hashed binding used `coordinator_node_id` before its rename to `hub_node_id`. Verify that exact historical encoding during offline migration, then write the canonical protocol-4 digest while preserving identities and random seals. Current-protocol validation stays strict.

Verified conversion and repeat-run idempotence on an isolated copy of affected persisted state. Retire this transformation with the existing protocol-3 migration after maintained fleets migrate and their protocol-3 rollback retention windows close.
