### PR TITLE
docs: explain sync ceilings and organization GitHub Apps

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1,4 +1,9 @@
 sync_interval = "5m"
+# Raise the local hourly sync allowance for large or active repositories.
+# Default: 500. Minimum: 50. Zero uses the default. Restart after changing.
+# See docs/configuration.md#sync-budget for budget sharing and provider quota.
+# sync_budget_per_hour = 3000
+
 # Environment variable containing your GitHub personal access token.
 # Required scopes: repo (private repos) or public_repo (public only).
 github_token_env = "KENN_FORGE_GITHUB_TOKEN"

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -6,6 +6,28 @@ historical requests.
 
 Reports read only local data. They do not spend provider requests.
 
+## Sync capacity
+
+GitHub archive sync uses spare REST and GraphQL quota from the credential
+reading the repository. Forge reserves 20% of each API's quota for live work,
+with a minimum reserve of 200. Archive work waits when a required API reaches
+that reserve or higher-priority sync work is active.
+
+Archive requests reserved against this provider quota do not spend the local
+`sync_budget_per_hour` allowance. They can proceed even when that local
+ceiling is exhausted. Raising the local ceiling does not add provider quota.
+If GitHub's required quota data is unknown or expired, archive work waits for
+fresh data.
+
+Other archive paths, including Forgejo and Gitea hosts that do not report
+rate limits, use spare [local sync budget](configuration.md#sync-budget).
+They share that allowance with live sync and keep capacity in reserve for
+live work.
+
+For a busy GitHub archive, a [separate archive App](configuration.md#github-app-reads)
+gives covered repositories their own installation quota. It must be a distinct
+App from the one used for ordinary sync.
+
 ## Coverage
 
 Full archival covers supported historical issues, pull requests or merge

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -145,6 +145,7 @@ the installed commands through `/hooks` once.
 
 ```sh
 kenn-forge-github-app create
+kenn-forge-github-app create --org your-org
 kenn-forge-github-app create --role archive
 kenn-forge-github-app list
 kenn-forge-github-app install
@@ -154,6 +155,11 @@ kenn-forge-github-app open
 ```
 
 Use this companion CLI when sync or archive reads should use GitHub App
-installation tokens. `--role archive` creates a separate installation route
+installation tokens. `create --org your-org` creates an organization-owned
+App; omit `--org` for personal ownership. Creation includes a browser-based
+installation step. See [GitHub App reads](configuration.md#github-app-reads)
+for setup and rate limits.
+
+`--role archive` creates a separate installation route
 for historical archive work. Comments, reviews, state changes, and merges
 still use the user PAT chain.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,19 +130,52 @@ owner to a PAT from a different GitHub user.
 
 ### GitHub App reads
 
-Use the companion CLI to keep sync reads off your personal rate limit:
+GitHub Apps are an advanced option for more sync capacity. Forge uses an App's
+installation quota for sync reads, leaving your personal quota for other tools
+and actions.
+
+An App can read only the repositories covered by its installation and granted
+permissions. Owning the App does not grant repository access. An installation
+in one organization does not cover another organization's repositories.
+Repositories outside that installation still need another credential route.
+
+The API quota belongs to each installation. Repositories in that installation
+share it; installing an App does not raise your personal token's rate limit.
+
+On GitHub.com, installation REST limits start at 5,000 requests per hour and
+can scale to 12,500 with repository and organization size. Installations on
+GitHub Enterprise Cloud organizations get 15,000. See
+[GitHub's installation rate limits](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api#primary-rate-limit-for-github-app-installations)
+for the current rules.
+
+Creating an organization-owned App requires organization owner access or
+permission to manage all of the organization's GitHub Apps. Installation may
+also require organization approval. If you do not have that access, ask an
+organization owner to help with setup. See
+[GitHub's App registration requirements](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app).
+
+Replace `your-org` with your organization:
 
 ```sh
-kenn-forge-github-app create
-kenn-forge-github-app install
+kenn-forge-github-app create --org your-org
 kenn-forge-github-app list
+kenn-forge daemon restart
 ```
+
+The create command opens a browser for App creation and installation. Choose
+the organization and repositories Forge should read. Omit `--org` to create a
+personally owned App. If you need to finish installation later, run
+`kenn-forge-github-app install --owner your-org`.
+
+Forge's [local sync budget](#sync-budget) still applies to App reads. Raise
+`sync_budget_per_hour` if the local ceiling stops sync while the installation
+has quota left.
 
 For a busy historical archive, create a second App with its own installation
 budget:
 
 ```sh
-kenn-forge-github-app create --role archive
+kenn-forge-github-app create --org your-org --role archive
 kenn-forge-github-app install --app-id <archive-app-id>
 ```
 
@@ -193,6 +226,9 @@ increase that quota. Leave room for other tools that use the same account,
 and check the provider's remaining quota before raising it again. See
 [Local sync ceiling reached](troubleshooting.md#local-sync-ceiling-reached)
 for recovery steps.
+
+If GitHub's quota is the bottleneck, [set up a GitHub App](#github-app-reads)
+to move sync reads to an installation quota.
 
 ## Activity defaults
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -160,6 +160,40 @@ Selected repository access is a startup routing snapshot. New grants use the
 PAT route until refresh. Revoked App access can return 404, and Forge does
 not retry that response with a PAT because 404 can also mean missing or private.
 
+## Sync budget
+
+`sync_budget_per_hour` limits the API requests Forge spends on background sync
+each hour. It defaults to 500. For a large or active repository, raise it in
+`~/.kenn/forge/config.toml`:
+
+```toml
+sync_budget_per_hour = 3000
+```
+
+Put this at the top level, before any `[section]` or `[[repos]]` header. If
+the key already exists, change its value. Restart Forge to apply it:
+
+```sh
+kenn-forge daemon restart
+```
+
+The value must be at least 50. Omitting it or setting it to `0` uses the
+500-request default; zero does not disable the ceiling.
+
+The same configured limit applies to each budget. GitHub repositories share a
+budget when they use the same GitHub user or App installation on a host.
+Other providers share a budget per provider host.
+
+Forge reserves 10% for discovering new and closed issues and pull requests.
+With a limit of 3,000, optional work such as detail refreshes and archive sync
+stops at 2,700, while discovery can use the full 3,000.
+
+Raising this value lets Forge use more of your provider quota. It does not
+increase that quota. Leave room for other tools that use the same account,
+and check the provider's remaining quota before raising it again. See
+[Local sync ceiling reached](troubleshooting.md#local-sync-ceiling-reached)
+for recovery steps.
+
 ## Activity defaults
 
 ```toml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,7 +167,8 @@ the organization and repositories Forge should read. Omit `--org` to create a
 personally owned App. If you need to finish installation later, run
 `kenn-forge-github-app install --owner your-org`.
 
-Forge's [local sync budget](#sync-budget) still applies to App reads. Raise
+Forge's [local sync budget](#sync-budget) still applies to ordinary App sync
+reads. Raise
 `sync_budget_per_hour` if the local ceiling stops sync while the installation
 has quota left.
 
@@ -195,8 +196,8 @@ not retry that response with a PAT because 404 can also mean missing or private.
 
 ## Sync budget
 
-`sync_budget_per_hour` limits the API requests Forge spends on background sync
-each hour. It defaults to 500. For a large or active repository, raise it in
+`sync_budget_per_hour` limits the API requests Forge spends on live background
+sync each hour. It defaults to 500. For a large or active repository, raise it in
 `~/.kenn/forge/config.toml`:
 
 ```toml
@@ -218,8 +219,13 @@ budget when they use the same GitHub user or App installation on a host.
 Other providers share a budget per provider host.
 
 Forge reserves 10% for discovering new and closed issues and pull requests.
-With a limit of 3,000, optional work such as detail refreshes and archive sync
+With a limit of 3,000, optional live work such as detail refreshes
 stops at 2,700, while discovery can use the full 3,000.
+
+GitHub archive requests reserved against provider quota do not spend this
+local allowance. Other archive paths can use it. See
+[Archive sync capacity](archive.md#sync-capacity) for provider reserves and
+local-budget behavior.
 
 Raising this value lets Forge use more of your provider quota. It does not
 increase that quota. Leave room for other tools that use the same account,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -108,8 +108,8 @@ App access covers only the installed repositories. Organization setup requires
 owner access or delegated App permissions, so you may need an administrator's
 help.
 
-Forge's
-[local sync ceiling](#local-sync-ceiling-reached) still applies, so raise it
+Forge's [local sync ceiling](#local-sync-ceiling-reached) still applies to
+ordinary sync, so raise it
 if the App has quota left but sync stops at the local limit.
 
 If ordinary sync is healthy but historical archive work is competing for the
@@ -117,6 +117,9 @@ same installation budget, add a separate App with
 `kenn-forge-github-app create --role archive`, install it on the repository
 account, and restart Forge. `kenn-forge-github-app list` shows each App's
 role and independent rate-limit state.
+
+See [Archive sync capacity](archive.md#sync-capacity) for how provider quota
+and reserves control historical work.
 
 Mutating actions still use the user credential chain so comments, approvals, and
 merges are attributed to you. Multiple PAT entries issued to the same GitHub

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -87,7 +87,7 @@ does not clear the spent allowance.
 
 Raise the limit only while the provider has quota to spare. If the provider
 quota is exhausted too, wait for its reset or use a
-[GitHub App for sync reads](#github-sync-hits-rate-limits). See
+[GitHub App for sync reads](configuration.md#github-app-reads). See
 [Sync budget](configuration.md#sync-budget) for the default, shared budgets,
 and the capacity Forge reserves for discovering issues and pull requests.
 
@@ -100,13 +100,17 @@ fallback.
 
 ## GitHub sync hits rate limits
 
-Use a GitHub App for sync reads:
+For more GitHub API capacity, use the advanced
+[GitHub App setup](configuration.md#github-app-reads). App installations have
+their own quota, and organization installations can qualify for higher rate
+limits. The setup guide covers organization and personal ownership.
+App access covers only the installed repositories. Organization setup requires
+owner access or delegated App permissions, so you may need an administrator's
+help.
 
-```sh
-kenn-forge-github-app create
-kenn-forge-github-app install
-kenn-forge-github-app list
-```
+Forge's
+[local sync ceiling](#local-sync-ceiling-reached) still applies, so raise it
+if the App has quota left but sync stops at the local limit.
 
 If ordinary sync is healthy but historical archive work is competing for the
 same installation budget, add a separate App with

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -46,7 +46,8 @@ Check these in order:
 3. The token env var or token file is present in the daemon environment.
 4. The token has read access to repository metadata, PRs/MRs, issues, comments,
    commits, tags, releases, and CI/status data.
-5. The provider rate limit is not exhausted.
+5. Neither the [local sync ceiling](#local-sync-ceiling-reached) nor the
+   provider rate limit is exhausted.
 
 For GitHub, `gh auth token --hostname HOST` can supply the token when the
 configured token source is absent. The unscoped `gh auth token` fallback applies
@@ -55,6 +56,40 @@ With `[[github_owner_tokens]]`, confirm the entered owner matches the mapping
 exactly after case folding and restart after changing the PAT to one issued by
 a different GitHub user. A missing owner route reports the GitHub host and owner
 without exposing token material.
+
+## Local sync ceiling reached
+
+"Local sync ceiling reached (500/500)" means Forge has spent its local hourly
+sync allowance. Sync requests that need more of that allowance must wait.
+The provider may still have quota available.
+
+To give a large or active repository more capacity:
+
+1. Open `~/.kenn/forge/config.toml`, or `$KENN_FORGE_HOME/config.toml` if you
+    set a custom home.
+2. Add or update this top-level setting, before any `[section]` or `[[repos]]`
+    header. This example raises the allowance to 3,000 requests per hour:
+
+    ```toml
+    sync_budget_per_hour = 3000
+    ```
+
+3. Restart Forge to apply the new limit:
+
+    ```sh
+    kenn-forge daemon restart
+    ```
+
+4. Retry sync and check that the local ceiling now shows a limit of 3,000.
+
+You can also wait for the local hourly window to reset. Clicking sync again
+does not clear the spent allowance.
+
+Raise the limit only while the provider has quota to spare. If the provider
+quota is exhausted too, wait for its reset or use a
+[GitHub App for sync reads](#github-sync-hits-rate-limits). See
+[Sync budget](configuration.md#sync-budget) for the default, shared budgets,
+and the capacity Forge reserves for discovering issues and pull requests.
 
 ## Mutating actions are disabled
 


### PR DESCRIPTION
Explain how to recover from "local sync ceiling reached" by raising `sync_budget_per_hour` and restarting Forge. Cover shared budgets and the discovery reserve, and distinguish GitHub archive quota from the local sync ceiling.

Document organization-owned GitHub App setup with `create --org`, installation quotas and repository access, and the organization permissions needed. Link troubleshooting to the setup and archive guides.

Closes #1077.
