### PR TITLE
fix: show original authors on rebased timeline commits

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -288,6 +288,9 @@ Persisted controls must state their scope clearly.
   `schema-constraints` module, never from hand-copied numbers, and show an inline
   invalid state instead of sending a request the server would reject
   (`scripts/generate-schema-constraints.mjs`, `frontend/src/lib/components/settings/DetailSettings.svelte::validateLimit`).
+- Rebasing must not hide commit authorship: show the original author and label a
+  distinct committer, while preserving committer-based activity identity and time
+  (`frontend/src/lib/components/detail/EventTimeline.svelte::eventAttribution`).
 - Detail timelines apply the server-backed entry limit after filtering and grouping,
   then make the remainder explicit and mount it in bounded idle batches; harnesses
   that require every fixture row pass a large limit. An explicit full-timeline request

--- a/frontend/src/lib/components/detail/EventTimeline.svelte
+++ b/frontend/src/lib/components/detail/EventTimeline.svelte
@@ -978,6 +978,14 @@
     return typeof value === "string" && value.length > 0 ? value : null;
   }
 
+  function eventAttribution(event: PREvent | IssueEvent): string {
+    const author = event.EventType === "commit"
+      ? metadataString(parseMetadata(event), "commit_author")
+      : null;
+    if (!author || author === event.Author) return event.Author;
+    return event.Author ? `${author} committed by ${event.Author}` : author;
+  }
+
   function metadataNumber(metadata: Record<string, unknown>, key: string): number | null {
     const value = metadata[key];
     if (typeof value === "number" && Number.isInteger(value) && value > 0) return value;
@@ -1819,7 +1827,7 @@
     {#if isLifecycleTransitionEvent(event.EventType) && event.Author}
       <span class="event-author-prefix">by</span> {event.Author}
     {:else}
-      {event.Author || "Unknown"}
+      {eventAttribution(event) || "Unknown"}
     {/if}
   </span>
 {/snippet}
@@ -1922,8 +1930,8 @@
               <div class="obsolete-commit-list">
                 {#each entry.obsoleteCommits as commit (commit.ID)}
                   <div class="obsolete-commit-row">
-                    {#if commit.Author}
-                      <span class="event-author">{commit.Author}</span>
+                    {#if eventAttribution(commit)}
+                      <span class="event-author">{eventAttribution(commit)}</span>
                     {/if}
                     <span class="commit-sha">{shortCommit(commit.Summary)}</span>
                     <span class="commit-title">{commitTitle(commit.Body)}</span>
@@ -2056,8 +2064,8 @@
                 >
                   {systemEventLabel(event.EventType)}
                 </span>
-                {#if event.Author}
-                  <span class="event-author">{event.Author}</span>
+                {#if eventAttribution(event)}
+                  <span class="event-author">{eventAttribution(event)}</span>
                 {/if}
                 <span class="commit-sha">{shortCommit(event.Summary)}</span>
                 {#if !showCommitDetails}

--- a/frontend/src/lib/components/detail/EventTimeline.test.ts
+++ b/frontend/src/lib/components/detail/EventTimeline.test.ts
@@ -1573,26 +1573,27 @@ describe("EventTimeline", () => {
     expect(toggle?.getAttribute("aria-expanded")).toBe("true");
   });
 
-  it("renders the normalized committer identity for rebased commits", () => {
-    const { container } = renderTimeline({
-      props: {
-        activityViewMode: "compact",
-        events: [
-          makeEvent({
-            EventType: "commit",
-            Author: "rebase-committer",
-            MetadataJSON: '{"commit_author":"original-author"}',
-            Summary: "abcdef1234567890",
-            Body: "feat: rewrite commit",
-          }),
-        ],
-      },
-    });
+  it.each(["normal", "compact"] as const)(
+    "shows author and committer for rebased commits in %s view",
+    (activityViewMode) => {
+      const { container } = renderTimeline({
+        props: {
+          activityViewMode,
+          events: [
+            makeEvent({
+              EventType: "commit",
+              Author: "rebase-committer",
+              MetadataJSON: '{"commit_author":"original-author"}',
+              Summary: "abcdef1234567890",
+              Body: "feat: rewrite commit",
+            }),
+          ],
+        },
+      });
 
-    const row = container.querySelector<HTMLElement>(".event-card--compact-row");
-    expect(row?.textContent).toContain("rebase-committer");
-    expect(row?.textContent).not.toContain("original-author");
-  });
+      expect(container.textContent).toContain("original-author committed by rebase-committer");
+    },
+  );
 
   it("keeps compact commit details collapsed when commit details are hidden", () => {
     const { container } = renderTimeline({


### PR DESCRIPTION
Rebased commits now show the original author followed by "committed by" when the committer differs. Previously, the timeline showed only the committer.

This applies to normal, compact, and expanded obsolete commit rows while preserving activity ordering and timestamps.
