### PR TITLE
feat: retain provider roles separately from landing proof

### DIFF
--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -73,6 +73,12 @@ Overlap conflicts block the proven landing ranges, not unrelated earlier
 commits; unknown-start candidate gaps still block from the base (`landedwork/origins.go::rejectOverlaps`).
 Collection must preserve unfinished candidates and the exact prepared query;
 missing provider evidence is never direct-push evidence (`landedwork/collect/collect.go::Collect`).
+Roles and lifecycle times belong to observations, not landing proof; complete
+landing coverage does not certify complete attribution (`platform/landing_evidence.go::LandingChange`).
+Metadata-only rechecks replace the entire observation, including absent fields;
+proof changes retain the initial incomplete observation (`landedwork/collect/candidates.go::observe`).
+Account identity needs the enclosing provider and instance; never infer a human
+or a missing ID from a login (`platform/landing_evidence.go::Account`).
 Keep malformed object IDs in observations, not analyzer candidates; a provider
 gap must not become a fatal caller-input error (`landedwork/collect/candidates.go::candidate`).
 Reject an over-budget query without a result; never trim commits or gaps to fit.

--- a/landedwork/collect/candidates.go
+++ b/landedwork/collect/candidates.go
@@ -23,6 +23,9 @@ func (c *collector) observe(ctx context.Context, ref platform.LandingChangeRef, 
 		return Observation{}, err
 	}
 	if !c.chargeAccounts(detail) {
+		// The detail record was already charged; omit only the uncharged roles.
+		detail.Author, detail.Merger = nil, nil
+		o.Change = cloneChange(detail)
 		return c.incomplete(o, "exhausted_limits", "detail", ""), nil
 	}
 	o.Change = cloneChange(detail)

--- a/landedwork/collect/candidates.go
+++ b/landedwork/collect/candidates.go
@@ -22,6 +22,9 @@ func (c *collector) observe(ctx context.Context, ref platform.LandingChangeRef, 
 	if err := c.identity(detail, ref); err != nil {
 		return Observation{}, err
 	}
+	if !c.chargeAccounts(detail) {
+		return c.incomplete(o, "exhausted_limits", "detail", ""), nil
+	}
 	o.Change = cloneChange(detail)
 	if detail.TargetID <= 0 || detail.Merged == nil {
 		return c.incomplete(o, "invalid_observation", "detail", ""), nil
@@ -52,14 +55,36 @@ func (c *collector) observe(ctx context.Context, ref platform.LandingChangeRef, 
 	if err := c.identity(after, ref); err != nil {
 		return Observation{}, err
 	}
+	if !c.chargeAccounts(after) {
+		return c.incomplete(o, "exhausted_limits", "detail_recheck", ""), nil
+	}
 	if after.TargetID <= 0 {
 		return c.incomplete(o, "invalid_observation", "detail_recheck", ""), nil
 	}
-	if !reflect.DeepEqual(o.Change, after) {
+	if !sameProof(o.Change, after) {
 		return c.incomplete(o, "changed_observation", "detail_recheck", ""), nil
 	}
+	o.Change = cloneChange(after)
 	o.SourceComplete = true
 	return o, nil
+}
+
+func sameProof(a, b platform.LandingChange) bool {
+	// Metadata may change independently of the source/landing evidence. Compare
+	// all proof fields, including pointer presence, without profile stabilization.
+	a.Author, a.Merger, a.OpenedAt, a.MergedAt = nil, nil, nil, nil
+	b.Author, b.Merger, b.OpenedAt, b.MergedAt = nil, nil, nil, nil
+	return reflect.DeepEqual(a, b)
+}
+
+func (c *collector) chargeAccounts(d platform.LandingChange) bool {
+	var n int64
+	for _, a := range []*platform.Account{d.Author, d.Merger} {
+		if a != nil {
+			n++
+		}
+	}
+	return c.records(n)
 }
 
 func (c *collector) sources(ctx context.Context, o Observation) Observation {
@@ -129,7 +154,16 @@ func cloneChange(d platform.LandingChange) platform.LandingChange {
 	d.SourceID, d.Merged = clonePointer(d.SourceID), clonePointer(d.Merged)
 	d.MergeSHA, d.SquashSHA, d.SourceHead = clonePointer(d.MergeSHA), clonePointer(d.SquashSHA), clonePointer(d.SourceHead)
 	d.SourceCount = clonePointer(d.SourceCount)
+	d.Author, d.Merger = cloneAccount(d.Author), cloneAccount(d.Merger)
+	d.OpenedAt, d.MergedAt = clonePointer(d.OpenedAt), clonePointer(d.MergedAt)
 	return d
+}
+
+func cloneAccount(a *platform.Account) *platform.Account {
+	if a == nil {
+		return nil
+	}
+	return &platform.Account{ID: clonePointer(a.ID), Login: clonePointer(a.Login), Type: a.Type}
 }
 
 func candidate(bounds landedwork.Bounds, o Observation) landedwork.Candidate {

--- a/landedwork/collect/limits.go
+++ b/landedwork/collect/limits.go
@@ -80,6 +80,14 @@ func resultBytes(r Result) int64 {
 				n += int64(len(*s))
 			}
 		}
+		for _, a := range []*platform.Account{d.Author, d.Merger} {
+			if a != nil {
+				n += int64(len(a.Type))
+				if a.Login != nil {
+					n += int64(len(*a.Login))
+				}
+			}
+		}
 	}
 	return n
 }

--- a/landedwork/collect/roles_integration_test.go
+++ b/landedwork/collect/roles_integration_test.go
@@ -1,0 +1,139 @@
+package collect_test
+
+import (
+	"context"
+	"encoding/json/v2"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/testutil/gitsafe"
+	"go.kenn.io/forge/landedwork"
+	"go.kenn.io/forge/landedwork/collect"
+	"go.kenn.io/forge/platform"
+	"go.kenn.io/forge/platform/github"
+	gittest "go.kenn.io/kit/git/test"
+)
+
+func TestIntegratedRoleObservations(t *testing.T) {
+	for _, mode := range []string{"reported", "changed", "removed"} {
+		t.Run(mode, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			r := gittest.NewRepo(t, gittest.Options{InitArgs: []string{"init", "-b", "main"}, ConfigureUser: true})
+			r.Runner = gitsafe.Runner()
+			base := r.CommitFile("base.txt", "base\n", "base")
+			r.Checkout("-b", "topic")
+			source := r.CommitFile("work.txt", "work\n", "change")
+			r.Checkout("-b", "integration", base)
+			side := r.CommitFile("side.txt", "side\n", "integration starts")
+			r.Run("merge", "--no-ff", "topic", "-m", "inner")
+			inner := r.Head()
+			r.Checkout("main")
+			r.Run("merge", "--no-ff", "integration", "-m", "outer")
+			head := r.Head()
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+			defer cancel()
+			analysisLimits := landedwork.Limits{Records: 1000, Nodes: 1000, InputBytes: 1 << 20, OutputBytes: 1 << 20}
+			prepared, err := landedwork.Prepare(ctx, r.Root, landedwork.Bounds{Repository: query.Bounds.Repository, Base: base, Head: head}, analysisLimits)
+			require.NoError(err)
+			calls := 0
+			transport := integratedRoleTransport(t, mode, source, side, inner, head)
+			hc := &http.Client{Transport: platform.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				return transport.RoundTrip(req)
+			})}
+			client, err := github.NewClient(github.ClientConfig{Read: hc, Write: hc, Notifications: hc, Clock: time.Now})
+			require.NoError(err)
+			reader, err := github.NewProvider(github.ProviderConfig{Host: "github.com", Client: client, Clock: time.Now})
+			require.NoError(err)
+			got, err := collect.Collect(ctx, reader, route, prepared.Query(), limits)
+			require.NoError(err)
+			require.Len(got.Observations, 2)
+			assert.Equal(11, calls, "repository + four associations + two sets of detail/source/recheck")
+			for i, o := range got.Observations {
+				if mode == "removed" {
+					assert.Nil(o.Change.Author)
+					assert.Nil(o.Change.Merger)
+					assert.Nil(o.Change.OpenedAt)
+					assert.Nil(o.Change.MergedAt)
+					continue
+				}
+				require.NotNil(o.Change.Author)
+				require.NotNil(o.Change.Merger)
+				assert.Equal(new(int64(21+i*10)), o.Change.Author.ID)
+				assert.Equal(platform.AccountTypeUser, o.Change.Author.Type)
+				assert.Equal(new(int64(22+i*10)), o.Change.Merger.ID)
+				assert.Equal(platform.AccountTypeBot, o.Change.Merger.Type)
+				assert.Equal(new(time.Date(2026, 1, 2+i, 0, 0, 0, 0, time.UTC)), o.Change.MergedAt)
+				if mode == "changed" {
+					assert.Equal(new("renamed"), o.Change.Author.Login)
+					assert.Nil(o.Change.OpenedAt)
+				} else {
+					assert.Equal(new(time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC)), o.Change.OpenedAt)
+				}
+			}
+			analysis, err := landedwork.Analyze(ctx, prepared, got.Evidence, analysisLimits)
+			require.NoError(err)
+			assert.True(analysis.Coverage.Complete)
+			assert.Equal(head, analysis.Coverage.CertifiedHead)
+			require.Len(analysis.Landings, 1)
+			assert.Equal("8", analysis.Landings[0].CandidateID)
+			assert.Equal([]landedwork.IntegratedCandidate{{CandidateID: "7", ThroughCandidateID: "8"}}, analysis.Integrated)
+			assert.Empty(analysis.DirectPushes)
+			assert.Empty(analysis.Unattributed)
+		})
+	}
+}
+
+func integratedRoleTransport(t *testing.T, mode, source, side, inner, head string) http.RoundTripper {
+	t.Helper()
+	details := make(map[int]int)
+	return platform.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body := ""
+		switch {
+		case req.URL.Path == "/repos/example/project":
+			body = `{"id":12,"name":"project","owner":{"login":"example"}}`
+		case strings.HasSuffix(req.URL.Path, "/pulls"):
+			id, number := 8, 4
+			if strings.Contains(req.URL.Path, source) {
+				id, number = 7, 3
+			}
+			body = fmt.Sprintf(`[{"id":%d,"number":%d,"base":{"repo":{"id":12}}}]`, id, number)
+		case req.URL.Path == "/repos/example/project/pulls/3/commits":
+			body = fmt.Sprintf(`[{"sha":%q}]`, source)
+		case req.URL.Path == "/repos/example/project/pulls/4/commits":
+			body = fmt.Sprintf(`[{"sha":%q},{"sha":%q},{"sha":%q}]`, source, side, inner)
+		case req.URL.Path == "/repos/example/project/pulls/3", req.URL.Path == "/repos/example/project/pulls/4":
+			id, number, count, terminal, sourceHead, branch, author := 7, 3, 1, inner, source, "integration", 21
+			if strings.HasSuffix(req.URL.Path, "/4") {
+				id, number, count, terminal, sourceHead, branch, author = 8, 4, 3, head, inner, "main", 31
+			}
+			details[number]++
+			body = fmt.Sprintf(`{"id":%d,"number":%d,"merged":true,"merge_commit_sha":%q,"commits":%d,"base":{"ref":%q,"repo":{"id":12}},"head":{"sha":%q,"repo":{"id":12}}}`, id, number, terminal, count, branch, sourceHead)
+			var fields map[string]any
+			require.NoError(t, json.Unmarshal([]byte(body), &fields))
+			if mode != "removed" || details[number] == 1 {
+				login := "user-a"
+				if mode == "changed" && details[number] == 2 {
+					login = "renamed"
+				} else {
+					fields["created_at"] = "2026-01-01T03:00:00+02:00"
+				}
+				fields["user"] = map[string]any{"id": author, "login": login, "type": "User"}
+				fields["merged_by"] = map[string]any{"id": author + 1, "type": "Bot"}
+				fields["merged_at"] = fmt.Sprintf("2026-01-%02dT00:00:00Z", number-1)
+			}
+			encoded, err := json.Marshal(fields)
+			require.NoError(t, err)
+			body = string(encoded)
+		default:
+			require.Fail(t, "unexpected request", req.URL.String())
+		}
+		return &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body)), Request: req}, nil
+	})
+}

--- a/landedwork/collect/roles_test.go
+++ b/landedwork/collect/roles_test.go
@@ -1,0 +1,138 @@
+package collect_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/landedwork"
+	"go.kenn.io/forge/landedwork/collect"
+	"go.kenn.io/forge/platform"
+)
+
+func TestCollectRoleRecheck(t *testing.T) {
+	for _, mode := range []string{"replace", "remove", "proof changed", "recheck failed"} {
+		t.Run(mode, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+			defer cancel()
+			s := mergedScript(t)
+			initial := s.steps[4].value.(platform.LandingChange)
+			initial.Author = &platform.Account{ID: new(int64(21)), Login: new("user-a"), Type: platform.AccountTypeUser}
+			initial.OpenedAt = new(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+			s.steps[4].value = initial
+			final := s.steps[6].value.(platform.LandingChange)
+			if mode != "remove" {
+				final.Author = &platform.Account{Login: new(""), Type: platform.AccountTypeUnknown}
+				final.Merger = &platform.Account{ID: new(int64(22)), Login: new("merge-app"), Type: platform.AccountTypeBot}
+				final.OpenedAt = new(time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC))
+				final.MergedAt = new(time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC))
+			}
+			s.steps[6].value = final
+			want, reason := final, ""
+			switch mode {
+			case "proof changed":
+				final.TargetBranch = "other"
+				s.steps[6].value = final
+				want, reason = initial, "changed_observation"
+			case "recheck failed":
+				s.steps[6].err = errors.New("provider unavailable")
+				want, reason = initial, "request_failed"
+			}
+			got, err := collect.Collect(ctx, s, route, query, limits)
+			require.NoError(err)
+			require.Len(got.Observations, 1)
+			assert.Equal(want, got.Observations[0].Change)
+			assert.Equal(reason, got.Evidence.Inventory.Reason)
+			assert.Equal(reason == "", got.Evidence.Inventory.Complete)
+			assert.Equal(reason == "", got.Observations[0].SourceComplete)
+			assert.Empty(s.steps)
+		})
+	}
+}
+
+func TestCollectRolesOwnedSnapshot(t *testing.T) {
+	assert, require := assert.New(t), require.New(t)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+	s := mergedScript(t)
+	d := s.steps[4].value.(platform.LandingChange)
+	stamp := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	d.Author = &platform.Account{ID: new(int64(21)), Login: new("user-a"), Type: platform.AccountTypeUser}
+	d.Merger = d.Author // Same provider account is still two independently owned roles.
+	d.OpenedAt, d.MergedAt = new(stamp), new(stamp)
+	s.steps[4].value, s.steps[6].value = d, d
+	got, err := collect.Collect(ctx, s, route, query, limits)
+	require.NoError(err)
+	require.Len(got.Observations, 1)
+	*d.Author.ID, *d.Author.Login, d.Author.Type = 99, "changed", platform.AccountTypeBot
+	*d.OpenedAt, *d.MergedAt = time.Time{}, time.Time{}
+	observation := got.Observations[0].Change
+	want := &platform.Account{ID: new(int64(21)), Login: new("user-a"), Type: platform.AccountTypeUser}
+	assert.Equal(want, observation.Author)
+	assert.Equal(want, observation.Merger)
+	assert.Equal(&stamp, observation.OpenedAt)
+	assert.Equal(&stamp, observation.MergedAt)
+	*observation.Author.Login = "local edit"
+	assert.Equal(new("user-a"), observation.Merger.Login)
+}
+
+func TestCollectRoleBudgets(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		records, bytes int64
+		stage          string
+		outputError    bool
+	}{
+		// 17 original records plus two accounts on each detail read.
+		// 515 original string bytes plus (6 login + 4 type) for each role.
+		{"exact fit", 21, 535, "", false},
+		{"initial accounts do not fit", 14, 100000, "detail", false},
+		{"recheck accounts do not fit", 20, 100000, "detail_recheck", false},
+		{"output one short", 21, 534, "", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+			defer cancel()
+			s := mergedScript(t)
+			d := s.steps[4].value.(platform.LandingChange)
+			d.Author = &platform.Account{ID: new(int64(21)), Login: new("user-a"), Type: platform.AccountTypeUser}
+			d.Merger = d.Author
+			s.steps[4].value, s.steps[6].value = d, d
+			if tc.stage == "detail_recheck" {
+				after := d
+				after.Merger = &platform.Account{ID: new(int64(99)), Login: new("not-retained"), Type: platform.AccountTypeBot}
+				s.steps[6].value = after
+			}
+			l := limits
+			l.Records, l.OutputBytes = tc.records, tc.bytes
+			got, err := collect.Collect(ctx, s, route, query, l)
+			if tc.outputError {
+				require.ErrorIs(err, landedwork.ErrOutputBudget)
+				assert.Equal(collect.Result{}, got)
+				return
+			}
+			require.NoError(err)
+			require.Len(got.Observations, 1)
+			o := got.Observations[0]
+			assert.Equal(tc.stage, o.FailureStage)
+			assert.Equal(tc.stage == "", got.Evidence.Inventory.Complete)
+			if tc.stage != "" {
+				assert.Equal("exhausted_limits", o.Reason)
+			}
+			if tc.stage == "detail" {
+				assert.Nil(o.Change.Author)
+				assert.Nil(o.Change.Merger)
+				assert.Len(s.steps, 2, "must stop before source paging")
+			} else {
+				assert.Equal(d.Author, o.Change.Author)
+				assert.Equal(d.Merger, o.Change.Merger)
+				assert.Empty(s.steps)
+			}
+		})
+	}
+}

--- a/landedwork/collect/roles_test.go
+++ b/landedwork/collect/roles_test.go
@@ -127,6 +127,12 @@ func TestCollectRoleBudgets(t *testing.T) {
 			if tc.stage == "detail" {
 				assert.Nil(o.Change.Author)
 				assert.Nil(o.Change.Merger)
+				want := d
+				want.Author, want.Merger = nil, nil
+				assert.Equal(want, o.Change, "retain the already charged detail without uncharged accounts")
+				require.Len(got.Evidence.Candidates, 1)
+				assert.Equal(head, got.Evidence.Candidates[0].Terminal)
+				assert.Equal("merged_commit_sha", got.Evidence.Candidates[0].TerminalEvidence)
 				assert.Len(s.steps, 2, "must stop before source paging")
 			} else {
 				assert.Equal(d.Author, o.Change.Author)

--- a/platform/github/landing_evidence.go
+++ b/platform/github/landing_evidence.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	gh "github.com/google/go-github/v89/github"
 	"go.kenn.io/forge/platform"
@@ -142,6 +143,8 @@ func (c *Client) GetLandingChange(ctx context.Context, ref platform.RepoRef, cha
 		return platform.LandingChange{}, platform.ErrLandingIdentityMismatch
 	}
 	d := platform.LandingChange{Ref: change, TargetID: pr.GetBase().GetRepo().GetID(), TargetBranch: pr.GetBase().GetRef(), Merged: pr.Merged, MergeSHA: pr.MergeCommitSHA}
+	d.Author, d.Merger = landingAccount(pr.User), landingAccount(pr.MergedBy)
+	d.OpenedAt, d.MergedAt = landingTime(pr.CreatedAt), landingTime(pr.MergedAt)
 	if pr.Head != nil {
 		d.SourceHead = pr.Head.SHA
 	}
@@ -162,6 +165,35 @@ func (c *Client) GetLandingChange(ctx context.Context, ref platform.RepoRef, cha
 		d.TerminalEvidence = "merged_commit_sha"
 	}
 	return d, nil
+}
+
+func landingAccount(user *gh.User) *platform.Account {
+	if user == nil {
+		return nil
+	}
+	a := &platform.Account{Type: platform.AccountTypeUnknown}
+	if user.ID != nil {
+		a.ID = new(*user.ID)
+	}
+	if user.Login != nil {
+		a.Login = new(*user.Login)
+	}
+	switch user.GetType() {
+	case "User":
+		a.Type = platform.AccountTypeUser
+	case "Bot":
+		a.Type = platform.AccountTypeBot
+	case "Organization":
+		a.Type = platform.AccountTypeOrganization
+	}
+	return a
+}
+
+func landingTime(stamp *gh.Timestamp) *time.Time {
+	if stamp == nil {
+		return nil
+	}
+	return new(stamp.UTC())
 }
 
 func (c *Client) ListLandingSource(ctx context.Context, ref platform.RepoRef, change platform.LandingChangeRef, cursor string) (platform.Page[string], error) {

--- a/platform/github/landing_evidence_test.go
+++ b/platform/github/landing_evidence_test.go
@@ -134,14 +134,13 @@ func TestLandingRoles(t *testing.T) {
 func TestLandingTimes(t *testing.T) {
 	assert, require := assert.New(t), require.New(t)
 	hc := &http.Client{Transport: platform.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		body := `{"id":7,"number":3,"created_at":"2026-01-02T03:04:05+02:00","merged_at":"2026-01-01T18:04:05-07:00"}`
+		body := `{"id":7,"number":3,"created_at":"2026-01-02T03:04:05+02:00","merged_at":"2026-01-03T18:04:05-07:00"}`
 		return &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body)), Request: req}, nil
 	})}
 	c, err := github.NewClient(github.ClientConfig{Read: hc, Write: hc, Notifications: hc, Clock: time.Now})
 	require.NoError(err)
 	d, err := c.GetLandingChange(t.Context(), platform.RepoRef{Platform: platform.KindGitHub, Host: "github.com", Owner: "example", Name: "project"}, platform.LandingChangeRef{ID: 7, Number: 3})
 	require.NoError(err)
-	want := time.Date(2026, 1, 2, 1, 4, 5, 0, time.UTC)
-	assert.Equal(&want, d.OpenedAt)
-	assert.Equal(&want, d.MergedAt)
+	assert.Equal(new(time.Date(2026, 1, 2, 1, 4, 5, 0, time.UTC)), d.OpenedAt)
+	assert.Equal(new(time.Date(2026, 1, 4, 1, 4, 5, 0, time.UTC)), d.MergedAt)
 }

--- a/platform/github/landing_evidence_test.go
+++ b/platform/github/landing_evidence_test.go
@@ -90,3 +90,58 @@ func TestLandingRejectsCrossInstanceSource(t *testing.T) {
 	_, err = c.GetLandingChange(t.Context(), platform.RepoRef{Platform: platform.KindGitHub, Host: "github.com", Owner: "example", Name: "project"}, platform.LandingChangeRef{ID: 7, Number: 3})
 	assert.ErrorIs(t, err, platform.ErrLandingIdentityMismatch)
 }
+
+func TestLandingRoles(t *testing.T) {
+	for _, tc := range []struct {
+		name, fields   string
+		author, merger *platform.Account
+	}{
+		{"human author bot merger", `"user":{"id":21,"login":"user-a","type":"User"},"merged_by":{"id":22,"login":"merge-app","type":"Bot"}`,
+			&platform.Account{ID: new(int64(21)), Login: new("user-a"), Type: platform.AccountTypeUser},
+			&platform.Account{ID: new(int64(22)), Login: new("merge-app"), Type: platform.AccountTypeBot}},
+		{"same ID distinct roles", `"user":{"id":21,"type":"User"},"merged_by":{"id":21,"login":"user-a","type":"User"}`,
+			&platform.Account{ID: new(int64(21)), Type: platform.AccountTypeUser},
+			&platform.Account{ID: new(int64(21)), Login: new("user-a"), Type: platform.AccountTypeUser}},
+		{"absent roles", `"user":null,"merged_by":null`, nil, nil},
+		{"missing ID empty login", `"user":{"login":"","type":"Organization"}`,
+			&platform.Account{Login: new(""), Type: platform.AccountTypeOrganization}, nil},
+		{"invalid IDs unknown types", `"user":{"id":0,"login":"robot[bot]"},"merged_by":{"id":-1,"type":"FutureType"}`,
+			&platform.Account{ID: new(int64(0)), Login: new("robot[bot]"), Type: platform.AccountTypeUnknown},
+			&platform.Account{ID: new(int64(-1)), Type: platform.AccountTypeUnknown}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			calls := 0
+			hc := &http.Client{Transport: platform.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				assert.Equal("/repos/example/project/pulls/3", req.URL.Path)
+				body := `{"id":7,"number":3,` + tc.fields + `}`
+				return &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body)), Request: req}, nil
+			})}
+			c, err := github.NewClient(github.ClientConfig{Read: hc, Write: hc, Notifications: hc, Clock: time.Now})
+			require.NoError(err)
+			d, err := c.GetLandingChange(t.Context(), platform.RepoRef{Platform: platform.KindGitHub, Host: "github.com", Owner: "example", Name: "project"}, platform.LandingChangeRef{ID: 7, Number: 3})
+			require.NoError(err)
+			assert.Equal(tc.author, d.Author)
+			assert.Equal(tc.merger, d.Merger)
+			assert.Nil(d.OpenedAt)
+			assert.Nil(d.MergedAt)
+			assert.Equal(1, calls)
+		})
+	}
+}
+
+func TestLandingTimes(t *testing.T) {
+	assert, require := assert.New(t), require.New(t)
+	hc := &http.Client{Transport: platform.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body := `{"id":7,"number":3,"created_at":"2026-01-02T03:04:05+02:00","merged_at":"2026-01-01T18:04:05-07:00"}`
+		return &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body)), Request: req}, nil
+	})}
+	c, err := github.NewClient(github.ClientConfig{Read: hc, Write: hc, Notifications: hc, Clock: time.Now})
+	require.NoError(err)
+	d, err := c.GetLandingChange(t.Context(), platform.RepoRef{Platform: platform.KindGitHub, Host: "github.com", Owner: "example", Name: "project"}, platform.LandingChangeRef{ID: 7, Number: 3})
+	require.NoError(err)
+	want := time.Date(2026, 1, 2, 1, 4, 5, 0, time.UTC)
+	assert.Equal(&want, d.OpenedAt)
+	assert.Equal(&want, d.MergedAt)
+}

--- a/platform/landing_evidence.go
+++ b/platform/landing_evidence.go
@@ -3,6 +3,7 @@ package platform
 import (
 	"context"
 	"errors"
+	"time"
 )
 
 // LandingChangeRef separates immutable REST identity from the mutable API route.
@@ -31,6 +32,26 @@ type LandingEvidenceSupport struct {
 	Sources                    LandingSourcePolicy
 }
 
+// AccountType is the provider-reported account classification, not authorship assurance.
+type AccountType string
+
+const (
+	AccountTypeUser         AccountType = "user"
+	AccountTypeBot          AccountType = "bot"
+	AccountTypeOrganization AccountType = "organization"
+	AccountTypeUnknown      AccountType = "unknown"
+)
+
+// Account is an observed account, not a complete identity on its own: the
+// enclosing query supplies the provider kind and instance. Only positive IDs
+// are usable identity claims; Login is display metadata. Absent and nonpositive
+// IDs are retained without guessing. Type does not establish a human author.
+type Account struct {
+	ID    *int64
+	Login *string
+	Type  AccountType
+}
+
 // LandingChange preserves field absence independently of application projections.
 // SourceID, when present, belongs to the same provider instance as TargetID.
 // TerminalEvidence names a provider fact; it does not infer a merge method.
@@ -43,6 +64,10 @@ type LandingChange struct {
 	MergeSHA, SquashSHA, SourceHead *string
 	SourceCount                     *int64
 	Terminal, TerminalEvidence      string
+	// Roles and UTC lifecycle times are observations, not landing proof.
+	// Nil means unreported; complete landing coverage does not certify these fields.
+	Author, Merger     *Account
+	OpenedAt, MergedAt *time.Time
 }
 
 // LandingEvidenceReader reads bounded pages for an exact prepared Git interval.


### PR DESCRIPTION
Retain the PR author, merger, and opened/merged times already returned by GitHub, so callers can distinguish who proposed work from who merged it without guessing from Git bylines.

- Keep roles and timestamps separate from landing proof. Metadata-only updates retain the final detail response; missing fields remain missing.
- Preserve bot and unknown account types, copy returned observations, and charge the added records and strings against existing collection limits.
- Add fields to the public `platform.LandingChange` struct. External positional literals must be updated; entry-point signatures and analyzer results are unchanged.

GitHub.com library-only change: no extra requests, new permissions, UI, archive integration, or additional provider hosts. Real-Git fixtures cover integrated PRs with distinct authors and bot mergers without double-counting landings.
