### PR TITLE
fix: resume workspace agents through shared CLI builders

### DIFF
--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -202,8 +202,11 @@ create a local process, PTY, or durable transport session
 - Missing tmux agents resume the newest matching Codex, Claude, or Pi hook session
   by exact ID, preserving configured flags and runtime identity without replaying
   the initial prompt (`internal/server/workspaceapi/agent_resume.go::Handler.resumeWorkspaceAgent`).
-- Recovery never resets worktrees or replays configured positional prompts;
-  unsupported command shapes retain the saved runtime and report for recovery
+- Kit owns generated resume arguments; configured arguments pass through
+  unchanged, with their meaning and validity owned by the caller
+  (`internal/workspace/localruntime/agent_resume.go::agentResumeCommand`).
+- Recovery never resets worktrees or resends the initial message; failed
+  recovery retains the saved runtime and report for another attempt
   (`internal/server/workspaceapi/lifecycle.go::Handler.RestoreRuntimeSessions`).
 - Restore base terminals before agents, including retained creating/error retries;
   startup recovery shares a 30-second budget and preserves uncompleted attempts

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/yuin/goldmark v1.8.5
 	gitlab.com/gitlab-org/api/client-go/v2 v2.58.0
 	go.kenn.io/kata v0.14.3
-	go.kenn.io/kit v0.24.2-0.20260908171250-013919314217
+	go.kenn.io/kit v0.24.2-0.20260908191132-2512d86eca5c
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/yuin/goldmark v1.8.5
 	gitlab.com/gitlab-org/api/client-go/v2 v2.58.0
 	go.kenn.io/kata v0.14.3
-	go.kenn.io/kit v0.21.1
+	go.kenn.io/kit v0.24.2-0.20260908171250-013919314217
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0

--- a/go.sum
+++ b/go.sum
@@ -637,8 +637,8 @@ gitlab.com/gitlab-org/api/client-go/v2 v2.58.0 h1:quZfEo1oY4uK92HkI2ZVuAI8cktpBH
 gitlab.com/gitlab-org/api/client-go/v2 v2.58.0/go.mod h1:gcqiTA4aFvyvPZspm+YwnMFObw2t8K3YCXxAwJgY51g=
 go.kenn.io/kata v0.14.3 h1:AsvwkUtR0UkWXG5i0dfb0QRd4vP+9gxhwkRhsuCAovE=
 go.kenn.io/kata v0.14.3/go.mod h1:zolatYiLoa+OsrQalAUyz5qMAh3fw22bV2t5nchK4MM=
-go.kenn.io/kit v0.24.2-0.20260908171250-013919314217 h1:5tfVg+K0fMqfQ+na0NNGiC00lZ32iIb/CGaTnqkY66M=
-go.kenn.io/kit v0.24.2-0.20260908171250-013919314217/go.mod h1:dO7SImegZe4P9PdnxuANdSQFbnrUvF3eE6/RDOfOMqo=
+go.kenn.io/kit v0.24.2-0.20260908191132-2512d86eca5c h1:LOTl10ajuYB2HIgah+i0WGOk+bWAWmEUlj1nZAJPMt4=
+go.kenn.io/kit v0.24.2-0.20260908191132-2512d86eca5c/go.mod h1:dO7SImegZe4P9PdnxuANdSQFbnrUvF3eE6/RDOfOMqo=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/go.sum
+++ b/go.sum
@@ -637,8 +637,8 @@ gitlab.com/gitlab-org/api/client-go/v2 v2.58.0 h1:quZfEo1oY4uK92HkI2ZVuAI8cktpBH
 gitlab.com/gitlab-org/api/client-go/v2 v2.58.0/go.mod h1:gcqiTA4aFvyvPZspm+YwnMFObw2t8K3YCXxAwJgY51g=
 go.kenn.io/kata v0.14.3 h1:AsvwkUtR0UkWXG5i0dfb0QRd4vP+9gxhwkRhsuCAovE=
 go.kenn.io/kata v0.14.3/go.mod h1:zolatYiLoa+OsrQalAUyz5qMAh3fw22bV2t5nchK4MM=
-go.kenn.io/kit v0.21.1 h1:YIdLvMN2Ad/BOp0+oH2vzObBOsIAv8Hmok043Kh+wPk=
-go.kenn.io/kit v0.21.1/go.mod h1:Cg1V5dG+XaSDYr/nE0tvmCxotfpYtW1vPhyc+Ph9Ny0=
+go.kenn.io/kit v0.24.2-0.20260908171250-013919314217 h1:5tfVg+K0fMqfQ+na0NNGiC00lZ32iIb/CGaTnqkY66M=
+go.kenn.io/kit v0.24.2-0.20260908171250-013919314217/go.mod h1:dO7SImegZe4P9PdnxuANdSQFbnrUvF3eE6/RDOfOMqo=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/internal/server/workspaceapi/agent_resume_test.go
+++ b/internal/server/workspaceapi/agent_resume_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestRestoreRuntimeSessionsResumesSavedConversationAfterTmuxLoss(t *testing.T) {
-	for _, status := range []string{"ready", "creating", "error", "unavailable", "ambiguous", "fairness", "stopped"} {
+	for _, status := range []string{"ready", "creating", "error", "unavailable", "fairness", "stopped"} {
 		t.Run(status, func(t *testing.T) {
 			require := require.New(t)
 			assert := assert.New(t)
@@ -104,15 +104,11 @@ exec sleep 60
 				require.NoError(workspaces.ForgetRuntimeSession(ctx, "workspace", "aaa-blocked"))
 				handler.setRuntimeRecoveryPending("aaa-blocked", false)
 			}
-			if status == "unavailable" || status == "ambiguous" || status == "stopped" {
+			if status == "unavailable" || status == "stopped" {
 				require.NoError(database.UpdateWorkspaceStatus(ctx, "workspace", "ready", nil))
 				targets := runtime.LaunchTargets()
 				targets = append(targets, localruntime.LaunchTarget{Key: "shell", Kind: localruntime.LaunchTargetShell, Available: true, Command: tmux})
-				if status == "unavailable" || status == "stopped" {
-					targets[0].Available = false
-				} else {
-					targets[0].Command = append(targets[0].Command, "--", "original prompt")
-				}
+				targets[0].Available = false
 				runtime.UpdateTargets(targets)
 				require.NoError(handler.RestoreRuntimeSessions(ctx))
 				handler.runWorkspaceTmuxPrune(ctx)
@@ -138,7 +134,7 @@ exec sleep 60
 				targets[0].Command = []string{agent, "--model", "model-a"}
 				runtime.UpdateTargets(targets)
 			}
-			if status == "unavailable" || status == "ambiguous" {
+			if status == "unavailable" {
 				done, start := handler.beginWorkspaceSetup("workspace")
 				require.True(start)
 				handler.runWorkspaceTmuxPrune(ctx)

--- a/internal/workspace/localruntime/agent_resume.go
+++ b/internal/workspace/localruntime/agent_resume.go
@@ -10,29 +10,27 @@ import (
 
 	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/procutil"
+	"go.kenn.io/kit/agentcli"
 )
 
 // agentResumeCommand preserves configured options and uses the hook's agent
 // identity, since configured target names need not identify an agent family.
 func agentResumeCommand(command []string, agent, sessionID string) ([]string, error) {
-	if len(command) == 0 || strings.TrimSpace(sessionID) == "" || strings.HasPrefix(sessionID, "-") {
-		return nil, fmt.Errorf("agent resume requires a command and session ID")
+	if len(command) == 0 || command[0] == "" {
+		return nil, fmt.Errorf("agent resume requires a configured command")
 	}
-	if err := validateAgentResumeOptions(command[1:], agent); err != nil {
+	adapter, err := agentcli.New(agentcli.Name(agent), agentcli.Command{
+		Executable: command[0],
+		Options:    command[1:],
+	})
+	if err != nil {
 		return nil, err
 	}
-	result := slices.Clone(command)
-	switch agent {
-	case "codex":
-		result = append(result, "resume", sessionID)
-	case "claude":
-		result = append(result, "--resume", sessionID)
-	case "pi":
-		result = append(result, "--session", sessionID)
-	default:
-		return nil, fmt.Errorf("session resume is not supported for agent %q", agent)
+	invocation, err := adapter.Resume(sessionID, agentcli.Request{Mode: agentcli.Interactive})
+	if err != nil {
+		return nil, err
 	}
-	return result, nil
+	return invocation.Argv, nil
 }
 
 // A successful PTY spawn does not mean tmux attached. Probe before spawning so
@@ -56,45 +54,6 @@ func (m *Manager) requireTmuxSession(ctx context.Context, session string) error 
 			return fmt.Errorf("%w: %s", ErrSessionNotFound, session)
 		}
 		return fmt.Errorf("%w: check tmux session: %v: %s", ErrSessionUnavailable, err, strings.TrimSpace(stderr.String()))
-	}
-	return nil
-}
-
-// Recovery accepts options with known arity only. Positional input, existing
-// session selectors and end-of-options delimiters could turn resume into a
-// fresh prompt. Retain those sessions for manual recovery instead of guessing.
-func validateAgentResumeOptions(args []string, agent string) error {
-	var valueOptions, switchOptions string
-	switch agent {
-	case "codex":
-		valueOptions = "-c --config --enable --disable -m --model -p --profile -s --sandbox -a --ask-for-approval -C --cd --add-dir --local-provider --remote --remote-auth-token-env"
-		switchOptions = "--full-auto --oss --strict-config --approve-for-me --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust --search --no-alt-screen"
-	case "claude":
-		valueOptions = "--model --effort --agent --agents --permission-mode --settings --setting-sources --mcp-config --add-dir --allowedTools --allowed-tools --disallowedTools --disallowed-tools --tools --system-prompt --append-system-prompt --plugin-dir"
-		switchOptions = "--dangerously-skip-permissions --allow-dangerously-skip-permissions --verbose --strict-mcp-config --bare --chrome --no-chrome"
-	case "pi":
-		valueOptions = "--provider --model --api-key --system-prompt --append-system-prompt --models --tools -t --exclude-tools -xt --thinking --extension -e --skill --prompt-template --theme --use-theme --tui-mode --session-dir"
-		switchOptions = "--no-tools -nt --no-builtin-tools -nbt --no-extensions -ne --no-skills -ns --no-prompt-templates -np --no-themes --no-context-files -nc --verbose --approve -a --no-approve -na --offline"
-	default:
-		return fmt.Errorf("session resume is not supported for agent %q", agent)
-	}
-	values, switches := strings.Fields(valueOptions), strings.Fields(switchOptions)
-	for i := 0; i < len(args); i++ {
-		option, _, inline := strings.Cut(args[i], "=")
-		if slices.Contains(values, option) {
-			if inline {
-				continue
-			}
-			if i+1 == len(args) || strings.HasPrefix(args[i+1], "-") {
-				return fmt.Errorf("cannot resume %s: option %q requires a value", agent, option)
-			}
-			i++
-			continue
-		}
-		if slices.Contains(switches, option) && !inline {
-			continue
-		}
-		return fmt.Errorf("cannot automatically resume %s: unsupported configured argument %q; use an options-only agent command or resume manually", agent, option)
 	}
 	return nil
 }

--- a/internal/workspace/localruntime/agent_resume_test.go
+++ b/internal/workspace/localruntime/agent_resume_test.go
@@ -16,39 +16,24 @@ func TestAgentResumeCommand(t *testing.T) {
 		{"pi", []string{"--session", "conversation"}},
 	} {
 		t.Run(tc.agent, func(t *testing.T) {
-			command, err := agentResumeCommand([]string{tc.agent, "--model", "model-a"}, tc.agent, "conversation")
+			command, err := agentResumeCommand([]string{"custom-worker", "--model", "model-a"}, tc.agent, "conversation")
 			require.NoError(t, err)
-			assert.Equal(t, append([]string{tc.agent, "--model", "model-a"}, tc.suffix...), command)
+			assert.Equal(t, append([]string{"custom-worker", "--model", "model-a"}, tc.suffix...), command)
 		})
 	}
 	_, err := agentResumeCommand([]string{"other"}, "other", "conversation")
 	require.Error(t, err)
 }
 
-func TestAgentResumeRejectsAmbiguousConfiguredArguments(t *testing.T) {
-	for _, tc := range []struct {
-		agent string
-		args  []string
-	}{
-		{"codex", []string{"--", "original prompt"}},
-		{"codex", []string{"exec", "original prompt"}},
-		{"codex", []string{"resume", "old-session"}},
-		{"codex", []string{"--model"}},
-		{"claude", []string{"original prompt"}},
-		{"claude", []string{"--resume=old-session"}},
-		{"claude", []string{"--continue"}},
-		{"pi", []string{"--session-id", "other-session"}},
-		{"pi", []string{"--", "original prompt"}},
-	} {
-		t.Run(tc.agent+"/"+tc.args[0], func(t *testing.T) {
-			_, err := agentResumeCommand(append([]string{tc.agent}, tc.args...), tc.agent, "saved-session")
-			require.Error(t, err)
-		})
-	}
-}
-
 func TestAgentResumePreservesCodexFullAuto(t *testing.T) {
 	command, err := agentResumeCommand([]string{"codex", "--full-auto", "--search"}, "codex", "saved-session")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"codex", "--full-auto", "--search", "resume", "saved-session"}, command)
+}
+
+func TestAgentResumeRequiresConfiguredCommand(t *testing.T) {
+	for _, command := range [][]string{nil, {""}} {
+		_, err := agentResumeCommand(command, "codex", "saved-session")
+		require.Error(t, err)
+	}
 }


### PR DESCRIPTION
Resume saved Codex, Claude, and Pi workspace conversations through kit's shared CLI builders. Preserve configured executables and arguments, including `--full-auto`, while removing Forge's duplicate argument allowlist.

Uses the merged argument-passthrough change from kenn-io/kit#82. Runtime identity, persistence, and recovery retries remain owned by Forge.
