### PR TITLE
fix: stabilize Chromium browser and agent-status e2e tests

### DIFF
--- a/context/testing.md
+++ b/context/testing.md
@@ -228,6 +228,9 @@ and materialize `node_modules` from the lockfile before invoking baked `vp`
 (`.github/workflows/ci.yml::ensure_playwright_image`, `.github/docker/playwright/Dockerfile:3`).
 Frontend unit tests use the runner's 14 guaranteed cores; the previous single-worker
 cap was for the retired memory-constrained runner (`frontend/vite.config.ts::resolveUnitTestWorkers`).
+Run CI Vitest unit and browser projects separately: their worker limits differ,
+which Vitest rejects in the same execution group
+(`frontend/vite.config.ts::resolveBrowserTestWorkers`).
 Threaded unit tests must not start and stop a complete Vite/Rolldown dev server merely
 to exercise plugin middleware; native handles can survive worker teardown under CI
 concurrency (`frontend/src/lib/dev/healthcheckPlugin.test.ts::startServer`).

--- a/context/testing.md
+++ b/context/testing.md
@@ -123,6 +123,9 @@ owner:
 - Browser specs live beside their components under `frontend/src`; the browser
   project includes `src/**/*.browser.svelte.ts`, while the jsdom unit project
   also includes GitHub App setup tests (`frontend/vite.config.ts::jsdomUnitTestProject`).
+- Verify browser cleanup changes with repeated full runs in the CI Playwright Linux image;
+  macOS passes and a single retry can miss intermittent orchestrator disconnects
+  (`frontend/src/test/browserSetup.ts:7`).
 - Responsive layout tests must await the geometry invariant itself; repeated first-paint
   measurements do not prove ResizeObserver has delivered its layout update
   (`frontend/src/RoborevReviewDrawer.footer-layout.browser.svelte.ts:229`).

--- a/frontend/src/test/browserSetup.ts
+++ b/frontend/src/test/browserSetup.ts
@@ -1,0 +1,9 @@
+import { afterAll } from "vite-plus/test";
+import { cdp } from "vite-plus/test/browser";
+
+// Chromium retains resources from completed Vitest iframes across files.
+// Release them between files in this Chromium-only project.
+// https://github.com/vitest-dev/vitest/issues/9437
+afterAll(async () => {
+  await cdp().send("HeapProfiler.collectGarbage");
+});

--- a/frontend/tests/e2e/list-agent-status.spec.ts
+++ b/frontend/tests/e2e/list-agent-status.spec.ts
@@ -14,17 +14,17 @@ async function expectAgentAtRight(page: Page): Promise<void> {
   expect(gap).toBeLessThanOrEqual(1);
 }
 
-test("Forge config preference shows linked agent states across item lists", async ({ page }) => {
-  test.setTimeout(60_000);
+async function mockAgentStatus(page: Page, enabled = false) {
   await mockApi(page);
-  let settings = structuredClone(mockSettings);
+  const state = { settings: structuredClone(mockSettings), pullAgentState: "working" };
+  state.settings.workspaces.show_agent_status_in_lists = enabled;
   await page.route("**/api/v1/settings", async (route) => {
     if (route.request().method() === "PUT") {
       const update = route.request().postDataJSON();
       expect(update).toEqual({ workspaces: { show_agent_status_in_lists: true } });
-      settings = { ...settings, workspaces: { ...settings.workspaces, ...update.workspaces } };
+      state.settings = { ...state.settings, workspaces: { ...state.settings.workspaces, ...update.workspaces } };
     }
-    await route.fulfill({ json: settings });
+    await route.fulfill({ json: state.settings });
   });
   const api = createMockApiHandler();
   const pulls: PullRequest[] = await api
@@ -35,12 +35,11 @@ test("Forge config preference shows linked agent states across item lists", asyn
     .json();
   const pull = pulls[0]!;
   const issue = issues[0]!;
-  let pullAgentState = "working";
   await page.route("**/api/v1/pulls?*", (route) =>
     route.fulfill({
       json: pulls.map((item) => ({
         ...item,
-        workspace: { id: `pr-${item.Number}`, status: "ready", agent_state: pullAgentState },
+        workspace: { id: `pr-${item.Number}`, status: "ready", agent_state: state.pullAgentState },
       })),
     }),
   );
@@ -80,6 +79,13 @@ test("Forge config preference shows linked agent states across item lists", asyn
     }),
   );
 
+  return { state, pull, issue };
+}
+
+test("Forge config preference enables linked pull agent states without changing row layout", async ({ page }) => {
+  test.setTimeout(60_000);
+  const { state, pull } = await mockAgentStatus(page);
+
   await page.goto("/pulls");
   await expect(page.locator(".pr-list-row").filter({ hasText: pull.Title })).toBeVisible();
   await expect(page.locator(".pr-list-row .agent-state")).toHaveCount(0);
@@ -87,7 +93,7 @@ test("Forge config preference shows linked agent states across item lists", asyn
     .locator(".pr-list-row")
     .filter({ hasText: pull.Title })
     .evaluate((row) => row.getBoundingClientRect().height);
-  await page.goto("/settings");
+  await page.locator('button[title="Settings"]').click();
   await page
     .getByRole("navigation", { name: "Settings" })
     .getByRole("button", { name: /^Workspaces / })
@@ -95,7 +101,7 @@ test("Forge config preference shows linked agent states across item lists", asyn
   const toggle = page.getByRole("button", { name: "Show agent status in lists" });
   await toggle.click();
   await expect(toggle).toHaveAttribute("aria-pressed", "true");
-  await expect.poll(() => settings.workspaces.show_agent_status_in_lists).toBe(true);
+  await expect.poll(() => state.settings.workspaces.show_agent_status_in_lists).toBe(true);
   await page.evaluate(() => localStorage.clear());
   await page.goto("/pulls");
   await expect(
@@ -122,19 +128,26 @@ test("Forge config preference shows linked agent states across item lists", asyn
     expect(gap.vertical).toBeLessThan(1);
   }
   await page.screenshot({ path: test.info().outputPath("pull-list-agent-status.png") });
-  pullAgentState = "input";
+  state.pullAgentState = "input";
   await expect(
     page.locator(".pr-list-row").filter({ hasText: pull.Title }).getByText("Input", { exact: true }),
   ).toBeVisible({ timeout: 12_000 });
+});
+
+test("shows linked issue agent states when enabled in Forge config", async ({ page }) => {
+  const { issue } = await mockAgentStatus(page, true);
   await page.goto("/issues");
   await expect(
     page.locator(".issue-item").filter({ hasText: issue.Title }).getByText("Approval", { exact: true }),
   ).toBeVisible();
-  await page.goto("/?view=flat");
-  await expect(page.locator(".agent-state").getByText("Done", { exact: true }).first()).toBeVisible();
-  await expectAgentAtRight(page);
-  await page.goto("/?view=threaded");
-  await expect(page.locator(".agent-state").getByText("Done", { exact: true }).first()).toBeVisible();
-  await expectAgentAtRight(page);
-  await page.screenshot({ path: test.info().outputPath("list-agent-status.png") });
 });
+
+for (const view of ["flat", "threaded"] as const) {
+  test(`shows linked agent states at the right of ${view} Activity rows`, async ({ page }) => {
+    await mockAgentStatus(page, true);
+    await page.goto(`/?view=${view}`);
+    await expect(page.locator(".agent-state").getByText("Done", { exact: true }).first()).toBeVisible();
+    await expectAgentAtRight(page);
+    await page.screenshot({ path: test.info().outputPath(`list-agent-status-${view}.png`) });
+  });
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -214,6 +214,7 @@ const browserTestProject = defineProject(async () => {
     },
     test: {
       name: "browser",
+      setupFiles: ["./src/test/browserSetup.ts"],
       include: ["src/**/*.browser.svelte.ts"],
       ...(maxWorkers ? { maxWorkers } : {}),
       browser: {


### PR DESCRIPTION
- Release retained Chromium resources between browser test files to address intermittent Linux orchestrator disconnects.
- Keep agent-status e2e checks within the CI time budget while preserving coverage for saved preferences, row layout, and live agent updates.
