### PR TITLE
feat: prove single-parent landings from GitHub evidence

### DIFF
--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -42,6 +42,9 @@ evidence for the exact prepared interval. Missing history and exhausted budgets
 remain gaps, never empty complete inventories (`landedwork/prepare.go::Prepare`).
 Unsupported landing methods remain unresolved; generic squash proof does not
 establish any provider's squash capability (`landedwork/analyze.go::Analyze`).
+Landing ownership is explicit and independent of correspondence labels; labels
+must not be interpreted as historical provider merge actions
+(`landedwork/evidence.go::Landing`).
 Direct-push origins require complete inventory and an unblocked, unowned spine
 commit; they establish neither a pusher nor a trusted update time
 (`landedwork/direct.go::classifyDirectPushes`).

--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -45,6 +45,11 @@ establish any provider's squash capability (`landedwork/analyze.go::Analyze`).
 Landing ownership is explicit and independent of correspondence labels; labels
 must not be interpreted as historical provider merge actions
 (`landedwork/evidence.go::Landing`).
+Automatic single-parent proofs require every alternative to be conclusive and
+every match to own the same origin; unavailable evidence cannot lose to a match
+(`landedwork/alternatives.go::resolveAlternatives`).
+Fixed pre-base reads can disprove a range, never expand the query or select a
+shorter origin when that range matches (`landedwork/git.go::firstParentSuffix`).
 Direct-push origins require complete inventory and an unblocked, unowned spine
 commit; they establish neither a pusher nor a trusted update time
 (`landedwork/direct.go::classifyDirectPushes`).

--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -40,6 +40,9 @@ cache policy and admission remain internal
 The public landing API uses local objects only; callers own collection and supply
 evidence for the exact prepared interval. Missing history and exhausted budgets
 remain gaps, never empty complete inventories (`landedwork/prepare.go::Prepare`).
+Default-branch clones may omit original PR objects; callers may fetch PR-head
+refs after collection, but must keep the pinned query and observed source SHAs
+unchanged (`landedwork/analyze.go::Analyze`).
 Unsupported landing methods remain unresolved; generic squash proof does not
 establish any provider's squash capability (`landedwork/analyze.go::Analyze`).
 Landing ownership is explicit and independent of correspondence labels; labels

--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -55,6 +55,9 @@ Git's commit-graph can outlive commit objects; verify required commits physicall
 including each landing's first parent (`landedwork/git.go::parents`, `landedwork/proof.go::proveAt`).
 Rewritten ranges compare exact edit bytes, not whitespace-insensitive patch IDs;
 empty or duplicate rewritten edits stay unproven (`landedwork/range.go::rangeCorrespondence`).
+Squash proof compares the net source-boundary delta, not concatenated patches;
+even an explicit method label requires a complete linear source chain
+(`landedwork/single_parent.go::proveSquash`).
 Offset-free text proof requires uniquely occurring removed bytes or a unique
 insertion neighborhood; repeated locations stay unproven (`landedwork/edits.go::fileEdits`).
 Overlap conflicts block the proven landing ranges, not unrelated earlier

--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -51,8 +51,9 @@ must not be interpreted as historical provider merge actions
 Automatic single-parent proofs require every alternative to be conclusive and
 every match to own the same origin; unavailable evidence cannot lose to a match
 (`landedwork/alternatives.go::resolveAlternatives`).
-Fixed pre-base reads can disprove a range, never expand the query or select a
-shorter origin when that range matches (`landedwork/git.go::firstParentSuffix`).
+A conclusive unequal pair disproves a range despite other ambiguous pairs;
+walk from the terminal only as far as needed, never shorten a matching origin
+(`landedwork/range.go::rangeCorrespondence`).
 Direct-push origins require complete inventory and an unblocked, unowned spine
 commit; they establish neither a pusher nor a trusted update time
 (`landedwork/direct.go::classifyDirectPushes`).

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -6,6 +6,9 @@ fixtures, or changing shell-script coverage.
 - Pass `-shuffle=on` when invoking `go test` directly; `make test` and
   `make test-short` already include it. Do not pass redundant `-count=1`; use
   `-count=N` only when `N > 1` for repeated runs.
+- Before pushing Go changes, run `make nilaway` as well as `make lint-check`;
+  passing golangci-lint alone does not cover CI's Go analysis checks
+  (`.github/workflows/ci.yml::lint`).
 - Routine local Go lanes and hooks bound package/processor concurrency and share
   Go caches; `GO_TEST_P=` intentionally restores native package concurrency.
   (`scripts/run-hook-go.sh`, `prek.toml`)

--- a/landedwork/accounting.go
+++ b/landedwork/accounting.go
@@ -43,8 +43,8 @@ func checkResultOutput(r Result, l Limits) error {
 	}
 	n += stringBytes(r.Unattributed)
 	for _, landing := range r.Landings {
-		n += int64(len(landing.CandidateID)+len(landing.Method)+len(landing.Before)+len(landing.Terminal)) + stringBytes(landing.Source) + stringBytes(landing.Introduced)
-		records += int64(len(landing.Source) + len(landing.Introduced))
+		n += int64(len(landing.CandidateID)+len(landing.Before)+len(landing.Terminal)) + stringBytes(landing.Source) + stringBytes(landing.Introduced) + stringBytes(landing.Proofs) + stringBytes(landing.Spine)
+		records += int64(len(landing.Source) + len(landing.Introduced) + len(landing.Proofs) + len(landing.Spine))
 	}
 	if n > l.OutputBytes || records > l.Records {
 		return ErrOutputBudget

--- a/landedwork/alternatives.go
+++ b/landedwork/alternatives.go
@@ -1,0 +1,77 @@
+package landedwork
+
+import "slices"
+
+type attemptState uint8
+
+const (
+	attemptInconclusive attemptState = iota
+	attemptMismatch
+	attemptMatch
+)
+
+type proofAttempt struct {
+	state       attemptState
+	landing     Landing
+	gap         Gap
+	crossesBase bool
+}
+
+type firstParentRange struct {
+	before      string
+	commits     []string
+	crossesBase bool
+}
+
+// Order determines only the reported inconclusive reason, never a winning
+// method. An unavailable alternative must not lose to an earlier match.
+func resolveAlternatives(c Candidate, attempts []proofAttempt, budgetFailed bool) (Landing, Gap) {
+	g := Gap{CandidateID: c.ID, ObjectID: c.Terminal}
+	if budgetFailed {
+		g.Reason = "input_budget_exhausted"
+		return Landing{}, g
+	}
+	for _, a := range attempts {
+		if a.state == attemptInconclusive {
+			return Landing{}, a.gap
+		}
+	}
+	for _, a := range attempts {
+		if a.state == attemptMatch && a.crossesBase {
+			g.Reason = "range_crosses_base"
+			return Landing{}, g
+		}
+	}
+	var accepted Landing
+	for _, a := range attempts {
+		if a.state != attemptMatch {
+			continue
+		}
+		if accepted.CandidateID == "" {
+			accepted = a.landing
+		} else {
+			if !sameOrigin(accepted, a.landing) {
+				g.Reason = "origin_ambiguous"
+				return Landing{}, g
+			}
+			accepted.Proofs = append(accepted.Proofs, a.landing.Proofs...)
+		}
+	}
+	if accepted.CandidateID == "" {
+		g.Reason = "source_correspondence_unproven"
+		return Landing{}, g
+	}
+	slices.Sort(accepted.Proofs)
+	accepted.Proofs = slices.Compact(accepted.Proofs)
+	return accepted, Gap{}
+}
+
+func sameOrigin(a, b Landing) bool {
+	if a.CandidateID != b.CandidateID || a.Before != b.Before || a.Terminal != b.Terminal || !slices.Equal(a.Spine, b.Spine) {
+		return false
+	}
+	x, y := slices.Clone(a.Introduced), slices.Clone(b.Introduced)
+	slices.Sort(x)
+	slices.Sort(y)
+	return slices.Equal(x, y)
+}

--- a/landedwork/alternatives.go
+++ b/landedwork/alternatives.go
@@ -18,9 +18,8 @@ type proofAttempt struct {
 }
 
 type firstParentRange struct {
-	before      string
-	commits     []string
-	crossesBase bool
+	before  string
+	commits []string
 }
 
 // Order determines only the reported inconclusive reason, never a winning

--- a/landedwork/alternatives_test.go
+++ b/landedwork/alternatives_test.go
@@ -75,7 +75,7 @@ func TestAutomaticSingleParent(t *testing.T) {
 }
 
 func TestAutomaticEarlierHistory(t *testing.T) {
-	for _, mode := range []string{"disproved", "missing", "budget", "shallow"} {
+	for _, mode := range []string{"disproved", "missing", "missing boundary", "bounded mismatch", "budget", "shallow"} {
 		t.Run(mode, func(t *testing.T) {
 			require := require.New(t)
 			f := buildFixture(t, true)
@@ -104,11 +104,19 @@ func TestAutomaticEarlierHistory(t *testing.T) {
 				require.NoError(os.Remove(filepath.Join(f.repo.GitDir, "objects", earlier[:2], earlier[2:])))
 				_, _, err := f.repo.Runner.Run(ctx, f.repo.Root, nil, "cat-file", "-e", earlier)
 				require.Error(err)
-				reason, object = "objects_unavailable", earlier
+				// The terminal pair already disproves the range. Older unrelated
+				// history is not needed to accept the proven squash.
+			case "missing boundary":
+				require.NoError(os.Remove(filepath.Join(f.repo.GitDir, "objects", f.base[:2], f.base[2:])))
+				reason, object = "objects_unavailable", f.base
+			case "bounded mismatch":
+				// Enough to prove the squash and reject the terminal range pair,
+				// but not to walk the rest of the three-commit alternative.
+				limits.Nodes = 7
 			case "budget":
-				// Fourteen reads finish source validation and both aggregate deltas;
-				// the fixed suffix still needs a read and cannot be skipped.
-				limits.Nodes = 14
+				// Source and squash checks fit; the alternative is still untested
+				// when its next boundary read exhausts the allowance.
+				limits.Nodes = 6
 				reason, object = "input_budget_exhausted", terminal
 			case "shallow":
 				require.NoError(os.WriteFile(filepath.Join(f.repo.GitDir, "shallow"), []byte(earlier+"\n"), 0600))

--- a/landedwork/alternatives_test.go
+++ b/landedwork/alternatives_test.go
@@ -1,0 +1,178 @@
+package landedwork_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/landedwork"
+)
+
+func TestAutomaticSingleParent(t *testing.T) {
+	for _, mode := range []string{"squash", "replay", "rebase", "fast forward", "ambiguous", "crosses base", "disabled"} {
+		t.Run(mode, func(t *testing.T) {
+			f := buildFixture(t, true)
+			proofs, spine := []string{"squash"}, []string{f.head}
+			reason := ""
+			switch mode {
+			case "replay", "rebase":
+				f.repo.Checkout("-b", "replay", f.base)
+				f.base = f.repo.CommitFile("other", "context\n", "advance")
+				first := f.repo.CommitFile("work.txt", "new\nkeep\n", "replay first")
+				f.head = first
+				spine = []string{first}
+				proofs = []string{"rebase", "squash"}
+				if mode == "replay" {
+					f.source = f.source[:1]
+				} else {
+					f.head = f.repo.CommitFile("work.txt", "new\nkeep\none\ntwo\n", "replay second")
+					spine = append(spine, f.head)
+					proofs = []string{"rebase"}
+				}
+			case "fast forward":
+				f.head = f.source[1]
+				spine, proofs = f.source, []string{"fast_forward", "rebase"}
+			case "ambiguous", "crosses base":
+				f.repo.Checkout("-b", "exact", f.base)
+				f.repo.Run("commit", "--allow-empty", "-m", "empty prefix")
+				prefix := f.repo.Head()
+				f.head = f.repo.CommitFile("work.txt", "changed\n", "content")
+				f.source = []string{prefix, f.head}
+				reason = "origin_ambiguous"
+				if mode == "crosses base" {
+					f.base = prefix
+					reason = "range_crosses_base"
+				}
+			case "disabled":
+				reason = "method_unproven"
+			}
+			ctx, p := f.prepare(t)
+			e := fixtureEvidence(f, p, "")
+			e.Candidates[0].MethodEvidence = ""
+			e.Capabilities = landedwork.Capabilities{SingleParentCorrespondence: mode != "disabled"}
+			r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+			require.NoError(t, err)
+			assert := assert.New(t)
+			assert.Empty(r.DirectPushes)
+			if reason != "" {
+				assert.Empty(r.Landings)
+				assert.False(r.Coverage.Complete)
+				assert.Equal(f.base, r.Coverage.CertifiedHead)
+				assert.Equal([]landedwork.Gap{{CandidateID: "7", ObjectID: f.head, Reason: reason,
+					Span: landedwork.Span{Before: f.base, Through: f.head}}}, r.Coverage.Gaps)
+				return
+			}
+			require.Len(t, r.Landings, 1)
+			assert.Equal(landedwork.Landing{CandidateID: "7", Proofs: proofs, Before: f.base,
+				Terminal: f.head, Source: f.source, Spine: spine, Introduced: spine}, r.Landings[0])
+			assert.True(r.Coverage.Complete)
+			assert.Equal(f.head, r.Coverage.CertifiedHead)
+			assert.Empty(r.Coverage.Gaps)
+		})
+	}
+}
+
+func TestAutomaticEarlierHistory(t *testing.T) {
+	for _, mode := range []string{"disproved", "missing", "budget", "shallow"} {
+		t.Run(mode, func(t *testing.T) {
+			require := require.New(t)
+			f := buildFixture(t, true)
+			f.repo.Checkout("topic")
+			f.source = append(f.source, f.repo.CommitFile("source-extra", "extra\n", "third"))
+			f.repo.Checkout("-b", "target", f.base)
+			earlier := f.repo.CommitFile("other", "earlier\n", "earlier")
+			f.base = f.repo.CommitFile("other", "base\n", "advance")
+			f.repo.Run("merge", "--squash", "topic")
+			f.repo.Run("commit", "-m", "squash")
+			terminal := f.repo.Head()
+			f.head = terminal
+			if mode == "budget" {
+				f.head = f.repo.CommitFile("later", "later\n", "after candidate")
+			}
+			f.repo.Run("commit-graph", "write", "--reachable")
+			ctx, p := f.prepare(t)
+			e := fixtureEvidence(f, p, "")
+			e.Candidates[0].Terminal = terminal
+			e.Candidates[0].MethodEvidence = ""
+			e.Capabilities = landedwork.Capabilities{SingleParentCorrespondence: true}
+			limits := fixtureLimits()
+			reason, object := "", ""
+			switch mode {
+			case "missing":
+				require.NoError(os.Remove(filepath.Join(f.repo.GitDir, "objects", earlier[:2], earlier[2:])))
+				_, _, err := f.repo.Runner.Run(ctx, f.repo.Root, nil, "cat-file", "-e", earlier)
+				require.Error(err)
+				reason, object = "objects_unavailable", earlier
+			case "budget":
+				// Fourteen reads finish source validation and both aggregate deltas;
+				// the fixed suffix still needs a read and cannot be skipped.
+				limits.Nodes = 14
+				reason, object = "input_budget_exhausted", terminal
+			case "shallow":
+				require.NoError(os.WriteFile(filepath.Join(f.repo.GitDir, "shallow"), []byte(earlier+"\n"), 0600))
+				reason = "shallow_boundary"
+			}
+			r, err := landedwork.Analyze(ctx, p, e, limits)
+			require.NoError(err)
+			assert := assert.New(t)
+			if reason == "" {
+				require.Len(r.Landings, 1)
+				assert.Equal([]string{"squash"}, r.Landings[0].Proofs)
+				assert.Equal([]string{terminal}, r.Landings[0].Spine)
+				assert.Equal(f.base, r.Landings[0].Before)
+				assert.True(r.Coverage.Complete)
+				assert.Equal(f.head, r.Coverage.CertifiedHead)
+				return
+			}
+			require.Len(r.Coverage.Gaps, 1)
+			assert.Equal(reason, r.Coverage.Gaps[0].Reason)
+			assert.Equal(object, r.Coverage.Gaps[0].ObjectID)
+			assert.Equal(landedwork.Span{Before: f.base, Through: f.head}, r.Coverage.Gaps[0].Span)
+			assert.Empty(r.Landings)
+			assert.Empty(r.DirectPushes)
+			assert.False(r.Coverage.Complete)
+			assert.Equal(f.base, r.Coverage.CertifiedHead)
+		})
+	}
+}
+
+func TestAutomaticAggregateCancellation(t *testing.T) {
+	for _, empty := range []bool{false, true} {
+		f := buildFixture(t, true)
+		f.repo.Checkout("topic")
+		f.source = append(f.source, f.repo.CommitFile("extra", "temporary\n", "insert"))
+		f.repo.Run("rm", "extra")
+		f.repo.Run("commit", "-m", "cancel")
+		f.source = append(f.source, f.repo.Head())
+		if empty {
+			f.source = append(f.source, f.repo.CommitFile("work.txt", "old\nkeep\n", "undo all"))
+		}
+		f.repo.Checkout("-b", "target", f.base)
+		f.repo.Run("merge", "--squash", "topic")
+		f.repo.Run("commit", "--allow-empty", "-m", "aggregate")
+		f.head = f.repo.Head()
+		ctx, p := f.prepare(t)
+		e := fixtureEvidence(f, p, "")
+		e.Candidates[0].MethodEvidence = ""
+		e.Capabilities = landedwork.Capabilities{SingleParentCorrespondence: true}
+		r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+		require.NoError(t, err)
+		assert := assert.New(t)
+		assert.Empty(r.DirectPushes)
+		if empty {
+			assert.Empty(r.Landings)
+			assert.False(r.Coverage.Complete)
+			assert.Equal(f.base, r.Coverage.CertifiedHead)
+			require.Len(t, r.Coverage.Gaps, 1)
+			assert.Equal("edits_unavailable", r.Coverage.Gaps[0].Reason)
+		} else {
+			require.Len(t, r.Landings, 1)
+			assert.Equal([]string{"squash"}, r.Landings[0].Proofs)
+			assert.Equal([]string{f.head}, r.Landings[0].Spine)
+			assert.True(r.Coverage.Complete)
+			assert.Equal(f.head, r.Coverage.CertifiedHead)
+		}
+	}
+}

--- a/landedwork/analyze.go
+++ b/landedwork/analyze.go
@@ -10,6 +10,9 @@ import (
 // Analyze accepts only evidence for p.Query(). Missing proof returns a named
 // coverage gap; malformed inputs, cancellation and unrepresentable output return
 // errors. Callers must never publish a result returned with an error.
+// Callers may acquire original source objects after Collect, then analyze the
+// same prepared interval and evidence. A fetched ref never replaces an observed
+// source SHA; missing originals remain gaps. Analyze never fetches objects.
 func Analyze(ctx context.Context, p *Interval, e Evidence, limits Limits) (r Result, err error) {
 	if p == nil {
 		return r, errors.New("prepared interval required")

--- a/landedwork/budget_test.go
+++ b/landedwork/budget_test.go
@@ -24,3 +24,27 @@ func TestCommitStreamStopsBeforeRetainingOverBudgetRecord(t *testing.T) {
 	require.ErrorIs(t, err, ErrInputBudget)
 	assert.Equal(t, []string{first}, stream.ids)
 }
+
+func TestResultOwnershipBudget(t *testing.T) {
+	// One landing plus two labels and three occurrences of the owned ID.
+	r := Result{Landings: []Landing{{CandidateID: "7", Before: "a", Terminal: "b",
+		Proofs: []string{"rebase", "squash"}, Spine: []string{"b"}, Source: []string{"c"}, Introduced: []string{"b"}}}}
+	for _, tc := range []struct {
+		name           string
+		bytes, records int64
+		fails          bool
+	}{
+		{"exact", 18, 6, false},
+		{"bytes", 17, 6, true},
+		{"records", 18, 5, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkResultOutput(r, Limits{OutputBytes: tc.bytes, Records: tc.records})
+			if tc.fails {
+				require.ErrorIs(t, err, ErrOutputBudget)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/landedwork/budget_test.go
+++ b/landedwork/budget_test.go
@@ -26,7 +26,7 @@ func TestCommitStreamStopsBeforeRetainingOverBudgetRecord(t *testing.T) {
 }
 
 func TestResultOwnershipBudget(t *testing.T) {
-	// One landing plus two labels and three occurrences of the owned ID.
+	// One landing plus two labels and three retained commit-list entries.
 	r := Result{Landings: []Landing{{CandidateID: "7", Before: "a", Terminal: "b",
 		Proofs: []string{"rebase", "squash"}, Spine: []string{"b"}, Source: []string{"c"}, Introduced: []string{"b"}}}}
 	for _, tc := range []struct {

--- a/landedwork/collect/collect.go
+++ b/landedwork/collect/collect.go
@@ -52,7 +52,9 @@ func Collect(ctx context.Context, reader platform.LandingEvidenceReader, route p
 	}
 	query.Commits, query.Gaps = slices.Clone(query.Commits), slices.Clone(query.Gaps)
 	support := reader.LandingEvidenceSupport()
-	c := collector{reader: reader, route: route, remaining: limits, refs: make(map[int64]platform.LandingChangeRef), result: Result{Evidence: landedwork.Evidence{Query: query, Inventory: landedwork.Inventory{Supported: support.Inventory}, Capabilities: landedwork.Capabilities{Merge: support.OrdinaryMerge}}}}
+	c := collector{reader: reader, route: route, remaining: limits, refs: make(map[int64]platform.LandingChangeRef), result: Result{Evidence: landedwork.Evidence{Query: query, Inventory: landedwork.Inventory{Supported: support.Inventory}, Capabilities: landedwork.Capabilities{
+		Merge: support.OrdinaryMerge, SingleParentCorrespondence: support.SingleParentCorrespondence,
+	}}}}
 	c.remaining.Records -= int64(len(query.Commits)) + int64(len(query.Gaps))
 	defer func() {
 		if c.fatal != nil {

--- a/landedwork/collect/github_test.go
+++ b/landedwork/collect/github_test.go
@@ -129,12 +129,16 @@ func TestGitHubCollectionAnalysis(t *testing.T) {
 				}
 			}
 			switch mode {
-			case "merge":
+			case "merge", "one parent":
 				assert.True(analysis.Coverage.Complete)
 				assert.Equal(head, analysis.Coverage.CertifiedHead)
 				require.Len(analysis.Landings, 1)
 				assert.Equal(base, analysis.Landings[0].Before)
 				assert.Equal(head, analysis.Landings[0].Terminal)
+				if mode == "one parent" {
+					assert.Equal([]string{"rebase", "squash"}, analysis.Landings[0].Proofs)
+					assert.Equal([]string{head}, analysis.Landings[0].Spine)
+				}
 			case "no associations":
 				assert.True(analysis.Coverage.Complete)
 				require.Len(analysis.DirectPushes, 1)

--- a/landedwork/collect/source_fetch_test.go
+++ b/landedwork/collect/source_fetch_test.go
@@ -1,0 +1,185 @@
+package collect_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/testutil/gitsafe"
+	"go.kenn.io/forge/landedwork"
+	"go.kenn.io/forge/landedwork/collect"
+	"go.kenn.io/forge/platform"
+	"go.kenn.io/forge/platform/github"
+	gittest "go.kenn.io/kit/git/test"
+)
+
+var proofLimits = landedwork.Limits{Records: 1000, Nodes: 1000, InputBytes: 1 << 20, OutputBytes: 1 << 20}
+
+// The HTTP boundary supplies observed SHAs, never the Git objects themselves.
+func collectGitHubProof(t *testing.T, ctx context.Context, path string, b landedwork.Bounds, sources []string, host string) (*landedwork.Interval, landedwork.Evidence) {
+	t.Helper()
+	require, assert := require.New(t), assert.New(t)
+	p, err := landedwork.Prepare(ctx, path, b, proofLimits)
+	require.NoError(err)
+	require.True(p.Query().Complete)
+	hc := &http.Client{Transport: platform.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body := ""
+		switch req.URL.Path {
+		case "/repos/example/project":
+			body = `{"id":12,"name":"project","owner":{"login":"example"}}`
+		case "/repos/example/project/pulls/3":
+			body = fmt.Sprintf(`{"id":7,"number":3,"merged":true,"merge_commit_sha":%q,"commits":%d,"base":{"ref":"main","repo":{"id":12}},"head":{"sha":%q,"repo":{"id":12}}}`, b.Head, len(sources), sources[len(sources)-1])
+		case "/repos/example/project/pulls/3/commits":
+			rows := make([]string, len(sources))
+			for i, sha := range sources {
+				rows[i] = fmt.Sprintf(`{"sha":%q}`, sha)
+			}
+			body = "[" + strings.Join(rows, ",") + "]"
+		default:
+			sha := strings.TrimSuffix(strings.TrimPrefix(req.URL.Path, "/repos/example/project/commits/"), "/pulls")
+			require.True(slices.Contains(p.Query().Commits, sha), "unexpected association: %s", req.URL.Path)
+			body = `[{"id":7,"number":3,"base":{"repo":{"id":12}}}]`
+		}
+		return &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body)), Request: req}, nil
+	})}
+	client, err := github.NewClient(github.ClientConfig{Read: hc, Write: hc, Notifications: hc, Clock: time.Now})
+	require.NoError(err)
+	reader, err := github.NewProvider(github.ProviderConfig{Host: host, Client: client, Clock: time.Now})
+	require.NoError(err)
+	r := route
+	r.Host = host
+	c, err := collect.Collect(ctx, reader, r, p.Query(), limits)
+	require.NoError(err)
+	if host == "github.com" {
+		require.True(c.Evidence.Inventory.Complete)
+		require.Len(c.Evidence.Candidates, 1)
+		assert.Equal(sources, c.Evidence.Candidates[0].Source)
+		assert.Empty(c.Evidence.Candidates[0].Method)
+		assert.Empty(c.Evidence.Candidates[0].MethodEvidence)
+	}
+	return p, c.Evidence
+}
+
+func TestGitHubSingleParentCollection(t *testing.T) {
+	for _, mode := range []string{"squash", "rebase", "enterprise"} {
+		t.Run(mode, func(t *testing.T) {
+			r := gittest.NewRepo(t, gittest.Options{InitArgs: []string{"init", "-b", "main"}, ConfigureUser: true})
+			r.Runner = gitsafe.Runner()
+			base := r.CommitFile("work.txt", "old\nkeep\n", "base")
+			r.Checkout("-b", "topic")
+			sources := []string{r.CommitFile("work.txt", "new\nkeep\n", "first")}
+			sources = append(sources, r.CommitFile("work.txt", "new\nkeep\nlast\n", "second"))
+			r.Checkout("main")
+			var spine []string
+			proofs := []string{"squash"}
+			if mode == "rebase" {
+				base = r.CommitFile("context", "advance\n", "advance")
+				spine = append(spine, r.CommitFile("work.txt", "new\nkeep\n", "replay first"))
+				r.CommitFile("work.txt", "new\nkeep\nlast\n", "replay second")
+				proofs = []string{"rebase"}
+			} else {
+				r.Run("merge", "--squash", "topic")
+				r.Run("commit", "-m", "squash")
+			}
+			head := r.Head()
+			spine = append(spine, head)
+			b := landedwork.Bounds{Repository: query.Bounds.Repository, Base: base, Head: head}
+			if mode == "enterprise" {
+				b.Repository.Host = "code.example.com"
+			}
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+			defer cancel()
+			p, e := collectGitHubProof(t, ctx, r.Root, b, sources, b.Repository.Host)
+			result, err := landedwork.Analyze(ctx, p, e, proofLimits)
+			require.NoError(t, err)
+			assert := assert.New(t)
+			assert.Empty(result.DirectPushes)
+			if mode == "enterprise" {
+				assert.Empty(result.Landings)
+				assert.False(result.Coverage.Complete)
+				assert.Equal(base, result.Coverage.CertifiedHead)
+				assert.Equal("unsupported_discovery", result.Coverage.Inventory.Reason)
+				return
+			}
+			assert.Equal([]landedwork.Landing{{CandidateID: "7", Before: base, Terminal: head, Source: sources,
+				Proofs: proofs, Spine: spine, Introduced: spine}}, result.Landings)
+			assert.True(result.Coverage.Complete)
+			assert.Equal(head, result.Coverage.CertifiedHead)
+			assert.Empty(result.Coverage.Gaps)
+		})
+	}
+}
+
+func TestCallerFetchesObservedSource(t *testing.T) {
+	for _, moved := range []bool{false, true} {
+		t.Run(fmt.Sprintf("moved=%t", moved), func(t *testing.T) {
+			require, assert := require.New(t), assert.New(t)
+			r := gittest.NewRepo(t, gittest.Options{InitArgs: []string{"init", "-b", "main"}, ConfigureUser: true})
+			r.Runner = gitsafe.Runner()
+			base := r.CommitFile("work.txt", "old\nkeep\n", "base")
+			r.Checkout("-b", "topic")
+			sources := []string{r.CommitFile("work.txt", "new\nkeep\n", "first")}
+			sources = append(sources, r.CommitFile("work.txt", "new\nkeep\nlast\n", "second"))
+			source := sources[1]
+			r.Checkout("main")
+			r.Run("merge", "--squash", "topic")
+			r.Run("commit", "-m", "squash")
+			head := r.Head()
+			remote, clone := filepath.Join(t.TempDir(), "remote.git"), filepath.Join(t.TempDir(), "clone")
+			r.Run("clone", "--bare", "--no-local", r.Root, remote)
+			r.Run("--git-dir="+remote, "update-ref", "refs/pull/3/head", source)
+			r.Run("--git-dir="+remote, "update-ref", "-d", "refs/heads/topic")
+			fetched := source
+			if moved {
+				fetched = r.CommitFile("unrelated", "new head\n", "repushed head")
+				r.Run("push", remote, "+"+fetched+":refs/pull/3/head")
+			}
+			r.Run("clone", "--no-local", "--single-branch", "--branch", "main", "--no-tags", remote, clone)
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+			defer cancel()
+			_, _, err := r.Runner.Run(ctx, clone, nil, "cat-file", "-e", source+"^{commit}")
+			require.Error(err, "default-only clone must not contain the original source")
+			b := landedwork.Bounds{Repository: query.Bounds.Repository, Base: base, Head: head}
+			p, e := collectGitHubProof(t, ctx, clone, b, sources, "github.com")
+			missing, err := landedwork.Analyze(ctx, p, e, proofLimits)
+			require.NoError(err)
+			assert.Empty(missing.Landings)
+			assert.Empty(missing.DirectPushes)
+			assert.False(missing.Coverage.Complete)
+			assert.Equal(base, missing.Coverage.CertifiedHead)
+			require.Len(missing.Coverage.Gaps, 1)
+			assert.Equal("objects_unavailable", missing.Coverage.Gaps[0].Reason)
+			assert.Equal(sources[0], missing.Coverage.Gaps[0].ObjectID)
+			_, _, err = r.Runner.Run(ctx, clone, nil, "fetch", remote, "refs/pull/3/head:refs/test/pull/3/head")
+			require.NoError(err)
+			_, _, err = r.Runner.Run(ctx, clone, nil, "cat-file", "-e", fetched+"^{commit}")
+			require.NoError(err)
+			_, _, err = r.Runner.Run(ctx, clone, nil, "cat-file", "-e", source+"^{commit}")
+			if moved {
+				require.Error(err)
+			} else {
+				require.NoError(err)
+			}
+			result, err := landedwork.Analyze(ctx, p, e, proofLimits)
+			require.NoError(err)
+			if moved {
+				assert.Equal(missing, result, "a different fetched head cannot replace observed evidence")
+				return
+			}
+			assert.Equal([]landedwork.Landing{{CandidateID: "7", Proofs: []string{"squash"}, Before: base, Terminal: head,
+				Source: sources, Spine: []string{head}, Introduced: []string{head}}}, result.Landings)
+			assert.True(result.Coverage.Complete)
+			assert.Equal(head, result.Coverage.CertifiedHead)
+			assert.Empty(result.Coverage.Gaps)
+			assert.Empty(result.DirectPushes)
+		})
+	}
+}

--- a/landedwork/edits.go
+++ b/landedwork/edits.go
@@ -39,40 +39,45 @@ func sameEdits(a, b []fileEdit) bool {
 	})
 }
 
-func (v *objectView) commitEdits(ctx context.Context, id string) ([]fileEdit, error) {
-	parents, err := v.parents(ctx, id)
+// Callers physically verify the boundary commits before comparing their trees.
+// A different path/mode inventory disproves correspondence without parsing text.
+func (v *objectView) compareTreeEdits(ctx context.Context, sourceBefore, source, before, after string) ([]fileEdit, error) {
+	a, err := v.treeFiles(ctx, sourceBefore, source)
 	if err != nil {
 		return nil, err
 	}
-	if len(parents) != 1 {
+	b, err := v.treeFiles(ctx, before, after)
+	if err != nil {
+		return nil, err
+	}
+	if !slices.EqualFunc(a, b, func(a, b fileEdit) bool {
+		return a.path == b.path && a.oldMode == b.oldMode && a.newMode == b.newMode
+	}) {
+		return nil, errCorrespondence
+	}
+	if len(a) == 0 {
 		return nil, errEdits
 	}
-	return v.treeEdits(ctx, parents[0], id)
-}
-
-func (v *objectView) treeEdits(ctx context.Context, before, after string) ([]fileEdit, error) {
-	for _, id := range []string{before, after} {
-		if _, err := v.parents(ctx, id); err != nil {
+	for i := range a {
+		if err := v.fileEdits(ctx, sourceBefore, source, &a[i]); err != nil {
+			return nil, err
+		}
+		if err := v.fileEdits(ctx, before, after, &b[i]); err != nil {
 			return nil, err
 		}
 	}
+	if !sameEdits(a, b) {
+		return nil, errCorrespondence
+	}
+	return a, nil
+}
+
+func (v *objectView) treeFiles(ctx context.Context, before, after string) ([]fileEdit, error) {
 	raw, err := v.run(ctx, "diff", "--raw", "-z", "--no-abbrev", "--no-renames", "--no-ext-diff", "--no-textconv", before, after, "--")
 	if err != nil {
 		return nil, err
 	}
-	files, err := parseEditFiles(raw)
-	if err != nil {
-		return nil, err
-	}
-	for i := range files {
-		if err = ctx.Err(); err != nil {
-			return nil, err
-		}
-		if err = v.fileEdits(ctx, before, after, &files[i]); err != nil {
-			return nil, err
-		}
-	}
-	return files, nil
+	return parseEditFiles(raw)
 }
 
 // Metadata is NUL-delimited; Git path quoting never changes the comparison key.

--- a/landedwork/edits.go
+++ b/landedwork/edits.go
@@ -47,10 +47,16 @@ func (v *objectView) commitEdits(ctx context.Context, id string) ([]fileEdit, er
 	if len(parents) != 1 {
 		return nil, errEdits
 	}
-	if _, err = v.parents(ctx, parents[0]); err != nil {
-		return nil, err
+	return v.treeEdits(ctx, parents[0], id)
+}
+
+func (v *objectView) treeEdits(ctx context.Context, before, after string) ([]fileEdit, error) {
+	for _, id := range []string{before, after} {
+		if _, err := v.parents(ctx, id); err != nil {
+			return nil, err
+		}
 	}
-	raw, err := v.run(ctx, "diff", "--raw", "-z", "--no-abbrev", "--no-renames", "--no-ext-diff", "--no-textconv", parents[0], id, "--")
+	raw, err := v.run(ctx, "diff", "--raw", "-z", "--no-abbrev", "--no-renames", "--no-ext-diff", "--no-textconv", before, after, "--")
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +68,7 @@ func (v *objectView) commitEdits(ctx context.Context, id string) ([]fileEdit, er
 		if err = ctx.Err(); err != nil {
 			return nil, err
 		}
-		if err = v.fileEdits(ctx, parents[0], id, &files[i]); err != nil {
+		if err = v.fileEdits(ctx, before, after, &files[i]); err != nil {
 			return nil, err
 		}
 	}

--- a/landedwork/edits.go
+++ b/landedwork/edits.go
@@ -55,7 +55,7 @@ func (v *objectView) compareTreeEdits(ctx context.Context, sourceBefore, source,
 	}) {
 		return nil, errCorrespondence
 	}
-	if len(a) == 0 {
+	if len(a) == 0 || len(b) == 0 {
 		return nil, errEdits
 	}
 	for i := range a {

--- a/landedwork/evidence.go
+++ b/landedwork/evidence.go
@@ -13,7 +13,11 @@ type Inventory struct {
 }
 
 // Capabilities authorize generic proof paths, not inferred provider support.
-type Capabilities struct{ Merge, Squash, Rebase, FastForward bool }
+type Capabilities struct {
+	Merge, Squash, Rebase, FastForward bool
+	// SingleParentCorrespondence authorizes all automatic alternatives together.
+	SingleParentCorrespondence bool
+}
 
 // Candidate contains provider facts bound to a stable target repository.
 // Evidence labels name the facts establishing method and terminal, not guesses

--- a/landedwork/evidence.go
+++ b/landedwork/evidence.go
@@ -35,8 +35,11 @@ type Evidence struct {
 }
 
 type Landing struct {
-	CandidateID, Method, Before, Terminal string
-	Source, Introduced                    []string
+	CandidateID, Before, Terminal string
+	// Proofs are sorted correspondence labels, not historical merge actions.
+	Proofs []string
+	// Spine is the ordered first-parent ownership, independent of proof labels.
+	Spine, Source, Introduced []string
 }
 
 type Coverage struct {

--- a/landedwork/git.go
+++ b/landedwork/git.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"iter"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	gitcmd "go.kenn.io/kit/git/cmd"
@@ -151,30 +151,29 @@ func (v *objectView) introduced(ctx context.Context, base, head string) ([]strin
 	return out.ids, nil
 }
 
-// Read only the fixed suffix and its boundary, including pre-interval history
-// needed to disprove a range. Analyze's shallow check precedes this walk.
-func (v *objectView) firstParentSuffix(ctx context.Context, p *Interval, terminal string, count int) (firstParentRange, bool, string, error) {
-	end := slices.Index(p.spine, terminal)
-	r := firstParentRange{crossesBase: end+1 < count}
-	id := terminal
-	for i := range count {
-		if pos := end - i; pos >= 0 {
-			id = p.spine[pos]
+type commitBoundary struct{ id, before string }
+
+// The caller has read terminal and its single parent. Walk only as far as the
+// comparison needs, physically reading each next commit before yielding a pair.
+// Analyze's shallow check precedes this walk, including pre-interval history.
+func (v *objectView) firstParentSuffix(ctx context.Context, terminal, before string, count int) iter.Seq2[commitBoundary, error] {
+	return func(yield func(commitBoundary, error) bool) {
+		id := terminal
+		for i := range count {
+			parents, err := v.parents(ctx, before)
+			pair := commitBoundary{id: id, before: before}
+			if err != nil {
+				yield(pair, err)
+				return
+			}
+			if !yield(pair, nil) || i == count-1 {
+				return
+			}
+			if len(parents) != 1 {
+				yield(commitBoundary{id: before, before: before}, errCorrespondence)
+				return
+			}
+			id, before = before, parents[0]
 		}
-		parents, err := v.parents(ctx, id)
-		if err != nil {
-			return firstParentRange{}, false, id, err
-		}
-		if len(parents) != 1 {
-			return firstParentRange{}, false, "", nil
-		}
-		r.commits = append(r.commits, id)
-		id = parents[0]
 	}
-	if _, err := v.parents(ctx, id); err != nil {
-		return firstParentRange{}, false, id, err
-	}
-	r.before = id
-	slices.Reverse(r.commits)
-	return r, true, "", nil
 }

--- a/landedwork/git.go
+++ b/landedwork/git.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	gitcmd "go.kenn.io/kit/git/cmd"
@@ -148,4 +149,32 @@ func (v *objectView) introduced(ctx context.Context, base, head string) ([]strin
 		return nil, errors.New("incomplete revision object ID")
 	}
 	return out.ids, nil
+}
+
+// Read only the fixed suffix and its boundary, including pre-interval history
+// needed to disprove a range. Analyze's shallow check precedes this walk.
+func (v *objectView) firstParentSuffix(ctx context.Context, p *Interval, terminal string, count int) (firstParentRange, bool, string, error) {
+	end := slices.Index(p.spine, terminal)
+	r := firstParentRange{crossesBase: end+1 < count}
+	id := terminal
+	for i := range count {
+		if pos := end - i; pos >= 0 {
+			id = p.spine[pos]
+		}
+		parents, err := v.parents(ctx, id)
+		if err != nil {
+			return firstParentRange{}, false, id, err
+		}
+		if len(parents) != 1 {
+			return firstParentRange{}, false, "", nil
+		}
+		r.commits = append(r.commits, id)
+		id = parents[0]
+	}
+	if _, err := v.parents(ctx, id); err != nil {
+		return firstParentRange{}, false, id, err
+	}
+	r.before = id
+	slices.Reverse(r.commits)
+	return r, true, "", nil
 }

--- a/landedwork/origins.go
+++ b/landedwork/origins.go
@@ -22,10 +22,7 @@ func candidateGap(p *Interval, c Candidate, g Gap) Gap {
 }
 
 func ownedSpine(l Landing) []string {
-	if l.Method == "rebase" || l.Method == "fast_forward" {
-		return l.Introduced
-	}
-	return []string{l.Terminal}
+	return l.Spine
 }
 
 func landingOwners(landings []Landing) map[string]bool {
@@ -121,7 +118,7 @@ func integratedThrough(ctx context.Context, v *objectView, p *Interval, c Candid
 			g.Reason = graphReason(err)
 			return "", g
 		}
-		if outer.Method != "merge" {
+		if !slices.Equal(outer.Proofs, []string{"merge"}) {
 			continue
 		}
 		introduced := make(map[string]bool, len(outer.Introduced))

--- a/landedwork/origins_test.go
+++ b/landedwork/origins_test.go
@@ -198,36 +198,43 @@ func TestIntegratedMerges(t *testing.T) {
 }
 
 func TestOriginOverlaps(t *testing.T) {
-	for _, reverse := range []bool{false, true} {
-		f := buildFixture(t, false)
-		f.repo.Checkout("-b", "overlap", f.base)
-		direct := f.repo.CommitFile("other", "direct\n", "direct")
-		f.source = []string{f.repo.CommitFile("work.txt", "new\nkeep\n", "first")}
-		f.source = append(f.source, f.repo.CommitFile("work.txt", "new\nkeep\nlast\n", "last"))
-		f.head = f.repo.Head()
-		ctx, p := f.prepare(t)
-		e := fixtureEvidence(f, p, "fast_forward")
-		e.Capabilities.FastForward = true
-		c := e.Candidates[0]
-		c.ID = "8"
-		c.Terminal = f.source[0]
-		c.SourceHead = f.source[0]
-		c.Source = c.Source[:1]
-		e.Candidates = append(e.Candidates, c)
-		if reverse {
-			slices.Reverse(e.Candidates)
+	for _, automatic := range []bool{false, true} {
+		for _, reverse := range []bool{false, true} {
+			f := buildFixture(t, false)
+			f.repo.Checkout("-b", "overlap", f.base)
+			direct := f.repo.CommitFile("other", "direct\n", "direct")
+			f.source = []string{f.repo.CommitFile("work.txt", "new\nkeep\n", "first")}
+			f.source = append(f.source, f.repo.CommitFile("work.txt", "new\nkeep\nlast\n", "last"))
+			f.head = f.repo.Head()
+			ctx, p := f.prepare(t)
+			e := fixtureEvidence(f, p, "fast_forward")
+			e.Capabilities.FastForward = true
+			if automatic {
+				e.Candidates[0].Method, e.Candidates[0].MethodEvidence = "", ""
+				e.Capabilities = landedwork.Capabilities{SingleParentCorrespondence: true}
+			}
+			c := e.Candidates[0]
+			c.ID = "8"
+			c.Terminal = f.source[0]
+			c.SourceHead = f.source[0]
+			c.Source = c.Source[:1]
+			e.Candidates = append(e.Candidates, c)
+			if reverse {
+				slices.Reverse(e.Candidates)
+			}
+			r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+			require.NoError(t, err)
+			assert := assert.New(t)
+			assert.Empty(r.Landings)
+			assert.False(r.Coverage.Complete)
+			assert.Equal(direct, r.Coverage.CertifiedHead)
+			require.Len(t, r.Coverage.Gaps, 2)
+			assert.Equal(landedwork.Span{Before: direct, Through: f.head}, r.Coverage.Gaps[0].Span)
+			assert.Equal("candidate_conflict", r.Coverage.Gaps[0].Reason)
+			assert.Equal([]landedwork.DirectPush{{Before: f.base, Terminal: direct, Introduced: []string{direct}}}, r.DirectPushes)
 		}
-		r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
-		require.NoError(t, err)
-		assert := assert.New(t)
-		assert.Empty(r.Landings)
-		assert.False(r.Coverage.Complete)
-		assert.Equal(direct, r.Coverage.CertifiedHead)
-		require.Len(t, r.Coverage.Gaps, 2)
-		assert.Equal(landedwork.Span{Before: direct, Through: f.head}, r.Coverage.Gaps[0].Span)
-		assert.Equal("candidate_conflict", r.Coverage.Gaps[0].Reason)
-		assert.Equal([]landedwork.DirectPush{{Before: f.base, Terminal: direct, Introduced: []string{direct}}}, r.DirectPushes)
 	}
+
 }
 
 func TestBlockedSpan(t *testing.T) {

--- a/landedwork/proof.go
+++ b/landedwork/proof.go
@@ -30,6 +30,9 @@ func proveAt(ctx context.Context, v *objectView, p *Interval, c Candidate, caps 
 		return reject(graphReason(err))
 	}
 	method := c.Method
+	if method == "" && len(parents) == 1 && caps.SingleParentCorrespondence && slices.Contains(p.spine, c.Terminal) {
+		return proveSingleParent(ctx, v, p, c)
+	}
 	if method == "" && len(parents) == 2 {
 		method = "merge"
 	}

--- a/landedwork/proof.go
+++ b/landedwork/proof.go
@@ -45,6 +45,9 @@ func proveAt(ctx context.Context, v *objectView, p *Interval, c Candidate, caps 
 	if method == "merge" && parents[1] != c.SourceHead {
 		return reject("source_head_mismatch")
 	}
+	if method == "squash" {
+		return proveSquash(ctx, v, c, parents[0])
+	}
 	if reason, object := checkSources(ctx, v, c); reason != "" {
 		gap.ObjectID = object
 		return reject(reason)

--- a/landedwork/proof.go
+++ b/landedwork/proof.go
@@ -68,7 +68,7 @@ func proveAt(ctx context.Context, v *objectView, p *Interval, c Candidate, caps 
 			return reject(graphReason(err))
 		}
 	}
-	return Landing{CandidateID: c.ID, Method: method, Before: parents[0], Terminal: c.Terminal,
+	return Landing{CandidateID: c.ID, Proofs: []string{method}, Spine: []string{c.Terminal}, Before: parents[0], Terminal: c.Terminal,
 		Source: slices.Clone(c.Source), Introduced: introduced}, Gap{}
 }
 

--- a/landedwork/proof.go
+++ b/landedwork/proof.go
@@ -31,7 +31,7 @@ func proveAt(ctx context.Context, v *objectView, p *Interval, c Candidate, caps 
 	}
 	method := c.Method
 	if method == "" && len(parents) == 1 && caps.SingleParentCorrespondence && slices.Contains(p.spine, c.Terminal) {
-		return proveSingleParent(ctx, v, p, c)
+		return proveSingleParent(ctx, v, p, c, parents[0])
 	}
 	if method == "" && len(parents) == 2 {
 		method = "merge"

--- a/landedwork/proof_test.go
+++ b/landedwork/proof_test.go
@@ -95,6 +95,12 @@ func TestAnalyzeProof(t *testing.T) {
 			assert.Equal("7", landing.CandidateID)
 			assert.Equal(f.base, landing.Before)
 			assert.Equal(f.head, landing.Terminal)
+			wantProof := method
+			if wantProof == "" {
+				wantProof = "merge"
+			}
+			assert.Equal([]string{wantProof}, landing.Proofs)
+			assert.Equal([]string{f.head}, landing.Spine)
 			assert.Equal(f.source, landing.Source)
 			assert.Equal(f.bounds(), result.Coverage.Bounds)
 			assert.True(result.Coverage.Complete)

--- a/landedwork/range.go
+++ b/landedwork/range.go
@@ -79,7 +79,10 @@ func rangeCorrespondence(ctx context.Context, v *objectView, c Candidate, landed
 		if err != nil {
 			return landed[i], err
 		}
-		if len(a) == 0 || !sameEdits(a, b) {
+		if len(a) == 0 || len(b) == 0 {
+			return source, errEdits
+		}
+		if !sameEdits(a, b) {
 			return source, errCorrespondence
 		}
 		for _, previous := range rewritten {
@@ -87,10 +90,37 @@ func rangeCorrespondence(ctx context.Context, v *objectView, c Candidate, landed
 				return source, err
 			}
 			if sameEdits(previous, a) {
-				return source, errCorrespondence
+				return source, errEdits
 			}
 		}
 		rewritten = append(rewritten, a)
 	}
 	return "", nil
+}
+
+func rangeAlternatives(ctx context.Context, v *objectView, p *Interval, c Candidate) [2]proofAttempt {
+	r, possible, object, err := v.firstParentSuffix(ctx, p, c.Terminal, len(c.Source))
+	if err != nil {
+		a := proofAttempt{gap: Gap{CandidateID: c.ID, ObjectID: object, Reason: graphReason(err)}}
+		return [2]proofAttempt{a, a}
+	}
+	if !possible {
+		return [2]proofAttempt{{state: attemptMismatch}, {state: attemptMismatch}}
+	}
+	var attempts [2]proofAttempt
+	for i, method := range []string{"rebase", "fast_forward"} {
+		c.Method = method
+		object, err := rangeCorrespondence(ctx, v, c, r.commits)
+		switch {
+		case errors.Is(err, errCorrespondence):
+			attempts[i].state = attemptMismatch
+		case err != nil:
+			attempts[i].gap = Gap{CandidateID: c.ID, ObjectID: object, Reason: editReason(err)}
+		default:
+			attempts[i] = proofAttempt{state: attemptMatch, crossesBase: r.crossesBase,
+				landing: Landing{CandidateID: c.ID, Proofs: []string{method}, Before: r.before, Terminal: c.Terminal,
+					Source: slices.Clone(c.Source), Spine: slices.Clone(r.commits), Introduced: slices.Clone(r.commits)}}
+		}
+	}
+	return attempts
 }

--- a/landedwork/range.go
+++ b/landedwork/range.go
@@ -10,117 +10,101 @@ func proveRange(ctx context.Context, v *objectView, p *Interval, c Candidate) (L
 	gap := Gap{CandidateID: c.ID, ObjectID: c.Terminal}
 	reject := func(reason string) (Landing, Gap) { gap.Reason = reason; return Landing{}, gap }
 	end := slices.Index(p.spine, c.Terminal) + 1
-	start := end - len(c.Source)
-	if start < 0 || end == 0 {
+	if end < len(c.Source) || end == 0 {
 		return reject("range_crosses_base")
 	}
-	if c.Source[len(c.Source)-1] != c.SourceHead {
-		return reject("source_head_mismatch")
+	sourceBefore, g := sourceBoundary(ctx, v, c)
+	if g.Reason != "" {
+		return Landing{}, g
 	}
-	if reason, object := checkSources(ctx, v, c); reason != "" {
-		gap.ObjectID = object
-		return reject(reason)
-	}
-	landed := p.spine[start:end]
-	before := p.query.Bounds.Base
-	if start > 0 {
-		before = p.spine[start-1]
-	}
-	if _, err := v.parents(ctx, before); err != nil {
-		gap.ObjectID = before
+	parents, err := v.parents(ctx, c.Terminal)
+	if err != nil {
 		return reject(graphReason(err))
 	}
-	for i, source := range c.Source {
-		for _, id := range []string{source, landed[i]} {
-			gap.ObjectID = id
-			parents, err := v.parents(ctx, id)
-			if err != nil {
-				return reject(graphReason(err))
-			}
-			if len(parents) != 1 {
-				return reject("topology_unproven")
-			}
-			if id == source && i > 0 && parents[0] != c.Source[i-1] {
-				return reject("source_order_unproven")
-			}
-		}
+	if len(parents) != 1 {
+		return reject("topology_unproven")
 	}
-	if object, err := rangeCorrespondence(ctx, v, c, landed); err != nil {
-		gap.ObjectID = object
-		if errors.Is(err, errCorrespondence) {
-			return reject("source_correspondence_unproven")
-		}
-		if errors.Is(err, errEdits) {
-			return reject("edits_unavailable")
-		}
-		return reject(graphReason(err))
+	attempts := rangeAlternatives(ctx, v, p, c, sourceBefore, parents[0])
+	a := attempts[0]
+	if c.Method == "fast_forward" {
+		a = attempts[1]
 	}
-	return Landing{CandidateID: c.ID, Proofs: []string{c.Method}, Spine: slices.Clone(landed), Before: before, Terminal: c.Terminal,
-		Source: slices.Clone(c.Source), Introduced: slices.Clone(landed)}, Gap{}
+	if a.state == attemptMismatch {
+		return reject("source_correspondence_unproven")
+	}
+	return a.landing, a.gap
 }
 
-func rangeCorrespondence(ctx context.Context, v *objectView, c Candidate, landed []string) (string, error) {
+// Compare the fixed range from its terminal backward. Any unequal pair rejects
+// the range, even if another pair was ambiguous. A successful proof still reads
+// every required commit and its boundary; it never shortens the owned range.
+func rangeCorrespondence(ctx context.Context, v *objectView, c Candidate, sourceBefore, before string) (r firstParentRange, identical bool, object string, err error) {
+	identical = true
 	var rewritten [][]fileEdit
-	for i, source := range c.Source {
-		if err := ctx.Err(); err != nil {
-			return source, err
+	var pending error
+	var pendingObject string
+	i := len(c.Source) - 1
+	for pair, readErr := range v.firstParentSuffix(ctx, c.Terminal, before, len(c.Source)) {
+		if readErr != nil {
+			return r, identical, pair.before, readErr
 		}
-		if source == landed[i] {
+		r.commits = append(r.commits, pair.id)
+		r.before = pair.before
+		source := c.Source[i]
+		parent := sourceBefore
+		if i > 0 {
+			parent = c.Source[i-1]
+		}
+		i--
+		if source == pair.id {
 			continue
 		}
+		identical = false
 		if c.Method == "fast_forward" {
-			return source, errCorrespondence
+			return r, identical, source, errCorrespondence
 		}
-		a, err := v.commitEdits(ctx, source)
-		if err != nil {
-			return source, err
-		}
-		b, err := v.commitEdits(ctx, landed[i])
-		if err != nil {
-			return landed[i], err
-		}
-		if len(a) == 0 || len(b) == 0 {
-			return source, errEdits
-		}
-		if !sameEdits(a, b) {
-			return source, errCorrespondence
-		}
-		for _, previous := range rewritten {
-			if err := ctx.Err(); err != nil {
-				return source, err
+		edits, compareErr := v.compareTreeEdits(ctx, parent, source, pair.before, pair.id)
+		if compareErr == nil {
+			for _, previous := range rewritten {
+				if sameEdits(previous, edits) {
+					compareErr = errEdits
+					break
+				}
 			}
-			if sameEdits(previous, a) {
-				return source, errEdits
-			}
+			rewritten = append(rewritten, edits)
 		}
-		rewritten = append(rewritten, a)
+		if errors.Is(compareErr, errEdits) {
+			if pending == nil {
+				pending, pendingObject = compareErr, source
+			}
+			continue
+		}
+		if compareErr != nil {
+			return r, identical, source, compareErr
+		}
 	}
-	return "", nil
+	slices.Reverse(r.commits)
+	return r, identical, pendingObject, pending
 }
 
-func rangeAlternatives(ctx context.Context, v *objectView, p *Interval, c Candidate) [2]proofAttempt {
-	r, possible, object, err := v.firstParentSuffix(ctx, p, c.Terminal, len(c.Source))
-	if err != nil {
-		a := proofAttempt{gap: Gap{CandidateID: c.ID, ObjectID: object, Reason: graphReason(err)}}
-		return [2]proofAttempt{a, a}
-	}
-	if !possible {
+func rangeAlternatives(ctx context.Context, v *objectView, p *Interval, c Candidate, sourceBefore, before string) [2]proofAttempt {
+	r, identical, object, err := rangeCorrespondence(ctx, v, c, sourceBefore, before)
+	if errors.Is(err, errCorrespondence) {
 		return [2]proofAttempt{{state: attemptMismatch}, {state: attemptMismatch}}
 	}
-	var attempts [2]proofAttempt
-	for i, method := range []string{"rebase", "fast_forward"} {
-		c.Method = method
-		object, err := rangeCorrespondence(ctx, v, c, r.commits)
-		switch {
-		case errors.Is(err, errCorrespondence):
-			attempts[i].state = attemptMismatch
-		case err != nil:
-			attempts[i].gap = Gap{CandidateID: c.ID, ObjectID: object, Reason: editReason(err)}
-		default:
-			attempts[i] = proofAttempt{state: attemptMatch, crossesBase: r.crossesBase,
-				landing: Landing{CandidateID: c.ID, Proofs: []string{method}, Before: r.before, Terminal: c.Terminal,
-					Source: slices.Clone(c.Source), Spine: slices.Clone(r.commits), Introduced: slices.Clone(r.commits)}}
+	a := proofAttempt{gap: Gap{CandidateID: c.ID, ObjectID: object, Reason: editReason(err)}}
+	if err == nil {
+		a = proofAttempt{state: attemptMatch,
+			crossesBase: slices.Index(p.spine, c.Terminal)+1 < len(c.Source),
+			landing: Landing{CandidateID: c.ID, Proofs: []string{"rebase"}, Before: r.before, Terminal: c.Terminal,
+				Source: slices.Clone(c.Source), Spine: r.commits, Introduced: slices.Clone(r.commits)}}
+	}
+	fastForward := proofAttempt{state: attemptMismatch}
+	if identical {
+		fastForward = a
+		if a.state == attemptMatch {
+			fastForward.landing.Proofs = []string{"fast_forward"}
 		}
 	}
-	return attempts
+	return [2]proofAttempt{a, fastForward}
 }

--- a/landedwork/range.go
+++ b/landedwork/range.go
@@ -55,7 +55,7 @@ func proveRange(ctx context.Context, v *objectView, p *Interval, c Candidate) (L
 		}
 		return reject(graphReason(err))
 	}
-	return Landing{CandidateID: c.ID, Method: c.Method, Before: before, Terminal: c.Terminal,
+	return Landing{CandidateID: c.ID, Proofs: []string{c.Method}, Spine: slices.Clone(landed), Before: before, Terminal: c.Terminal,
 		Source: slices.Clone(c.Source), Introduced: slices.Clone(landed)}, Gap{}
 }
 

--- a/landedwork/range_internal_test.go
+++ b/landedwork/range_internal_test.go
@@ -20,16 +20,16 @@ func TestRangeStopsAtConclusiveMismatch(t *testing.T) {
 	sources = append(sources, r.CommitFile("extra", "extra\n", "source second"))
 	r.Checkout("-b", "target", base)
 	landed := []string{r.CommitFile("text", "different\n", "target first")}
-	landed = append(landed, r.CommitFile("extra", "extra\n", "target second"))
+	landed = append(landed, r.CommitFile("extra", "different\n", "target second"))
 	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
 	defer cancel()
-	// The comparison's first pair needs six physical commit reads. Evaluating
-	// the second pair would spend more, but cannot rescue the mismatched first.
-	m := &meter{limits: Limits{Records: 100, Nodes: 6, InputBytes: 1 << 20}}
+	// The terminal pair disagrees. One boundary read suffices; reading an older
+	// pair would exceed this budget without changing the rejection.
+	m := &meter{limits: Limits{Records: 100, Nodes: 1, InputBytes: 1 << 20}}
 	v, err := openView(ctx, r.Root, m)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, v.close()) })
-	object, err := rangeCorrespondence(ctx, v, Candidate{Method: "rebase", Source: sources}, landed)
+	_, _, object, err := rangeCorrespondence(ctx, v, Candidate{Method: "rebase", Source: sources, Terminal: landed[1]}, base, landed[0])
 	require.ErrorIs(t, err, errCorrespondence)
-	assert.Equal(t, sources[0], object)
+	assert.Equal(t, sources[1], object)
 }

--- a/landedwork/range_internal_test.go
+++ b/landedwork/range_internal_test.go
@@ -1,0 +1,35 @@
+package landedwork
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/testutil/gitsafe"
+	gittest "go.kenn.io/kit/git/test"
+)
+
+func TestRangeStopsAtConclusiveMismatch(t *testing.T) {
+	r := gittest.NewRepo(t, gittest.Options{InitArgs: []string{"init", "-b", "main"}, ConfigureUser: true})
+	r.Runner = gitsafe.Runner()
+	base := r.CommitFile("text", "old\n", "base")
+	r.Checkout("-b", "source")
+	sources := []string{r.CommitFile("text", "source\n", "source first")}
+	sources = append(sources, r.CommitFile("extra", "extra\n", "source second"))
+	r.Checkout("-b", "target", base)
+	landed := []string{r.CommitFile("text", "different\n", "target first")}
+	landed = append(landed, r.CommitFile("extra", "extra\n", "target second"))
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+	// The comparison's first pair needs six physical commit reads. Evaluating
+	// the second pair would spend more, but cannot rescue the mismatched first.
+	m := &meter{limits: Limits{Records: 100, Nodes: 6, InputBytes: 1 << 20}}
+	v, err := openView(ctx, r.Root, m)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, v.close()) })
+	object, err := rangeCorrespondence(ctx, v, Candidate{Method: "rebase", Source: sources}, landed)
+	require.ErrorIs(t, err, errCorrespondence)
+	assert.Equal(t, sources[0], object)
+}

--- a/landedwork/range_rejection_test.go
+++ b/landedwork/range_rejection_test.go
@@ -1,0 +1,98 @@
+package landedwork_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/landedwork"
+)
+
+func TestRebaseMismatchOutweighsAmbiguousPair(t *testing.T) {
+	for _, ambiguousFirst := range []bool{true, false} {
+		t.Run(map[bool]string{true: "first", false: "last"}[ambiguousFirst], func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			f := buildFixture(t, true)
+			f.repo.Checkout("-b", "common", f.base)
+			f.base = f.repo.CommitFile("repeat", "same\nsame\n", "repeated lines")
+			for _, branch := range []string{"source", "target"} {
+				f.repo.Checkout("-b", branch, f.base)
+				var commits []string
+				for _, ambiguous := range []bool{ambiguousFirst, !ambiguousFirst} {
+					if ambiguous {
+						commits = append(commits, f.repo.CommitFile("repeat", "same\n", branch+" removes one occurrence"))
+					} else {
+						commits = append(commits, f.repo.CommitFile("other", branch+"\n", branch+" differs"))
+					}
+				}
+				if branch == "source" {
+					f.source = commits
+				} else {
+					f.head = commits[1]
+				}
+			}
+			ctx, p := f.prepare(t)
+			e := fixtureEvidence(f, p, "rebase")
+			e.Capabilities.Rebase = true
+			r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+			require.NoError(err)
+			require.Len(r.Coverage.Gaps, 1)
+			assert.Equal("source_correspondence_unproven", r.Coverage.Gaps[0].Reason)
+			assert.Empty(r.Landings)
+		})
+	}
+}
+
+func TestRebaseOneSidedEmptyIsMismatch(t *testing.T) {
+	for _, emptySource := range []bool{false, true} {
+		t.Run(map[bool]string{true: "source", false: "target"}[emptySource], func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			f := buildFixture(t, true)
+			f.repo.Checkout("-b", "empty", f.base)
+			f.repo.Run("commit", "--allow-empty", "-m", "empty")
+			f.head = f.repo.Head()
+			f.source = f.source[:1]
+			if emptySource {
+				f.head, f.source[0] = f.source[0], f.head
+			}
+			ctx, p := f.prepare(t)
+			e := fixtureEvidence(f, p, "rebase")
+			e.Capabilities.Rebase = true
+			r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+			require.NoError(err)
+			require.Len(r.Coverage.Gaps, 1)
+			assert.Equal("source_correspondence_unproven", r.Coverage.Gaps[0].Reason)
+			assert.Empty(r.Landings)
+		})
+	}
+}
+
+func TestAutomaticSquashRejectsRangeBeforeHunks(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := buildFixture(t, true)
+	f.repo.Checkout("-b", "common", f.base)
+	f.base = f.repo.CommitFile("repeat", "same\nsame\n", "repeated lines")
+	f.repo.Checkout("-b", "source")
+	f.source = []string{f.repo.CommitFile("repeat", "same\n", "remove occurrence")}
+	require.NoError(os.WriteFile(filepath.Join(f.repo.Root, "repeat"), []byte("same\nsame\n"), 0600))
+	f.repo.Run("add", "repeat")
+	f.source = append(f.source, f.repo.CommitFile("extra", "extra\n", "restore and add"))
+	f.repo.Checkout("-b", "target", f.base)
+	f.base = f.repo.CommitFile("other", "other\n", "advance")
+	f.repo.Run("merge", "--squash", "source")
+	f.repo.Run("commit", "-m", "squash")
+	f.head = f.repo.Head()
+	ctx, p := f.prepare(t)
+	e := fixtureEvidence(f, p, "")
+	e.Capabilities.SingleParentCorrespondence = true
+	r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+	require.NoError(err)
+	require.Len(r.Landings, 1)
+	assert.Equal([]string{"squash"}, r.Landings[0].Proofs)
+	assert.True(r.Coverage.Complete)
+}

--- a/landedwork/range_test.go
+++ b/landedwork/range_test.go
@@ -238,8 +238,8 @@ func TestFastForward(t *testing.T) {
 				assert.NotEmpty(r.Coverage.Gaps)
 				return
 			}
-			assert.Equal([]landedwork.Landing{{CandidateID: "7", Method: "fast_forward", Before: f.base,
-				Terminal: f.head, Source: f.source, Introduced: f.source}}, r.Landings)
+			assert.Equal([]landedwork.Landing{{CandidateID: "7", Proofs: []string{"fast_forward"}, Before: f.base,
+				Terminal: f.head, Source: f.source, Spine: f.source, Introduced: f.source}}, r.Landings)
 			assert.True(r.Coverage.Complete)
 			assert.Equal(f.head, r.Coverage.CertifiedHead)
 			assert.Empty(r.Unattributed)

--- a/landedwork/range_test.go
+++ b/landedwork/range_test.go
@@ -12,132 +12,156 @@ import (
 )
 
 func TestRebaseFileChanges(t *testing.T) {
-	for _, tc := range []struct {
-		name, path, old, source, replay string
-		mode                            bool
-		accept                          bool
-	}{
-		{"binary exact", "data.bin", "old\x00", "new\x00", "new\x00", false, true},
-		{"binary differs", "data.bin", "old\x00", "new\x00", "other\x00", false, false},
-		{"raw name and bytes", "odd\n\xff.txt", "old\xff\n", "new\xfe\n", "new\xfe\n", false, true},
-		{"missing newline", "text", "old\n", "new", "new", false, true},
-		{"old missing newline", "text", "old", "new\n", "new\n", false, true},
-		{"newline differs", "text", "old\n", "new", "new\n", false, false},
-		{"mode differs", "script", "old\n", "new\n", "new\n", true, false},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			require := require.New(t)
-			assert := assert.New(t)
-			f := buildFixture(t, false)
-			f.repo.Checkout("-b", "file-base", f.base)
-			base := f.repo.CommitFile(tc.path, tc.old, "file base")
-			f.repo.Checkout("-b", "file-source")
-			f.source = []string{f.repo.CommitFile(tc.path, tc.source, "source")}
-			f.repo.Checkout("-b", "file-replay", base)
-			f.base = f.repo.CommitFile("unrelated", "context\n", "advance")
-			if tc.mode {
-				require.NoError(os.Chmod(filepath.Join(f.repo.Root, tc.path), 0755))
-			}
-			f.head = f.repo.CommitFile(tc.path, tc.replay, "replay")
-			ctx, p := f.prepare(t)
-			e := fixtureEvidence(f, p, "rebase")
-			e.Capabilities.Rebase = true
-			r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
-			require.NoError(err)
-			assert.Equal(tc.accept, r.Coverage.Complete)
-			if tc.accept {
-				assert.Len(r.Landings, 1)
-			} else {
-				assert.Empty(r.Landings)
-			}
-		})
+	for _, method := range []string{"rebase", "squash", "automatic"} {
+		for _, tc := range []struct {
+			name, path, old, source, replay string
+			mode                            bool
+			accept                          bool
+		}{
+			{"binary exact", "data.bin", "old\x00", "new\x00", "new\x00", false, true},
+			{"binary differs", "data.bin", "old\x00", "new\x00", "other\x00", false, false},
+			{"raw name and bytes", "odd\n\xff.txt", "old\xff\n", "new\xfe\n", "new\xfe\n", false, true},
+			{"missing newline", "text", "old\n", "new", "new", false, true},
+			{"old missing newline", "text", "old", "new\n", "new\n", false, true},
+			{"newline differs", "text", "old\n", "new", "new\n", false, false},
+			{"mode differs", "script", "old\n", "new\n", "new\n", true, false},
+		} {
+			t.Run(method+"/"+tc.name, func(t *testing.T) {
+				require := require.New(t)
+				assert := assert.New(t)
+				f := buildFixture(t, false)
+				f.repo.Checkout("-b", "file-base", f.base)
+				base := f.repo.CommitFile(tc.path, tc.old, "file base")
+				f.repo.Checkout("-b", "file-source")
+				f.source = []string{f.repo.CommitFile(tc.path, tc.source, "source")}
+				f.repo.Checkout("-b", "file-replay", base)
+				f.base = f.repo.CommitFile("unrelated", "context\n", "advance")
+				if tc.mode {
+					require.NoError(os.Chmod(filepath.Join(f.repo.Root, tc.path), 0755))
+				}
+				f.head = f.repo.CommitFile(tc.path, tc.replay, "replay")
+				ctx, p := f.prepare(t)
+				e := fixtureEvidence(f, p, method)
+				if method == "automatic" {
+					e.Candidates[0].Method, e.Candidates[0].MethodEvidence = "", ""
+					e.Capabilities.SingleParentCorrespondence = true
+				}
+				e.Capabilities.Rebase = true
+				r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+				require.NoError(err)
+				assert.Equal(tc.accept, r.Coverage.Complete)
+				if tc.accept {
+					assert.Len(r.Landings, 1)
+				} else {
+					assert.Empty(r.Landings)
+				}
+			})
+		}
 	}
 }
 
 func TestRebaseOldSideNewline(t *testing.T) {
-	for _, tc := range []struct {
-		name, sourceOld, replayOld string
-		accept                     bool
-	}{
-		{"matching", "old", "old", true},
-		{"source missing newline", "old", "old\n", false},
-		{"replay missing newline", "old\n", "old", false},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			require := require.New(t)
-			assert := assert.New(t)
-			f := buildFixture(t, false)
-			f.repo.Checkout("-b", "newline-source", f.base)
-			f.repo.CommitFile("text", tc.sourceOld, "source base")
-			f.source = []string{f.repo.CommitFile("text", "new\n", "source")}
-			f.repo.Checkout("-b", "newline-replay", f.base)
-			f.base = f.repo.CommitFile("text", tc.replayOld, "replay base")
-			f.head = f.repo.CommitFile("text", "new\n", "replay")
-			ctx, p := f.prepare(t)
-			e := fixtureEvidence(f, p, "rebase")
-			e.Capabilities.Rebase = true
-			r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
-			require.NoError(err)
-			assert.Equal(tc.accept, r.Coverage.Complete)
-			if tc.accept {
-				assert.Len(r.Landings, 1)
-				assert.Equal(f.head, r.Coverage.CertifiedHead)
-			} else {
-				assert.Empty(r.Landings)
-				assert.Equal(f.base, r.Coverage.CertifiedHead)
-				require.Len(r.Coverage.Gaps, 1)
-				assert.Equal("source_correspondence_unproven", r.Coverage.Gaps[0].Reason)
-			}
-		})
+	for _, method := range []string{"rebase", "squash", "automatic"} {
+		for _, tc := range []struct {
+			name, sourceOld, replayOld string
+			accept                     bool
+		}{
+			{"matching", "old", "old", true},
+			{"source missing newline", "old", "old\n", false},
+			{"replay missing newline", "old\n", "old", false},
+		} {
+			t.Run(method+"/"+tc.name, func(t *testing.T) {
+				require := require.New(t)
+				assert := assert.New(t)
+				f := buildFixture(t, false)
+				f.repo.Checkout("-b", "newline-source", f.base)
+				f.repo.CommitFile("text", tc.sourceOld, "source base")
+				f.source = []string{f.repo.CommitFile("text", "new\n", "source")}
+				f.repo.Checkout("-b", "newline-replay", f.base)
+				f.base = f.repo.CommitFile("text", tc.replayOld, "replay base")
+				f.head = f.repo.CommitFile("text", "new\n", "replay")
+				ctx, p := f.prepare(t)
+				e := fixtureEvidence(f, p, method)
+				if method == "automatic" {
+					e.Candidates[0].Method, e.Candidates[0].MethodEvidence = "", ""
+					e.Capabilities.SingleParentCorrespondence = true
+				}
+				e.Capabilities.Rebase = true
+				r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+				require.NoError(err)
+				assert.Equal(tc.accept, r.Coverage.Complete)
+				if tc.accept {
+					assert.Len(r.Landings, 1)
+					assert.Equal(f.head, r.Coverage.CertifiedHead)
+				} else {
+					assert.Empty(r.Landings)
+					assert.Equal(f.base, r.Coverage.CertifiedHead)
+					require.Len(r.Coverage.Gaps, 1)
+					assert.Equal("source_correspondence_unproven", r.Coverage.Gaps[0].Reason)
+				}
+			})
+		}
 	}
 }
 
 func TestRebaseRepeatedOccurrence(t *testing.T) {
-	for _, insertion := range []bool{false, true} {
-		f := buildFixture(t, false)
-		f.repo.Checkout("-b", "occurrence-source", f.base)
-		base := f.repo.CommitFile("text", "old\nkeep\nold\nkeep\n", "repeated text")
-		source, replay := "new\nkeep\nold\nkeep\n", "old\nkeep\nnew\nkeep\n"
-		if insertion {
-			source, replay = "old\nnew\nkeep\nold\nkeep\n", "old\nkeep\nold\nnew\nkeep\n"
+	for _, method := range []string{"rebase", "squash", "automatic"} {
+		for _, insertion := range []bool{false, true} {
+			f := buildFixture(t, false)
+			f.repo.Checkout("-b", "occurrence-source", f.base)
+			base := f.repo.CommitFile("text", "old\nkeep\nold\nkeep\n", "repeated text")
+			source, replay := "new\nkeep\nold\nkeep\n", "old\nkeep\nnew\nkeep\n"
+			if insertion {
+				source, replay = "old\nnew\nkeep\nold\nkeep\n", "old\nkeep\nold\nnew\nkeep\n"
+			}
+			f.source = []string{f.repo.CommitFile("text", source, "source")}
+			f.repo.Checkout("-b", "occurrence-replay", base)
+			f.base = f.repo.CommitFile("other", "unrelated\n", "advance")
+			f.head = f.repo.CommitFile("text", replay, "replay")
+			ctx, p := f.prepare(t)
+			e := fixtureEvidence(f, p, method)
+			if method == "automatic" {
+				e.Candidates[0].Method, e.Candidates[0].MethodEvidence = "", ""
+				e.Capabilities.SingleParentCorrespondence = true
+			}
+			e.Capabilities.Rebase = true
+			r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+			require := require.New(t)
+			assert := assert.New(t)
+			require.NoError(err)
+			assert.Empty(r.Landings)
+			assert.False(r.Coverage.Complete)
+			assert.Equal(f.base, r.Coverage.CertifiedHead)
+			require.Len(r.Coverage.Gaps, 1)
+			assert.Equal("edits_unavailable", r.Coverage.Gaps[0].Reason)
 		}
-		f.source = []string{f.repo.CommitFile("text", source, "source")}
-		f.repo.Checkout("-b", "occurrence-replay", base)
-		f.base = f.repo.CommitFile("other", "unrelated\n", "advance")
-		f.head = f.repo.CommitFile("text", replay, "replay")
-		ctx, p := f.prepare(t)
-		e := fixtureEvidence(f, p, "rebase")
-		e.Capabilities.Rebase = true
-		r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
-		require := require.New(t)
-		assert := assert.New(t)
-		require.NoError(err)
-		assert.Empty(r.Landings)
-		assert.False(r.Coverage.Complete)
-		assert.Equal(f.base, r.Coverage.CertifiedHead)
-		require.Len(r.Coverage.Gaps, 1)
-		assert.Equal("edits_unavailable", r.Coverage.Gaps[0].Reason)
 	}
 }
 
 func TestRebaseDuplicateEdits(t *testing.T) {
-	f := buildFixture(t, false)
-	f.repo.Checkout("-b", "repeat-source", f.base)
-	f.source = []string{f.repo.CommitFile("work.txt", "new\nkeep\n", "first")}
-	f.source = append(f.source, f.repo.CommitFile("work.txt", "old\nkeep\n", "undo"))
-	f.source = append(f.source, f.repo.CommitFile("work.txt", "new\nkeep\n", "repeat"))
-	f.repo.Checkout("-b", "repeat-replay", f.base)
-	f.base = f.repo.CommitFile("unrelated", "context\n", "advance")
-	f.repo.CommitFile("work.txt", "new\nkeep\n", "replay first")
-	f.repo.CommitFile("work.txt", "old\nkeep\n", "replay undo")
-	f.head = f.repo.CommitFile("work.txt", "new\nkeep\n", "replay repeat")
-	ctx, p := f.prepare(t)
-	e := fixtureEvidence(f, p, "rebase")
-	e.Capabilities.Rebase = true
-	r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
-	require.NoError(t, err)
-	assert.Empty(t, r.Landings)
-	assert.False(t, r.Coverage.Complete)
+	for _, automatic := range []bool{false, true} {
+		f := buildFixture(t, false)
+		f.repo.Checkout("-b", "repeat-source", f.base)
+		f.source = []string{f.repo.CommitFile("work.txt", "new\nkeep\n", "first")}
+		f.source = append(f.source, f.repo.CommitFile("work.txt", "old\nkeep\n", "undo"))
+		f.source = append(f.source, f.repo.CommitFile("work.txt", "new\nkeep\n", "repeat"))
+		f.repo.Checkout("-b", "repeat-replay", f.base)
+		f.base = f.repo.CommitFile("unrelated", "context\n", "advance")
+		f.repo.CommitFile("work.txt", "new\nkeep\n", "replay first")
+		f.repo.CommitFile("work.txt", "old\nkeep\n", "replay undo")
+		f.head = f.repo.CommitFile("work.txt", "new\nkeep\n", "replay repeat")
+		ctx, p := f.prepare(t)
+		e := fixtureEvidence(f, p, "rebase")
+		e.Capabilities.Rebase = true
+		if automatic {
+			e.Candidates[0].Method, e.Candidates[0].MethodEvidence = "", ""
+			e.Capabilities.SingleParentCorrespondence = true
+		}
+		r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+		require.NoError(t, err)
+		assert.Empty(t, r.Landings)
+		assert.False(t, r.Coverage.Complete)
+	}
 }
 
 func TestRebase(t *testing.T) {

--- a/landedwork/single_parent.go
+++ b/landedwork/single_parent.go
@@ -13,8 +13,14 @@ func sourceBoundary(ctx context.Context, v *objectView, c Candidate) (string, Ga
 		return "", g
 	}
 	before := ""
+	seen := make(map[string]bool, len(c.Source))
 	for i, id := range c.Source {
 		g.ObjectID = id
+		if id == "" || seen[id] {
+			g.Reason = "source_invalid"
+			return "", g
+		}
+		seen[id] = true
 		parents, err := v.parents(ctx, id)
 		if err != nil {
 			g.Reason = graphReason(err)
@@ -43,6 +49,9 @@ func proveSquash(ctx context.Context, v *objectView, c Candidate, before string)
 	if g.Reason != "" {
 		return Landing{}, g
 	}
+	if _, err := v.parents(ctx, before); err != nil {
+		return Landing{}, Gap{CandidateID: c.ID, ObjectID: before, Reason: graphReason(err)}
+	}
 	matched, g := squashCorrespondence(ctx, v, c, sourceBefore, before)
 	if g.Reason != "" {
 		return Landing{}, g
@@ -50,35 +59,22 @@ func proveSquash(ctx context.Context, v *objectView, c Candidate, before string)
 	if !matched {
 		return Landing{}, Gap{CandidateID: c.ID, ObjectID: c.Terminal, Reason: "source_correspondence_unproven"}
 	}
-	return Landing{CandidateID: c.ID, Proofs: []string{"squash"}, Before: before, Terminal: c.Terminal,
-		Spine: []string{c.Terminal}, Source: slices.Clone(c.Source), Introduced: []string{c.Terminal}}, Gap{}
+	return squashLanding(c, before), Gap{}
 }
 
 // False with no gap is a conclusive mismatch. Unreadable or ambiguous edits are
 // not evidence against this alternative and must prevent choosing another one.
 func squashCorrespondence(ctx context.Context, v *objectView, c Candidate, sourceBefore, before string) (bool, Gap) {
 	g := Gap{CandidateID: c.ID}
-	for _, id := range []string{sourceBefore, c.SourceHead, before, c.Terminal} {
-		if _, err := v.parents(ctx, id); err != nil {
-			g.ObjectID, g.Reason = id, graphReason(err)
-			return false, g
-		}
+	_, err := v.compareTreeEdits(ctx, sourceBefore, c.SourceHead, before, c.Terminal)
+	if errors.Is(err, errCorrespondence) {
+		return false, Gap{}
 	}
-	source, err := v.treeEdits(ctx, sourceBefore, c.SourceHead)
-	if err != nil {
-		g.ObjectID, g.Reason = c.SourceHead, editReason(err)
-		return false, g
-	}
-	landed, err := v.treeEdits(ctx, before, c.Terminal)
 	if err != nil {
 		g.ObjectID, g.Reason = c.Terminal, editReason(err)
 		return false, g
 	}
-	if len(source) == 0 || len(landed) == 0 {
-		g.ObjectID, g.Reason = c.Terminal, "edits_unavailable"
-		return false, g
-	}
-	return sameEdits(source, landed), Gap{}
+	return true, Gap{}
 }
 
 func editReason(err error) string {
@@ -88,23 +84,26 @@ func editReason(err error) string {
 	return graphReason(err)
 }
 
-func proveSingleParent(ctx context.Context, v *objectView, p *Interval, c Candidate) (Landing, Gap) {
+func proveSingleParent(ctx context.Context, v *objectView, p *Interval, c Candidate, before string) (Landing, Gap) {
 	sourceBefore, g := sourceBoundary(ctx, v, c)
 	if g.Reason != "" {
 		return Landing{}, g
 	}
-	parents, err := v.parents(ctx, c.Terminal)
-	if err != nil {
-		return Landing{}, Gap{CandidateID: c.ID, ObjectID: c.Terminal, Reason: graphReason(err)}
+	if _, err := v.parents(ctx, before); err != nil {
+		return Landing{}, Gap{CandidateID: c.ID, ObjectID: before, Reason: graphReason(err)}
 	}
-	matched, g := squashCorrespondence(ctx, v, c, sourceBefore, parents[0])
+	matched, g := squashCorrespondence(ctx, v, c, sourceBefore, before)
 	squash := proofAttempt{state: attemptMismatch}
 	if g.Reason != "" {
 		squash = proofAttempt{gap: g}
 	} else if matched {
-		squash = proofAttempt{state: attemptMatch, landing: Landing{CandidateID: c.ID, Proofs: []string{"squash"},
-			Before: parents[0], Terminal: c.Terminal, Source: slices.Clone(c.Source), Spine: []string{c.Terminal}, Introduced: []string{c.Terminal}}}
+		squash = proofAttempt{state: attemptMatch, landing: squashLanding(c, before)}
 	}
-	ranges := rangeAlternatives(ctx, v, p, c)
+	ranges := rangeAlternatives(ctx, v, p, c, sourceBefore, before)
 	return resolveAlternatives(c, []proofAttempt{squash, ranges[0], ranges[1]}, v.meter.failed)
+}
+
+func squashLanding(c Candidate, before string) Landing {
+	return Landing{CandidateID: c.ID, Proofs: []string{"squash"}, Before: before, Terminal: c.Terminal,
+		Spine: []string{c.Terminal}, Source: slices.Clone(c.Source), Introduced: []string{c.Terminal}}
 }

--- a/landedwork/single_parent.go
+++ b/landedwork/single_parent.go
@@ -87,3 +87,24 @@ func editReason(err error) string {
 	}
 	return graphReason(err)
 }
+
+func proveSingleParent(ctx context.Context, v *objectView, p *Interval, c Candidate) (Landing, Gap) {
+	sourceBefore, g := sourceBoundary(ctx, v, c)
+	if g.Reason != "" {
+		return Landing{}, g
+	}
+	parents, err := v.parents(ctx, c.Terminal)
+	if err != nil {
+		return Landing{}, Gap{CandidateID: c.ID, ObjectID: c.Terminal, Reason: graphReason(err)}
+	}
+	matched, g := squashCorrespondence(ctx, v, c, sourceBefore, parents[0])
+	squash := proofAttempt{state: attemptMismatch}
+	if g.Reason != "" {
+		squash = proofAttempt{gap: g}
+	} else if matched {
+		squash = proofAttempt{state: attemptMatch, landing: Landing{CandidateID: c.ID, Proofs: []string{"squash"},
+			Before: parents[0], Terminal: c.Terminal, Source: slices.Clone(c.Source), Spine: []string{c.Terminal}, Introduced: []string{c.Terminal}}}
+	}
+	ranges := rangeAlternatives(ctx, v, p, c)
+	return resolveAlternatives(c, []proofAttempt{squash, ranges[0], ranges[1]}, v.meter.failed)
+}

--- a/landedwork/single_parent.go
+++ b/landedwork/single_parent.go
@@ -1,0 +1,89 @@
+package landedwork
+
+import (
+	"context"
+	"errors"
+	"slices"
+)
+
+func sourceBoundary(ctx context.Context, v *objectView, c Candidate) (string, Gap) {
+	g := Gap{CandidateID: c.ID, ObjectID: c.SourceHead}
+	if c.Source[len(c.Source)-1] != c.SourceHead {
+		g.Reason = "source_head_mismatch"
+		return "", g
+	}
+	before := ""
+	for i, id := range c.Source {
+		g.ObjectID = id
+		parents, err := v.parents(ctx, id)
+		if err != nil {
+			g.Reason = graphReason(err)
+			return "", g
+		}
+		if len(parents) != 1 {
+			g.Reason = "topology_unproven"
+			return "", g
+		}
+		if i == 0 {
+			before = parents[0]
+		} else if parents[0] != c.Source[i-1] {
+			g.Reason = "source_order_unproven"
+			return "", g
+		}
+	}
+	if _, err := v.parents(ctx, before); err != nil {
+		g.ObjectID, g.Reason = before, graphReason(err)
+		return "", g
+	}
+	return before, Gap{}
+}
+
+func proveSquash(ctx context.Context, v *objectView, c Candidate, before string) (Landing, Gap) {
+	sourceBefore, g := sourceBoundary(ctx, v, c)
+	if g.Reason != "" {
+		return Landing{}, g
+	}
+	matched, g := squashCorrespondence(ctx, v, c, sourceBefore, before)
+	if g.Reason != "" {
+		return Landing{}, g
+	}
+	if !matched {
+		return Landing{}, Gap{CandidateID: c.ID, ObjectID: c.Terminal, Reason: "source_correspondence_unproven"}
+	}
+	return Landing{CandidateID: c.ID, Proofs: []string{"squash"}, Before: before, Terminal: c.Terminal,
+		Spine: []string{c.Terminal}, Source: slices.Clone(c.Source), Introduced: []string{c.Terminal}}, Gap{}
+}
+
+// False with no gap is a conclusive mismatch. Unreadable or ambiguous edits are
+// not evidence against this alternative and must prevent choosing another one.
+func squashCorrespondence(ctx context.Context, v *objectView, c Candidate, sourceBefore, before string) (bool, Gap) {
+	g := Gap{CandidateID: c.ID}
+	for _, id := range []string{sourceBefore, c.SourceHead, before, c.Terminal} {
+		if _, err := v.parents(ctx, id); err != nil {
+			g.ObjectID, g.Reason = id, graphReason(err)
+			return false, g
+		}
+	}
+	source, err := v.treeEdits(ctx, sourceBefore, c.SourceHead)
+	if err != nil {
+		g.ObjectID, g.Reason = c.SourceHead, editReason(err)
+		return false, g
+	}
+	landed, err := v.treeEdits(ctx, before, c.Terminal)
+	if err != nil {
+		g.ObjectID, g.Reason = c.Terminal, editReason(err)
+		return false, g
+	}
+	if len(source) == 0 || len(landed) == 0 {
+		g.ObjectID, g.Reason = c.Terminal, "edits_unavailable"
+		return false, g
+	}
+	return sameEdits(source, landed), Gap{}
+}
+
+func editReason(err error) string {
+	if errors.Is(err, errEdits) {
+		return "edits_unavailable"
+	}
+	return graphReason(err)
+}

--- a/landedwork/single_parent_test.go
+++ b/landedwork/single_parent_test.go
@@ -1,0 +1,74 @@
+package landedwork_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/landedwork"
+)
+
+func TestExplicitSquashRejectsDifferentAggregate(t *testing.T) {
+	f := buildFixture(t, true)
+	f.repo.Checkout("-b", "different", f.base)
+	f.head = f.repo.CommitFile("work.txt", "unrelated\n", "different change")
+	ctx, p := f.prepare(t)
+	r, err := landedwork.Analyze(ctx, p, fixtureEvidence(f, p, "squash"), fixtureLimits())
+	require.NoError(t, err)
+	assert := assert.New(t)
+	assert.Empty(r.Landings)
+	assert.Empty(r.DirectPushes)
+	assert.False(r.Coverage.Complete)
+	assert.Equal(f.base, r.Coverage.CertifiedHead)
+	assert.Equal([]landedwork.Gap{{CandidateID: "7", ObjectID: f.head, Reason: "source_correspondence_unproven",
+		Span: landedwork.Span{Before: f.base, Through: f.head}}}, r.Coverage.Gaps)
+}
+
+func TestSquashRequiresSourceChain(t *testing.T) {
+	for _, tc := range []struct{ name, reason string }{
+		{"order", "source_order_unproven"},
+		{"omitted", "source_order_unproven"},
+		{"head", "source_head_mismatch"},
+		{"root", "topology_unproven"},
+		{"merge", "topology_unproven"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := buildFixture(t, true)
+			f.repo.Checkout("topic")
+			last := f.repo.CommitFile("extra", "extra\n", "last source")
+			f.source = append(f.source, last)
+			if tc.name == "merge" {
+				f.repo.Checkout("-b", "side", f.base)
+				f.repo.CommitFile("side", "side\n", "side")
+				f.repo.Checkout("topic")
+				f.repo.Run("merge", "--no-ff", "side", "-m", "merge side")
+				f.source = append(f.source, f.repo.Head())
+			}
+			f.repo.Checkout("-b", "target", f.base)
+			f.repo.Run("merge", "--squash", "topic")
+			f.repo.Run("commit", "-m", "squash")
+			f.head = f.repo.Head()
+			ctx, p := f.prepare(t)
+			e := fixtureEvidence(f, p, "squash")
+			switch tc.name {
+			case "order":
+				e.Candidates[0].Source = []string{f.source[1], f.source[0], last}
+			case "omitted":
+				e.Candidates[0].Source = []string{f.source[0], last}
+			case "head":
+				e.Candidates[0].SourceHead = f.source[0]
+			case "root":
+				e.Candidates[0].Source = append([]string{f.base}, f.source...)
+			}
+			r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+			require.NoError(t, err)
+			require.Len(t, r.Coverage.Gaps, 1)
+			assert := assert.New(t)
+			assert.Equal(tc.reason, r.Coverage.Gaps[0].Reason)
+			assert.Empty(r.Landings)
+			assert.Empty(r.DirectPushes)
+			assert.False(r.Coverage.Complete)
+			assert.Equal(f.base, r.Coverage.CertifiedHead)
+		})
+	}
+}

--- a/landedwork/single_parent_test.go
+++ b/landedwork/single_parent_test.go
@@ -31,6 +31,7 @@ func TestSquashRequiresSourceChain(t *testing.T) {
 		{"head", "source_head_mismatch"},
 		{"root", "topology_unproven"},
 		{"merge", "topology_unproven"},
+		{"empty ID", "source_invalid"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := buildFixture(t, true)
@@ -51,6 +52,8 @@ func TestSquashRequiresSourceChain(t *testing.T) {
 			ctx, p := f.prepare(t)
 			e := fixtureEvidence(f, p, "squash")
 			switch tc.name {
+			case "empty ID":
+				e.Candidates[0].Source[0] = ""
 			case "order":
 				e.Candidates[0].Source = []string{f.source[1], f.source[0], last}
 			case "omitted":

--- a/landedwork/special_edits_test.go
+++ b/landedwork/special_edits_test.go
@@ -1,0 +1,64 @@
+package landedwork_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/landedwork"
+)
+
+func TestAutomaticSpecialObjects(t *testing.T) {
+	for _, mode := range []string{"120000", "160000"} {
+		for _, match := range []bool{false, true} {
+			f := buildFixture(t, true)
+			ctx, _ := f.prepare(t)
+			require, assert := require.New(t), assert.New(t)
+			ids := []string{f.base, f.source[0], f.source[1]}
+			if mode == "120000" {
+				// Index entries test symlink bytes without OS symlink privileges.
+				for i, target := range []string{"old-target", "new-target", "other-target"} {
+					out, _, err := f.repo.Runner.Run(ctx, f.repo.Root, strings.NewReader(target), "hash-object", "-w", "--stdin")
+					require.NoError(err)
+					ids[i] = strings.TrimSpace(string(out))
+				}
+			}
+			f.repo.Checkout("-b", "special", f.base)
+			f.repo.Run("update-index", "--add", "--cacheinfo", mode, ids[0], "entry")
+			f.repo.Run("commit", "-m", "entry base")
+			f.base = f.repo.Head()
+			f.repo.Checkout("-b", "special-source")
+			f.repo.Run("update-index", "--cacheinfo", mode, ids[1], "entry")
+			f.repo.Run("commit", "-m", "entry source")
+			f.source = []string{f.repo.Head()}
+			f.repo.Checkout("-b", "special-target", f.base)
+			target := ids[2]
+			if match {
+				target = ids[1]
+			}
+			f.repo.Run("update-index", "--cacheinfo", mode, target, "entry")
+			f.repo.Run("commit", "-m", "entry replay")
+			f.head = f.repo.Head()
+			ctx, p := f.prepare(t)
+			e := fixtureEvidence(f, p, "")
+			e.Candidates[0].MethodEvidence = ""
+			e.Capabilities = landedwork.Capabilities{SingleParentCorrespondence: true}
+			r, err := landedwork.Analyze(ctx, p, e, fixtureLimits())
+			require.NoError(err)
+			assert.Empty(r.DirectPushes)
+			assert.Equal(match, r.Coverage.Complete)
+			if match {
+				require.Len(r.Landings, 1)
+				assert.Equal([]string{"rebase", "squash"}, r.Landings[0].Proofs)
+				assert.Equal([]string{f.head}, r.Landings[0].Spine)
+				assert.Equal(f.head, r.Coverage.CertifiedHead)
+			} else {
+				assert.Empty(r.Landings)
+				require.Len(r.Coverage.Gaps, 1)
+				assert.Equal("source_correspondence_unproven", r.Coverage.Gaps[0].Reason)
+				assert.Equal(f.base, r.Coverage.CertifiedHead)
+			}
+		}
+	}
+}

--- a/platform/github/landing_evidence.go
+++ b/platform/github/landing_evidence.go
@@ -33,7 +33,8 @@ func (p *Provider) LandingEvidenceSupport() platform.LandingEvidenceSupport {
 	if !ok || p.host != "github.com" {
 		return platform.LandingEvidenceSupport{Reason: "unverified_endpoint_contract"}
 	}
-	return platform.LandingEvidenceSupport{Inventory: true, OrdinaryMerge: true, Sources: platform.LandingSourcePolicy{RequireCount: true, MaxCommits: 250}}
+	return platform.LandingEvidenceSupport{Inventory: true, OrdinaryMerge: true, SingleParentCorrespondence: true,
+		Sources: platform.LandingSourcePolicy{RequireCount: true, MaxCommits: 250}}
 }
 
 func (p *Provider) ListLandingAssociations(ctx context.Context, ref platform.RepoRef, sha, cursor string) (platform.Page[platform.LandingChangeRef], error) {

--- a/platform/landing_evidence.go
+++ b/platform/landing_evidence.go
@@ -24,8 +24,11 @@ type LandingSourcePolicy struct {
 // LandingEvidenceSupport is an endpoint contract, not the outcome of one sweep.
 type LandingEvidenceSupport struct {
 	Inventory, OrdinaryMerge bool
-	Reason                   string
-	Sources                  LandingSourcePolicy
+	// SingleParentCorrespondence supplies evidence for all automatic alternatives,
+	// not a historical squash/rebase label.
+	SingleParentCorrespondence bool
+	Reason                     string
+	Sources                    LandingSourcePolicy
 }
 
 // LandingChange preserves field absence independently of application projections.


### PR DESCRIPTION
GitHub landing analysis can now resolve squash, rebase, and fast-forward correspondence instead of leaving single-parent history unresolved. It proves commit ownership, not which merge button was used.

- Accept multiple proof labels only when they identify the same origin. Missing objects, ambiguous edits, exhausted budgets, and conflicting ownership remain coverage gaps.
- Replace the public Go API's `Landing.Method` with `Landing.Proofs` and add explicit `Landing.Spine` ownership. Entry-point signatures remain unchanged.
- Keep fetching with the caller. A default-branch-only clone may need original PR objects; fetching a moved PR head cannot replace the observed source SHA.

Library-only change: no UI or archive integration, and no additional provider hosts enabled.

Affected tests, race tests, build, vet, and lint pass. The full Go suite has two configuration-permission failures that also reproduce in the pre-change checkout (`TestLoadOrCreateCopiesLegacyDefaultConfig` and `TestLoadOrCreateCopiesLegacyCredentialFiles`).
