### PR TITLE
feat: let App clients discover repositories a page at a time

### DIFF
--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -35,6 +35,13 @@ cache policy and admission remain internal
 (`cmd/kenn-forge/provider_startup.go::defaultProviderFactories`,
 `internal/tokenauth/source.go::githubAppTokenStore`).
 
+App discovery pages are observations, not atomic inventories; callers own total
+budgets and must not equate stopping with exhaustion
+(`githubapp/discovery.go::InstallationPage`).
+Installation absence requires the expected App's authenticated exact-ID read;
+JWT rejection does not prove key revocation, and repository 404s prove neither
+(`githubapp/installation.go::Client.CheckInstallation`).
+
 ## Adding A Provider
 
 The public landing API uses local objects only; callers own collection and supply

--- a/githubapp/client.go
+++ b/githubapp/client.go
@@ -33,10 +33,9 @@ func WebBaseForHost(host string) string {
 	return "https://" + host
 }
 
-// Client is a minimal GitHub App management client. It speaks only
-// the app-scoped endpoints the kenn-forge-github-app CLI and the
-// installation token minter need; repository data access stays on the
-// main provider clients.
+// Client handles GitHub App management and installation discovery. Repository
+// content access stays on the provider clients. Callers own credentials,
+// persistence, retry policy and admission.
 type Client struct {
 	apiBase    string
 	httpClient *http.Client
@@ -70,6 +69,7 @@ type AppCredentials struct {
 }
 
 type Account struct {
+	ID    int64  `json:"id"`
 	Login string `json:"login"`
 	Type  string `json:"type"`
 }
@@ -85,9 +85,11 @@ type App struct {
 
 // Installation is one account the app is installed on.
 type Installation struct {
-	ID                  int64   `json:"id"`
-	Account             Account `json:"account"`
-	RepositorySelection string  `json:"repository_selection"`
+	ID                  int64      `json:"id"`
+	AppID               int64      `json:"app_id"`
+	Account             Account    `json:"account"`
+	RepositorySelection string     `json:"repository_selection"`
+	SuspendedAt         *time.Time `json:"suspended_at"`
 }
 
 // InstallationToken is a minted installation access token.

--- a/githubapp/discovery.go
+++ b/githubapp/discovery.go
@@ -1,0 +1,89 @@
+package githubapp
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net/http"
+)
+
+// InstallationPage is one observation, not a snapshot of all installations.
+// NextPage is zero after a short page. A full page requires another read,
+// possibly empty. Callers own total request limits and stopping between pages.
+type InstallationPage struct {
+	Installations []Installation
+	NextPage      int
+}
+
+// Repository is an installation-visible repository. ID is stable within the
+// GitHub instance; names, owner and default branch are observed metadata.
+type Repository struct {
+	ID            int64   `json:"id"`
+	Name          string  `json:"name"`
+	FullName      string  `json:"full_name"`
+	Owner         Account `json:"owner"`
+	DefaultBranch string  `json:"default_branch"`
+	Private       bool    `json:"private"`
+}
+
+// RepositoryPage has the same continuation contract as InstallationPage.
+// Discovery does not grant access or select repositories on the caller's behalf.
+type RepositoryPage struct {
+	Repositories []Repository
+	NextPage     int
+}
+
+// ListInstallationsPage reads one page using an App JWT; it never mints an
+// installation token. page starts at one and perPage must be between 1 and 100.
+func (c *Client) ListInstallationsPage(
+	ctx context.Context, appJWT string, page, perPage int,
+) (InstallationPage, error) {
+	path, err := discoveryPath("/app/installations", page, perPage)
+	if err != nil {
+		return InstallationPage{}, err
+	}
+	var items []Installation
+	if err := c.do(ctx, http.MethodGet, path, appJWT, nil, &items); err != nil {
+		return InstallationPage{}, fmt.Errorf("listing app installations: %w", err)
+	}
+	if items == nil || len(items) > perPage {
+		return InstallationPage{}, fmt.Errorf("missing or oversized installation page")
+	}
+	result := InstallationPage{Installations: items}
+	if len(items) == perPage {
+		result.NextPage = page + 1
+	}
+	return result, nil
+}
+
+// ListInstallationRepositoriesPage reads one page with an installation token,
+// not an App JWT. page starts at one; perPage must be between 1 and 100.
+func (c *Client) ListInstallationRepositoriesPage(
+	ctx context.Context, installationToken string, page, perPage int,
+) (RepositoryPage, error) {
+	path, err := discoveryPath("/installation/repositories", page, perPage)
+	if err != nil {
+		return RepositoryPage{}, err
+	}
+	var out struct {
+		Repositories []Repository `json:"repositories"`
+	}
+	if err := c.do(ctx, http.MethodGet, path, installationToken, nil, &out); err != nil {
+		return RepositoryPage{}, fmt.Errorf("listing installation repositories: %w", err)
+	}
+	if out.Repositories == nil || len(out.Repositories) > perPage {
+		return RepositoryPage{}, fmt.Errorf("missing or oversized repository page")
+	}
+	result := RepositoryPage{Repositories: out.Repositories}
+	if len(out.Repositories) == perPage {
+		result.NextPage = page + 1
+	}
+	return result, nil
+}
+
+func discoveryPath(path string, page, perPage int) (string, error) {
+	if page < 1 || page == math.MaxInt || perPage < 1 || perPage > 100 {
+		return "", fmt.Errorf("page must be positive and incrementable; perPage must be between 1 and 100")
+	}
+	return fmt.Sprintf("%s?per_page=%d&page=%d", path, perPage, page), nil
+}

--- a/githubapp/discovery_test.go
+++ b/githubapp/discovery_test.go
@@ -1,0 +1,125 @@
+package githubapp_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/githubapp"
+)
+
+func TestInstallationDiscoveryIsPaged(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		assert.Equal("/api/v3/app/installations", r.URL.Path)
+		assert.Equal("Bearer app-jwt", r.Header.Get("Authorization"))
+		assert.Equal("1", r.URL.Query().Get("per_page"))
+		switch r.URL.Query().Get("page") {
+		case "2":
+			fmt.Fprint(w, `[{"id":42,"app_id":7,"account":{"id":81,"login":"org-a","type":"Organization"},"repository_selection":"all","suspended_at":"2026-01-02T03:04:05Z"}]`)
+		case "3":
+			fmt.Fprint(w, `[]`)
+		default:
+			http.Error(w, "wrong page", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+	client := githubapp.NewClientWithBase(server.URL + "/api/v3")
+	page, err := client.ListInstallationsPage(t.Context(), "app-jwt", 2, 1)
+	require.NoError(err)
+	require.Len(page.Installations, 1)
+	assert.Equal(1, requests)
+	assert.Equal(3, page.NextPage)
+	installation := page.Installations[0]
+	assert.Equal(int64(42), installation.ID)
+	assert.Equal(int64(7), installation.AppID)
+	assert.Equal(int64(81), installation.Account.ID)
+	assert.Equal("org-a", installation.Account.Login)
+	assert.Equal("all", installation.RepositorySelection)
+	require.NotNil(installation.SuspendedAt)
+	assert.Equal(int64(1767323045), installation.SuspendedAt.Unix())
+	last, err := client.ListInstallationsPage(t.Context(), "app-jwt", page.NextPage, 1)
+	require.NoError(err)
+	assert.Empty(last.Installations)
+	assert.Zero(last.NextPage)
+}
+
+func TestRepositoryDiscoveryPreservesIdentity(t *testing.T) {
+	assert := assert.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("/installation/repositories", r.URL.Path)
+		assert.Equal("Bearer installation-token", r.Header.Get("Authorization"))
+		assert.Equal("4", r.URL.Query().Get("page"))
+		assert.Equal("2", r.URL.Query().Get("per_page"))
+		fmt.Fprint(w, `{"total_count":7,"repositories":[{"id":91,"name":"project-a","full_name":"org-a/project-a","owner":{"id":81,"login":"org-a","type":"Organization"},"default_branch":"trunk","private":true}]}`)
+	}))
+	defer server.Close()
+	page, err := githubapp.NewClientWithBase(server.URL).ListInstallationRepositoriesPage(t.Context(), "installation-token", 4, 2)
+	require.NoError(t, err)
+	require.Len(t, page.Repositories, 1)
+	assert.Zero(page.NextPage)
+	assert.Equal(githubapp.Repository{
+		ID: 91, Name: "project-a", FullName: "org-a/project-a",
+		Owner:         githubapp.Account{ID: 81, Login: "org-a", Type: "Organization"},
+		DefaultBranch: "trunk", Private: true,
+	}, page.Repositories[0])
+}
+
+func TestDiscoveryRejectsInvalidBounds(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		fmt.Fprint(w, `[]`)
+	}))
+	defer server.Close()
+	client := githubapp.NewClientWithBase(server.URL)
+	for _, bounds := range [][2]int{{0, 1}, {-1, 1}, {1, 0}, {1, 101}} {
+		_, err := client.ListInstallationsPage(t.Context(), "app-jwt", bounds[0], bounds[1])
+		require.Error(t, err)
+		_, err = client.ListInstallationRepositoriesPage(t.Context(), "installation-token", bounds[0], bounds[1])
+		require.Error(t, err)
+	}
+	assert.Zero(t, requests)
+}
+
+func TestDiscoveryRejectsOversizedPage(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/app/installations" {
+			fmt.Fprint(w, `[{"id":1},{"id":2}]`)
+			return
+		}
+		fmt.Fprint(w, `{"repositories":[{"id":1},{"id":2}]}`)
+	}))
+	defer server.Close()
+	client := githubapp.NewClientWithBase(server.URL)
+	installations, err := client.ListInstallationsPage(t.Context(), "app-jwt", 1, 1)
+	require.Error(err)
+	assert.Empty(installations.Installations)
+	repositories, err := client.ListInstallationRepositoriesPage(t.Context(), "installation-token", 1, 1)
+	require.Error(err)
+	assert.Empty(repositories.Repositories)
+}
+
+func TestDiscoveryDoesNotTurnUnreadablePagesIntoEmptyInventory(t *testing.T) {
+	for _, body := range []string{`null`, `{}`, `{"repositories":null}`} {
+		t.Run(body, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, body)
+			}))
+			defer server.Close()
+			client := githubapp.NewClientWithBase(server.URL)
+			_, err := client.ListInstallationsPage(t.Context(), "app-jwt", 1, 10)
+			require.Error(t, err)
+			_, err = client.ListInstallationRepositoriesPage(t.Context(), "installation-token", 1, 10)
+			require.Error(t, err)
+		})
+	}
+}

--- a/githubapp/installation.go
+++ b/githubapp/installation.go
@@ -1,0 +1,91 @@
+package githubapp
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// InstallationFailure identifies a confirmed outcome of CheckInstallation.
+// Network errors, rate limits, generic forbidden responses and identity
+// mismatches are not installation lifecycle facts.
+type InstallationFailure string
+
+const (
+	// AppAuthenticationRejected means the supplied JWT was rejected. It may
+	// have expired; callers must not infer that the signing key was revoked.
+	AppAuthenticationRejected InstallationFailure = "app_authentication_rejected"
+	// InstallationSuspended comes from the installation's suspended_at field.
+	InstallationSuspended InstallationFailure = "installation_suspended"
+	// InstallationDeleted means the exact installation was absent after the
+	// same JWT authenticated as the expected App. Use this only for an
+	// installation previously known to belong to that App.
+	InstallationDeleted InstallationFailure = "installation_deleted"
+)
+
+// InstallationError reports a confirmed outcome without including the provider
+// response in its message. Unwrap preserves the underlying StatusError, whose
+// body may contain private data and must not be exposed to end users.
+type InstallationError struct {
+	Kind  InstallationFailure
+	cause error
+}
+
+func (e *InstallationError) Error() string { return string(e.Kind) }
+func (e *InstallationError) Unwrap() error { return e.cause }
+
+// GetInstallation reads one exact installation with an App JWT. A raw 404
+// does not establish deletion; CheckInstallation also verifies App identity.
+func (c *Client) GetInstallation(ctx context.Context, appJWT string, installationID int64) (*Installation, error) {
+	if installationID <= 0 {
+		return nil, fmt.Errorf("installation ID must be positive")
+	}
+	var installation Installation
+	path := fmt.Sprintf("/app/installations/%d", installationID)
+	if err := c.do(ctx, http.MethodGet, path, appJWT, nil, &installation); err != nil {
+		return nil, fmt.Errorf("getting installation: %w", err)
+	}
+	if installation.ID != installationID || installation.AppID <= 0 {
+		return nil, fmt.Errorf("installation response identity mismatch")
+	}
+	return &installation, nil
+}
+
+// CheckInstallation confirms the expected App first, then reads the exact
+// installation. It never mints tokens, retries or changes caller state. Callers
+// supply a fresh JWT and retain ownership of credential refresh and admission.
+// Each error returns no installation. Only InstallationError supplies a
+// lifecycle classification; every other error leaves availability unknown.
+func (c *Client) CheckInstallation(ctx context.Context, appJWT string, appID, installationID int64) (*Installation, error) {
+	if appID <= 0 || installationID <= 0 {
+		return nil, fmt.Errorf("App and installation IDs must be positive")
+	}
+	app, err := c.GetApp(ctx, appJWT)
+	if err != nil {
+		return nil, appAuthenticationError(err)
+	}
+	if app.ID != appID {
+		return nil, fmt.Errorf("authenticated App identity mismatch")
+	}
+	installation, err := c.GetInstallation(ctx, appJWT, installationID)
+	if err != nil {
+		if IsStatus(err, http.StatusNotFound) {
+			return nil, &InstallationError{Kind: InstallationDeleted, cause: err}
+		}
+		return nil, appAuthenticationError(err)
+	}
+	if installation.AppID != appID {
+		return nil, fmt.Errorf("installation App identity mismatch")
+	}
+	if installation.SuspendedAt != nil {
+		return nil, &InstallationError{Kind: InstallationSuspended}
+	}
+	return installation, nil
+}
+
+func appAuthenticationError(err error) error {
+	if IsStatus(err, http.StatusUnauthorized) {
+		return &InstallationError{Kind: AppAuthenticationRejected, cause: err}
+	}
+	return err
+}

--- a/githubapp/installation_test.go
+++ b/githubapp/installation_test.go
@@ -1,0 +1,87 @@
+package githubapp_test
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/githubapp"
+)
+
+func TestCheckInstallation(t *testing.T) {
+	cases := []struct {
+		name          string
+		appStatus     int
+		appBody       string
+		installStatus int
+		installBody   string
+		kind          githubapp.InstallationFailure
+		wantError     bool
+		reads         int
+	}{
+		{"active", 200, `{"id":7}`, 200, `{"id":42,"app_id":7,"repository_selection":"selected","account":{"id":81}}`, "", false, 2},
+		{"suspended", 200, `{"id":7}`, 200, `{"id":42,"app_id":7,"suspended_at":"2026-01-02T03:04:05Z"}`, githubapp.InstallationSuspended, true, 2},
+		{"deleted", 200, `{"id":7}`, 404, `{"message":"not found"}`, githubapp.InstallationDeleted, true, 2},
+		{"rejected JWT", 401, `{"message":"private response"}`, 200, `{}`, githubapp.AppAuthenticationRejected, true, 1},
+		{"JWT expires between reads", 200, `{"id":7}`, 401, `{}`, githubapp.AppAuthenticationRejected, true, 2},
+		{"app not found", 404, `{}`, 404, `{}`, "", true, 1},
+		{"wrong app", 200, `{"id":8}`, 404, `{}`, "", true, 1},
+		{"missing app ID", 200, `{}`, 404, `{}`, "", true, 1},
+		{"wrong installation", 200, `{"id":7}`, 200, `{"id":43,"app_id":7}`, "", true, 2},
+		{"wrong installation app", 200, `{"id":7}`, 200, `{"id":42,"app_id":8}`, "", true, 2},
+		{"forbidden", 200, `{"id":7}`, 403, `{}`, "", true, 2},
+		{"rate limited", 200, `{"id":7}`, 429, `{}`, "", true, 2},
+		{"server failure", 200, `{"id":7}`, 503, `{}`, "", true, 2},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			var paths []string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				paths = append(paths, r.URL.Path)
+				assert.Equal("GET", r.Method)
+				assert.Equal("Bearer app-jwt", r.Header.Get("Authorization"))
+				switch r.URL.Path {
+				case "/api/v3/app":
+					w.WriteHeader(tt.appStatus)
+					fmt.Fprint(w, tt.appBody)
+				case "/api/v3/app/installations/42":
+					w.WriteHeader(tt.installStatus)
+					fmt.Fprint(w, tt.installBody)
+				default:
+					http.Error(w, "unexpected route", http.StatusBadRequest)
+				}
+			}))
+			defer server.Close()
+			installation, err := githubapp.NewClientWithBase(server.URL+"/api/v3").CheckInstallation(t.Context(), "app-jwt", 7, 42)
+			if tt.wantError {
+				require.Error(err)
+				assert.Nil(installation)
+			} else {
+				require.NoError(err)
+				require.NotNil(installation)
+				assert.Equal(int64(42), installation.ID)
+				assert.Equal(int64(81), installation.Account.ID)
+				assert.Equal("selected", installation.RepositorySelection)
+			}
+			failure, ok := errors.AsType[*githubapp.InstallationError](err)
+			if tt.kind == "" {
+				assert.False(ok, "an uncertain response must not change credential lifecycle")
+			} else {
+				require.True(ok)
+				assert.Equal(tt.kind, failure.Kind)
+				assert.NotContains(err.Error(), "private response")
+			}
+			assert.Len(paths, tt.reads)
+			assert.Equal("/api/v3/app", paths[0])
+			if tt.kind == githubapp.InstallationDeleted {
+				assert.True(githubapp.IsStatus(err, http.StatusNotFound))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Let embedded callers discover GitHub App installations and repositories a page at a time, retaining stable IDs, installed accounts, repository selection mode and default branches. Callers keep control of total request budgets; existing full-list methods are unchanged.

- Add an exact installation check that confirms the expected App before classifying absence. Suspended installations and rejected JWTs are distinct; JWT rejection does not imply that a private key was revoked.
- Leave rate limits, server failures and other uncertain responses unclassified. Discovery itself never mints installation tokens.
- Extend the public `Account` and `Installation` structs; external positional literals need updating.

Library only: no UI, persistence, background worker or credential-storage changes.
