### PR TITLE
fix: warn before merging pull requests with failing CI

### DIFF
--- a/frontend/src/lib/components/detail/MergeModal.svelte
+++ b/frontend/src/lib/components/detail/MergeModal.svelte
@@ -40,6 +40,8 @@
     routeGeneration?: number;
     /** When true, the primary action waits for currently pending CI before merging. */
     deferUntilChecksPass?: boolean;
+    /** Warn before an immediate merge when aggregate CI has failed. */
+    ciFailed?: boolean;
     /**
      * True while a background merge is already queued for this PR. The
      * deferred action is withheld (the server would 409 on a second
@@ -70,6 +72,7 @@
     allowSquash, allowMerge, allowRebase,
     expectedHeadSha, requireHeadPin = false, routeGeneration = 0,
     deferUntilChecksPass = false,
+    ciFailed = false,
     alreadyQueued = false, workspaceId, midStackWarning,
     onclose, onmerged, onqueued, onstateconflict,
   }: Props = $props();
@@ -214,7 +217,8 @@
   function primaryButtonLabel(): string {
     if (activeMergeSubmission === "deferred") return "Merge scheduled...";
     if (activeMergeSubmission === "immediate" && !offerDeferredMerge) return "Merging...";
-    return offerDeferredMerge ? "Merge after CI is complete" : methodLabel();
+    if (offerDeferredMerge) return "Merge after CI is complete";
+    return ciFailed ? "Merge Anyway" : methodLabel();
   }
 
   function mergeAnywayButtonLabel(): string {
@@ -293,6 +297,11 @@
 
       {#if error}
         <p class="merge-error">{error}</p>
+      {/if}
+      {#if ciFailed}
+        <div class="ci-defer-note" role="alert">
+          CI has failed. Merging now will include changes with failing checks.
+        </div>
       {/if}
       {#if alreadyQueued}
         <div class="ci-defer-note">

--- a/frontend/src/lib/components/detail/MergeModal.svelte.test.ts
+++ b/frontend/src/lib/components/detail/MergeModal.svelte.test.ts
@@ -310,6 +310,18 @@ describe("MergeModal acknowledged merge commands", () => {
     expect(onmerged).toHaveBeenCalledOnce();
   });
 
+  it("requires an explicit merge anyway action when CI has failed", async () => {
+    const onmerged = vi.fn();
+    renderModal({ ciFailed: true, onmerged });
+
+    expect(screen.getByRole("alert").textContent).toContain("CI has failed.");
+    expect(mockMergePull).not.toHaveBeenCalled();
+    await fireEvent.click(screen.getByRole("button", { name: "Merge Anyway" }));
+
+    expect(mockMergePull.mock.calls[0]?.[3]).toBe(false);
+    expect(onmerged).toHaveBeenCalledOnce();
+  });
+
   it("keeps the merge action disabled until its acknowledgement settles", async () => {
     let settle = () => {};
     mockMergePull.mockImplementation((...args: unknown[]) => {

--- a/frontend/src/lib/components/detail/PullDetail.svelte
+++ b/frontend/src/lib/components/detail/PullDetail.svelte
@@ -2985,6 +2985,7 @@
           requireHeadPin={capabilities.mutation_head_binding}
           routeGeneration={mutationRouteGeneration}
           deferUntilChecksPass={shouldDeferMergeForCI(p.CIStatus, p.CIChecksJSON)}
+          ciFailed={ciStatusHasFailed(p.CIStatus)}
           alreadyQueued={deferredMergePending}
           workspaceId={d.workspace?.id}
           midStackWarning={midStackBlocker

--- a/frontend/src/lib/components/detail/PullDetail.test.ts
+++ b/frontend/src/lib/components/detail/PullDetail.test.ts
@@ -1907,7 +1907,33 @@ describe("PullDetail approvals", () => {
     expect(screen.getByRole("button", { name: "Squash and merge" })).toBeTruthy();
   });
 
-  it("opens the merge modal in normal mode when aggregate CI has already failed", async () => {
+  it.each(["failure", "failed", "error", "cancelled", "canceled", "timed_out"])(
+    "warns before merging when aggregate CI is %s without check rows",
+    async (status) => {
+      const detail = pullDetail();
+      detail.repo.capabilities.merge_mutation = true;
+      detail.merge_request.CIStatus = status;
+      detail.merge_request.CIChecksJSON = "";
+
+      renderPullDetail(detail, {
+        AllowSquashMerge: true,
+        AllowMergeCommit: false,
+        AllowRebaseMerge: false,
+        ViewerCanMerge: true,
+      });
+
+      await fireEvent.click(await screen.findByRole("button", { name: "Squash and merge" }));
+
+      const dialog = within(screen.getByRole("dialog", { name: "Merge Pull Request" }));
+      expect(dialog.getByRole("alert").textContent).toContain(
+        "CI has failed. Merging now will include changes with failing checks.",
+      );
+      expect(dialog.getByRole("button", { name: "Merge Anyway" })).toBeTruthy();
+      expect(dialog.queryByRole("button", { name: "Merge after CI is complete" })).toBeNull();
+    },
+  );
+
+  it("warns before merging when aggregate CI has failed with a check still running", async () => {
     const detail = pullDetail();
     detail.repo.capabilities.merge_mutation = true;
     detail.merge_request.CIStatus = "failure";
@@ -1941,6 +1967,8 @@ describe("PullDetail approvals", () => {
     // A failed aggregate with a still-running check must not route to deferred
     // merge, since the backend would reject that with a 409.
     expect(screen.queryByRole("button", { name: "Merge after CI is complete" })).toBeNull();
+    expect(screen.getByRole("alert").textContent).toContain("CI has failed.");
+    expect(screen.getByRole("button", { name: "Merge Anyway" })).toBeTruthy();
   });
 
   it("keeps a newer head conflict after an overlapping approval succeeds", async () => {

--- a/frontend/tests/e2e/merge-ci-warning.spec.ts
+++ b/frontend/tests/e2e/merge-ci-warning.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test";
+import type { PullDetail } from "../../src/lib/api/types.js";
+import { createMockApiHandler } from "../../src/test/mockApiFetch";
+import { mockApi } from "./support/mockApi";
+
+test("warns about failed CI before an explicit immediate merge", async ({ page }) => {
+  await mockApi(page);
+  const api = createMockApiHandler();
+  await page.route("**/api/v1/pulls/github/acme/widgets/42", async (route) => {
+    const response = api.handle({ method: "GET", url: new URL(route.request().url()), bodyText: "" });
+    const detail = (await response.json()) as PullDetail;
+    detail.merge_request.CIStatus = "failure";
+    detail.merge_request.CIChecksJSON = JSON.stringify([
+      { name: "build", status: "completed", conclusion: "failure", url: "", app: "CI" },
+      { name: "integration", status: "in_progress", conclusion: "", url: "", app: "CI" },
+    ]);
+    await route.fulfill({ json: detail });
+  });
+
+  const mergeRequests: string[] = [];
+  await page.route("**/api/v1/pulls/github/acme/widgets/42/merge**", async (route) => {
+    mergeRequests.push(new URL(route.request().url()).pathname);
+    await route.fulfill({ json: { merged: true, sha: "merge-sha", message: "merged" } });
+  });
+
+  await page.goto("/pulls/github/acme/widgets/42");
+  await page.locator(".btn--merge").first().click();
+  const dialog = page.getByRole("dialog", { name: "Merge Pull Request" });
+  await expect(dialog.getByRole("alert")).toHaveText(
+    "CI has failed. Merging now will include changes with failing checks.",
+  );
+  await expect(dialog.getByRole("button", { name: "Merge after CI is complete" })).toHaveCount(0);
+  expect(mergeRequests).toEqual([]);
+  await dialog.getByRole("button", { name: "Merge Anyway" }).click();
+  await expect(dialog).toHaveCount(0);
+  expect(mergeRequests).toEqual(["/api/v1/pulls/github/acme/widgets/42/merge"]);
+});


### PR DESCRIPTION
Warn when merging a pull request with failing CI and label the confirmation **Merge Anyway**. The warning also appears when other checks are still running or individual check details are unavailable.
