### PR TITLE
feat: collect bounded GitHub evidence for landing analysis

### DIFF
--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -62,6 +62,9 @@ Collector call limits do not bound HTTP retries or absence-confirmation reads;
 callers put wire limits below authentication (`platform/landing_evidence.go::LandingEvidenceReader`).
 GitHub collection relies on REST 2022-11-28 terminal semantics, not the newer
 API's omitted field; enterprise coverage remains unverified (`platform/github/landing_evidence.go::Provider.LandingEvidenceSupport`).
+The collector currently has one concrete reader: GitHub.com. GitLab discovery
+still needs the rewritten-commit contract checked; terminal-only Forgejo/Gitea
+lookups cannot prove absence inside a rewritten range (`platform/landing_evidence.go::LandingEvidenceReader`).
 
 Minimum provider checklist:
 

--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -58,6 +58,8 @@ Overlap conflicts block the proven landing ranges, not unrelated earlier
 commits; unknown-start candidate gaps still block from the base (`landedwork/origins.go::rejectOverlaps`).
 Collection must preserve unfinished candidates and the exact prepared query;
 missing provider evidence is never direct-push evidence (`landedwork/collect/collect.go::Collect`).
+Keep malformed object IDs in observations, not analyzer candidates; a provider
+gap must not become a fatal caller-input error (`landedwork/collect/candidates.go::candidate`).
 Reject an over-budget query without a result; never trim commits or gaps to fit.
 Even incomplete preparation and unsupported discovery retain query records that
 must be charged (`landedwork/collect/limits.go::validate`).

--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -58,6 +58,9 @@ Overlap conflicts block the proven landing ranges, not unrelated earlier
 commits; unknown-start candidate gaps still block from the base (`landedwork/origins.go::rejectOverlaps`).
 Collection must preserve unfinished candidates and the exact prepared query;
 missing provider evidence is never direct-push evidence (`landedwork/collect/collect.go::Collect`).
+GitHub associations can name upstream PRs when querying a fork. Preserve their
+target identity without fetching that PR number locally; foreign associations
+do not prove local absence (`landedwork/collect/collect.go::Collect`).
 Collector call limits do not bound HTTP retries or absence-confirmation reads;
 callers put wire limits below authentication (`platform/landing_evidence.go::LandingEvidenceReader`).
 GitHub collection relies on REST 2022-11-28 terminal semantics, not the newer

--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -60,6 +60,8 @@ Collection must preserve unfinished candidates and the exact prepared query;
 missing provider evidence is never direct-push evidence (`landedwork/collect/collect.go::Collect`).
 Collector call limits do not bound HTTP retries or absence-confirmation reads;
 callers put wire limits below authentication (`platform/landing_evidence.go::LandingEvidenceReader`).
+GitHub collection relies on REST 2022-11-28 terminal semantics, not the newer
+API's omitted field; enterprise coverage remains unverified (`platform/github/landing_evidence.go::Provider.LandingEvidenceSupport`).
 
 Minimum provider checklist:
 

--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -56,6 +56,10 @@ Offset-free text proof requires uniquely occurring removed bytes or a unique
 insertion neighborhood; repeated locations stay unproven (`landedwork/edits.go::fileEdits`).
 Overlap conflicts block the proven landing ranges, not unrelated earlier
 commits; unknown-start candidate gaps still block from the base (`landedwork/origins.go::rejectOverlaps`).
+Collection must preserve unfinished candidates and the exact prepared query;
+missing provider evidence is never direct-push evidence (`landedwork/collect/collect.go::Collect`).
+Collector call limits do not bound HTTP retries or absence-confirmation reads;
+callers put wire limits below authentication (`platform/landing_evidence.go::LandingEvidenceReader`).
 
 Minimum provider checklist:
 

--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -58,6 +58,9 @@ Overlap conflicts block the proven landing ranges, not unrelated earlier
 commits; unknown-start candidate gaps still block from the base (`landedwork/origins.go::rejectOverlaps`).
 Collection must preserve unfinished candidates and the exact prepared query;
 missing provider evidence is never direct-push evidence (`landedwork/collect/collect.go::Collect`).
+Reject an over-budget query without a result; never trim commits or gaps to fit.
+Even incomplete preparation and unsupported discovery retain query records that
+must be charged (`landedwork/collect/limits.go::validate`).
 GitHub associations can name upstream PRs when querying a fork. Preserve their
 target identity without fetching that PR number locally; foreign associations
 do not prove local absence (`landedwork/collect/collect.go::Collect`).

--- a/internal/github/auth_router.go
+++ b/internal/github/auth_router.go
@@ -406,6 +406,7 @@ var (
 	_ platformgithub.AssigneeAPI          = (*RoutedClient)(nil)
 	_ platformgithub.ReviewerAPI          = (*RoutedClient)(nil)
 	_ platformgithub.InventoryAPI         = (*RoutedClient)(nil)
+	_ platformgithub.LandingAPI           = (*RoutedClient)(nil)
 	_ markdownImageClient                 = (*RoutedClient)(nil)
 	_ repoUserClient                      = (*RoutedClient)(nil)
 	_ platformgithub.NativeStackClient    = (*RoutedClient)(nil)
@@ -455,6 +456,42 @@ func (c *RoutedClient) pageClientForRepo(
 		)
 	}
 	return paged, nil
+}
+
+func (c *RoutedClient) landingClientForRepo(ctx context.Context, repo platform.RepoRef) (platformgithub.LandingAPI, error) {
+	client, err := c.routeForRepoContext(ctx, repo.Owner, repo.Name)
+	if err != nil {
+		return nil, err
+	}
+	landing, ok := client.(platformgithub.LandingAPI)
+	if !ok {
+		return nil, platform.UnsupportedCapability(platform.KindGitHub, c.routes.host, "landing_evidence")
+	}
+	return landing, nil
+}
+
+func (c *RoutedClient) ListLandingAssociations(ctx context.Context, repo platform.RepoRef, commit, cursor string) (platform.Page[platform.LandingChangeRef], error) {
+	client, err := c.landingClientForRepo(ctx, repo)
+	if err != nil {
+		return platform.Page[platform.LandingChangeRef]{}, err
+	}
+	return client.ListLandingAssociations(ctx, repo, commit, cursor)
+}
+
+func (c *RoutedClient) GetLandingChange(ctx context.Context, repo platform.RepoRef, change platform.LandingChangeRef) (platform.LandingChange, error) {
+	client, err := c.landingClientForRepo(ctx, repo)
+	if err != nil {
+		return platform.LandingChange{}, err
+	}
+	return client.GetLandingChange(ctx, repo, change)
+}
+
+func (c *RoutedClient) ListLandingSource(ctx context.Context, repo platform.RepoRef, change platform.LandingChangeRef, cursor string) (platform.Page[string], error) {
+	client, err := c.landingClientForRepo(ctx, repo)
+	if err != nil {
+		return platform.Page[string]{}, err
+	}
+	return client.ListLandingSource(ctx, repo, change, cursor)
 }
 
 func (c *RoutedClient) ListInventoryIssuesPage(

--- a/internal/github/landing_evidence_test.go
+++ b/internal/github/landing_evidence_test.go
@@ -1,0 +1,72 @@
+package github
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/platform"
+	platformgithub "go.kenn.io/forge/platform/github"
+)
+
+func TestRoutedProviderLandingEvidence(t *testing.T) {
+	for _, archive := range []bool{false, true} {
+		name := "foreground"
+		if archive {
+			name = "archive"
+		}
+		t.Run(name, func(t *testing.T) {
+			require, assert := require.New(t), assert.New(t)
+			var paths []string
+			hc := &http.Client{Transport: platform.RoundTripFunc(func(r *http.Request) (*http.Response, error) {
+				paths = append(paths, r.URL.Path)
+				var body string
+				switch r.URL.Path {
+				case "/repos/example/project/commits/abc/pulls":
+					body = `[{"id":7,"number":3,"base":{"repo":{"id":12}}}]`
+				case "/repos/example/project/pulls/3":
+					body = `{"id":7,"number":3,"merged":true,"merge_commit_sha":"abc","base":{"repo":{"id":12}}}`
+				case "/repos/example/project/pulls/3/commits":
+					body = `[{"sha":"def"}]`
+				default:
+					require.Fail("unexpected request", r.URL.String())
+				}
+				return &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body)), Request: r}, nil
+			})}
+			client, err := platformgithub.NewClient(platformgithub.ClientConfig{Read: hc, Write: hc, Notifications: hc, Clock: time.Now})
+			require.NoError(err)
+			exact := &Route{Key: RouteKey{Host: "github.com", Owner: "example", Name: "project"}, Client: client}
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+			defer cancel()
+			if archive {
+				exact.Client, exact.ArchiveClient = &mockClient{}, client
+				ctx = WithArchiveSyncBudget(ctx)
+			}
+			router, err := NewHostRouter("github.com",
+				&Route{Key: RouteKey{Host: "github.com"}, Client: &mockClient{}},
+				&Route{Key: RouteKey{Host: "github.com", Owner: "example"}, Client: &mockClient{}}, exact)
+			require.NoError(err)
+			routed, err := NewRoutedClient(router)
+			require.NoError(err)
+			provider := newTestGitHubProvider(t, "github.com", routed)
+			require.True(provider.LandingEvidenceSupport().Inventory)
+			ref := platform.RepoRef{Platform: platform.KindGitHub, Host: "github.com", Owner: "example", Name: "project"}
+			page, err := provider.ListLandingAssociations(ctx, ref, "abc", "")
+			require.NoError(err)
+			require.Equal([]platform.LandingChangeRef{{ID: 7, Number: 3, TargetID: 12}}, page.Items)
+			detail, err := provider.GetLandingChange(ctx, ref, page.Items[0])
+			require.NoError(err)
+			assert.Equal("abc", detail.Terminal)
+			sources, err := provider.ListLandingSource(ctx, ref, page.Items[0], "")
+			require.NoError(err)
+			assert.Equal([]string{"def"}, sources.Items)
+			assert.True(sources.Exhausted)
+			assert.Equal([]string{"/repos/example/project/commits/abc/pulls", "/repos/example/project/pulls/3", "/repos/example/project/pulls/3/commits"}, paths)
+		})
+	}
+}

--- a/internal/github/public_api_guard_test.go
+++ b/internal/github/public_api_guard_test.go
@@ -67,6 +67,7 @@ func TestRoutedClientExplicitlyImplementsOwnerBearingClientMethods(t *testing.T)
 	}{
 		{file: "client.go", name: "Client"},
 		{file: "../../platform/github/native_stacks.go", name: "NativeStackClient"},
+		{file: "../../platform/github/landing_evidence.go", name: "LandingAPI"},
 	}
 	files := token.NewFileSet()
 	routerFile, err := parser.ParseFile(files, "auth_router.go", nil, 0)

--- a/landedwork/collect/candidates.go
+++ b/landedwork/collect/candidates.go
@@ -2,7 +2,6 @@ package collect
 
 import (
 	"context"
-	"errors"
 	"reflect"
 	"slices"
 	"strconv"
@@ -14,47 +13,50 @@ import (
 func (c *collector) observe(ctx context.Context, ref platform.LandingChangeRef, policy platform.LandingSourcePolicy) (Observation, error) {
 	o := Observation{Change: platform.LandingChange{Ref: ref}}
 	if !c.call() || !c.records(1) {
-		return c.incomplete(o, "exhausted_limits", ""), nil
+		return c.incomplete(o, "exhausted_limits", "detail", ""), nil
 	}
 	detail, err := c.reader.GetLandingChange(ctx, c.route, ref)
 	if err != nil {
-		return c.incomplete(o, c.reason(err), ""), nil
+		return c.incomplete(o, c.reason(err), "detail", ""), nil
 	}
 	if err := c.identity(detail, ref); err != nil {
 		return Observation{}, err
 	}
 	o.Change = cloneChange(detail)
-	if detail.Merged == nil {
-		return c.incomplete(o, "invalid_observation", ""), nil
+	if detail.TargetID <= 0 || detail.Merged == nil {
+		return c.incomplete(o, "invalid_observation", "detail", ""), nil
 	}
 	if !*detail.Merged {
 		return o, nil
 	}
 	if !validChange(detail, len(c.result.Evidence.Query.Bounds.Head)) {
-		return c.incomplete(o, "invalid_observation", ""), nil
+		return c.incomplete(o, "invalid_observation", "detail", ""), nil
 	}
 	if detail.SourceCount == nil && policy.RequireCount || detail.SourceCount != nil && (*detail.SourceCount < 0 || policy.MaxCommits > 0 && *detail.SourceCount > policy.MaxCommits) {
-		return c.incomplete(o, "provider_truncation", ""), nil
+		return c.incomplete(o, "provider_truncation", "detail", ""), nil
 	}
 	o = c.sources(ctx, o)
 	if o.Reason != "" {
 		return o, nil
 	}
 	if detail.SourceCount != nil && int64(len(o.Source)) != *detail.SourceCount || !slices.Contains(o.Source, *detail.SourceHead) {
-		return c.incomplete(o, "provider_truncation", ""), nil
+		return c.incomplete(o, "provider_truncation", "source", ""), nil
 	}
 	if !c.call() || !c.records(1) {
-		return c.incomplete(o, "exhausted_limits", ""), nil
+		return c.incomplete(o, "exhausted_limits", "detail_recheck", ""), nil
 	}
 	after, err := c.reader.GetLandingChange(ctx, c.route, ref)
 	if err != nil {
-		return c.incomplete(o, c.reason(err), ""), nil
+		return c.incomplete(o, c.reason(err), "detail_recheck", ""), nil
 	}
 	if err := c.identity(after, ref); err != nil {
 		return Observation{}, err
 	}
+	if after.TargetID <= 0 {
+		return c.incomplete(o, "invalid_observation", "detail_recheck", ""), nil
+	}
 	if !reflect.DeepEqual(o.Change, after) {
-		return c.incomplete(o, "changed_observation", ""), nil
+		return c.incomplete(o, "changed_observation", "detail_recheck", ""), nil
 	}
 	o.SourceComplete = true
 	return o, nil
@@ -65,21 +67,21 @@ func (c *collector) sources(ctx context.Context, o Observation) Observation {
 	seen, ids := make(map[string]bool), make(map[string]bool)
 	for {
 		if !c.call() {
-			return c.incomplete(o, "exhausted_limits", cursor)
+			return c.incomplete(o, "exhausted_limits", "source", cursor)
 		}
 		page, err := c.reader.ListLandingSource(ctx, c.route, o.Change.Ref, cursor)
 		if err != nil {
-			return c.incomplete(o, c.reason(err), cursor)
+			return c.incomplete(o, c.reason(err), "source", cursor)
 		}
 		if r := checkPage(c.reader, cursor, page, seen); r != "" {
-			return c.incomplete(o, r, cursor)
+			return c.incomplete(o, r, "source", cursor)
 		}
 		if !c.records(1 + int64(len(page.Items))*2) {
-			return c.incomplete(o, "exhausted_limits", cursor)
+			return c.incomplete(o, "exhausted_limits", "source", cursor)
 		}
 		for _, sha := range page.Items {
 			if !objectID(sha, len(c.result.Evidence.Query.Bounds.Head)) || ids[sha] {
-				return c.incomplete(o, "provider_truncation", cursor)
+				return c.incomplete(o, "provider_truncation", "source", cursor)
 			}
 			ids[sha] = true
 			o.Source = append(o.Source, sha)
@@ -91,15 +93,15 @@ func (c *collector) sources(ctx context.Context, o Observation) Observation {
 	}
 }
 
-func (c *collector) incomplete(o Observation, reason, page string) Observation {
-	o.Reason = reason
-	c.stop(reason, o.Change.Terminal, page)
+func (c *collector) incomplete(o Observation, reason, stage, page string) Observation {
+	o.Reason, o.FailureStage, o.NextPage = reason, stage, page
+	c.stop(reason, "", "")
 	return o
 }
 
 func (c *collector) identity(d platform.LandingChange, ref platform.LandingChangeRef) error {
-	if d.Ref != ref || d.TargetID <= 0 || strconv.FormatInt(d.TargetID, 10) != c.result.Evidence.Query.Bounds.Repository.ID {
-		return errors.New("landing change identity mismatch")
+	if d.Ref != ref || d.TargetID != 0 && strconv.FormatInt(d.TargetID, 10) != c.result.Evidence.Query.Bounds.Repository.ID {
+		return platform.ErrLandingIdentityMismatch
 	}
 	return nil
 }

--- a/landedwork/collect/candidates.go
+++ b/landedwork/collect/candidates.go
@@ -1,0 +1,139 @@
+package collect
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"slices"
+	"strconv"
+
+	"go.kenn.io/forge/landedwork"
+	"go.kenn.io/forge/platform"
+)
+
+func (c *collector) observe(ctx context.Context, ref platform.LandingChangeRef, policy platform.LandingSourcePolicy) (Observation, error) {
+	o := Observation{Change: platform.LandingChange{Ref: ref}}
+	if !c.call() || !c.records(1) {
+		return c.incomplete(o, "exhausted_limits", ""), nil
+	}
+	detail, err := c.reader.GetLandingChange(ctx, c.route, ref)
+	if err != nil {
+		return c.incomplete(o, reason(err), ""), nil
+	}
+	if err := c.identity(detail, ref); err != nil {
+		return Observation{}, err
+	}
+	o.Change = cloneChange(detail)
+	if detail.Merged == nil {
+		return c.incomplete(o, "invalid_observation", ""), nil
+	}
+	if !*detail.Merged {
+		return o, nil
+	}
+	if !validChange(detail, len(c.result.Evidence.Query.Bounds.Head)) {
+		return c.incomplete(o, "invalid_observation", ""), nil
+	}
+	if detail.SourceCount == nil && policy.RequireCount || detail.SourceCount != nil && (*detail.SourceCount < 0 || policy.MaxCommits > 0 && *detail.SourceCount > policy.MaxCommits) {
+		return c.incomplete(o, "provider_truncation", ""), nil
+	}
+	o = c.sources(ctx, o)
+	if o.Reason != "" {
+		return o, nil
+	}
+	if detail.SourceCount != nil && int64(len(o.Source)) != *detail.SourceCount || !slices.Contains(o.Source, *detail.SourceHead) {
+		return c.incomplete(o, "provider_truncation", ""), nil
+	}
+	if !c.call() || !c.records(1) {
+		return c.incomplete(o, "exhausted_limits", ""), nil
+	}
+	after, err := c.reader.GetLandingChange(ctx, c.route, ref)
+	if err != nil {
+		return c.incomplete(o, reason(err), ""), nil
+	}
+	if err := c.identity(after, ref); err != nil {
+		return Observation{}, err
+	}
+	if !reflect.DeepEqual(o.Change, after) {
+		return c.incomplete(o, "changed_observation", ""), nil
+	}
+	o.SourceComplete = true
+	return o, nil
+}
+
+func (c *collector) sources(ctx context.Context, o Observation) Observation {
+	cursor := ""
+	seen, ids := make(map[string]bool), make(map[string]bool)
+	for {
+		if !c.call() {
+			return c.incomplete(o, "exhausted_limits", cursor)
+		}
+		page, err := c.reader.ListLandingSource(ctx, c.route, o.Change.Ref, cursor)
+		if err != nil {
+			return c.incomplete(o, reason(err), cursor)
+		}
+		if r := checkPage(c.reader, cursor, page, seen); r != "" {
+			return c.incomplete(o, r, cursor)
+		}
+		if !c.records(1 + int64(len(page.Items))*2) {
+			return c.incomplete(o, "exhausted_limits", cursor)
+		}
+		for _, sha := range page.Items {
+			if !objectID(sha, len(c.result.Evidence.Query.Bounds.Head)) || ids[sha] {
+				return c.incomplete(o, "provider_truncation", cursor)
+			}
+			ids[sha] = true
+			o.Source = append(o.Source, sha)
+		}
+		if page.Exhausted {
+			return o
+		}
+		cursor = page.NextCursor
+	}
+}
+
+func (c *collector) incomplete(o Observation, reason, page string) Observation {
+	o.Reason = reason
+	c.stop(reason, o.Change.Terminal, page)
+	return o
+}
+
+func (c *collector) identity(d platform.LandingChange, ref platform.LandingChangeRef) error {
+	if d.Ref != ref || d.TargetID <= 0 || strconv.FormatInt(d.TargetID, 10) != c.result.Evidence.Query.Bounds.Repository.ID {
+		return errors.New("landing change identity mismatch")
+	}
+	return nil
+}
+
+func validChange(d platform.LandingChange, size int) bool {
+	if d.SourceHead == nil || !objectID(*d.SourceHead, size) || d.SourceID != nil && *d.SourceID <= 0 {
+		return false
+	}
+	for _, sha := range []*string{d.MergeSHA, d.SquashSHA} {
+		if sha != nil && *sha != "" && !objectID(*sha, size) {
+			return false
+		}
+	}
+	return d.Terminal == "" || objectID(d.Terminal, size)
+}
+
+func clonePointer[T any](p *T) *T {
+	if p == nil {
+		return nil
+	}
+	return new(*p)
+}
+
+func cloneChange(d platform.LandingChange) platform.LandingChange {
+	d.SourceID, d.Merged = clonePointer(d.SourceID), clonePointer(d.Merged)
+	d.MergeSHA, d.SquashSHA, d.SourceHead = clonePointer(d.MergeSHA), clonePointer(d.SquashSHA), clonePointer(d.SourceHead)
+	d.SourceCount = clonePointer(d.SourceCount)
+	return d
+}
+
+func candidate(repo landedwork.Repository, o Observation) landedwork.Candidate {
+	c := landedwork.Candidate{Repository: repo, ID: strconv.FormatInt(o.Change.Ref.ID, 10), Terminal: o.Change.Terminal, TerminalEvidence: o.Change.TerminalEvidence, Source: slices.Clone(o.Source), SourceComplete: o.SourceComplete}
+	if o.Change.SourceHead != nil {
+		c.SourceHead = *o.Change.SourceHead
+	}
+	return c
+}

--- a/landedwork/collect/candidates.go
+++ b/landedwork/collect/candidates.go
@@ -18,7 +18,7 @@ func (c *collector) observe(ctx context.Context, ref platform.LandingChangeRef, 
 	}
 	detail, err := c.reader.GetLandingChange(ctx, c.route, ref)
 	if err != nil {
-		return c.incomplete(o, reason(err), ""), nil
+		return c.incomplete(o, c.reason(err), ""), nil
 	}
 	if err := c.identity(detail, ref); err != nil {
 		return Observation{}, err
@@ -48,7 +48,7 @@ func (c *collector) observe(ctx context.Context, ref platform.LandingChangeRef, 
 	}
 	after, err := c.reader.GetLandingChange(ctx, c.route, ref)
 	if err != nil {
-		return c.incomplete(o, reason(err), ""), nil
+		return c.incomplete(o, c.reason(err), ""), nil
 	}
 	if err := c.identity(after, ref); err != nil {
 		return Observation{}, err
@@ -69,7 +69,7 @@ func (c *collector) sources(ctx context.Context, o Observation) Observation {
 		}
 		page, err := c.reader.ListLandingSource(ctx, c.route, o.Change.Ref, cursor)
 		if err != nil {
-			return c.incomplete(o, reason(err), cursor)
+			return c.incomplete(o, c.reason(err), cursor)
 		}
 		if r := checkPage(c.reader, cursor, page, seen); r != "" {
 			return c.incomplete(o, r, cursor)

--- a/landedwork/collect/candidates.go
+++ b/landedwork/collect/candidates.go
@@ -132,9 +132,14 @@ func cloneChange(d platform.LandingChange) platform.LandingChange {
 	return d
 }
 
-func candidate(repo landedwork.Repository, o Observation) landedwork.Candidate {
-	c := landedwork.Candidate{Repository: repo, ID: strconv.FormatInt(o.Change.Ref.ID, 10), Terminal: o.Change.Terminal, TerminalEvidence: o.Change.TerminalEvidence, Source: slices.Clone(o.Source), SourceComplete: o.SourceComplete}
-	if o.Change.SourceHead != nil {
+func candidate(bounds landedwork.Bounds, o Observation) landedwork.Candidate {
+	c := landedwork.Candidate{Repository: bounds.Repository, ID: strconv.FormatInt(o.Change.Ref.ID, 10), Source: slices.Clone(o.Source), SourceComplete: o.SourceComplete}
+	// Preserve malformed provider values in the observation, not the analyzer's
+	// object-ID fields: missing evidence is a gap, invalid input is an error.
+	if objectID(o.Change.Terminal, len(bounds.Head)) {
+		c.Terminal, c.TerminalEvidence = o.Change.Terminal, o.Change.TerminalEvidence
+	}
+	if o.Change.SourceHead != nil && objectID(*o.Change.SourceHead, len(bounds.Head)) {
 		c.SourceHead = *o.Change.SourceHead
 	}
 	return c

--- a/landedwork/collect/collect.go
+++ b/landedwork/collect/collect.go
@@ -120,7 +120,7 @@ func Collect(ctx context.Context, reader platform.LandingEvidenceReader, route p
 			continue
 		}
 		c.result.Observations = append(c.result.Observations, observation)
-		c.result.Evidence.Candidates = append(c.result.Evidence.Candidates, candidate(query.Bounds.Repository, observation))
+		c.result.Evidence.Candidates = append(c.result.Evidence.Candidates, candidate(query.Bounds, observation))
 	}
 	c.result.Evidence.Inventory.Complete = c.result.Evidence.Inventory.Reason == ""
 	return c.result, nil

--- a/landedwork/collect/collect.go
+++ b/landedwork/collect/collect.go
@@ -34,6 +34,7 @@ type collector struct {
 	remaining Limits
 	result    Result
 	refs      map[int64]platform.LandingChangeRef
+	fatal     error
 }
 
 // Collect sweeps every queried commit and preserves unfinished candidates.
@@ -47,6 +48,9 @@ func Collect(ctx context.Context, reader platform.LandingEvidenceReader, route p
 	support := reader.LandingEvidenceSupport()
 	c := collector{reader: reader, route: route, remaining: limits, refs: make(map[int64]platform.LandingChangeRef), result: Result{Evidence: landedwork.Evidence{Query: query, Inventory: landedwork.Inventory{Supported: support.Inventory}, Capabilities: landedwork.Capabilities{Merge: support.OrdinaryMerge}}}}
 	defer func() {
+		if c.fatal != nil {
+			err = c.fatal
+		}
 		if ctx.Err() != nil {
 			err = ctx.Err()
 		}
@@ -71,7 +75,7 @@ func Collect(ctx context.Context, reader platform.LandingEvidenceReader, route p
 	}
 	repo, readErr := reader.GetRepository(ctx, route)
 	if readErr != nil {
-		c.stop(reason(readErr), "", "")
+		c.stop(c.reason(readErr), "", "")
 		return c.result, nil
 	}
 	if repo.Ref.Platform != query.Bounds.Repository.Provider || repo.Ref.Host != query.Bounds.Repository.Host || repo.PlatformID <= 0 || strconv.FormatInt(repo.PlatformID, 10) != query.Bounds.Repository.ID {
@@ -119,7 +123,7 @@ func (c *collector) sweep(ctx context.Context, commits []string) {
 			}
 			page, err := c.reader.ListLandingAssociations(ctx, c.route, sha, cursor)
 			if err != nil {
-				c.stop(reason(err), sha, cursor)
+				c.stop(c.reason(err), sha, cursor)
 				return
 			}
 			if r := checkPage(c.reader, cursor, page, seen); r != "" {
@@ -160,8 +164,11 @@ func checkPage[T any](r platform.LandingEvidenceReader, cursor string, p platfor
 	return ""
 }
 
-func reason(err error) string {
+func (c *collector) reason(err error) string {
 	switch {
+	case errors.Is(err, platform.ErrLandingIdentityMismatch), errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		c.fatal = err
+		return "request_failed"
 	case errors.Is(err, platform.ErrLandingTransportLimit):
 		return "exhausted_limits"
 	case errors.Is(err, platform.ErrLandingAbsenceAmbiguous):

--- a/landedwork/collect/collect.go
+++ b/landedwork/collect/collect.go
@@ -21,6 +21,9 @@ type Observation struct {
 	Source         []string
 	SourceComplete bool
 	Reason         string
+	// FailureStage names association, detail, source, or detail_recheck.
+	// NextPage is a diagnostic source cursor, not a resumable collection token.
+	FailureStage, NextPage string
 }
 
 type Result struct {
@@ -40,6 +43,8 @@ type collector struct {
 // Collect sweeps every queried commit and preserves unfinished candidates.
 // Invalid input, identity mismatch, cancellation, or output overflow yields no
 // result. Other failures return incomplete inventory, never proven absence.
+// Inventory.NextCommit/NextPage describe association-sweep failures only;
+// observation failures have their own stage and page. Neither supports resume.
 func Collect(ctx context.Context, reader platform.LandingEvidenceReader, route platform.RepoRef, query landedwork.Query, limits Limits) (result Result, err error) {
 	if err = validate(ctx, reader, route, query, limits); err != nil {
 		return Result{}, err
@@ -92,7 +97,18 @@ func Collect(ctx context.Context, reader platform.LandingEvidenceReader, route p
 	}
 	slices.Sort(ids)
 	for _, id := range ids {
-		observation := Observation{Change: platform.LandingChange{Ref: c.refs[id]}}
+		ref := c.refs[id]
+		observation := Observation{Change: platform.LandingChange{Ref: ref, TargetID: ref.TargetID}}
+		if ref.TargetID > 0 && strconv.FormatInt(ref.TargetID, 10) != query.Bounds.Repository.ID {
+			// Network-wide associations do not establish local PR absence.
+			observation.Reason, observation.FailureStage = "foreign_repository", "association"
+			c.result.Observations = append(c.result.Observations, observation)
+			c.stop("ambiguous_absence", "", "")
+			continue
+		}
+		if ref.TargetID <= 0 {
+			observation = c.incomplete(observation, "invalid_observation", "association", "")
+		}
 		if c.result.Evidence.Inventory.Reason == "" {
 			if observation, err = c.observe(ctx, c.refs[id], support.Sources); err != nil {
 				return Result{}, err

--- a/landedwork/collect/collect.go
+++ b/landedwork/collect/collect.go
@@ -13,7 +13,8 @@ import (
 )
 
 // Limits are positive per-invocation maxima. Calls count reader invocations,
-// not HTTP attempts. OutputBytes counts each retained occurrence of a string.
+// not HTTP attempts. Records includes all query commits and gaps, charged once
+// before collection. OutputBytes counts each retained occurrence of a string.
 type Limits struct{ Calls, Records, OutputBytes int64 }
 
 type Observation struct {
@@ -52,6 +53,7 @@ func Collect(ctx context.Context, reader platform.LandingEvidenceReader, route p
 	query.Commits, query.Gaps = slices.Clone(query.Commits), slices.Clone(query.Gaps)
 	support := reader.LandingEvidenceSupport()
 	c := collector{reader: reader, route: route, remaining: limits, refs: make(map[int64]platform.LandingChangeRef), result: Result{Evidence: landedwork.Evidence{Query: query, Inventory: landedwork.Inventory{Supported: support.Inventory}, Capabilities: landedwork.Capabilities{Merge: support.OrdinaryMerge}}}}
+	c.remaining.Records -= int64(len(query.Commits)) + int64(len(query.Gaps))
 	defer func() {
 		if c.fatal != nil {
 			err = c.fatal
@@ -74,7 +76,7 @@ func Collect(ctx context.Context, reader platform.LandingEvidenceReader, route p
 		c.stop("unsupported_discovery", "", "")
 		return c.result, nil
 	}
-	if !c.records(int64(len(query.Gaps))) || !c.call() {
+	if !c.call() {
 		c.stop("exhausted_limits", "", "")
 		return c.result, nil
 	}
@@ -126,10 +128,6 @@ func Collect(ctx context.Context, reader platform.LandingEvidenceReader, route p
 
 func (c *collector) sweep(ctx context.Context, commits []string) {
 	for _, sha := range commits {
-		if !c.records(1) {
-			c.stop("exhausted_limits", sha, "")
-			return
-		}
 		cursor := ""
 		seen := make(map[string]bool)
 		for {

--- a/landedwork/collect/collect.go
+++ b/landedwork/collect/collect.go
@@ -1,0 +1,199 @@
+// Package collect obtains provider evidence for a prepared local Git interval.
+// It neither traverses Git nor supplies credentials or transport policy.
+package collect
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strconv"
+
+	"go.kenn.io/forge/landedwork"
+	"go.kenn.io/forge/platform"
+)
+
+// Limits are positive per-invocation maxima. Calls count reader invocations,
+// not HTTP attempts. OutputBytes counts each retained occurrence of a string.
+type Limits struct{ Calls, Records, OutputBytes int64 }
+
+type Observation struct {
+	Change         platform.LandingChange
+	Source         []string
+	SourceComplete bool
+	Reason         string
+}
+
+type Result struct {
+	Evidence     landedwork.Evidence
+	Observations []Observation
+}
+
+type collector struct {
+	reader    platform.LandingEvidenceReader
+	route     platform.RepoRef
+	remaining Limits
+	result    Result
+	refs      map[int64]platform.LandingChangeRef
+}
+
+// Collect sweeps every queried commit and preserves unfinished candidates.
+// Invalid input, identity mismatch, cancellation, or output overflow yields no
+// result. Other failures return incomplete inventory, never proven absence.
+func Collect(ctx context.Context, reader platform.LandingEvidenceReader, route platform.RepoRef, query landedwork.Query, limits Limits) (result Result, err error) {
+	if err = validate(ctx, reader, route, query, limits); err != nil {
+		return Result{}, err
+	}
+	query.Commits, query.Gaps = slices.Clone(query.Commits), slices.Clone(query.Gaps)
+	support := reader.LandingEvidenceSupport()
+	c := collector{reader: reader, route: route, remaining: limits, refs: make(map[int64]platform.LandingChangeRef), result: Result{Evidence: landedwork.Evidence{Query: query, Inventory: landedwork.Inventory{Supported: support.Inventory}, Capabilities: landedwork.Capabilities{Merge: support.OrdinaryMerge}}}}
+	defer func() {
+		if ctx.Err() != nil {
+			err = ctx.Err()
+		}
+		if err == nil && resultBytes(result) > limits.OutputBytes {
+			err = landedwork.ErrOutputBudget
+		}
+		if err != nil {
+			result = Result{}
+		}
+	}()
+	if !query.Complete {
+		c.stop("preparation_incomplete", "", "")
+		return c.result, nil
+	}
+	if !support.Inventory {
+		c.stop("unsupported_discovery", "", "")
+		return c.result, nil
+	}
+	if !c.records(int64(len(query.Gaps))) || !c.call() {
+		c.stop("exhausted_limits", "", "")
+		return c.result, nil
+	}
+	repo, readErr := reader.GetRepository(ctx, route)
+	if readErr != nil {
+		c.stop(reason(readErr), "", "")
+		return c.result, nil
+	}
+	if repo.Ref.Platform != query.Bounds.Repository.Provider || repo.Ref.Host != query.Bounds.Repository.Host || repo.PlatformID <= 0 || strconv.FormatInt(repo.PlatformID, 10) != query.Bounds.Repository.ID {
+		return Result{}, errors.New("landing repository identity mismatch")
+	}
+	if !c.records(1) {
+		c.stop("exhausted_limits", "", "")
+		return c.result, nil
+	}
+	c.sweep(ctx, query.Commits)
+	ids := make([]int64, 0, len(c.refs))
+	for id := range c.refs {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	for _, id := range ids {
+		observation := Observation{Change: platform.LandingChange{Ref: c.refs[id]}}
+		if c.result.Evidence.Inventory.Reason == "" {
+			if observation, err = c.observe(ctx, c.refs[id], support.Sources); err != nil {
+				return Result{}, err
+			}
+		}
+		if observation.Change.Merged != nil && !*observation.Change.Merged {
+			continue
+		}
+		c.result.Observations = append(c.result.Observations, observation)
+		c.result.Evidence.Candidates = append(c.result.Evidence.Candidates, candidate(query.Bounds.Repository, observation))
+	}
+	c.result.Evidence.Inventory.Complete = c.result.Evidence.Inventory.Reason == ""
+	return c.result, nil
+}
+
+func (c *collector) sweep(ctx context.Context, commits []string) {
+	for _, sha := range commits {
+		if !c.records(1) {
+			c.stop("exhausted_limits", sha, "")
+			return
+		}
+		cursor := ""
+		seen := make(map[string]bool)
+		for {
+			if !c.call() {
+				c.stop("exhausted_limits", sha, cursor)
+				return
+			}
+			page, err := c.reader.ListLandingAssociations(ctx, c.route, sha, cursor)
+			if err != nil {
+				c.stop(reason(err), sha, cursor)
+				return
+			}
+			if r := checkPage(c.reader, cursor, page, seen); r != "" {
+				c.stop(r, sha, cursor)
+				return
+			}
+			if !c.records(1 + int64(len(page.Items))*3) {
+				c.stop("exhausted_limits", sha, cursor)
+				return
+			}
+			for _, ref := range page.Items {
+				if ref.ID <= 0 || ref.Number <= 0 {
+					c.stop("invalid_observation", sha, cursor)
+					return
+				}
+				if old, ok := c.refs[ref.ID]; ok && old != ref {
+					c.stop("changed_observation", sha, cursor)
+					return
+				}
+				c.refs[ref.ID] = ref
+			}
+			if page.Exhausted {
+				break
+			}
+			cursor = page.NextCursor
+		}
+	}
+}
+
+func checkPage[T any](r platform.LandingEvidenceReader, cursor string, p platform.Page[T], seen map[string]bool) string {
+	if p.NextCursor != "" && (p.NextCursor == cursor || seen[p.NextCursor]) {
+		return "repeated_cursor"
+	}
+	if platform.ValidatePage(r.Platform(), r.Host(), cursor, p) != nil {
+		return "provider_truncation"
+	}
+	seen[p.NextCursor] = true
+	return ""
+}
+
+func reason(err error) string {
+	switch {
+	case errors.Is(err, platform.ErrLandingTransportLimit):
+		return "exhausted_limits"
+	case errors.Is(err, platform.ErrLandingAbsenceAmbiguous):
+		return "ambiguous_absence"
+	case errors.Is(err, platform.ErrUnsupportedCapability):
+		return "unsupported_discovery"
+	default:
+		return "request_failed"
+	}
+}
+
+func (c *collector) stop(reason, commit, page string) {
+	if c.result.Evidence.Inventory.Reason != "" {
+		return
+	}
+	c.result.Evidence.Inventory.Reason = reason
+	c.result.Evidence.Inventory.NextCommit = commit
+	c.result.Evidence.Inventory.NextPage = page
+}
+
+func (c *collector) call() bool {
+	if c.remaining.Calls == 0 {
+		return false
+	}
+	c.remaining.Calls--
+	return true
+}
+
+func (c *collector) records(n int64) bool {
+	if n > c.remaining.Records {
+		return false
+	}
+	c.remaining.Records -= n
+	return true
+}

--- a/landedwork/collect/collect_test.go
+++ b/landedwork/collect/collect_test.go
@@ -1,0 +1,302 @@
+package collect_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/landedwork"
+	"go.kenn.io/forge/landedwork/collect"
+	"go.kenn.io/forge/platform"
+)
+
+var (
+	base   = strings.Repeat("a", 40)
+	head   = strings.Repeat("b", 40)
+	source = strings.Repeat("c", 40)
+	route  = platform.RepoRef{Platform: platform.KindGitHub, Host: "github.com", Owner: "example", Name: "project"}
+	query  = landedwork.Query{Bounds: landedwork.Bounds{Repository: landedwork.Repository{Provider: platform.KindGitHub, Host: "github.com", ID: "12"}, Base: base, Head: head}, Commits: []string{head, source}, Complete: true}
+	limits = collect.Limits{Calls: 100, Records: 1000, OutputBytes: 100000}
+)
+
+type script struct {
+	platform.LandingEvidenceReader
+	t      *testing.T
+	steps  []step
+	policy platform.LandingSourcePolicy
+}
+
+type step struct {
+	key   string
+	value any
+	err   error
+}
+
+func (s *script) next(key string) (any, error) {
+	s.t.Helper()
+	require.NotEmpty(s.t, s.steps, "unexpected call %s", key)
+	v := s.steps[0]
+	s.steps = s.steps[1:]
+	require.Equal(s.t, v.key, key)
+	return v.value, v.err
+}
+
+func (s *script) Platform() platform.Kind { return platform.KindGitHub }
+func (s *script) Host() string            { return "github.com" }
+func (s *script) LandingEvidenceSupport() platform.LandingEvidenceSupport {
+	return platform.LandingEvidenceSupport{Inventory: true, OrdinaryMerge: true, Sources: s.policy}
+}
+func (s *script) GetRepository(_ context.Context, r platform.RepoRef) (platform.Repository, error) {
+	require.Equal(s.t, route, r)
+	v, err := s.next("repository")
+	if err != nil {
+		return platform.Repository{}, err
+	}
+	return v.(platform.Repository), nil
+}
+func (s *script) ListLandingAssociations(_ context.Context, r platform.RepoRef, sha, cursor string) (platform.Page[platform.LandingChangeRef], error) {
+	require.Equal(s.t, route, r)
+	v, err := s.next("association/" + sha + "/" + cursor)
+	if err != nil {
+		return platform.Page[platform.LandingChangeRef]{}, err
+	}
+	return v.(platform.Page[platform.LandingChangeRef]), nil
+}
+func (s *script) GetLandingChange(_ context.Context, _ platform.RepoRef, ref platform.LandingChangeRef) (platform.LandingChange, error) {
+	require.Equal(s.t, platform.LandingChangeRef{ID: 7, Number: 3}, ref)
+	v, err := s.next("detail")
+	if err != nil {
+		return platform.LandingChange{}, err
+	}
+	return v.(platform.LandingChange), nil
+}
+func (s *script) ListLandingSource(_ context.Context, _ platform.RepoRef, ref platform.LandingChangeRef, cursor string) (platform.Page[string], error) {
+	require.Equal(s.t, platform.LandingChangeRef{ID: 7, Number: 3}, ref)
+	v, err := s.next("source/" + cursor)
+	if err != nil {
+		return platform.Page[string]{}, err
+	}
+	return v.(platform.Page[string]), nil
+}
+
+func mergedScript(t *testing.T) *script {
+	t.Helper()
+	detail := platform.LandingChange{Ref: platform.LandingChangeRef{ID: 7, Number: 3}, TargetID: 12, TargetBranch: "main", Merged: new(true), MergeSHA: new(head), SourceHead: new(source), SourceCount: new(int64(1)), Terminal: head, TerminalEvidence: "merged_commit_sha"}
+	s := &script{t: t, policy: platform.LandingSourcePolicy{RequireCount: true, MaxCommits: 250}, steps: []step{
+		{key: "repository", value: platform.Repository{Ref: route, PlatformID: 12}},
+		{key: "association/" + head + "/", value: platform.Page[platform.LandingChangeRef]{Items: []platform.LandingChangeRef{{ID: 7, Number: 3}}, NextCursor: "next"}},
+		{key: "association/" + head + "/next", value: platform.Page[platform.LandingChangeRef]{Items: []platform.LandingChangeRef{{ID: 7, Number: 3}}, Exhausted: true}},
+		{key: "association/" + source + "/", value: platform.Page[platform.LandingChangeRef]{Exhausted: true}},
+		{key: "detail", value: detail},
+		{key: "source/", value: platform.Page[string]{Items: []string{source}, Exhausted: true}},
+		{key: "detail", value: detail},
+	}}
+	return s
+}
+
+func TestCollectCompleteSweep(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+	s := mergedScript(t)
+	got, err := collect.Collect(ctx, s, route, query, limits)
+	require.NoError(t, err)
+	assert := assert.New(t)
+	assert.Empty(s.steps)
+	assert.Equal(query, got.Evidence.Query)
+	assert.True(got.Evidence.Inventory.Complete)
+	require.Len(t, got.Evidence.Candidates, 1)
+	assert.Equal("7", got.Evidence.Candidates[0].ID)
+	assert.Equal([]string{source}, got.Evidence.Candidates[0].Source)
+	assert.True(got.Evidence.Candidates[0].SourceComplete)
+	assert.Equal(landedwork.Capabilities{Merge: true}, got.Evidence.Capabilities)
+}
+
+func TestCollectInterruptedSweepPreservesCandidate(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+	s := mergedScript(t)
+	s.steps = s.steps[:4]
+	s.steps[3] = step{key: "association/" + source + "/", err: errors.New("unavailable")}
+	got, err := collect.Collect(ctx, s, route, query, limits)
+	require.NoError(t, err)
+	assert := assert.New(t)
+	assert.False(got.Evidence.Inventory.Complete)
+	assert.Equal("request_failed", got.Evidence.Inventory.Reason)
+	assert.Equal(source, got.Evidence.Inventory.NextCommit)
+	require.Len(t, got.Evidence.Candidates, 1)
+	assert.Equal("7", got.Evidence.Candidates[0].ID)
+	assert.False(got.Evidence.Candidates[0].SourceComplete)
+}
+
+func TestCollectSourceProof(t *testing.T) {
+	for _, tc := range []struct {
+		name, reason string
+		edit         func(*script)
+	}{
+		{"required count absent", "provider_truncation", func(s *script) {
+			d := s.steps[4].value.(platform.LandingChange)
+			d.SourceCount = nil
+			s.steps[4].value = d
+			s.steps = s.steps[:5]
+		}},
+		{"optional count absent", "", func(s *script) {
+			s.policy.RequireCount = false
+			d := s.steps[4].value.(platform.LandingChange)
+			d.SourceCount = nil
+			s.steps[4].value = d
+			s.steps[6].value = d
+		}},
+		{"count beyond cap", "provider_truncation", func(s *script) {
+			d := s.steps[4].value.(platform.LandingChange)
+			d.SourceCount = new(int64(251))
+			s.steps[4].value = d
+			s.steps = s.steps[:5]
+		}},
+		{"count mismatch", "provider_truncation", func(s *script) {
+			d := s.steps[4].value.(platform.LandingChange)
+			d.SourceCount = new(int64(2))
+			s.steps[4].value = d
+			s.steps = s.steps[:6]
+		}},
+		{"head absent", "invalid_observation", func(s *script) {
+			d := s.steps[4].value.(platform.LandingChange)
+			d.SourceHead = nil
+			s.steps[4].value = d
+			s.steps = s.steps[:5]
+		}},
+		{"head outside sources", "provider_truncation", func(s *script) {
+			s.steps[5].value = platform.Page[string]{Items: []string{base}, Exhausted: true}
+			s.steps = s.steps[:6]
+		}},
+		{"duplicate source", "provider_truncation", func(s *script) {
+			s.steps[5].value = platform.Page[string]{Items: []string{source, source}, Exhausted: true}
+			s.steps = s.steps[:6]
+		}},
+		{"detail changed", "changed_observation", func(s *script) {
+			d := s.steps[6].value.(platform.LandingChange)
+			d.SourceCount = new(int64(2))
+			s.steps[6].value = d
+		}},
+		{"source continuation failed", "request_failed", func(s *script) {
+			s.steps[5].value = platform.Page[string]{Items: []string{source}, NextCursor: "next"}
+			s.steps[6] = step{key: "source/next", err: errors.New("unavailable")}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+			defer cancel()
+			s := mergedScript(t)
+			tc.edit(s)
+			got, err := collect.Collect(ctx, s, route, query, limits)
+			require.NoError(t, err)
+			assert := assert.New(t)
+			assert.Empty(s.steps)
+			assert.Equal(tc.reason, got.Evidence.Inventory.Reason)
+			require.Len(t, got.Evidence.Candidates, 1)
+			assert.Equal(tc.reason == "", got.Evidence.Candidates[0].SourceComplete)
+			assert.Equal(tc.reason == "", got.Evidence.Inventory.Complete)
+		})
+	}
+}
+
+func TestCollectLimitsAndFailures(t *testing.T) {
+	for _, tc := range []struct {
+		name, reason   string
+		calls, records int64
+		fail           error
+	}{
+		{"calls", "exhausted_limits", 2, 1000, nil},
+		{"whole page records", "exhausted_limits", 100, 5, nil},
+		{"transport limit", "exhausted_limits", 100, 1000, platform.ErrLandingTransportLimit},
+		{"ambiguous absence", "ambiguous_absence", 100, 1000, platform.ErrLandingAbsenceAmbiguous},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+			defer cancel()
+			s := mergedScript(t)
+			if tc.fail != nil {
+				s.steps[2] = step{key: "association/" + head + "/next", err: tc.fail}
+			}
+			got, err := collect.Collect(ctx, s, route, query, collect.Limits{Calls: tc.calls, Records: tc.records, OutputBytes: 100000})
+			require.NoError(t, err)
+			assert := assert.New(t)
+			assert.Equal(tc.reason, got.Evidence.Inventory.Reason)
+			assert.False(got.Evidence.Inventory.Complete)
+			assert.Equal(head, got.Evidence.Inventory.NextCommit)
+		})
+	}
+}
+
+func TestCollectNoResultOnInvalidInput(t *testing.T) {
+	for _, tc := range []string{"deadline", "canceled", "identity", "output", "duplicate query", "invalid limit"} {
+		t.Run(tc, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+			defer cancel()
+			s := mergedScript(t)
+			q, l := query, limits
+			switch tc {
+			case "deadline":
+				ctx = t.Context()
+			case "canceled":
+				cancel()
+			case "identity":
+				s.steps[0].value = platform.Repository{Ref: route, PlatformID: 99}
+			case "output":
+				l.OutputBytes = 1
+			case "duplicate query":
+				q.Commits = []string{head, head}
+			case "invalid limit":
+				l.Calls = 0
+			}
+			got, err := collect.Collect(ctx, s, route, q, l)
+			require.Error(t, err)
+			assert.Equal(t, collect.Result{}, got)
+		})
+	}
+}
+
+func TestCollectRetainsPreparationGapsWithoutReads(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+	s := &script{t: t}
+	q := query
+	q.Complete = false
+	q.Gaps = []landedwork.Gap{{ObjectID: base, Reason: "objects_unavailable"}}
+	got, err := collect.Collect(ctx, s, route, q, limits)
+	require.NoError(t, err)
+	assert.Equal(t, q, got.Evidence.Query)
+	assert.False(t, got.Evidence.Inventory.Complete)
+}
+
+func TestCollectOwnsObservations(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+	s := mergedScript(t)
+	d := s.steps[4].value.(platform.LandingChange)
+	got, err := collect.Collect(ctx, s, route, query, limits)
+	require.NoError(t, err)
+	*d.SourceCount = 42
+	got.Observations[0].Source[0] = base
+	got.Evidence.Query.Commits[0] = base
+	assert := assert.New(t)
+	assert.Equal(int64(1), *got.Observations[0].Change.SourceCount)
+	assert.Equal(source, got.Evidence.Candidates[0].Source[0])
+	assert.Equal(head, query.Commits[0])
+}
+
+func TestCollectCursorCycle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+	s := mergedScript(t)
+	s.steps = s.steps[:3]
+	s.steps[2].value = platform.Page[platform.LandingChangeRef]{NextCursor: "again", ProgressOnly: true}
+	s.steps = append(s.steps, step{key: "association/" + head + "/again", value: platform.Page[platform.LandingChangeRef]{NextCursor: "next", ProgressOnly: true}})
+	got, err := collect.Collect(ctx, s, route, query, limits)
+	require.NoError(t, err)
+	assert.Equal(t, "repeated_cursor", got.Evidence.Inventory.Reason)
+	assert.False(t, got.Evidence.Inventory.Complete)
+}

--- a/landedwork/collect/collect_test.go
+++ b/landedwork/collect/collect_test.go
@@ -232,7 +232,7 @@ func TestCollectLimitsAndFailures(t *testing.T) {
 }
 
 func TestCollectNoResultOnInvalidInput(t *testing.T) {
-	for _, tc := range []string{"deadline", "canceled", "identity", "output", "duplicate query", "invalid limit"} {
+	for _, tc := range []string{"deadline", "canceled", "identity", "reader identity", "output", "duplicate query", "invalid limit"} {
 		t.Run(tc, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
 			defer cancel()
@@ -245,6 +245,8 @@ func TestCollectNoResultOnInvalidInput(t *testing.T) {
 				cancel()
 			case "identity":
 				s.steps[0].value = platform.Repository{Ref: route, PlatformID: 99}
+			case "reader identity":
+				s.steps[4] = step{key: "detail", err: platform.ErrLandingIdentityMismatch}
 			case "output":
 				l.OutputBytes = 1
 			case "duplicate query":

--- a/landedwork/collect/collect_test.go
+++ b/landedwork/collect/collect_test.go
@@ -25,9 +25,10 @@ var (
 
 type script struct {
 	platform.LandingEvidenceReader
-	t      *testing.T
-	steps  []step
-	policy platform.LandingSourcePolicy
+	t           *testing.T
+	steps       []step
+	policy      platform.LandingSourcePolicy
+	unsupported bool
 }
 
 type step struct {
@@ -48,8 +49,59 @@ func (s *script) next(key string) (any, error) {
 func (s *script) Platform() platform.Kind { return platform.KindGitHub }
 func (s *script) Host() string            { return "github.com" }
 func (s *script) LandingEvidenceSupport() platform.LandingEvidenceSupport {
-	return platform.LandingEvidenceSupport{Inventory: true, OrdinaryMerge: true, Sources: s.policy}
+	return platform.LandingEvidenceSupport{Inventory: !s.unsupported, OrdinaryMerge: true, Sources: s.policy}
 }
+
+func TestCollectQueryRecordsBeforeEarlyReturn(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		commits  []string
+		gaps     []landedwork.Gap
+		complete bool
+	}{
+		{name: "incomplete commits", commits: []string{head, source}},
+		{name: "empty gaps", gaps: []landedwork.Gap{{}, {}}},
+		{name: "combined rows", commits: []string{head}, gaps: []landedwork.Gap{{}}},
+		{name: "unsupported discovery", commits: []string{head, source}, complete: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+			defer cancel()
+			q := query
+			q.Commits, q.Gaps, q.Complete = tc.commits, tc.gaps, tc.complete
+			s := &script{t: t, unsupported: tc.complete}
+			l := limits
+			l.Records = 1
+			got, err := collect.Collect(ctx, s, route, q, l)
+			require.ErrorIs(err, landedwork.ErrOutputBudget)
+			require.Equal(collect.Result{}, got)
+			l.Records = 2
+			got, err = collect.Collect(ctx, s, route, q, l)
+			require.NoError(err)
+			assert.Equal(t, q, got.Evidence.Query)
+			assert.False(t, got.Evidence.Inventory.Complete)
+		})
+	}
+}
+
+func TestCollectQueryRecordsChargedOnce(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+	s := &script{t: t, steps: []step{
+		{key: "repository", value: platform.Repository{Ref: route, PlatformID: 12}},
+		{key: "association/" + head + "/", value: platform.Page[platform.LandingChangeRef]{Exhausted: true}},
+		{key: "association/" + source + "/", value: platform.Page[platform.LandingChangeRef]{Exhausted: true}},
+	}}
+	l := limits
+	// Two query commits, one repository, and two empty association pages.
+	l.Records = 5
+	got, err := collect.Collect(ctx, s, route, query, l)
+	require.NoError(t, err)
+	assert.True(t, got.Evidence.Inventory.Complete)
+	assert.Empty(t, s.steps)
+}
+
 func (s *script) GetRepository(_ context.Context, r platform.RepoRef) (platform.Repository, error) {
 	require.Equal(s.t, route, r)
 	v, err := s.next("repository")

--- a/landedwork/collect/collect_test.go
+++ b/landedwork/collect/collect_test.go
@@ -67,7 +67,7 @@ func (s *script) ListLandingAssociations(_ context.Context, r platform.RepoRef, 
 	return v.(platform.Page[platform.LandingChangeRef]), nil
 }
 func (s *script) GetLandingChange(_ context.Context, _ platform.RepoRef, ref platform.LandingChangeRef) (platform.LandingChange, error) {
-	require.Equal(s.t, platform.LandingChangeRef{ID: 7, Number: 3}, ref)
+	require.Equal(s.t, platform.LandingChangeRef{ID: 7, Number: 3, TargetID: 12}, ref)
 	v, err := s.next("detail")
 	if err != nil {
 		return platform.LandingChange{}, err
@@ -75,7 +75,7 @@ func (s *script) GetLandingChange(_ context.Context, _ platform.RepoRef, ref pla
 	return v.(platform.LandingChange), nil
 }
 func (s *script) ListLandingSource(_ context.Context, _ platform.RepoRef, ref platform.LandingChangeRef, cursor string) (platform.Page[string], error) {
-	require.Equal(s.t, platform.LandingChangeRef{ID: 7, Number: 3}, ref)
+	require.Equal(s.t, platform.LandingChangeRef{ID: 7, Number: 3, TargetID: 12}, ref)
 	v, err := s.next("source/" + cursor)
 	if err != nil {
 		return platform.Page[string]{}, err
@@ -85,11 +85,11 @@ func (s *script) ListLandingSource(_ context.Context, _ platform.RepoRef, ref pl
 
 func mergedScript(t *testing.T) *script {
 	t.Helper()
-	detail := platform.LandingChange{Ref: platform.LandingChangeRef{ID: 7, Number: 3}, TargetID: 12, TargetBranch: "main", Merged: new(true), MergeSHA: new(head), SourceHead: new(source), SourceCount: new(int64(1)), Terminal: head, TerminalEvidence: "merged_commit_sha"}
+	detail := platform.LandingChange{Ref: platform.LandingChangeRef{ID: 7, Number: 3, TargetID: 12}, TargetID: 12, TargetBranch: "main", Merged: new(true), MergeSHA: new(head), SourceHead: new(source), SourceCount: new(int64(1)), Terminal: head, TerminalEvidence: "merged_commit_sha"}
 	s := &script{t: t, policy: platform.LandingSourcePolicy{RequireCount: true, MaxCommits: 250}, steps: []step{
 		{key: "repository", value: platform.Repository{Ref: route, PlatformID: 12}},
-		{key: "association/" + head + "/", value: platform.Page[platform.LandingChangeRef]{Items: []platform.LandingChangeRef{{ID: 7, Number: 3}}, NextCursor: "next"}},
-		{key: "association/" + head + "/next", value: platform.Page[platform.LandingChangeRef]{Items: []platform.LandingChangeRef{{ID: 7, Number: 3}}, Exhausted: true}},
+		{key: "association/" + head + "/", value: platform.Page[platform.LandingChangeRef]{Items: []platform.LandingChangeRef{{ID: 7, Number: 3, TargetID: 12}}, NextCursor: "next"}},
+		{key: "association/" + head + "/next", value: platform.Page[platform.LandingChangeRef]{Items: []platform.LandingChangeRef{{ID: 7, Number: 3, TargetID: 12}}, Exhausted: true}},
 		{key: "association/" + source + "/", value: platform.Page[platform.LandingChangeRef]{Exhausted: true}},
 		{key: "detail", value: detail},
 		{key: "source/", value: platform.Page[string]{Items: []string{source}, Exhausted: true}},
@@ -199,6 +199,8 @@ func TestCollectSourceProof(t *testing.T) {
 			require.Len(t, got.Evidence.Candidates, 1)
 			assert.Equal(tc.reason == "", got.Evidence.Candidates[0].SourceComplete)
 			assert.Equal(tc.reason == "", got.Evidence.Inventory.Complete)
+			assert.Empty(got.Evidence.Inventory.NextCommit, "candidate failures are not association sweep positions")
+			assert.Empty(got.Evidence.Inventory.NextPage, "source cursors are not association cursors")
 		})
 	}
 }
@@ -227,6 +229,77 @@ func TestCollectLimitsAndFailures(t *testing.T) {
 			assert.Equal(tc.reason, got.Evidence.Inventory.Reason)
 			assert.False(got.Evidence.Inventory.Complete)
 			assert.Equal(head, got.Evidence.Inventory.NextCommit)
+		})
+	}
+}
+
+func TestCollectObservationFailureLocation(t *testing.T) {
+	for _, tc := range []struct {
+		name, stage, page string
+		index             int
+	}{
+		{"first detail", "detail", "", 4},
+		{"source continuation", "source", "next", 6},
+		{"detail recheck", "detail_recheck", "", 6},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+			defer cancel()
+			s := mergedScript(t)
+			key := "detail"
+			if tc.stage == "source" {
+				s.steps[5].value = platform.Page[string]{Items: []string{source}, NextCursor: "next"}
+				key = "source/next"
+			}
+			s.steps[tc.index] = step{key: key, err: errors.New("unavailable")}
+			s.steps = s.steps[:tc.index+1]
+			got, err := collect.Collect(ctx, s, route, query, limits)
+			require.NoError(t, err)
+			require.Len(t, got.Observations, 1)
+			assert := assert.New(t)
+			assert.False(got.Evidence.Inventory.Complete)
+			assert.Empty(got.Evidence.Inventory.NextCommit)
+			assert.Empty(got.Evidence.Inventory.NextPage)
+			assert.Equal(int64(7), got.Observations[0].Change.Ref.ID)
+			assert.Equal("request_failed", got.Observations[0].Reason)
+			assert.Equal(tc.stage, got.Observations[0].FailureStage)
+			assert.Equal(tc.page, got.Observations[0].NextPage)
+		})
+	}
+}
+
+func TestCollectTargetIdentity(t *testing.T) {
+	for _, tc := range []struct {
+		name, stage string
+		index       int
+		target      int64
+	}{
+		{"missing detail target", "detail", 4, 0},
+		{"missing recheck target", "detail_recheck", 6, 0},
+		{"conflicting detail target", "detail", 4, 99},
+		{"conflicting recheck target", "detail_recheck", 6, 99},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+			defer cancel()
+			s := mergedScript(t)
+			d := s.steps[tc.index].value.(platform.LandingChange)
+			d.TargetID = tc.target
+			s.steps[tc.index].value = d
+			s.steps = s.steps[:tc.index+1]
+			got, err := collect.Collect(ctx, s, route, query, limits)
+			if tc.target != 0 {
+				require.ErrorIs(err, platform.ErrLandingIdentityMismatch)
+				assert.Equal(collect.Result{}, got)
+				return
+			}
+			require.NoError(err)
+			require.Len(got.Evidence.Candidates, 1)
+			require.Len(got.Observations, 1)
+			assert.False(got.Evidence.Inventory.Complete)
+			assert.Equal("invalid_observation", got.Observations[0].Reason)
+			assert.Equal(tc.stage, got.Observations[0].FailureStage)
 		})
 	}
 }

--- a/landedwork/collect/github_test.go
+++ b/landedwork/collect/github_test.go
@@ -23,7 +23,7 @@ import (
 func TestMain(m *testing.M) { os.Exit(gitsafe.RunIsolatedMain(m)) }
 
 func TestGitHubCollectionAnalysis(t *testing.T) {
-	for _, mode := range []string{"merge", "no associations", "failed page", "changed detail", "one parent", "foreign association", "missing base"} {
+	for _, mode := range []string{"merge", "no associations", "failed page", "changed detail", "one parent", "foreign association", "missing base", "malformed terminal", "malformed source head"} {
 		t.Run(mode, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			r := gittest.NewRepo(t, gittest.Options{InitArgs: []string{"init", "-b", "main"}, ConfigureUser: true})
@@ -74,7 +74,14 @@ func TestGitHubCollectionAnalysis(t *testing.T) {
 					if mode == "changed detail" && details == 2 {
 						count = 2
 					}
-					body = fmt.Sprintf(`{"id":7,"number":3,"merged":true,"merge_commit_sha":%q,"commits":%d,"base":{"ref":"main","repo":{"id":12}},"head":{"sha":%q,"repo":{"id":12}}}`, head, count, source)
+					terminal, sourceHead := head, source
+					if mode == "malformed terminal" {
+						terminal = "not-an-object-id"
+					}
+					if mode == "malformed source head" {
+						sourceHead = strings.Repeat("a", 64) // Wrong object format for this repository.
+					}
+					body = fmt.Sprintf(`{"id":7,"number":3,"merged":true,"merge_commit_sha":%q,"commits":%d,"base":{"ref":"main","repo":{"id":12}},"head":{"sha":%q,"repo":{"id":12}}}`, terminal, count, sourceHead)
 					if mode == "missing base" {
 						body = `{"id":7,"number":3,"merged":true}`
 					}
@@ -98,12 +105,29 @@ func TestGitHubCollectionAnalysis(t *testing.T) {
 				assert.Equal("foreign_repository", collected.Observations[0].Reason)
 				assert.Equal("ambiguous_absence", collected.Evidence.Inventory.Reason)
 			}
-			if mode == "missing base" {
+			if mode == "missing base" || strings.HasPrefix(mode, "malformed ") {
 				require.Len(collected.Evidence.Candidates, 1)
 				assert.Equal("invalid_observation", collected.Evidence.Inventory.Reason)
 			}
 			analysis, err := landedwork.Analyze(ctx, prepared, collected.Evidence, analysisLimits)
 			require.NoError(err)
+			if strings.HasPrefix(mode, "malformed ") {
+				require.Len(collected.Observations, 1)
+				assert.Equal("7", collected.Evidence.Candidates[0].ID)
+				assert.False(collected.Evidence.Candidates[0].SourceComplete)
+				assert.Equal("invalid_observation", analysis.Coverage.Inventory.Reason)
+				assert.Empty(analysis.Landings)
+				if mode == "malformed terminal" {
+					assert.Equal("not-an-object-id", collected.Observations[0].Change.Terminal)
+					assert.Empty(collected.Evidence.Candidates[0].Terminal)
+					assert.Empty(collected.Evidence.Candidates[0].TerminalEvidence)
+					assert.Equal(source, collected.Evidence.Candidates[0].SourceHead)
+				} else {
+					assert.Equal(new(strings.Repeat("a", 64)), collected.Observations[0].Change.SourceHead)
+					assert.Empty(collected.Evidence.Candidates[0].SourceHead)
+					assert.Equal(head, collected.Evidence.Candidates[0].Terminal)
+				}
+			}
 			switch mode {
 			case "merge":
 				assert.True(analysis.Coverage.Complete)

--- a/landedwork/collect/github_test.go
+++ b/landedwork/collect/github_test.go
@@ -1,0 +1,108 @@
+package collect_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/testutil/gitsafe"
+	"go.kenn.io/forge/landedwork"
+	"go.kenn.io/forge/landedwork/collect"
+	"go.kenn.io/forge/platform"
+	"go.kenn.io/forge/platform/github"
+	gittest "go.kenn.io/kit/git/test"
+)
+
+func TestMain(m *testing.M) { os.Exit(gitsafe.RunIsolatedMain(m)) }
+
+func TestGitHubCollectionAnalysis(t *testing.T) {
+	for _, mode := range []string{"merge", "no associations", "failed page", "changed detail", "one parent"} {
+		t.Run(mode, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			r := gittest.NewRepo(t, gittest.Options{InitArgs: []string{"init", "-b", "main"}, ConfigureUser: true})
+			r.Runner = gitsafe.Runner()
+			base := r.CommitFile("work.txt", "old\n", "base")
+			r.Checkout("-b", "topic")
+			source := r.CommitFile("work.txt", "new\n", "change")
+			r.Checkout("main")
+			if mode == "one parent" {
+				r.Run("merge", "--squash", "topic")
+				r.Run("commit", "-m", "squash")
+			} else {
+				r.Run("merge", "--no-ff", "topic", "-m", "merge")
+			}
+			head := r.Head()
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+			defer cancel()
+			analysisLimits := landedwork.Limits{Records: 1000, Nodes: 1000, InputBytes: 1 << 20, OutputBytes: 1 << 20}
+			prepared, err := landedwork.Prepare(ctx, r.Root, landedwork.Bounds{Repository: query.Bounds.Repository, Base: base, Head: head}, analysisLimits)
+			require.NoError(err)
+			details := 0
+			hc := &http.Client{Transport: platform.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				body := ""
+				status := 200
+				header := make(http.Header)
+				switch {
+				case req.URL.Path == "/repos/example/project":
+					body = `{"id":12,"name":"project","owner":{"login":"example"}}`
+				case strings.HasSuffix(req.URL.Path, "/pulls"):
+					body = `[{"id":7,"number":3}]`
+					if mode == "no associations" {
+						body = `[]`
+					}
+					if mode == "failed page" {
+						if req.URL.Query().Get("page") == "2" {
+							status = 503
+							body = `{}`
+						} else {
+							header.Set("Link", fmt.Sprintf(`<https://api.github.com%s?page=2>; rel="next"`, req.URL.Path))
+						}
+					}
+				case req.URL.Path == "/repos/example/project/pulls/3":
+					details++
+					count := 1
+					if mode == "changed detail" && details == 2 {
+						count = 2
+					}
+					body = fmt.Sprintf(`{"id":7,"number":3,"merged":true,"merge_commit_sha":%q,"commits":%d,"base":{"ref":"main","repo":{"id":12}},"head":{"sha":%q,"repo":{"id":12}}}`, head, count, source)
+				case req.URL.Path == "/repos/example/project/pulls/3/commits":
+					body = fmt.Sprintf(`[{"sha":%q}]`, source)
+				default:
+					require.Fail("unexpected request", req.URL.String())
+				}
+				return &http.Response{StatusCode: status, Header: header, Body: io.NopCloser(strings.NewReader(body)), Request: req}, nil
+			})}
+			client, err := github.NewClient(github.ClientConfig{Read: hc, Write: hc, Notifications: hc, Clock: time.Now})
+			require.NoError(err)
+			reader, err := github.NewProvider(github.ProviderConfig{Host: "github.com", Client: client, Clock: time.Now})
+			require.NoError(err)
+			collected, err := collect.Collect(ctx, reader, route, prepared.Query(), limits)
+			require.NoError(err)
+			analysis, err := landedwork.Analyze(ctx, prepared, collected.Evidence, analysisLimits)
+			require.NoError(err)
+			switch mode {
+			case "merge":
+				assert.True(analysis.Coverage.Complete)
+				assert.Equal(head, analysis.Coverage.CertifiedHead)
+				require.Len(analysis.Landings, 1)
+				assert.Equal(base, analysis.Landings[0].Before)
+				assert.Equal(head, analysis.Landings[0].Terminal)
+			case "no associations":
+				assert.True(analysis.Coverage.Complete)
+				require.Len(analysis.DirectPushes, 1)
+				assert.Equal(head, analysis.DirectPushes[0].Terminal)
+			default:
+				assert.False(analysis.Coverage.Complete)
+				assert.Equal(base, analysis.Coverage.CertifiedHead)
+				assert.Empty(analysis.DirectPushes)
+			}
+		})
+	}
+}

--- a/landedwork/collect/github_test.go
+++ b/landedwork/collect/github_test.go
@@ -23,7 +23,7 @@ import (
 func TestMain(m *testing.M) { os.Exit(gitsafe.RunIsolatedMain(m)) }
 
 func TestGitHubCollectionAnalysis(t *testing.T) {
-	for _, mode := range []string{"merge", "no associations", "failed page", "changed detail", "one parent"} {
+	for _, mode := range []string{"merge", "no associations", "failed page", "changed detail", "one parent", "foreign association", "missing base"} {
 		t.Run(mode, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 			r := gittest.NewRepo(t, gittest.Options{InitArgs: []string{"init", "-b", "main"}, ConfigureUser: true})
@@ -53,7 +53,10 @@ func TestGitHubCollectionAnalysis(t *testing.T) {
 				case req.URL.Path == "/repos/example/project":
 					body = `{"id":12,"name":"project","owner":{"login":"example"}}`
 				case strings.HasSuffix(req.URL.Path, "/pulls"):
-					body = `[{"id":7,"number":3}]`
+					body = `[{"id":7,"number":3,"base":{"repo":{"id":12}}}]`
+					if mode == "foreign association" {
+						body = `[{"id":8,"number":3,"base":{"repo":{"id":99}}}]`
+					}
 					if mode == "no associations" {
 						body = `[]`
 					}
@@ -72,6 +75,9 @@ func TestGitHubCollectionAnalysis(t *testing.T) {
 						count = 2
 					}
 					body = fmt.Sprintf(`{"id":7,"number":3,"merged":true,"merge_commit_sha":%q,"commits":%d,"base":{"ref":"main","repo":{"id":12}},"head":{"sha":%q,"repo":{"id":12}}}`, head, count, source)
+					if mode == "missing base" {
+						body = `{"id":7,"number":3,"merged":true}`
+					}
 				case req.URL.Path == "/repos/example/project/pulls/3/commits":
 					body = fmt.Sprintf(`[{"sha":%q}]`, source)
 				default:
@@ -85,6 +91,17 @@ func TestGitHubCollectionAnalysis(t *testing.T) {
 			require.NoError(err)
 			collected, err := collect.Collect(ctx, reader, route, prepared.Query(), limits)
 			require.NoError(err)
+			if mode == "foreign association" {
+				assert.Zero(details, "foreign PR numbers must not be fetched in the local repository")
+				assert.Empty(collected.Evidence.Candidates)
+				require.Len(collected.Observations, 1)
+				assert.Equal("foreign_repository", collected.Observations[0].Reason)
+				assert.Equal("ambiguous_absence", collected.Evidence.Inventory.Reason)
+			}
+			if mode == "missing base" {
+				require.Len(collected.Evidence.Candidates, 1)
+				assert.Equal("invalid_observation", collected.Evidence.Inventory.Reason)
+			}
 			analysis, err := landedwork.Analyze(ctx, prepared, collected.Evidence, analysisLimits)
 			require.NoError(err)
 			switch mode {

--- a/landedwork/collect/limits.go
+++ b/landedwork/collect/limits.go
@@ -69,7 +69,7 @@ func resultBytes(r Result) int64 {
 	}
 	for _, o := range r.Observations {
 		d := o.Change
-		n += stringsBytes(d.TargetBranch, d.Terminal, d.TerminalEvidence, o.Reason) + stringsBytes(o.Source...)
+		n += stringsBytes(d.TargetBranch, d.Terminal, d.TerminalEvidence, o.Reason, o.FailureStage, o.NextPage) + stringsBytes(o.Source...)
 		for _, s := range []*string{d.MergeSHA, d.SquashSHA, d.SourceHead} {
 			if s != nil {
 				n += int64(len(*s))

--- a/landedwork/collect/limits.go
+++ b/landedwork/collect/limits.go
@@ -21,6 +21,11 @@ func validate(ctx context.Context, r platform.LandingEvidenceReader, route platf
 	if l.Calls <= 0 || l.Records <= 0 || l.OutputBytes <= 0 {
 		return errors.New("landing collection limits must be positive")
 	}
+	// The exact query must fit even when preparation or discovery is incomplete.
+	// Check before validating individual commits or allocating retained copies.
+	if int64(len(q.Commits)) > l.Records || int64(len(q.Gaps)) > l.Records-int64(len(q.Commits)) {
+		return landedwork.ErrOutputBudget
+	}
 	if r == nil {
 		return errors.New("landing collection requires a reader")
 	}

--- a/landedwork/collect/limits.go
+++ b/landedwork/collect/limits.go
@@ -1,0 +1,88 @@
+package collect
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"strconv"
+	"strings"
+
+	"go.kenn.io/forge/landedwork"
+	"go.kenn.io/forge/platform"
+)
+
+func validate(ctx context.Context, r platform.LandingEvidenceReader, route platform.RepoRef, q landedwork.Query, l Limits) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		return errors.New("landing collection requires a deadline")
+	}
+	if l.Calls <= 0 || l.Records <= 0 || l.OutputBytes <= 0 {
+		return errors.New("landing collection limits must be positive")
+	}
+	if r == nil {
+		return errors.New("landing collection requires a reader")
+	}
+	if err := platform.ValidateCanonicalRepoRef(route); err != nil {
+		return err
+	}
+	repo := q.Bounds.Repository
+	id, err := strconv.ParseInt(repo.ID, 10, 64)
+	if err != nil || id <= 0 || strconv.FormatInt(id, 10) != repo.ID || route.Platform != r.Platform() || route.Host != r.Host() || repo.Provider != r.Platform() || repo.Host != r.Host() {
+		return errors.New("landing collection requires matching provider identity")
+	}
+	size := len(q.Bounds.Head)
+	if !objectID(q.Bounds.Base, size) || !objectID(q.Bounds.Head, size) || q.Complete && len(q.Gaps) != 0 {
+		return errors.New("invalid landing query")
+	}
+	seen := make(map[string]bool)
+	for _, sha := range q.Commits {
+		if !objectID(sha, size) || sha == q.Bounds.Base || seen[sha] {
+			return errors.New("invalid landing query commit")
+		}
+		seen[sha] = true
+	}
+	if q.Complete && q.Bounds.Base != q.Bounds.Head && !seen[q.Bounds.Head] {
+		return errors.New("landing query omits head")
+	}
+	return nil
+}
+
+func objectID(s string, size int) bool {
+	if len(s) != size || size != 40 && size != 64 || strings.ToLower(s) != s {
+		return false
+	}
+	_, err := hex.DecodeString(s)
+	return err == nil
+}
+
+func resultBytes(r Result) int64 {
+	q, inv := r.Evidence.Query, r.Evidence.Inventory
+	n := stringsBytes(string(q.Bounds.Repository.Provider), q.Bounds.Repository.Host, q.Bounds.Repository.ID, q.Bounds.Base, q.Bounds.Head, inv.Reason, inv.NextCommit, inv.NextPage)
+	n += stringsBytes(q.Commits...)
+	for _, g := range q.Gaps {
+		n += stringsBytes(g.CandidateID, g.ObjectID, g.Reason, g.Span.Before, g.Span.Through)
+	}
+	for _, c := range r.Evidence.Candidates {
+		n += stringsBytes(string(c.Repository.Provider), c.Repository.Host, c.Repository.ID, c.ID, c.Terminal, c.SourceHead, c.Method, c.MethodEvidence, c.TerminalEvidence) + stringsBytes(c.Source...)
+	}
+	for _, o := range r.Observations {
+		d := o.Change
+		n += stringsBytes(d.TargetBranch, d.Terminal, d.TerminalEvidence, o.Reason) + stringsBytes(o.Source...)
+		for _, s := range []*string{d.MergeSHA, d.SquashSHA, d.SourceHead} {
+			if s != nil {
+				n += int64(len(*s))
+			}
+		}
+	}
+	return n
+}
+
+func stringsBytes(values ...string) int64 {
+	var n int64
+	for _, s := range values {
+		n += int64(len(s))
+	}
+	return n
+}

--- a/landedwork/collect/transport_test.go
+++ b/landedwork/collect/transport_test.go
@@ -1,0 +1,143 @@
+package collect_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/landedwork/collect"
+	"go.kenn.io/forge/platform"
+	"go.kenn.io/forge/platform/github"
+)
+
+// This is caller policy, deliberately not a production transport framework.
+type wireLimit struct {
+	base                http.RoundTripper
+	attempts, bodyBytes int64
+}
+
+func (l *wireLimit) RoundTrip(r *http.Request) (*http.Response, error) {
+	if l.attempts == 0 {
+		return nil, platform.ErrLandingTransportLimit
+	}
+	l.attempts--
+	resp, err := l.base.RoundTrip(r)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body = &limitedBody{ReadCloser: resp.Body, remaining: l.bodyBytes}
+	return resp, nil
+}
+
+type limitedBody struct {
+	io.ReadCloser
+	remaining int64
+}
+
+func (b *limitedBody) Read(p []byte) (int, error) {
+	if b.remaining == 0 {
+		return 0, platform.ErrLandingTransportLimit
+	}
+	if int64(len(p)) > b.remaining {
+		p = p[:b.remaining]
+	}
+	n, err := b.ReadCloser.Read(p)
+	b.remaining -= int64(n)
+	return n, err
+}
+
+type replacementCredential struct{ invalidated bool }
+
+func (s *replacementCredential) Token(context.Context) (string, error) {
+	if s.invalidated {
+		return "replacement", nil
+	}
+	return "initial", nil
+}
+func (s *replacementCredential) Invalidate(string) { s.invalidated = true }
+
+func connectedReader(t *testing.T, endpoint string, hc *http.Client) *github.Provider {
+	t.Helper()
+	c, err := github.NewClient(github.ClientConfig{Read: hc, Write: hc, Notifications: hc, Clock: time.Now, APIBase: endpoint + "/", UploadBase: endpoint + "/"})
+	require.NoError(t, err)
+	p, err := github.NewProvider(github.ProviderConfig{Host: "github.com", Client: c, Clock: time.Now})
+	require.NoError(t, err)
+	return p
+}
+
+func TestCollectorSeesLimitsBelowAuthentication(t *testing.T) {
+	for _, mode := range []string{"retry", "body"} {
+		t.Run(mode, func(t *testing.T) {
+			var requests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests.Add(1)
+				if mode == "retry" {
+					w.WriteHeader(http.StatusUnauthorized)
+				}
+				_, _ = io.WriteString(w, `{"id":12,"name":"project","owner":{"login":"example"}}`)
+			}))
+			defer server.Close()
+			source := &replacementCredential{}
+			bodyBytes := int64(1000)
+			if mode == "body" {
+				bodyBytes = 10
+			}
+			transport := platform.AuthTransport{Source: source, SetHeader: platform.BearerAuthHeader, RetryOnUnauthorized: true, Base: &wireLimit{base: server.Client().Transport, attempts: 1, bodyBytes: bodyBytes}}
+			reader := connectedReader(t, server.URL, &http.Client{Transport: transport})
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+			defer cancel()
+			got, err := collect.Collect(ctx, reader, route, query, limits)
+			require.NoError(t, err)
+			assert := assert.New(t)
+			assert.False(got.Evidence.Inventory.Complete)
+			assert.Equal("exhausted_limits", got.Evidence.Inventory.Reason)
+			assert.Equal(int32(1), requests.Load())
+			if mode == "retry" {
+				assert.True(source.invalidated)
+			}
+		})
+	}
+}
+
+func TestCanceledCollectionDoesNotBlockAnotherReader(t *testing.T) {
+	assert, require := assert.New(t), require.New(t)
+	started := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+	reader := connectedReader(t, server.URL, server.Client())
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+	type outcome struct {
+		result collect.Result
+		err    error
+	}
+	done := make(chan outcome, 1)
+	go func() { r, err := collect.Collect(ctx, reader, route, query, limits); done <- outcome{r, err} }()
+	select {
+	case <-started:
+	case <-ctx.Done():
+		require.FailNow("provider request did not start")
+	}
+	otherCtx, otherCancel := context.WithTimeout(t.Context(), time.Minute)
+	defer otherCancel()
+	other, err := collect.Collect(otherCtx, mergedScript(t), route, query, limits)
+	require.NoError(err)
+	assert.True(other.Evidence.Inventory.Complete)
+	cancel()
+	select {
+	case got := <-done:
+		require.ErrorIs(got.err, context.Canceled)
+		assert.Equal(collect.Result{}, got.result)
+	case <-otherCtx.Done():
+		require.FailNow("canceled collection did not exit")
+	}
+}

--- a/platform/github/landing_evidence.go
+++ b/platform/github/landing_evidence.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json/v2"
 	"errors"
 	"fmt"
+	"net/url"
+	"strings"
 
 	gh "github.com/google/go-github/v89/github"
 	"go.kenn.io/forge/platform"
@@ -144,6 +146,12 @@ func (c *Client) GetLandingChange(ctx context.Context, ref platform.RepoRef, cha
 		d.SourceCount = new(int64(*pr.Commits))
 	}
 	if source := pr.GetHead().GetRepo(); source != nil {
+		if source.HTMLURL != nil {
+			u, err := url.Parse(*source.HTMLURL)
+			if err != nil || !strings.EqualFold(u.Host, c.platformHost) {
+				return platform.LandingChange{}, platform.ErrLandingIdentityMismatch
+			}
+		}
 		d.SourceID = source.ID
 	}
 	if pr.GetMerged() && pr.GetMergeCommitSHA() != "" {

--- a/platform/github/landing_evidence.go
+++ b/platform/github/landing_evidence.go
@@ -120,7 +120,7 @@ func (c *Client) ListLandingAssociations(ctx context.Context, ref platform.RepoR
 	}
 	items := make([]platform.LandingChangeRef, 0, len(prs))
 	for _, pr := range prs {
-		items = append(items, platform.LandingChangeRef{ID: pr.GetID(), Number: pr.GetNumber()})
+		items = append(items, platform.LandingChangeRef{ID: pr.GetID(), Number: pr.GetNumber(), TargetID: pr.GetBase().GetRepo().GetID()})
 	}
 	return landingPageResult(items, resp, state)
 }
@@ -135,7 +135,7 @@ func (c *Client) GetLandingChange(ctx context.Context, ref platform.RepoRef, cha
 	if err != nil {
 		return platform.LandingChange{}, err
 	}
-	if pr.GetID() != change.ID || pr.GetNumber() != change.Number || pr.GetBase().GetRepo().GetID() <= 0 {
+	if pr.GetID() != change.ID || pr.GetNumber() != change.Number {
 		return platform.LandingChange{}, platform.ErrLandingIdentityMismatch
 	}
 	d := platform.LandingChange{Ref: change, TargetID: pr.GetBase().GetRepo().GetID(), TargetBranch: pr.GetBase().GetRef(), Merged: pr.Merged, MergeSHA: pr.MergeCommitSHA}

--- a/platform/github/landing_evidence.go
+++ b/platform/github/landing_evidence.go
@@ -13,10 +13,12 @@ import (
 	"go.kenn.io/forge/platform"
 )
 
-type landingAPI interface {
-	ListLandingAssociations(context.Context, platform.RepoRef, string, string) (platform.Page[platform.LandingChangeRef], error)
-	GetLandingChange(context.Context, platform.RepoRef, platform.LandingChangeRef) (platform.LandingChange, error)
-	ListLandingSource(context.Context, platform.RepoRef, platform.LandingChangeRef, string) (platform.Page[string], error)
+// LandingAPI is the optional client surface for landing evidence. Client
+// wrappers must preserve repository-scoped routing for each operation.
+type LandingAPI interface {
+	ListLandingAssociations(ctx context.Context, repo platform.RepoRef, commit, cursor string) (platform.Page[platform.LandingChangeRef], error)
+	GetLandingChange(ctx context.Context, repo platform.RepoRef, change platform.LandingChangeRef) (platform.LandingChange, error)
+	ListLandingSource(ctx context.Context, repo platform.RepoRef, change platform.LandingChangeRef, cursor string) (platform.Page[string], error)
 }
 
 func (p *Provider) LandingEvidenceSupport() platform.LandingEvidenceSupport {
@@ -27,7 +29,7 @@ func (p *Provider) LandingEvidenceSupport() platform.LandingEvidenceSupport {
 	// rewritten ranges, absent associations, and a feature-branch integration
 	// whose inner commit and outer marker discover different PRs. This does
 	// not establish the corresponding contract on Enterprise Server versions.
-	_, ok := p.client.(landingAPI)
+	_, ok := p.client.(LandingAPI)
 	if !ok || p.host != "github.com" {
 		return platform.LandingEvidenceSupport{Reason: "unverified_endpoint_contract"}
 	}
@@ -35,21 +37,21 @@ func (p *Provider) LandingEvidenceSupport() platform.LandingEvidenceSupport {
 }
 
 func (p *Provider) ListLandingAssociations(ctx context.Context, ref platform.RepoRef, sha, cursor string) (platform.Page[platform.LandingChangeRef], error) {
-	if c, ok := p.client.(landingAPI); ok {
+	if c, ok := p.client.(LandingAPI); ok {
 		return c.ListLandingAssociations(ctx, ref, sha, cursor)
 	}
 	return platform.Page[platform.LandingChangeRef]{}, platform.UnsupportedCapability(p.Platform(), p.host, "landing_evidence")
 }
 
 func (p *Provider) GetLandingChange(ctx context.Context, ref platform.RepoRef, change platform.LandingChangeRef) (platform.LandingChange, error) {
-	if c, ok := p.client.(landingAPI); ok {
+	if c, ok := p.client.(LandingAPI); ok {
 		return c.GetLandingChange(ctx, ref, change)
 	}
 	return platform.LandingChange{}, platform.UnsupportedCapability(p.Platform(), p.host, "landing_evidence")
 }
 
 func (p *Provider) ListLandingSource(ctx context.Context, ref platform.RepoRef, change platform.LandingChangeRef, cursor string) (platform.Page[string], error) {
-	if c, ok := p.client.(landingAPI); ok {
+	if c, ok := p.client.(LandingAPI); ok {
 		return c.ListLandingSource(ctx, ref, change, cursor)
 	}
 	return platform.Page[string]{}, platform.UnsupportedCapability(p.Platform(), p.host, "landing_evidence")

--- a/platform/github/landing_evidence.go
+++ b/platform/github/landing_evidence.go
@@ -1,0 +1,172 @@
+package github
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+
+	gh "github.com/google/go-github/v89/github"
+	"go.kenn.io/forge/platform"
+)
+
+type landingAPI interface {
+	ListLandingAssociations(context.Context, platform.RepoRef, string, string) (platform.Page[platform.LandingChangeRef], error)
+	GetLandingChange(context.Context, platform.RepoRef, platform.LandingChangeRef) (platform.LandingChange, error)
+	ListLandingSource(context.Context, platform.RepoRef, platform.LandingChangeRef, string) (platform.Page[string], error)
+}
+
+func (p *Provider) LandingEvidenceSupport() platform.LandingEvidenceSupport {
+	// REST 2022-11-28 is the pinned SDK's default. Its commit association
+	// contract identifies the introducing PR, including rewritten commits:
+	// https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#list-pull-requests-associated-with-a-commit
+	// Read-only public probes on 2026-09-08 covered ordinary merge markers,
+	// rewritten ranges, absent associations, and a feature-branch integration
+	// whose inner commit and outer marker discover different PRs. This does
+	// not establish the corresponding contract on Enterprise Server versions.
+	_, ok := p.client.(landingAPI)
+	if !ok || p.host != "github.com" {
+		return platform.LandingEvidenceSupport{Reason: "unverified_endpoint_contract"}
+	}
+	return platform.LandingEvidenceSupport{Inventory: true, OrdinaryMerge: true, Sources: platform.LandingSourcePolicy{RequireCount: true, MaxCommits: 250}}
+}
+
+func (p *Provider) ListLandingAssociations(ctx context.Context, ref platform.RepoRef, sha, cursor string) (platform.Page[platform.LandingChangeRef], error) {
+	if c, ok := p.client.(landingAPI); ok {
+		return c.ListLandingAssociations(ctx, ref, sha, cursor)
+	}
+	return platform.Page[platform.LandingChangeRef]{}, platform.UnsupportedCapability(p.Platform(), p.host, "landing_evidence")
+}
+
+func (p *Provider) GetLandingChange(ctx context.Context, ref platform.RepoRef, change platform.LandingChangeRef) (platform.LandingChange, error) {
+	if c, ok := p.client.(landingAPI); ok {
+		return c.GetLandingChange(ctx, ref, change)
+	}
+	return platform.LandingChange{}, platform.UnsupportedCapability(p.Platform(), p.host, "landing_evidence")
+}
+
+func (p *Provider) ListLandingSource(ctx context.Context, ref platform.RepoRef, change platform.LandingChangeRef, cursor string) (platform.Page[string], error) {
+	if c, ok := p.client.(landingAPI); ok {
+		return c.ListLandingSource(ctx, ref, change, cursor)
+	}
+	return platform.Page[string]{}, platform.UnsupportedCapability(p.Platform(), p.host, "landing_evidence")
+}
+
+type landingCursor struct {
+	Host, Owner, Repository, Dataset string
+	Page                             int
+}
+
+func (c *Client) landingPage(ref platform.RepoRef, dataset, cursor string) (landingCursor, error) {
+	want := landingCursor{Host: c.platformHost, Owner: ref.Owner, Repository: ref.Name, Dataset: dataset, Page: 1}
+	if err := platform.ValidateCanonicalRepoRef(ref); err != nil {
+		return want, err
+	}
+	if ref.Platform != platform.KindGitHub || ref.Host != c.platformHost {
+		return want, errors.New("landing reader repository scope mismatch")
+	}
+	if cursor == "" {
+		return want, nil
+	}
+	data, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return want, err
+	}
+	var got landingCursor
+	if err = json.Unmarshal(data, &got); err != nil {
+		return want, err
+	}
+	want.Page = got.Page
+	if got != want || got.Page < 1 {
+		return want, errors.New("landing cursor scope mismatch")
+	}
+	return got, nil
+}
+
+func landingPageResult[T any](items []T, response *gh.Response, cursor landingCursor) (platform.Page[T], error) {
+	if response == nil {
+		return platform.Page[T]{}, errors.New("missing landing page response")
+	}
+	p := platform.Page[T]{Items: items, Exhausted: response.NextPage == 0}
+	if p.Exhausted {
+		return p, nil
+	}
+	if response.NextPage <= cursor.Page {
+		return p, errors.New("nonadvancing landing page")
+	}
+	cursor.Page = response.NextPage
+	data, err := json.Marshal(cursor)
+	if err != nil {
+		return p, err
+	}
+	p.NextCursor = base64.RawURLEncoding.EncodeToString(data)
+	p.ProgressOnly = len(items) == 0
+	return p, nil
+}
+
+func (c *Client) ListLandingAssociations(ctx context.Context, ref platform.RepoRef, sha, cursor string) (platform.Page[platform.LandingChangeRef], error) {
+	state, err := c.landingPage(ref, "association/"+sha, cursor)
+	if err != nil {
+		return platform.Page[platform.LandingChangeRef]{}, err
+	}
+	ctx = c.authContext(WithUnconditionalRead(ctx), ref.Owner, false)
+	prs, resp, err := c.gh.PullRequests.ListPullRequestsWithCommit(ctx, ref.Owner, ref.Name, sha, &gh.ListOptions{Page: state.Page, PerPage: 100})
+	c.trackRate(resp)
+	if err != nil {
+		return platform.Page[platform.LandingChangeRef]{}, err
+	}
+	items := make([]platform.LandingChangeRef, 0, len(prs))
+	for _, pr := range prs {
+		items = append(items, platform.LandingChangeRef{ID: pr.GetID(), Number: pr.GetNumber()})
+	}
+	return landingPageResult(items, resp, state)
+}
+
+func (c *Client) GetLandingChange(ctx context.Context, ref platform.RepoRef, change platform.LandingChangeRef) (platform.LandingChange, error) {
+	if _, err := c.landingPage(ref, "detail", ""); err != nil {
+		return platform.LandingChange{}, err
+	}
+	ctx = c.authContext(WithUnconditionalRead(ctx), ref.Owner, false)
+	pr, resp, err := c.gh.PullRequests.Get(ctx, ref.Owner, ref.Name, change.Number)
+	c.trackRate(resp)
+	if err != nil {
+		return platform.LandingChange{}, err
+	}
+	if pr.GetID() != change.ID || pr.GetNumber() != change.Number || pr.GetBase().GetRepo().GetID() <= 0 {
+		return platform.LandingChange{}, platform.ErrLandingIdentityMismatch
+	}
+	d := platform.LandingChange{Ref: change, TargetID: pr.GetBase().GetRepo().GetID(), TargetBranch: pr.GetBase().GetRef(), Merged: pr.Merged, MergeSHA: pr.MergeCommitSHA}
+	if pr.Head != nil {
+		d.SourceHead = pr.Head.SHA
+	}
+	if pr.Commits != nil {
+		d.SourceCount = new(int64(*pr.Commits))
+	}
+	if source := pr.GetHead().GetRepo(); source != nil {
+		d.SourceID = source.ID
+	}
+	if pr.GetMerged() && pr.GetMergeCommitSHA() != "" {
+		d.Terminal = pr.GetMergeCommitSHA()
+		d.TerminalEvidence = "merged_commit_sha"
+	}
+	return d, nil
+}
+
+func (c *Client) ListLandingSource(ctx context.Context, ref platform.RepoRef, change platform.LandingChangeRef, cursor string) (platform.Page[string], error) {
+	state, err := c.landingPage(ref, fmt.Sprintf("source/%d/%d", change.ID, change.Number), cursor)
+	if err != nil {
+		return platform.Page[string]{}, err
+	}
+	ctx = c.authContext(WithUnconditionalRead(ctx), ref.Owner, false)
+	commits, resp, err := c.gh.PullRequests.ListCommits(ctx, ref.Owner, ref.Name, change.Number, &gh.ListOptions{Page: state.Page, PerPage: 100})
+	c.trackRate(resp)
+	if err != nil {
+		return platform.Page[string]{}, err
+	}
+	items := make([]string, 0, len(commits))
+	for _, commit := range commits {
+		items = append(items, commit.GetSHA())
+	}
+	return landingPageResult(items, resp, state)
+}

--- a/platform/github/landing_evidence_test.go
+++ b/platform/github/landing_evidence_test.go
@@ -1,0 +1,82 @@
+package github_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/platform"
+	"go.kenn.io/forge/platform/github"
+)
+
+func TestLandingEvidencePages(t *testing.T) {
+	assert, require := assert.New(t), require.New(t)
+	sha := strings.Repeat("a", 40)
+	calls := 0
+	hc := &http.Client{Transport: platform.RoundTripFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		assert.Equal("2022-11-28", r.Header.Get("X-GitHub-Api-Version"))
+		header := make(http.Header)
+		body := ""
+		switch r.URL.Path {
+		case "/repos/example/project/commits/" + sha + "/pulls":
+			assert.Equal("100", r.URL.Query().Get("per_page"))
+			body = `[{"id":7,"number":3}]`
+			if r.URL.Query().Get("page") == "1" {
+				header.Set("Link", fmt.Sprintf(`<https://api.github.com%s?page=2&per_page=100>; rel="next"`, r.URL.Path))
+			}
+		case "/repos/example/project/pulls/3":
+			body = fmt.Sprintf(`{"id":7,"number":3,"merged":true,"merge_commit_sha":%q,"commits":1,"base":{"ref":"main","repo":{"id":12}},"head":{"sha":%q,"repo":{"id":15}}}`, sha, sha)
+		case "/repos/example/project/pulls/3/commits":
+			body = fmt.Sprintf(`[{"sha":%q}]`, sha)
+		default:
+			require.Fail("unexpected path", r.URL.String())
+		}
+		return &http.Response{StatusCode: 200, Header: header, Body: io.NopCloser(strings.NewReader(body)), Request: r}, nil
+	})}
+	c, err := github.NewClient(github.ClientConfig{Read: hc, Write: hc, Notifications: hc, Clock: time.Now})
+	require.NoError(err)
+	p, err := github.NewProvider(github.ProviderConfig{Host: "github.com", Client: c, Clock: time.Now})
+	require.NoError(err)
+	var reader platform.LandingEvidenceReader = p
+	route := platform.RepoRef{Platform: platform.KindGitHub, Host: "github.com", Owner: "example", Name: "project"}
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+	page, err := reader.ListLandingAssociations(ctx, route, sha, "")
+	require.NoError(err)
+	assert.False(page.Exhausted)
+	require.NotEmpty(page.NextCursor)
+	last, err := reader.ListLandingAssociations(ctx, route, sha, page.NextCursor)
+	require.NoError(err)
+	assert.True(last.Exhausted)
+	_, err = reader.ListLandingAssociations(ctx, route, strings.Repeat("b", 40), page.NextCursor)
+	require.Error(err)
+	detail, err := reader.GetLandingChange(ctx, route, page.Items[0])
+	require.NoError(err)
+	assert.Equal(int64(12), detail.TargetID)
+	assert.Equal(new(int64(15)), detail.SourceID)
+	assert.Equal(sha, detail.Terminal)
+	assert.Nil(detail.SquashSHA)
+	sources, err := reader.ListLandingSource(ctx, route, detail.Ref, "")
+	require.NoError(err)
+	assert.Equal([]string{sha}, sources.Items)
+	assert.True(sources.Exhausted)
+	assert.Equal(4, calls)
+}
+
+func TestLandingMissingHeadStaysAbsent(t *testing.T) {
+	hc := &http.Client{Transport: platform.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"id":7,"number":3,"merged":true,"base":{"repo":{"id":12}}}`)), Request: req}, nil
+	})}
+	c, err := github.NewClient(github.ClientConfig{Read: hc, Write: hc, Notifications: hc, Clock: time.Now})
+	require.NoError(t, err)
+	d, err := c.GetLandingChange(t.Context(), platform.RepoRef{Platform: platform.KindGitHub, Host: "github.com", Owner: "example", Name: "project"}, platform.LandingChangeRef{ID: 7, Number: 3})
+	require.NoError(t, err)
+	assert.Nil(t, d.SourceHead)
+}

--- a/platform/github/landing_evidence_test.go
+++ b/platform/github/landing_evidence_test.go
@@ -80,3 +80,13 @@ func TestLandingMissingHeadStaysAbsent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, d.SourceHead)
 }
+
+func TestLandingRejectsCrossInstanceSource(t *testing.T) {
+	hc := &http.Client{Transport: platform.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"id":7,"number":3,"merged":true,"base":{"repo":{"id":12}},"head":{"repo":{"id":12,"html_url":"https://other.example/project"}}}`)), Request: req}, nil
+	})}
+	c, err := github.NewClient(github.ClientConfig{Read: hc, Write: hc, Notifications: hc, Clock: time.Now})
+	require.NoError(t, err)
+	_, err = c.GetLandingChange(t.Context(), platform.RepoRef{Platform: platform.KindGitHub, Host: "github.com", Owner: "example", Name: "project"}, platform.LandingChangeRef{ID: 7, Number: 3})
+	assert.ErrorIs(t, err, platform.ErrLandingIdentityMismatch)
+}

--- a/platform/github/landing_evidence_test.go
+++ b/platform/github/landing_evidence_test.go
@@ -27,7 +27,7 @@ func TestLandingEvidencePages(t *testing.T) {
 		switch r.URL.Path {
 		case "/repos/example/project/commits/" + sha + "/pulls":
 			assert.Equal("100", r.URL.Query().Get("per_page"))
-			body = `[{"id":7,"number":3}]`
+			body = `[{"id":7,"number":3,"base":{"repo":{"id":12}}}]`
 			if r.URL.Query().Get("page") == "1" {
 				header.Set("Link", fmt.Sprintf(`<https://api.github.com%s?page=2&per_page=100>; rel="next"`, r.URL.Path))
 			}

--- a/platform/landing_evidence.go
+++ b/platform/landing_evidence.go
@@ -1,0 +1,58 @@
+package platform
+
+import (
+	"context"
+	"errors"
+)
+
+// LandingChangeRef separates immutable REST identity from the mutable API route.
+type LandingChangeRef struct {
+	ID     int64
+	Number int
+}
+
+// LandingSourcePolicy describes the provider's source-list completeness proof.
+// MaxCommits zero means no known endpoint cap, not an unlimited caller budget.
+type LandingSourcePolicy struct {
+	RequireCount bool
+	MaxCommits   int64
+}
+
+// LandingEvidenceSupport is an endpoint contract, not the outcome of one sweep.
+type LandingEvidenceSupport struct {
+	Inventory, OrdinaryMerge bool
+	Reason                   string
+	Sources                  LandingSourcePolicy
+}
+
+// LandingChange preserves field absence independently of application projections.
+// SourceID, when present, belongs to the same provider instance as TargetID.
+// TerminalEvidence names a provider fact; it does not infer a merge method.
+type LandingChange struct {
+	Ref                             LandingChangeRef
+	TargetID                        int64
+	TargetBranch                    string
+	SourceID                        *int64
+	Merged                          *bool
+	MergeSHA, SquashSHA, SourceHead *string
+	SourceCount                     *int64
+	Terminal, TerminalEvidence      string
+}
+
+// LandingEvidenceReader reads bounded pages for an exact prepared Git interval.
+// Callers own credentials, admission, deadlines, and a wire-attempt/body limiter
+// below authentication and SDK retries. One reader call may make multiple HTTP
+// attempts. An empty exhausted association page must establish observed absence.
+type LandingEvidenceReader interface {
+	Provider
+	RepositoryReader
+	LandingEvidenceSupport() LandingEvidenceSupport
+	ListLandingAssociations(ctx context.Context, repo RepoRef, commit, cursor string) (Page[LandingChangeRef], error)
+	GetLandingChange(ctx context.Context, repo RepoRef, change LandingChangeRef) (LandingChange, error)
+	ListLandingSource(ctx context.Context, repo RepoRef, change LandingChangeRef, cursor string) (Page[string], error)
+}
+
+var (
+	ErrLandingAbsenceAmbiguous = errors.New("landing association absence unconfirmed")
+	ErrLandingTransportLimit   = errors.New("landing transport limit exhausted")
+)

--- a/platform/landing_evidence.go
+++ b/platform/landing_evidence.go
@@ -55,4 +55,5 @@ type LandingEvidenceReader interface {
 var (
 	ErrLandingAbsenceAmbiguous = errors.New("landing association absence unconfirmed")
 	ErrLandingTransportLimit   = errors.New("landing transport limit exhausted")
+	ErrLandingIdentityMismatch = errors.New("landing identity mismatch")
 )

--- a/platform/landing_evidence.go
+++ b/platform/landing_evidence.go
@@ -9,6 +9,9 @@ import (
 type LandingChangeRef struct {
 	ID     int64
 	Number int
+	// TargetID is the observed base repository, not necessarily the queried
+	// repository. Zero means the association did not establish its target.
+	TargetID int64
 }
 
 // LandingSourcePolicy describes the provider's source-list completeness proof.


### PR DESCRIPTION
Connects prepared Git intervals to GitHub evidence so library callers can analyze landed work without assembling PR inventories themselves.

- Adds a provider-neutral reader contract and collector, with a GitHub.com implementation for ordinary merges.
- Preserves incomplete coverage and discovered candidates when pages, source lists, or limits prevent proof. Missing evidence must not become direct-push evidence.
- Leaves credentials, deadlines, and HTTP limits with the caller. Reader-call limits are separate from retry and response-byte limits.

Squash, rebase, and fast-forward landings remain unresolved. GitHub Enterprise Server, GitLab, Forgejo, and Gitea collection are not enabled in this PR. This is library-only work, with no UI or archive integration.

Collection costs at least one association request per queried commit, plus repository, PR-detail, and source-page reads; large intervals can consume substantial API quota, so callers must choose limits accordingly.
