### PR TITLE
ci: capture evidence when browser tests disconnect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -778,4 +778,25 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Run frontend browser tests
-        run: cd frontend && ../node_modules/.bin/vp test run --project browser
+        shell: bash
+        env:
+          # Record who closes the browser connection; the final RPC error alone
+          # cannot distinguish a renderer crash, optimizer reload, or teardown.
+          DEBUG: vitest:browser:*,pw:browser,vite:deps
+          VITEST_PW_DEBUG: "1"
+        run: |
+          report_memory() {
+            echo "::group::Browser test container memory"
+            for metric in memory.current memory.peak memory.max memory.events; do
+              if [ -r "/sys/fs/cgroup/$metric" ]; then
+                echo "$metric"
+                cat "/sys/fs/cgroup/$metric"
+              fi
+            done
+            echo "::endgroup::"
+          }
+          # Compare counters before/after, including when Vitest exits nonzero.
+          trap report_memory EXIT
+          report_memory
+          cd frontend
+          ../node_modules/.bin/vp test run --project browser

--- a/context/testing.md
+++ b/context/testing.md
@@ -215,6 +215,10 @@ Vitest owns unhandled errors in the root runner, so `onUnhandledError` belongs
 in the root `test` config rather than a browser project; keep any ignored error
 exact by message and framework stack frame (`frontend/vite.config.ts:495`).
 
+A successful CI retry proves recovery, not a fix for an intermittent failure.
+Identify the cause or retain targeted diagnostics for the next occurrence;
+do not close the investigation solely because the rerun passed.
+
 Playwright CI uses the private image from `ensure_playwright_image`; keep its
 Playwright, Bun, and Vite+ pins in the recipe, cache only `/usr/local/install/cache`,
 and materialize `node_modules` from the lockfile before invoking baked `vp`


### PR DESCRIPTION
CI run #5249 lost its browser-test connection and passed on retry without revealing why. Capture browser diagnostics and memory counters to help investigate a recurrence, while preserving test failures.

The original cause remains unresolved. Document that a passing retry is recovery, not a fix.
