### PR TITLE
feat: prove rebased ranges and classify direct-push origins

### DIFF
--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -45,6 +45,8 @@ direct-push claims; generic squash proof does not establish any provider's
 squash capability (`landedwork/analyze.go::Analyze`).
 Git's commit-graph can outlive commit objects; verify required commits physically,
 including each landing's first parent (`landedwork/git.go::parents`, `landedwork/proof.go::prove`).
+Rewritten ranges compare exact edit bytes, not whitespace-insensitive patch IDs;
+empty or duplicate rewritten edits stay unproven (`landedwork/range.go::rangeCorrespondence`).
 
 Minimum provider checklist:
 

--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -40,9 +40,14 @@ cache policy and admission remain internal
 The public landing API uses local objects only; callers own collection and supply
 evidence for the exact prepared interval. Missing history and exhausted budgets
 remain gaps, never empty complete inventories (`landedwork/prepare.go::Prepare`).
-Unsupported landing methods remain unresolved, and unowned commits are not
-direct-push claims; generic squash proof does not establish any provider's
-squash capability (`landedwork/analyze.go::Analyze`).
+Unsupported landing methods remain unresolved; generic squash proof does not
+establish any provider's squash capability (`landedwork/analyze.go::Analyze`).
+Direct-push origins require complete inventory and an unblocked, unowned spine
+commit; they establish neither a pusher nor a trusted update time
+(`landedwork/direct.go::classifyDirectPushes`).
+Integrated candidates own nothing: prove exact containment in an accepted
+ordinary merge, never resolve through another integrated candidate
+(`landedwork/origins.go::integratedThrough`).
 Git's commit-graph can outlive commit objects; verify required commits physically,
 including each landing's first parent (`landedwork/git.go::parents`, `landedwork/proof.go::prove`).
 Rewritten ranges compare exact edit bytes, not whitespace-insensitive patch IDs;

--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -52,6 +52,10 @@ Git's commit-graph can outlive commit objects; verify required commits physicall
 including each landing's first parent (`landedwork/git.go::parents`, `landedwork/proof.go::proveAt`).
 Rewritten ranges compare exact edit bytes, not whitespace-insensitive patch IDs;
 empty or duplicate rewritten edits stay unproven (`landedwork/range.go::rangeCorrespondence`).
+Offset-free text proof requires uniquely occurring removed bytes or a unique
+insertion neighborhood; repeated locations stay unproven (`landedwork/edits.go::fileEdits`).
+Overlap conflicts block the proven landing ranges, not unrelated earlier
+commits; unknown-start candidate gaps still block from the base (`landedwork/origins.go::rejectOverlaps`).
 
 Minimum provider checklist:
 

--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -49,7 +49,7 @@ Integrated candidates own nothing: prove exact containment in an accepted
 ordinary merge, never resolve through another integrated candidate
 (`landedwork/origins.go::integratedThrough`).
 Git's commit-graph can outlive commit objects; verify required commits physically,
-including each landing's first parent (`landedwork/git.go::parents`, `landedwork/proof.go::prove`).
+including each landing's first parent (`landedwork/git.go::parents`, `landedwork/proof.go::proveAt`).
 Rewritten ranges compare exact edit bytes, not whitespace-insensitive patch IDs;
 empty or duplicate rewritten edits stay unproven (`landedwork/range.go::rangeCorrespondence`).
 

--- a/landedwork/accounting.go
+++ b/landedwork/accounting.go
@@ -29,6 +29,10 @@ func checkResultOutput(r Result, l Limits) error {
 	c := r.Coverage
 	n := repositoryBytes(c.Bounds.Repository) + int64(len(c.Bounds.Base)+len(c.Bounds.Head)+len(c.CertifiedHead)) + inventoryBytes(c.Inventory)
 	records := int64(len(c.Gaps) + len(r.Landings) + len(r.Unattributed))
+	records += int64(len(r.Integrated))
+	for _, i := range r.Integrated {
+		n += int64(len(i.CandidateID) + len(i.ThroughCandidateID))
+	}
 	for _, gap := range c.Gaps {
 		n += gapBytes(gap)
 	}

--- a/landedwork/accounting.go
+++ b/landedwork/accounting.go
@@ -1,7 +1,9 @@
 package landedwork
 
 func repositoryBytes(r Repository) int64 { return int64(len(r.Provider) + len(r.Host) + len(r.ID)) }
-func gapBytes(g Gap) int64               { return int64(len(g.CandidateID) + len(g.ObjectID) + len(g.Reason)) }
+func gapBytes(g Gap) int64 {
+	return int64(len(g.CandidateID) + len(g.ObjectID) + len(g.Reason) + len(g.Span.Before) + len(g.Span.Through))
+}
 func stringBytes(ids []string) int64 {
 	var n int64
 	for _, id := range ids {

--- a/landedwork/accounting.go
+++ b/landedwork/accounting.go
@@ -30,6 +30,11 @@ func checkResultOutput(r Result, l Limits) error {
 	n := repositoryBytes(c.Bounds.Repository) + int64(len(c.Bounds.Base)+len(c.Bounds.Head)+len(c.CertifiedHead)) + inventoryBytes(c.Inventory)
 	records := int64(len(c.Gaps) + len(r.Landings) + len(r.Unattributed))
 	records += int64(len(r.Integrated))
+	records += int64(len(r.DirectPushes))
+	for _, d := range r.DirectPushes {
+		n += int64(len(d.Before)+len(d.Terminal)) + stringBytes(d.Introduced)
+		records += int64(len(d.Introduced))
+	}
 	for _, i := range r.Integrated {
 		n += int64(len(i.CandidateID) + len(i.ThroughCandidateID))
 	}

--- a/landedwork/analyze.go
+++ b/landedwork/analyze.go
@@ -82,12 +82,7 @@ func candidateCounts(candidates []Candidate) (map[string]int, map[string]int) {
 }
 
 func finishCoverage(r *Result, p *Interval) {
-	owners, positions := map[string]bool{}, map[string]int{}
-	for _, landing := range r.Landings {
-		for _, id := range ownedSpine(landing) {
-			owners[id] = true
-		}
-	}
+	owners, positions := landingOwners(r.Landings), map[string]int{}
 	for _, d := range r.DirectPushes {
 		owners[d.Terminal] = true
 	}

--- a/landedwork/analyze.go
+++ b/landedwork/analyze.go
@@ -94,6 +94,11 @@ func finishCoverage(r *Result, p *Interval) {
 	owners, positions := map[string]bool{}, map[string]int{}
 	for _, landing := range r.Landings {
 		owners[landing.Terminal] = true
+		if landing.Method == "rebase" || landing.Method == "fast_forward" {
+			for _, id := range landing.Introduced {
+				owners[id] = true
+			}
+		}
 	}
 	complete := len(r.Coverage.Gaps) == 0
 	for index, id := range p.spine {

--- a/landedwork/analyze.go
+++ b/landedwork/analyze.go
@@ -25,6 +25,11 @@ func Analyze(ctx context.Context, p *Interval, e Evidence, limits Limits) (r Res
 			err = ctx.Err()
 		}
 		if err == nil {
+			for i := range r.Coverage.Gaps {
+				if r.Coverage.Gaps[i].Span == (Span{}) {
+					r.Coverage.Gaps[i].Span = fullSpan(p)
+				}
+			}
 			if p.query.Complete {
 				finishCoverage(&r, p)
 			}
@@ -61,22 +66,8 @@ func Analyze(ctx context.Context, p *Interval, e Evidence, limits Limits) (r Res
 		r.Coverage.Gaps = append(r.Coverage.Gaps, Gap{Reason: graphReason(shallowErr)})
 		return r, nil
 	}
-	terminals, ids := candidateCounts(e.Candidates)
-	candidates := slices.Clone(e.Candidates)
-	slices.SortFunc(candidates, func(a, b Candidate) int { return cmp.Compare(a.ID, b.ID) })
-	for _, c := range candidates {
-		if terminals[c.Terminal] > 1 || ids[c.ID] > 1 {
-			r.Coverage.Gaps = append(r.Coverage.Gaps, Gap{CandidateID: c.ID, ObjectID: c.Terminal, Reason: "candidate_conflict"})
-			continue
-		}
-		landing, gap := prove(ctx, v, p, c, e.Capabilities)
-		if gap.Reason != "" {
-			r.Coverage.Gaps = append(r.Coverage.Gaps, gap)
-		} else {
-			r.Landings = append(r.Landings, landing)
-		}
-	}
-	return r, nil
+	err = resolveOrigins(ctx, v, p, e.Candidates, e.Capabilities, &r)
+	return r, err
 }
 
 func candidateCounts(candidates []Candidate) (map[string]int, map[string]int) {
@@ -93,16 +84,17 @@ func candidateCounts(candidates []Candidate) (map[string]int, map[string]int) {
 func finishCoverage(r *Result, p *Interval) {
 	owners, positions := map[string]bool{}, map[string]int{}
 	for _, landing := range r.Landings {
-		owners[landing.Terminal] = true
-		if landing.Method == "rebase" || landing.Method == "fast_forward" {
-			for _, id := range landing.Introduced {
-				owners[id] = true
-			}
+		for _, id := range ownedSpine(landing) {
+			owners[id] = true
 		}
 	}
-	complete := len(r.Coverage.Gaps) == 0
+	blocked := blockedSpine(r, p)
+	complete := true
 	for index, id := range p.spine {
 		positions[id] = index
+		if blocked[id] {
+			complete = false
+		}
 		if !owners[id] {
 			r.Unattributed = append(r.Unattributed, id)
 			complete = false
@@ -111,7 +103,7 @@ func finishCoverage(r *Result, p *Interval) {
 			r.Coverage.CertifiedHead = id
 		}
 	}
-	r.Coverage.Complete = complete
+	r.Coverage.Complete = complete && len(r.Coverage.Gaps) == 0
 	slices.SortFunc(r.Landings, func(a, b Landing) int { return cmp.Compare(positions[a.Terminal], positions[b.Terminal]) })
 	slices.SortFunc(r.Coverage.Gaps, func(a, b Gap) int {
 		if n := cmp.Compare(a.CandidateID, b.CandidateID); n != 0 {
@@ -120,6 +112,12 @@ func finishCoverage(r *Result, p *Interval) {
 		if n := cmp.Compare(a.Reason, b.Reason); n != 0 {
 			return n
 		}
-		return cmp.Compare(a.ObjectID, b.ObjectID)
+		if n := cmp.Compare(a.ObjectID, b.ObjectID); n != 0 {
+			return n
+		}
+		if n := cmp.Compare(a.Span.Before, b.Span.Before); n != 0 {
+			return n
+		}
+		return cmp.Compare(a.Span.Through, b.Span.Through)
 	})
 }

--- a/landedwork/analyze.go
+++ b/landedwork/analyze.go
@@ -88,6 +88,9 @@ func finishCoverage(r *Result, p *Interval) {
 			owners[id] = true
 		}
 	}
+	for _, d := range r.DirectPushes {
+		owners[d.Terminal] = true
+	}
 	blocked := blockedSpine(r, p)
 	complete := true
 	for index, id := range p.spine {

--- a/landedwork/coverage_test.go
+++ b/landedwork/coverage_test.go
@@ -86,10 +86,18 @@ func TestAnalyzeCoverageNoCandidateAndConflict(t *testing.T) {
 			require.NoError(t, err)
 			assert := assert.New(t)
 			assert.Empty(r.Landings)
-			assert.Equal([]string{f.head}, r.Unattributed)
 			assert.Equal(f.bounds(), r.Coverage.Bounds)
-			assert.False(r.Coverage.Complete)
-			assert.Equal(f.base, r.Coverage.CertifiedHead)
+			if name == "unattributed" {
+				assert.Empty(r.Unattributed)
+				assert.True(r.Coverage.Complete)
+				assert.Equal(f.head, r.Coverage.CertifiedHead)
+				assert.Len(r.DirectPushes, 1)
+			} else {
+				assert.Equal([]string{f.head}, r.Unattributed)
+				assert.False(r.Coverage.Complete)
+				assert.Equal(f.base, r.Coverage.CertifiedHead)
+				assert.Empty(r.DirectPushes)
+			}
 			switch name {
 			case "unattributed":
 				assert.Empty(r.Coverage.Gaps)

--- a/landedwork/coverage_test.go
+++ b/landedwork/coverage_test.go
@@ -94,9 +94,9 @@ func TestAnalyzeCoverageNoCandidateAndConflict(t *testing.T) {
 			case "unattributed":
 				assert.Empty(r.Coverage.Gaps)
 			case "conflict":
-				assert.Equal([]landedwork.Gap{{CandidateID: "7", ObjectID: f.head, Reason: "candidate_conflict"}, {CandidateID: "8", ObjectID: f.head, Reason: "candidate_conflict"}}, r.Coverage.Gaps)
+				assert.Equal([]landedwork.Gap{{CandidateID: "7", ObjectID: f.head, Reason: "candidate_conflict", Span: landedwork.Span{Before: f.base, Through: f.head}}, {CandidateID: "8", ObjectID: f.head, Reason: "candidate_conflict", Span: landedwork.Span{Before: f.base, Through: f.head}}}, r.Coverage.Gaps)
 			case "rebase with merge":
-				assert.Equal([]landedwork.Gap{{CandidateID: "7", ObjectID: f.head, Reason: "method_unsupported"}}, r.Coverage.Gaps)
+				assert.Equal([]landedwork.Gap{{CandidateID: "7", ObjectID: f.head, Reason: "method_unsupported", Span: landedwork.Span{Before: f.base, Through: f.head}}}, r.Coverage.Gaps)
 			}
 		})
 	}

--- a/landedwork/direct.go
+++ b/landedwork/direct.go
@@ -1,0 +1,67 @@
+package landedwork
+
+import "context"
+
+func classifyDirectPushes(ctx context.Context, v *objectView, p *Interval, r *Result) error {
+	blocked := blockedSpine(r, p)
+	owners := map[string]bool{}
+	for _, l := range r.Landings {
+		for _, id := range ownedSpine(l) {
+			owners[id] = true
+		}
+	}
+	before := p.query.Bounds.Base
+	for _, id := range p.spine {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if !blocked[id] && !owners[id] {
+			d, g := directPush(ctx, v, before, id)
+			if g.Reason != "" {
+				g.Span = Span{Before: before, Through: id}
+				if v.meter.failed {
+					g.Span.Through = p.query.Bounds.Head
+				}
+				r.Coverage.Gaps = append(r.Coverage.Gaps, g)
+				if v.meter.failed {
+					break
+				}
+			} else {
+				r.DirectPushes = append(r.DirectPushes, d)
+			}
+		}
+		before = id
+	}
+	return ctx.Err()
+}
+
+func directPush(ctx context.Context, v *objectView, before, terminal string) (DirectPush, Gap) {
+	g := Gap{ObjectID: terminal}
+	parents, err := v.parents(ctx, terminal)
+	if err != nil {
+		g.Reason = graphReason(err)
+		return DirectPush{}, g
+	}
+	if len(parents) == 0 || parents[0] != before {
+		g.Reason = "topology_unproven"
+		return DirectPush{}, g
+	}
+	if _, err = v.parents(ctx, before); err != nil {
+		g.ObjectID = before
+		g.Reason = graphReason(err)
+		return DirectPush{}, g
+	}
+	ids, err := v.introduced(ctx, before, terminal)
+	if err != nil {
+		g.Reason = graphReason(err)
+		return DirectPush{}, g
+	}
+	for _, id := range ids {
+		if _, err = v.parents(ctx, id); err != nil {
+			g.ObjectID = id
+			g.Reason = graphReason(err)
+			return DirectPush{}, g
+		}
+	}
+	return DirectPush{Before: before, Terminal: terminal, Introduced: ids}, Gap{}
+}

--- a/landedwork/direct.go
+++ b/landedwork/direct.go
@@ -4,12 +4,7 @@ import "context"
 
 func classifyDirectPushes(ctx context.Context, v *objectView, p *Interval, r *Result) error {
 	blocked := blockedSpine(r, p)
-	owners := map[string]bool{}
-	for _, l := range r.Landings {
-		for _, id := range ownedSpine(l) {
-			owners[id] = true
-		}
-	}
+	owners := landingOwners(r.Landings)
 	before := p.query.Bounds.Base
 	for _, id := range p.spine {
 		if err := ctx.Err(); err != nil {

--- a/landedwork/edits.go
+++ b/landedwork/edits.go
@@ -118,7 +118,8 @@ func (v *objectView) fileEdits(ctx context.Context, before, after string, f *fil
 	if f.binary {
 		return nil
 	}
-	// Each literal path has exactly one patch. The raw metadata supplies its name.
+	// Require one patch for the raw metadata path. File-to-directory changes can
+	// match descendants too; ambiguous output stays unproven rather than guessed.
 	patch, err := v.run(ctx, "--literal-pathspecs", "diff", "--patch", "--text", "-U0", "--full-index", "--no-renames",
 		"--no-ext-diff", "--no-textconv", "--no-color", "--diff-algorithm=myers", "--no-indent-heuristic", before, after, "--", f.path)
 	if err != nil {
@@ -129,6 +130,8 @@ func (v *objectView) fileEdits(ctx context.Context, before, after string, f *fil
 		return errors.Join(errEdits, err)
 	}
 	if len(parsed) != 1 {
+		// go-diff can also split header-like removed/added lines into files.
+		// This safe false negative loses proof, not edit differences.
 		return errEdits
 	}
 	for _, h := range parsed[0].Hunks {

--- a/landedwork/edits.go
+++ b/landedwork/edits.go
@@ -1,0 +1,178 @@
+package landedwork
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"slices"
+	"strings"
+
+	gitdiff "github.com/sourcegraph/go-diff/diff"
+)
+
+var errEdits = errors.New("edit correspondence unavailable")
+
+type editRun struct{ removed, added string }
+type fileEdit struct {
+	path, oldMode, newMode, oldID, newID string
+	binary                               bool
+	runs                                 []editRun
+}
+
+func sameEdits(a, b []fileEdit) bool {
+	return slices.EqualFunc(a, b, func(a, b fileEdit) bool {
+		if a.path != b.path || a.oldMode != b.oldMode || a.newMode != b.newMode || a.binary != b.binary {
+			return false
+		}
+		if a.binary {
+			return a.oldID == b.oldID && a.newID == b.newID
+		}
+		return slices.Equal(a.runs, b.runs)
+	})
+}
+
+func (v *objectView) commitEdits(ctx context.Context, id string) ([]fileEdit, error) {
+	parents, err := v.parents(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if len(parents) != 1 {
+		return nil, errEdits
+	}
+	if _, err = v.parents(ctx, parents[0]); err != nil {
+		return nil, err
+	}
+	raw, err := v.run(ctx, "diff", "--raw", "-z", "--no-abbrev", "--no-renames", "--no-ext-diff", "--no-textconv", parents[0], id, "--")
+	if err != nil {
+		return nil, err
+	}
+	files, err := parseEditFiles(raw)
+	if err != nil {
+		return nil, err
+	}
+	for i := range files {
+		if err = ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err = v.fileEdits(ctx, parents[0], id, &files[i]); err != nil {
+			return nil, err
+		}
+	}
+	return files, nil
+}
+
+// Metadata is NUL-delimited; Git path quoting never changes the comparison key.
+func parseEditFiles(raw []byte) ([]fileEdit, error) {
+	var files []fileEdit
+	for len(raw) > 0 {
+		header, tail, ok := bytes.Cut(raw, []byte{0})
+		if !ok {
+			return nil, errEdits
+		}
+		path, rest, ok := bytes.Cut(tail, []byte{0})
+		fields := strings.Fields(string(header))
+		if !ok || len(path) == 0 || len(fields) != 5 || !strings.HasPrefix(fields[0], ":") {
+			return nil, errEdits
+		}
+		oldMode, newMode := strings.TrimPrefix(fields[0], ":"), fields[1]
+		if !editMode(oldMode) || !editMode(newMode) || !objectID(fields[2]) || !objectID(fields[3]) || !strings.Contains("ADMT", fields[4]) || len(fields[4]) != 1 {
+			return nil, errEdits
+		}
+		files = append(files, fileEdit{path: string(path), oldMode: oldMode, newMode: newMode, oldID: fields[2], newID: fields[3]})
+		raw = rest
+	}
+	slices.SortFunc(files, func(a, b fileEdit) int { return strings.Compare(a.path, b.path) })
+	for i := 1; i < len(files); i++ {
+		if files[i-1].path == files[i].path {
+			return nil, errEdits
+		}
+	}
+	return files, nil
+}
+
+func editMode(mode string) bool {
+	switch mode {
+	case "000000", "100644", "100755", "120000", "160000":
+		return true
+	}
+	return false
+}
+
+func (v *objectView) fileEdits(ctx context.Context, before, after string, f *fileEdit) error {
+	for _, side := range []struct{ mode, id string }{{f.oldMode, f.oldID}, {f.newMode, f.newID}} {
+		if side.mode == "000000" {
+			continue
+		}
+		if side.mode == "160000" {
+			f.binary = true
+			continue
+		}
+		blob, err := v.run(ctx, "cat-file", "blob", side.id)
+		if err != nil {
+			return err
+		}
+		if side.mode == "120000" || bytes.IndexByte(blob, 0) >= 0 {
+			f.binary = true
+		}
+	}
+	if f.binary {
+		return nil
+	}
+	// Each literal path has exactly one patch. The raw metadata supplies its name.
+	patch, err := v.run(ctx, "--literal-pathspecs", "diff", "--patch", "--text", "-U0", "--full-index", "--no-renames",
+		"--no-ext-diff", "--no-textconv", "--no-color", "--diff-algorithm=myers", "--no-indent-heuristic", before, after, "--", f.path)
+	if err != nil {
+		return err
+	}
+	parsed, err := gitdiff.ParseMultiFileDiff(patch)
+	if err != nil {
+		return errors.Join(errEdits, err)
+	}
+	if len(parsed) != 1 {
+		return errEdits
+	}
+	for _, h := range parsed[0].Hunks {
+		run, err := editHunk(h)
+		if err != nil {
+			return err
+		}
+		f.runs = append(f.runs, run)
+	}
+	if f.oldID != f.newID && len(f.runs) == 0 {
+		// Adding/removing an empty file has no hunk but still changes its mode.
+		if f.oldMode != "000000" && f.newMode != "000000" {
+			return errEdits
+		}
+	}
+	return nil
+}
+
+func editHunk(h *gitdiff.Hunk) (editRun, error) {
+	var removed, added strings.Builder
+	offset, oldLines, newLines := 0, int32(0), int32(0)
+	for len(h.Body) > offset {
+		line := h.Body[offset:]
+		if end := bytes.IndexByte(line, '\n'); end >= 0 {
+			line = line[:end+1]
+		}
+		offset += len(line)
+		content := line[1:]
+		switch line[0] {
+		case '-':
+			if int32(offset) == h.OrigNoNewlineAt {
+				content = bytes.TrimSuffix(content, []byte{'\n'})
+			}
+			removed.Write(content)
+			oldLines++
+		case '+':
+			added.Write(content)
+			newLines++
+		default:
+			return editRun{}, errEdits
+		}
+	}
+	if oldLines != h.OrigLines || newLines != h.NewLines {
+		return editRun{}, errEdits
+	}
+	return editRun{removed: removed.String(), added: added.String()}, nil
+}

--- a/landedwork/edits.go
+++ b/landedwork/edits.go
@@ -12,7 +12,15 @@ import (
 
 var errEdits = errors.New("edit correspondence unavailable")
 
-type editRun struct{ removed, added string }
+type editRun struct {
+	removed, added string
+	anchor         insertionAnchor
+}
+
+type insertionAnchor struct {
+	before, after  string
+	atStart, atEnd bool
+}
 type fileEdit struct {
 	path, oldMode, newMode, oldID, newID string
 	binary                               bool
@@ -99,6 +107,7 @@ func editMode(mode string) bool {
 }
 
 func (v *objectView) fileEdits(ctx context.Context, before, after string, f *fileEdit) error {
+	var old []byte
 	for _, side := range []struct{ mode, id string }{{f.oldMode, f.oldID}, {f.newMode, f.newID}} {
 		if side.mode == "000000" {
 			continue
@@ -113,6 +122,9 @@ func (v *objectView) fileEdits(ctx context.Context, before, after string, f *fil
 		}
 		if side.mode == "120000" || bytes.IndexByte(blob, 0) >= 0 {
 			f.binary = true
+		}
+		if side.id == f.oldID {
+			old = blob
 		}
 	}
 	if f.binary {
@@ -139,6 +151,17 @@ func (v *objectView) fileEdits(ctx context.Context, before, after string, f *fil
 		if err != nil {
 			return err
 		}
+		if run.removed != "" {
+			// Offset-free correspondence is valid only for a unique occurrence.
+			if !uniqueBytes(old, []byte(run.removed)) {
+				return errEdits
+			}
+		} else {
+			run.anchor, err = insertionSite(old, h.OrigStartLine)
+			if err != nil {
+				return err
+			}
+		}
 		f.runs = append(f.runs, run)
 	}
 	if f.oldID != f.newID && len(f.runs) == 0 {
@@ -148,6 +171,35 @@ func (v *objectView) fileEdits(ctx context.Context, before, after string, f *fil
 		}
 	}
 	return nil
+}
+
+func uniqueBytes(text, part []byte) bool {
+	i := bytes.Index(text, part)
+	return i >= 0 && i == bytes.LastIndex(text, part)
+}
+
+// An insertion has no removed bytes. Pin it to its adjacent original lines,
+// requiring that neighborhood to occur once, including file-edge identity.
+func insertionSite(old []byte, position int32) (insertionAnchor, error) {
+	lines := bytes.SplitAfter(old, []byte{'\n'})
+	if len(lines[len(lines)-1]) == 0 {
+		lines = lines[:len(lines)-1]
+	}
+	i := int(position)
+	if i < 0 || i > len(lines) {
+		return insertionAnchor{}, errEdits
+	}
+	a := insertionAnchor{atStart: i == 0, atEnd: i == len(lines)}
+	if i > 0 {
+		a.before = string(lines[i-1])
+	}
+	if i < len(lines) {
+		a.after = string(lines[i])
+	}
+	if len(old) > 0 && !uniqueBytes(old, []byte(a.before+a.after)) {
+		return insertionAnchor{}, errEdits
+	}
+	return a, nil
 }
 
 func editHunk(h *gitdiff.Hunk) (editRun, error) {

--- a/landedwork/edits_test.go
+++ b/landedwork/edits_test.go
@@ -1,0 +1,32 @@
+package landedwork
+
+import (
+	"testing"
+
+	gitdiff "github.com/sourcegraph/go-diff/diff"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEditHunkBytes(t *testing.T) {
+	for _, tc := range []struct {
+		body           string
+		mark           int32
+		removed, added string
+	}{
+		{"-old\n+new", 0, "old\n", "new"},
+		{"-old\n+new\n", 5, "old", "new\n"},
+		{"-\xff\r\n+\xfe\r\n", 0, "\xff\r\n", "\xfe\r\n"},
+	} {
+		run, err := editHunk(&gitdiff.Hunk{Body: []byte(tc.body), OrigNoNewlineAt: tc.mark, OrigLines: 1, NewLines: 1})
+		require.NoError(t, err)
+		assert.Equal(t, editRun{removed: tc.removed, added: tc.added}, run)
+	}
+}
+
+func TestEditMetadataRejectsTruncation(t *testing.T) {
+	for _, raw := range []string{":100644 100644\x00name\x00", ":100644 100644 a b M\x00name", "garbage"} {
+		_, err := parseEditFiles([]byte(raw))
+		require.ErrorIs(t, err, errEdits)
+	}
+}

--- a/landedwork/evidence.go
+++ b/landedwork/evidence.go
@@ -50,10 +50,18 @@ type Coverage struct {
 // IntegratedCandidate arrived through an ordinary merge, without a second origin.
 type IntegratedCandidate struct{ CandidateID, ThroughCandidateID string }
 
+// DirectPush is a graph origin without an associated provider landing. It does
+// not establish a pusher or a trusted ref-update time. Introduced includes merges.
+type DirectPush struct {
+	Before, Terminal string
+	Introduced       []string
+}
+
 // Result is evidence, never a total when Coverage.Complete is false.
 type Result struct {
 	Landings     []Landing
 	Integrated   []IntegratedCandidate
+	DirectPushes []DirectPush
 	Unattributed []string
 	Coverage     Coverage
 }

--- a/landedwork/evidence.go
+++ b/landedwork/evidence.go
@@ -13,7 +13,7 @@ type Inventory struct {
 }
 
 // Capabilities authorize generic proof paths, not inferred provider support.
-type Capabilities struct{ Merge, Squash bool }
+type Capabilities struct{ Merge, Squash, Rebase, FastForward bool }
 
 // Candidate contains provider facts bound to a stable target repository.
 // Evidence labels name the facts establishing method and terminal, not guesses

--- a/landedwork/evidence.go
+++ b/landedwork/evidence.go
@@ -47,9 +47,13 @@ type Coverage struct {
 	Gaps          []Gap
 }
 
+// IntegratedCandidate arrived through an ordinary merge, without a second origin.
+type IntegratedCandidate struct{ CandidateID, ThroughCandidateID string }
+
 // Result is evidence, never a total when Coverage.Complete is false.
 type Result struct {
 	Landings     []Landing
+	Integrated   []IntegratedCandidate
 	Unattributed []string
 	Coverage     Coverage
 }

--- a/landedwork/interval_test.go
+++ b/landedwork/interval_test.go
@@ -61,9 +61,10 @@ func TestAnalyzeMixedCoverage(t *testing.T) {
 				assert.Equal([]landedwork.Gap{{CandidateID: "8", ObjectID: f.head, Reason: "source_incomplete", Span: landedwork.Span{Before: f.base, Through: f.head}}}, r.Coverage.Gaps)
 			case "unattributed":
 				assert.Len(r.Landings, 1)
-				assert.False(r.Coverage.Complete)
-				assert.Equal(candidates[0].Terminal, r.Coverage.CertifiedHead)
-				assert.Equal([]string{f.head}, r.Unattributed)
+				assert.True(r.Coverage.Complete)
+				assert.Equal(f.head, r.Coverage.CertifiedHead)
+				assert.Empty(r.Unattributed)
+				assert.Equal([]landedwork.DirectPush{{Before: candidates[0].Terminal, Terminal: f.head, Introduced: []string{candidates[1].SourceHead, f.head}}}, r.DirectPushes)
 				assert.Empty(r.Coverage.Gaps)
 			}
 		})

--- a/landedwork/interval_test.go
+++ b/landedwork/interval_test.go
@@ -58,7 +58,7 @@ func TestAnalyzeMixedCoverage(t *testing.T) {
 				assert.False(r.Coverage.Complete)
 				assert.Equal(f.base, r.Coverage.CertifiedHead)
 				assert.Equal([]string{f.head}, r.Unattributed)
-				assert.Equal([]landedwork.Gap{{CandidateID: "8", ObjectID: f.head, Reason: "source_incomplete"}}, r.Coverage.Gaps)
+				assert.Equal([]landedwork.Gap{{CandidateID: "8", ObjectID: f.head, Reason: "source_incomplete", Span: landedwork.Span{Before: f.base, Through: f.head}}}, r.Coverage.Gaps)
 			case "unattributed":
 				assert.Len(r.Landings, 1)
 				assert.False(r.Coverage.Complete)
@@ -137,14 +137,14 @@ func TestAnalyzeBudgetPreservesPreparedGaps(t *testing.T) {
 	p, err := landedwork.Prepare(ctx, f.repo.Root, bounds, fixtureLimits())
 	require := require.New(t)
 	require.NoError(err)
-	expected := []landedwork.Gap{{ObjectID: bounds.Head, Reason: "objects_unavailable"}}
+	expected := []landedwork.Gap{{ObjectID: bounds.Head, Reason: "objects_unavailable", Span: landedwork.Span{Before: bounds.Base, Through: bounds.Head}}}
 	require.Equal(expected, p.Query().Gaps)
 	limits := fixtureLimits()
 	limits.InputBytes = 1
 	r, err := landedwork.Analyze(ctx, p, fixtureEvidence(f, p, "merge"), limits)
 	require.NoError(err)
 	assert := assert.New(t)
-	assert.Equal(append(expected, landedwork.Gap{Reason: "input_budget_exhausted"}), r.Coverage.Gaps)
+	assert.Equal(append(expected, landedwork.Gap{Reason: "input_budget_exhausted", Span: landedwork.Span{Before: bounds.Base, Through: bounds.Head}}), r.Coverage.Gaps)
 	assert.False(r.Coverage.Complete)
 	assert.Equal(bounds, r.Coverage.Bounds)
 	assert.Equal(bounds.Base, r.Coverage.CertifiedHead)

--- a/landedwork/model.go
+++ b/landedwork/model.go
@@ -30,7 +30,12 @@ type Bounds struct {
 // Git's internal traversal work is bounded by the required context deadline.
 type Limits struct{ Records, Nodes, InputBytes, OutputBytes int64 }
 
-type Gap struct{ CandidateID, ObjectID, Reason string }
+// Span blocks first-parent commits after Before through Through, inclusively.
+type Span struct{ Before, Through string }
+type Gap struct {
+	CandidateID, ObjectID, Reason string
+	Span                          Span
+}
 
 // Query is the exact newly reachable set to collect, including side ancestry.
 type Query struct {

--- a/landedwork/origins.go
+++ b/landedwork/origins.go
@@ -83,7 +83,7 @@ func resolveOrigins(ctx context.Context, v *objectView, p *Interval, candidates 
 			break
 		}
 	}
-	rejectOverlaps(r, p)
+	rejectOverlaps(r)
 	if !v.meter.failed {
 		for _, c := range offSpine {
 			if err := ctx.Err(); err != nil {
@@ -160,7 +160,7 @@ func integratedThrough(ctx context.Context, v *objectView, p *Interval, c Candid
 	return through, Gap{}
 }
 
-func rejectOverlaps(r *Result, p *Interval) {
+func rejectOverlaps(r *Result) {
 	owners := map[string]int{}
 	conflicts := map[int]bool{}
 	for i, l := range r.Landings {
@@ -175,7 +175,7 @@ func rejectOverlaps(r *Result, p *Interval) {
 	accepted := r.Landings[:0]
 	for i, l := range r.Landings {
 		if conflicts[i] {
-			r.Coverage.Gaps = append(r.Coverage.Gaps, Gap{CandidateID: l.CandidateID, ObjectID: l.Terminal, Reason: "candidate_conflict", Span: Span{Before: p.query.Bounds.Base, Through: l.Terminal}})
+			r.Coverage.Gaps = append(r.Coverage.Gaps, Gap{CandidateID: l.CandidateID, ObjectID: l.Terminal, Reason: "candidate_conflict", Span: Span{Before: l.Before, Through: l.Terminal}})
 		} else {
 			accepted = append(accepted, l)
 		}

--- a/landedwork/origins.go
+++ b/landedwork/origins.go
@@ -1,0 +1,96 @@
+package landedwork
+
+import (
+	"cmp"
+	"context"
+	"slices"
+)
+
+func fullSpan(p *Interval) Span {
+	return Span{Before: p.query.Bounds.Base, Through: p.query.Bounds.Head}
+}
+
+func candidateGap(p *Interval, c Candidate, g Gap) Gap {
+	g.Span = fullSpan(p)
+	if c.TerminalEvidence != "" && slices.Contains(p.spine, c.Terminal) {
+		g.Span.Through = c.Terminal
+	}
+	if g.Reason == "input_budget_exhausted" {
+		g.Span = fullSpan(p)
+	}
+	return g
+}
+
+func ownedSpine(l Landing) []string {
+	if l.Method == "rebase" || l.Method == "fast_forward" {
+		return l.Introduced
+	}
+	return []string{l.Terminal}
+}
+
+func blockedSpine(r *Result, p *Interval) map[string]bool {
+	positions := map[string]int{p.query.Bounds.Base: -1}
+	for i, id := range p.spine {
+		positions[id] = i
+	}
+	blocked := map[string]bool{}
+	for _, g := range r.Coverage.Gaps {
+		span := g.Span
+		if span == (Span{}) {
+			span = fullSpan(p)
+		}
+		for i := positions[span.Before] + 1; i <= positions[span.Through]; i++ {
+			blocked[p.spine[i]] = true
+		}
+	}
+	return blocked
+}
+
+func resolveOrigins(ctx context.Context, v *objectView, p *Interval, candidates []Candidate, caps Capabilities, r *Result) error {
+	terminals, ids := candidateCounts(candidates)
+	candidates = slices.Clone(candidates)
+	slices.SortFunc(candidates, func(a, b Candidate) int { return cmp.Compare(a.ID, b.ID) })
+	for _, c := range candidates {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if terminals[c.Terminal] > 1 || ids[c.ID] > 1 {
+			r.Coverage.Gaps = append(r.Coverage.Gaps, candidateGap(p, c, Gap{CandidateID: c.ID, ObjectID: c.Terminal, Reason: "candidate_conflict"}))
+			continue
+		}
+		l, g := prove(ctx, v, p, c, caps)
+		if g.Reason != "" {
+			r.Coverage.Gaps = append(r.Coverage.Gaps, candidateGap(p, c, g))
+		} else {
+			r.Landings = append(r.Landings, l)
+		}
+		if v.meter.failed {
+			break
+		}
+	}
+	rejectOverlaps(r, p)
+	return ctx.Err()
+}
+
+func rejectOverlaps(r *Result, p *Interval) {
+	owners := map[string]int{}
+	conflicts := map[int]bool{}
+	for i, l := range r.Landings {
+		for _, id := range ownedSpine(l) {
+			if previous, ok := owners[id]; ok {
+				conflicts[previous], conflicts[i] = true, true
+			} else {
+				owners[id] = i
+			}
+		}
+	}
+	accepted := r.Landings[:0]
+	for i, l := range r.Landings {
+		if conflicts[i] {
+			r.Coverage.Gaps = append(r.Coverage.Gaps, Gap{CandidateID: l.CandidateID, ObjectID: l.Terminal, Reason: "candidate_conflict", Span: Span{Before: p.query.Bounds.Base, Through: l.Terminal}})
+		} else {
+			accepted = append(accepted, l)
+		}
+	}
+	r.Landings = accepted
+}

--- a/landedwork/origins.go
+++ b/landedwork/origins.go
@@ -28,6 +28,16 @@ func ownedSpine(l Landing) []string {
 	return []string{l.Terminal}
 }
 
+func landingOwners(landings []Landing) map[string]bool {
+	owners := map[string]bool{}
+	for _, l := range landings {
+		for _, id := range ownedSpine(l) {
+			owners[id] = true
+		}
+	}
+	return owners
+}
+
 func blockedSpine(r *Result, p *Interval) map[string]bool {
 	positions := map[string]int{p.query.Bounds.Base: -1}
 	for i, id := range p.spine {
@@ -63,7 +73,7 @@ func resolveOrigins(ctx context.Context, v *objectView, p *Interval, candidates 
 			offSpine = append(offSpine, c)
 			continue
 		}
-		l, g := prove(ctx, v, p, c, caps)
+		l, g := proveAt(ctx, v, p, c, caps)
 		if g.Reason != "" {
 			r.Coverage.Gaps = append(r.Coverage.Gaps, candidateGap(p, c, g))
 		} else {
@@ -111,7 +121,18 @@ func integratedThrough(ctx context.Context, v *objectView, p *Interval, c Candid
 			g.Reason = graphReason(err)
 			return "", g
 		}
-		if outer.Method != "merge" || !slices.Contains(outer.Introduced, inner.Terminal) {
+		if outer.Method != "merge" {
+			continue
+		}
+		introduced := make(map[string]bool, len(outer.Introduced))
+		for _, id := range outer.Introduced {
+			if err := ctx.Err(); err != nil {
+				g.Reason = graphReason(err)
+				return "", g
+			}
+			introduced[id] = true
+		}
+		if !introduced[inner.Terminal] {
 			continue
 		}
 		contained := true
@@ -120,7 +141,7 @@ func integratedThrough(ctx context.Context, v *objectView, p *Interval, c Candid
 				g.Reason = graphReason(err)
 				return "", g
 			}
-			if !slices.Contains(outer.Introduced, id) {
+			if !introduced[id] {
 				contained = false
 				break
 			}

--- a/landedwork/origins.go
+++ b/landedwork/origins.go
@@ -90,6 +90,9 @@ func resolveOrigins(ctx context.Context, v *objectView, p *Interval, candidates 
 			}
 		}
 	}
+	if !v.meter.failed {
+		return classifyDirectPushes(ctx, v, p, r)
+	}
 	return ctx.Err()
 }
 

--- a/landedwork/origins.go
+++ b/landedwork/origins.go
@@ -50,12 +50,17 @@ func resolveOrigins(ctx context.Context, v *objectView, p *Interval, candidates 
 	terminals, ids := candidateCounts(candidates)
 	candidates = slices.Clone(candidates)
 	slices.SortFunc(candidates, func(a, b Candidate) int { return cmp.Compare(a.ID, b.ID) })
+	var offSpine []Candidate
 	for _, c := range candidates {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 		if terminals[c.Terminal] > 1 || ids[c.ID] > 1 {
 			r.Coverage.Gaps = append(r.Coverage.Gaps, candidateGap(p, c, Gap{CandidateID: c.ID, ObjectID: c.Terminal, Reason: "candidate_conflict"}))
+			continue
+		}
+		if c.Terminal != "" && c.TerminalEvidence != "" && !slices.Contains(p.spine, c.Terminal) {
+			offSpine = append(offSpine, c)
 			continue
 		}
 		l, g := prove(ctx, v, p, c, caps)
@@ -69,7 +74,66 @@ func resolveOrigins(ctx context.Context, v *objectView, p *Interval, candidates 
 		}
 	}
 	rejectOverlaps(r, p)
+	if !v.meter.failed {
+		for _, c := range offSpine {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			through, g := integratedThrough(ctx, v, p, c, caps, r.Landings)
+			if g.Reason != "" {
+				r.Coverage.Gaps = append(r.Coverage.Gaps, candidateGap(p, c, g))
+			} else {
+				r.Integrated = append(r.Integrated, IntegratedCandidate{CandidateID: c.ID, ThroughCandidateID: through})
+			}
+			if v.meter.failed {
+				break
+			}
+		}
+	}
 	return ctx.Err()
+}
+
+func integratedThrough(ctx context.Context, v *objectView, p *Interval, c Candidate, caps Capabilities, outers []Landing) (string, Gap) {
+	g := Gap{CandidateID: c.ID, ObjectID: c.Terminal, Reason: "terminal_outside_spine"}
+	if c.Method != "merge" && c.Method != "" {
+		return "", g
+	}
+	inner, failed := proveAt(ctx, v, p, c, caps)
+	if failed.Reason != "" {
+		return "", failed
+	}
+	through := ""
+	for _, outer := range outers {
+		if err := ctx.Err(); err != nil {
+			g.Reason = graphReason(err)
+			return "", g
+		}
+		if outer.Method != "merge" || !slices.Contains(outer.Introduced, inner.Terminal) {
+			continue
+		}
+		contained := true
+		for _, id := range inner.Introduced {
+			if err := ctx.Err(); err != nil {
+				g.Reason = graphReason(err)
+				return "", g
+			}
+			if !slices.Contains(outer.Introduced, id) {
+				contained = false
+				break
+			}
+		}
+		if contained {
+			if through != "" {
+				g.Reason = "candidate_conflict"
+				return "", g
+			}
+			through = outer.CandidateID
+		}
+	}
+	if through == "" {
+		return "", g
+	}
+	return through, Gap{}
 }
 
 func rejectOverlaps(r *Result, p *Interval) {

--- a/landedwork/origins_test.go
+++ b/landedwork/origins_test.go
@@ -1,0 +1,64 @@
+package landedwork_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/landedwork"
+)
+
+func TestOriginOverlaps(t *testing.T) {
+	for _, reverse := range []bool{false, true} {
+		f := buildFixture(t, false)
+		f.head = f.source[1]
+		ctx, p := f.prepare(t)
+		e := fixtureEvidence(f, p, "fast_forward")
+		e.Capabilities.FastForward = true
+		c := e.Candidates[0]
+		c.ID = "8"
+		c.Terminal = f.source[0]
+		c.SourceHead = f.source[0]
+		c.Source = c.Source[:1]
+		e.Candidates = append(e.Candidates, c)
+		if reverse {
+			slices.Reverse(e.Candidates)
+		}
+		r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+		require.NoError(t, err)
+		assert := assert.New(t)
+		assert.Empty(r.Landings)
+		assert.False(r.Coverage.Complete)
+		assert.Equal(f.base, r.Coverage.CertifiedHead)
+		require.Len(t, r.Coverage.Gaps, 2)
+		assert.Equal(landedwork.Span{Before: f.base, Through: f.head}, r.Coverage.Gaps[0].Span)
+		assert.Equal("candidate_conflict", r.Coverage.Gaps[0].Reason)
+	}
+}
+
+func TestBlockedSpan(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	for _, terminalKnown := range []bool{true, false} {
+		f := buildFixture(t, true)
+		terminal := f.head
+		f.head = f.repo.CommitFile("later", "later\n", "later")
+		ctx, p := f.prepare(t)
+		e := fixtureEvidence(f, p, "squash")
+		e.Candidates[0].Terminal = terminal
+		e.Candidates[0].SourceComplete = false
+		if !terminalKnown {
+			e.Candidates[0].TerminalEvidence = ""
+		}
+		r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+		require.NoError(err)
+		require.NotEmpty(r.Coverage.Gaps)
+		through := terminal
+		if !terminalKnown {
+			through = f.head
+		}
+		assert.Equal(landedwork.Span{Before: f.base, Through: through}, r.Coverage.Gaps[0].Span)
+		assert.Equal(f.base, r.Coverage.CertifiedHead)
+	}
+}

--- a/landedwork/origins_test.go
+++ b/landedwork/origins_test.go
@@ -200,7 +200,11 @@ func TestIntegratedMerges(t *testing.T) {
 func TestOriginOverlaps(t *testing.T) {
 	for _, reverse := range []bool{false, true} {
 		f := buildFixture(t, false)
-		f.head = f.source[1]
+		f.repo.Checkout("-b", "overlap", f.base)
+		direct := f.repo.CommitFile("other", "direct\n", "direct")
+		f.source = []string{f.repo.CommitFile("work.txt", "new\nkeep\n", "first")}
+		f.source = append(f.source, f.repo.CommitFile("work.txt", "new\nkeep\nlast\n", "last"))
+		f.head = f.repo.Head()
 		ctx, p := f.prepare(t)
 		e := fixtureEvidence(f, p, "fast_forward")
 		e.Capabilities.FastForward = true
@@ -218,10 +222,11 @@ func TestOriginOverlaps(t *testing.T) {
 		assert := assert.New(t)
 		assert.Empty(r.Landings)
 		assert.False(r.Coverage.Complete)
-		assert.Equal(f.base, r.Coverage.CertifiedHead)
+		assert.Equal(direct, r.Coverage.CertifiedHead)
 		require.Len(t, r.Coverage.Gaps, 2)
-		assert.Equal(landedwork.Span{Before: f.base, Through: f.head}, r.Coverage.Gaps[0].Span)
+		assert.Equal(landedwork.Span{Before: direct, Through: f.head}, r.Coverage.Gaps[0].Span)
 		assert.Equal("candidate_conflict", r.Coverage.Gaps[0].Reason)
+		assert.Equal([]landedwork.DirectPush{{Before: f.base, Terminal: direct, Introduced: []string{direct}}}, r.DirectPushes)
 	}
 }
 

--- a/landedwork/origins_test.go
+++ b/landedwork/origins_test.go
@@ -9,6 +9,65 @@ import (
 	"go.kenn.io/forge/landedwork"
 )
 
+func TestIntegratedMerges(t *testing.T) {
+	for _, variant := range []string{"nested", "reverse", "partial inner", "rejected outer", "unsupported inner"} {
+		t.Run(variant, func(t *testing.T) {
+			f := buildFixture(t, false)
+			inner := f.head
+			f.repo.Checkout("-b", "integration", f.base)
+			side := f.repo.CommitFile("integration.txt", "side\n", "integration starts")
+			f.repo.Run("merge", "--no-ff", "main", "-m", "middle merge")
+			middle := f.repo.Head()
+			f.repo.Checkout("-b", "final", f.base)
+			f.repo.Run("merge", "--no-ff", "integration", "-m", "outer merge")
+			f.head = f.repo.Head()
+			ctx, p := f.prepare(t)
+			e := fixtureEvidence(f, p, "merge")
+			innerCandidate := e.Candidates[0]
+			innerCandidate.ID = "inner"
+			innerCandidate.Terminal = inner
+			middleCandidate := innerCandidate
+			middleCandidate.ID = "middle"
+			middleCandidate.Terminal = middle
+			middleCandidate.SourceHead = inner
+			middleCandidate.Source = append(slices.Clone(f.source), inner)
+			outer := middleCandidate
+			outer.ID = "outer"
+			outer.Terminal = f.head
+			outer.SourceHead = middle
+			outer.Source = append(slices.Clone(middleCandidate.Source), side, middle)
+			e.Candidates = []landedwork.Candidate{innerCandidate, middleCandidate, outer}
+			switch variant {
+			case "reverse":
+				slices.Reverse(e.Candidates)
+			case "partial inner":
+				e.Candidates[0].SourceComplete = false
+			case "rejected outer":
+				e.Candidates[2].SourceComplete = false
+			case "unsupported inner":
+				e.Candidates[0].Method = "squash"
+			}
+			r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+			require := require.New(t)
+			assert := assert.New(t)
+			require.NoError(err)
+			if variant != "nested" && variant != "reverse" {
+				assert.False(r.Coverage.Complete)
+				assert.Equal(f.base, r.Coverage.CertifiedHead)
+				require.NotEmpty(r.Coverage.Gaps)
+				assert.Equal(landedwork.Span{Before: f.base, Through: f.head}, r.Coverage.Gaps[0].Span)
+				return
+			}
+			assert.Equal([]landedwork.IntegratedCandidate{{CandidateID: "inner", ThroughCandidateID: "outer"}, {CandidateID: "middle", ThroughCandidateID: "outer"}}, r.Integrated)
+			require.Len(r.Landings, 1)
+			assert.Equal("outer", r.Landings[0].CandidateID)
+			assert.True(r.Coverage.Complete)
+			assert.Equal(f.head, r.Coverage.CertifiedHead)
+			assert.Empty(r.Coverage.Gaps)
+		})
+	}
+}
+
 func TestOriginOverlaps(t *testing.T) {
 	for _, reverse := range []bool{false, true} {
 		f := buildFixture(t, false)

--- a/landedwork/origins_test.go
+++ b/landedwork/origins_test.go
@@ -1,13 +1,142 @@
 package landedwork_test
 
 import (
+	"os"
+	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/landedwork"
 )
+
+func TestDirectPushAfterBoundedGap(t *testing.T) {
+	for _, variant := range []string{"bounded", "unknown terminal", "incomplete inventory"} {
+		t.Run(variant, func(t *testing.T) {
+			f, candidates := twoLandings(t)
+			before := f.head
+			f.head = f.repo.CommitFile("direct", "direct\n", "direct")
+			candidates[0].SourceComplete = false
+			ctx, p := f.prepare(t)
+			e := fixtureEvidence(f, p, "merge")
+			e.Candidates = candidates
+			if variant == "unknown terminal" {
+				e.Candidates[0].TerminalEvidence = ""
+			}
+			if variant == "incomplete inventory" {
+				e.Inventory.Complete = false
+			}
+			r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+			require := require.New(t)
+			assert := assert.New(t)
+			require.NoError(err)
+			require.Len(r.Landings, 1)
+			assert.Equal("8", r.Landings[0].CandidateID)
+			assert.False(r.Coverage.Complete)
+			assert.Equal(f.base, r.Coverage.CertifiedHead)
+			if variant == "bounded" {
+				assert.Equal([]landedwork.DirectPush{{Before: before, Terminal: f.head, Introduced: []string{f.head}}}, r.DirectPushes)
+				assert.Equal([]string{candidates[0].Terminal}, r.Unattributed)
+			} else {
+				assert.Empty(r.DirectPushes)
+			}
+		})
+	}
+}
+
+func TestRebaseExhaustionPreservesGaps(t *testing.T) {
+	f := buildFixture(t, false)
+	f.repo.Checkout("topic")
+	f.source = append(slices.Clone(f.source), f.repo.CommitFile("large", strings.Repeat("large edit\n", 2048), "large"))
+	f.repo.Checkout("-b", "large-replay", f.base)
+	f.base = f.repo.CommitFile("other", "context\n", "advance")
+	for _, id := range f.source {
+		f.repo.Run("cherry-pick", id)
+	}
+	f.head = f.repo.Head()
+	ctx, p := f.prepare(t)
+	e := fixtureEvidence(f, p, "rebase")
+	e.Capabilities.Rebase = true
+	unknown := e.Candidates[0]
+	unknown.ID = "0"
+	unknown.Terminal = ""
+	unknown.TerminalEvidence = ""
+	e.Candidates = append(e.Candidates, unknown)
+	limits := fixtureLimits()
+	limits.InputBytes = 8192 // Fits metadata and small edits, not the large blob.
+	r, err := landedwork.Analyze(ctx, p, e, limits)
+	require := require.New(t)
+	assert := assert.New(t)
+	require.NoError(err)
+	assert.Empty(r.DirectPushes)
+	assert.False(r.Coverage.Complete)
+	assert.Equal(f.base, r.Coverage.CertifiedHead)
+	require.Len(r.Coverage.Gaps, 2)
+	assert.Equal("terminal_unproven", r.Coverage.Gaps[0].Reason)
+	assert.Equal("input_budget_exhausted", r.Coverage.Gaps[1].Reason)
+	assert.Equal(landedwork.Span{Before: f.base, Through: f.head}, r.Coverage.Gaps[1].Span)
+}
+
+func TestDirectPushes(t *testing.T) {
+	for _, merge := range []bool{false, true} {
+		f := buildFixture(t, false)
+		if !merge {
+			f.head = f.source[1]
+		}
+		ctx, p := f.prepare(t)
+		e := fixtureEvidence(f, p, "merge")
+		e.Candidates = nil
+		r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+		require := require.New(t)
+		assert := assert.New(t)
+		require.NoError(err)
+		if merge {
+			require.Len(r.DirectPushes, 1)
+			assert.Equal(f.base, r.DirectPushes[0].Before)
+			assert.Equal(f.head, r.DirectPushes[0].Terminal)
+			assert.ElementsMatch(append(slices.Clone(f.source), f.head), r.DirectPushes[0].Introduced)
+		} else {
+			assert.Equal([]landedwork.DirectPush{{Before: f.base, Terminal: f.source[0], Introduced: f.source[:1]},
+				{Before: f.source[0], Terminal: f.head, Introduced: f.source[1:]}}, r.DirectPushes)
+		}
+		assert.Empty(r.Landings)
+		assert.Empty(r.Unattributed)
+		assert.True(r.Coverage.Complete)
+		assert.Equal(f.head, r.Coverage.CertifiedHead)
+	}
+}
+
+func TestDirectPushMissingObjects(t *testing.T) {
+	for _, target := range []string{"base", "source", "terminal"} {
+		t.Run(target, func(t *testing.T) {
+			f := buildFixture(t, false)
+			f.repo.Run("commit-graph", "write", "--reachable")
+			ctx, p := f.prepare(t)
+			missing := f.base
+			if target == "source" {
+				missing = f.source[0]
+			}
+			if target == "terminal" {
+				missing = f.head
+			}
+			require := require.New(t)
+			assert := assert.New(t)
+			require.NoError(os.Remove(filepath.Join(f.repo.GitDir, "objects", missing[:2], missing[2:])))
+			e := fixtureEvidence(f, p, "merge")
+			e.Candidates = nil
+			r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+			require.NoError(err)
+			assert.Empty(r.DirectPushes)
+			assert.False(r.Coverage.Complete)
+			assert.Equal(f.base, r.Coverage.CertifiedHead)
+			require.Len(r.Coverage.Gaps, 1)
+			assert.Equal(missing, r.Coverage.Gaps[0].ObjectID)
+			assert.Equal("objects_unavailable", r.Coverage.Gaps[0].Reason)
+		})
+	}
+}
 
 func TestIntegratedMerges(t *testing.T) {
 	for _, variant := range []string{"nested", "reverse", "partial inner", "rejected outer", "unsupported inner"} {

--- a/landedwork/prepare.go
+++ b/landedwork/prepare.go
@@ -30,6 +30,9 @@ func Prepare(ctx context.Context, path string, bounds Bounds, limits Limits) (p 
 		if err != nil {
 			return
 		}
+		for i := range p.query.Gaps {
+			p.query.Gaps[i].Span = Span{Before: bounds.Base, Through: bounds.Head}
+		}
 		if err = checkQueryOutput(p.query, limits); err != nil {
 			p = nil
 		}

--- a/landedwork/prepare_test.go
+++ b/landedwork/prepare_test.go
@@ -87,7 +87,7 @@ func TestAnalyzeCachedMissingSourceOrTerminal(t *testing.T) {
 			assert.Empty(r.Landings)
 			assert.False(r.Coverage.Complete)
 			assert.Equal(f.base, r.Coverage.CertifiedHead)
-			assert.Equal([]landedwork.Gap{{CandidateID: "7", ObjectID: missing, Reason: "objects_unavailable"}}, r.Coverage.Gaps)
+			assert.Equal([]landedwork.Gap{{CandidateID: "7", ObjectID: missing, Reason: "objects_unavailable", Span: landedwork.Span{Before: f.base, Through: f.head}}}, r.Coverage.Gaps)
 		})
 	}
 }
@@ -199,7 +199,7 @@ func TestPrepareRequiresRepositoryRoot(t *testing.T) {
 	assert := assert.New(t)
 	assert.False(p.Query().Complete)
 	assert.Empty(p.Query().Commits)
-	assert.Equal([]landedwork.Gap{{Reason: "objects_unavailable"}}, p.Query().Gaps)
+	assert.Equal([]landedwork.Gap{{Reason: "objects_unavailable", Span: landedwork.Span{Before: f.base, Through: f.head}}}, p.Query().Gaps)
 }
 
 func TestPrepareBareAndLinkedRepositories(t *testing.T) {

--- a/landedwork/proof.go
+++ b/landedwork/proof.go
@@ -9,7 +9,7 @@ import (
 func prove(ctx context.Context, v *objectView, p *Interval, c Candidate, caps Capabilities) (Landing, Gap) {
 	gap := Gap{CandidateID: c.ID, ObjectID: c.Terminal}
 	reject := func(reason string) (Landing, Gap) { gap.Reason = reason; return Landing{}, gap }
-	if c.Method == "rebase" || c.Method == "fast_forward" {
+	if (c.Method == "rebase" && !caps.Rebase) || (c.Method == "fast_forward" && !caps.FastForward) {
 		return reject("method_unsupported")
 	}
 	if c.Terminal == "" || c.TerminalEvidence == "" {
@@ -23,6 +23,9 @@ func prove(ctx context.Context, v *objectView, p *Interval, c Candidate, caps Ca
 	}
 	if !c.SourceComplete || len(c.Source) == 0 || c.SourceHead == "" {
 		return reject("source_incomplete")
+	}
+	if c.Method == "rebase" || c.Method == "fast_forward" {
+		return proveRange(ctx, v, p, c)
 	}
 	parents, err := v.parents(ctx, c.Terminal)
 	if err != nil {

--- a/landedwork/proof.go
+++ b/landedwork/proof.go
@@ -7,6 +7,14 @@ import (
 )
 
 func prove(ctx context.Context, v *objectView, p *Interval, c Candidate, caps Capabilities) (Landing, Gap) {
+	if c.Terminal != "" && c.TerminalEvidence != "" && !slices.Contains(p.spine, c.Terminal) {
+		return Landing{}, Gap{CandidateID: c.ID, ObjectID: c.Terminal, Reason: "terminal_outside_spine"}
+	}
+	return proveAt(ctx, v, p, c, caps)
+}
+
+// proveAt checks the method independently of its admission to the target spine.
+func proveAt(ctx context.Context, v *objectView, p *Interval, c Candidate, caps Capabilities) (Landing, Gap) {
 	gap := Gap{CandidateID: c.ID, ObjectID: c.Terminal}
 	reject := func(reason string) (Landing, Gap) { gap.Reason = reason; return Landing{}, gap }
 	if (c.Method == "rebase" && !caps.Rebase) || (c.Method == "fast_forward" && !caps.FastForward) {
@@ -14,9 +22,6 @@ func prove(ctx context.Context, v *objectView, p *Interval, c Candidate, caps Ca
 	}
 	if c.Terminal == "" || c.TerminalEvidence == "" {
 		return reject("terminal_unproven")
-	}
-	if !slices.Contains(p.spine, c.Terminal) {
-		return reject("terminal_outside_spine")
 	}
 	if c.Method != "" && c.MethodEvidence == "" {
 		return reject("method_unproven")

--- a/landedwork/proof.go
+++ b/landedwork/proof.go
@@ -6,13 +6,6 @@ import (
 	"slices"
 )
 
-func prove(ctx context.Context, v *objectView, p *Interval, c Candidate, caps Capabilities) (Landing, Gap) {
-	if c.Terminal != "" && c.TerminalEvidence != "" && !slices.Contains(p.spine, c.Terminal) {
-		return Landing{}, Gap{CandidateID: c.ID, ObjectID: c.Terminal, Reason: "terminal_outside_spine"}
-	}
-	return proveAt(ctx, v, p, c, caps)
-}
-
 // proveAt checks the method independently of its admission to the target spine.
 func proveAt(ctx context.Context, v *objectView, p *Interval, c Candidate, caps Capabilities) (Landing, Gap) {
 	gap := Gap{CandidateID: c.ID, ObjectID: c.Terminal}

--- a/landedwork/range.go
+++ b/landedwork/range.go
@@ -1,0 +1,52 @@
+package landedwork
+
+import (
+	"context"
+	"slices"
+)
+
+func proveRange(ctx context.Context, v *objectView, p *Interval, c Candidate) (Landing, Gap) {
+	gap := Gap{CandidateID: c.ID, ObjectID: c.Terminal}
+	reject := func(reason string) (Landing, Gap) { gap.Reason = reason; return Landing{}, gap }
+	end := slices.Index(p.spine, c.Terminal) + 1
+	start := end - len(c.Source)
+	if start < 0 || end == 0 {
+		return reject("range_crosses_base")
+	}
+	if c.Source[len(c.Source)-1] != c.SourceHead {
+		return reject("source_head_mismatch")
+	}
+	if reason, object := checkSources(ctx, v, c); reason != "" {
+		gap.ObjectID = object
+		return reject(reason)
+	}
+	landed := p.spine[start:end]
+	before := p.query.Bounds.Base
+	if start > 0 {
+		before = p.spine[start-1]
+	}
+	if _, err := v.parents(ctx, before); err != nil {
+		gap.ObjectID = before
+		return reject(graphReason(err))
+	}
+	for i, source := range c.Source {
+		for _, id := range []string{source, landed[i]} {
+			gap.ObjectID = id
+			parents, err := v.parents(ctx, id)
+			if err != nil {
+				return reject(graphReason(err))
+			}
+			if len(parents) != 1 {
+				return reject("topology_unproven")
+			}
+			if id == source && i > 0 && parents[0] != c.Source[i-1] {
+				return reject("source_order_unproven")
+			}
+		}
+		if source != landed[i] {
+			return reject("source_correspondence_unproven")
+		}
+	}
+	return Landing{CandidateID: c.ID, Method: c.Method, Before: before, Terminal: c.Terminal,
+		Source: slices.Clone(c.Source), Introduced: slices.Clone(landed)}, Gap{}
+}

--- a/landedwork/range.go
+++ b/landedwork/range.go
@@ -2,6 +2,7 @@ package landedwork
 
 import (
 	"context"
+	"errors"
 	"slices"
 )
 
@@ -43,10 +44,53 @@ func proveRange(ctx context.Context, v *objectView, p *Interval, c Candidate) (L
 				return reject("source_order_unproven")
 			}
 		}
-		if source != landed[i] {
+	}
+	if object, err := rangeCorrespondence(ctx, v, c, landed); err != nil {
+		gap.ObjectID = object
+		if errors.Is(err, errCorrespondence) {
 			return reject("source_correspondence_unproven")
 		}
+		if errors.Is(err, errEdits) {
+			return reject("edits_unavailable")
+		}
+		return reject(graphReason(err))
 	}
 	return Landing{CandidateID: c.ID, Method: c.Method, Before: before, Terminal: c.Terminal,
 		Source: slices.Clone(c.Source), Introduced: slices.Clone(landed)}, Gap{}
+}
+
+func rangeCorrespondence(ctx context.Context, v *objectView, c Candidate, landed []string) (string, error) {
+	var rewritten [][]fileEdit
+	for i, source := range c.Source {
+		if err := ctx.Err(); err != nil {
+			return source, err
+		}
+		if source == landed[i] {
+			continue
+		}
+		if c.Method == "fast_forward" {
+			return source, errCorrespondence
+		}
+		a, err := v.commitEdits(ctx, source)
+		if err != nil {
+			return source, err
+		}
+		b, err := v.commitEdits(ctx, landed[i])
+		if err != nil {
+			return landed[i], err
+		}
+		if len(a) == 0 || !sameEdits(a, b) {
+			return source, errCorrespondence
+		}
+		for _, previous := range rewritten {
+			if err := ctx.Err(); err != nil {
+				return source, err
+			}
+			if sameEdits(previous, a) {
+				return source, errCorrespondence
+			}
+		}
+		rewritten = append(rewritten, a)
+	}
+	return "", nil
 }

--- a/landedwork/range_test.go
+++ b/landedwork/range_test.go
@@ -1,6 +1,8 @@
 package landedwork_test
 
 import (
+	"os"
+	"path/filepath"
 	"slices"
 	"testing"
 
@@ -8,6 +10,129 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/landedwork"
 )
+
+func TestRebaseFileChanges(t *testing.T) {
+	for _, tc := range []struct {
+		name, path, old, source, replay string
+		mode                            bool
+		accept                          bool
+	}{
+		{"binary exact", "data.bin", "old\x00", "new\x00", "new\x00", false, true},
+		{"binary differs", "data.bin", "old\x00", "new\x00", "other\x00", false, false},
+		{"raw name and bytes", "odd\n\xff.txt", "old\xff\n", "new\xfe\n", "new\xfe\n", false, true},
+		{"missing newline", "text", "old\n", "new", "new", false, true},
+		{"old missing newline", "text", "old", "new\n", "new\n", false, true},
+		{"newline differs", "text", "old\n", "new", "new\n", false, false},
+		{"mode differs", "script", "old\n", "new\n", "new\n", true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			f := buildFixture(t, false)
+			f.repo.Checkout("-b", "file-base", f.base)
+			base := f.repo.CommitFile(tc.path, tc.old, "file base")
+			f.repo.Checkout("-b", "file-source")
+			f.source = []string{f.repo.CommitFile(tc.path, tc.source, "source")}
+			f.repo.Checkout("-b", "file-replay", base)
+			f.base = f.repo.CommitFile("unrelated", "context\n", "advance")
+			if tc.mode {
+				require.NoError(os.Chmod(filepath.Join(f.repo.Root, tc.path), 0755))
+			}
+			f.head = f.repo.CommitFile(tc.path, tc.replay, "replay")
+			ctx, p := f.prepare(t)
+			e := fixtureEvidence(f, p, "rebase")
+			e.Capabilities.Rebase = true
+			r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+			require.NoError(err)
+			assert.Equal(tc.accept, r.Coverage.Complete)
+			if tc.accept {
+				assert.Len(r.Landings, 1)
+			} else {
+				assert.Empty(r.Landings)
+			}
+		})
+	}
+}
+
+func TestRebaseDuplicateEdits(t *testing.T) {
+	f := buildFixture(t, false)
+	f.repo.Checkout("-b", "repeat-source", f.base)
+	f.source = []string{f.repo.CommitFile("work.txt", "new\nkeep\n", "first")}
+	f.source = append(f.source, f.repo.CommitFile("work.txt", "old\nkeep\n", "undo"))
+	f.source = append(f.source, f.repo.CommitFile("work.txt", "new\nkeep\n", "repeat"))
+	f.repo.Checkout("-b", "repeat-replay", f.base)
+	f.base = f.repo.CommitFile("unrelated", "context\n", "advance")
+	f.repo.CommitFile("work.txt", "new\nkeep\n", "replay first")
+	f.repo.CommitFile("work.txt", "old\nkeep\n", "replay undo")
+	f.head = f.repo.CommitFile("work.txt", "new\nkeep\n", "replay repeat")
+	ctx, p := f.prepare(t)
+	e := fixtureEvidence(f, p, "rebase")
+	e.Capabilities.Rebase = true
+	r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+	require.NoError(t, err)
+	assert.Empty(t, r.Landings)
+	assert.False(t, r.Coverage.Complete)
+}
+
+func TestRebase(t *testing.T) {
+	for _, variant := range []string{"offset", "changed bytes", "whitespace", "newline", "empty", "binary"} {
+		t.Run(variant, func(t *testing.T) {
+			f := buildFixture(t, false)
+			f.repo.Checkout("-b", "replay", f.base)
+			f.base = f.repo.CommitFile("other.txt", "unrelated\n", "advance")
+			prefix := ""
+			if variant == "offset" {
+				prefix = "context\n"
+				f.base = f.repo.CommitFile("work.txt", prefix+"old\nkeep\n", "shift")
+			}
+			if variant == "empty" {
+				f.repo.Checkout("topic")
+				f.repo.Run("commit", "--allow-empty", "-m", "empty source")
+				f.source = append(slices.Clone(f.source), f.repo.Head())
+				f.repo.Checkout("replay")
+			}
+			first := f.repo.CommitFile("work.txt", prefix+"new\nkeep\n", "rewritten first")
+			content := prefix + "new\nkeep\none\ntwo\n"
+			switch variant {
+			case "changed bytes":
+				content = prefix + "new\nkeep\none\nother\n"
+			case "whitespace":
+				content = prefix + "new\nkeep\none\ntwo \n"
+			case "newline":
+				content = prefix + "new\nkeep\none\ntwo"
+			case "binary":
+				content += "\x00"
+			}
+			last := f.repo.CommitFile("work.txt", content, "rewritten last")
+			introduced := []string{first, last}
+			if variant == "empty" {
+				f.repo.Run("commit", "--allow-empty", "-m", "empty replay")
+				introduced = append(introduced, f.repo.Head())
+			}
+			f.head = f.repo.Head()
+			ctx, p := f.prepare(t)
+			e := fixtureEvidence(f, p, "rebase")
+			e.Capabilities.Rebase = true
+			r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+			require := require.New(t)
+			assert := assert.New(t)
+			require.NoError(err)
+			if variant != "offset" {
+				assert.Empty(r.Landings)
+				assert.False(r.Coverage.Complete)
+				assert.Equal(f.base, r.Coverage.CertifiedHead)
+				assert.NotEmpty(r.Coverage.Gaps)
+				return
+			}
+			require.Len(r.Landings, 1)
+			assert.Equal(introduced, r.Landings[0].Introduced)
+			assert.Equal(f.source, r.Landings[0].Source)
+			assert.Equal("3\t1\twork.txt", f.repo.Run("diff", "--numstat", r.Landings[0].Before, r.Landings[0].Terminal))
+			assert.True(r.Coverage.Complete)
+			assert.Equal(f.head, r.Coverage.CertifiedHead)
+		})
+	}
+}
 
 func TestFastForward(t *testing.T) {
 	for _, variant := range []string{"complete", "disabled", "reordered", "partial", "missing method", "missing terminal", "crosses base", "merge member"} {

--- a/landedwork/range_test.go
+++ b/landedwork/range_test.go
@@ -54,6 +54,44 @@ func TestRebaseFileChanges(t *testing.T) {
 	}
 }
 
+func TestRebaseOldSideNewline(t *testing.T) {
+	for _, tc := range []struct {
+		name, sourceOld, replayOld string
+		accept                     bool
+	}{
+		{"matching", "old", "old", true},
+		{"source missing newline", "old", "old\n", false},
+		{"replay missing newline", "old\n", "old", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			f := buildFixture(t, false)
+			f.repo.Checkout("-b", "newline-source", f.base)
+			f.repo.CommitFile("text", tc.sourceOld, "source base")
+			f.source = []string{f.repo.CommitFile("text", "new\n", "source")}
+			f.repo.Checkout("-b", "newline-replay", f.base)
+			f.base = f.repo.CommitFile("text", tc.replayOld, "replay base")
+			f.head = f.repo.CommitFile("text", "new\n", "replay")
+			ctx, p := f.prepare(t)
+			e := fixtureEvidence(f, p, "rebase")
+			e.Capabilities.Rebase = true
+			r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+			require.NoError(err)
+			assert.Equal(tc.accept, r.Coverage.Complete)
+			if tc.accept {
+				assert.Len(r.Landings, 1)
+				assert.Equal(f.head, r.Coverage.CertifiedHead)
+			} else {
+				assert.Empty(r.Landings)
+				assert.Equal(f.base, r.Coverage.CertifiedHead)
+				require.Len(r.Coverage.Gaps, 1)
+				assert.Equal("source_correspondence_unproven", r.Coverage.Gaps[0].Reason)
+			}
+		})
+	}
+}
+
 func TestRebaseDuplicateEdits(t *testing.T) {
 	f := buildFixture(t, false)
 	f.repo.Checkout("-b", "repeat-source", f.base)

--- a/landedwork/range_test.go
+++ b/landedwork/range_test.go
@@ -92,6 +92,34 @@ func TestRebaseOldSideNewline(t *testing.T) {
 	}
 }
 
+func TestRebaseRepeatedOccurrence(t *testing.T) {
+	for _, insertion := range []bool{false, true} {
+		f := buildFixture(t, false)
+		f.repo.Checkout("-b", "occurrence-source", f.base)
+		base := f.repo.CommitFile("text", "old\nkeep\nold\nkeep\n", "repeated text")
+		source, replay := "new\nkeep\nold\nkeep\n", "old\nkeep\nnew\nkeep\n"
+		if insertion {
+			source, replay = "old\nnew\nkeep\nold\nkeep\n", "old\nkeep\nold\nnew\nkeep\n"
+		}
+		f.source = []string{f.repo.CommitFile("text", source, "source")}
+		f.repo.Checkout("-b", "occurrence-replay", base)
+		f.base = f.repo.CommitFile("other", "unrelated\n", "advance")
+		f.head = f.repo.CommitFile("text", replay, "replay")
+		ctx, p := f.prepare(t)
+		e := fixtureEvidence(f, p, "rebase")
+		e.Capabilities.Rebase = true
+		r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+		require := require.New(t)
+		assert := assert.New(t)
+		require.NoError(err)
+		assert.Empty(r.Landings)
+		assert.False(r.Coverage.Complete)
+		assert.Equal(f.base, r.Coverage.CertifiedHead)
+		require.Len(r.Coverage.Gaps, 1)
+		assert.Equal("edits_unavailable", r.Coverage.Gaps[0].Reason)
+	}
+}
+
 func TestRebaseDuplicateEdits(t *testing.T) {
 	f := buildFixture(t, false)
 	f.repo.Checkout("-b", "repeat-source", f.base)

--- a/landedwork/range_test.go
+++ b/landedwork/range_test.go
@@ -1,0 +1,58 @@
+package landedwork_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/landedwork"
+)
+
+func TestFastForward(t *testing.T) {
+	for _, variant := range []string{"complete", "disabled", "reordered", "partial", "missing method", "missing terminal", "crosses base", "merge member"} {
+		t.Run(variant, func(t *testing.T) {
+			f := buildFixture(t, false)
+			f.head = f.source[1]
+			if variant == "crosses base" {
+				f.base = f.source[0]
+			}
+			if variant == "merge member" {
+				f.head = f.repo.Head()
+				f.source = append(slices.Clone(f.source), f.head)
+			}
+			ctx, p := f.prepare(t)
+			e := fixtureEvidence(f, p, "fast_forward")
+			e.Capabilities.FastForward = true
+			switch variant {
+			case "disabled":
+				e.Capabilities.FastForward = false
+			case "reordered":
+				e.Candidates[0].Source = []string{f.source[1], f.source[0]}
+			case "partial":
+				e.Candidates[0].SourceComplete = false
+			case "missing method":
+				e.Candidates[0].MethodEvidence = ""
+			case "missing terminal":
+				e.Candidates[0].TerminalEvidence = ""
+			}
+			r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+			require := require.New(t)
+			assert := assert.New(t)
+			require.NoError(err)
+			if variant != "complete" {
+				assert.Empty(r.Landings)
+				assert.False(r.Coverage.Complete)
+				assert.Equal(f.base, r.Coverage.CertifiedHead)
+				assert.NotEmpty(r.Coverage.Gaps)
+				return
+			}
+			assert.Equal([]landedwork.Landing{{CandidateID: "7", Method: "fast_forward", Before: f.base,
+				Terminal: f.head, Source: f.source, Introduced: f.source}}, r.Landings)
+			assert.True(r.Coverage.Complete)
+			assert.Equal(f.head, r.Coverage.CertifiedHead)
+			assert.Empty(r.Unattributed)
+			assert.Equal("3\t1\twork.txt", f.repo.Run("diff", "--numstat", r.Landings[0].Before, r.Landings[0].Terminal))
+		})
+	}
+}

--- a/landedwork/validation_test.go
+++ b/landedwork/validation_test.go
@@ -33,7 +33,7 @@ func TestAnalyzeSquashRequiresIndependentProof(t *testing.T) {
 			assert := assert.New(t)
 			assert.Empty(r.Landings)
 			assert.Equal(f.bounds(), r.Coverage.Bounds)
-			assert.Equal([]landedwork.Gap{{CandidateID: "7", ObjectID: f.head, Reason: reason}}, r.Coverage.Gaps)
+			assert.Equal([]landedwork.Gap{{CandidateID: "7", ObjectID: f.head, Reason: reason, Span: landedwork.Span{Before: f.base, Through: f.head}}}, r.Coverage.Gaps)
 			assert.Equal([]string{f.head}, r.Unattributed)
 			assert.False(r.Coverage.Complete)
 			assert.Equal(f.base, r.Coverage.CertifiedHead)


### PR DESCRIPTION
Extends the public landing-proof library to recognize fast-forward and rebased ranges, rather than leaving them unsupported.

- Match rewritten commits by exact edit bytes, preserving paths, modes, binary identities, and newline differences. Ambiguous or incomplete proof stays unresolved.
- Keep later proven work visible when an earlier candidate is unresolved, without certifying past the gap.
- Recognize ordinary merges integrated through another accepted merge without counting a second origin.
- Classify direct-push origins only with complete inventory outside blocked spans; do not infer a pusher or update time.

Real Git fixtures cover rewritten ranges, overlapping claims, integration branches, missing objects, and resource limits. Collection, churn policy, archive integration, and UI remain out of scope.
