### PR TITLE
feat(mcp): expose active listeners through CLI status

### DIFF
--- a/cmd/kenn-forge/mcp_cli.go
+++ b/cmd/kenn-forge/mcp_cli.go
@@ -23,6 +23,8 @@ const mcpTokenEnvironment = "KENN_FORGE_API_TOKEN"
 type mcpQuickstartLoader func(context.Context, string, time.Duration) (mcpQuickstartInfo, error)
 
 type mcpQuickstartInfo struct {
+	pid             int
+	backendURL      string
 	Enabled         bool                    `json:"enabled"`
 	Active          bool                    `json:"active"`
 	RestartRequired bool                    `json:"restart_required"`
@@ -91,7 +93,7 @@ func newMCPCommand(stdout io.Writer, load mcpQuickstartLoader) *cobra.Command {
 	)
 	quickstart.Flags().BoolVar(&asJSON, "json", false, "render output as JSON")
 	quickstart.Flags().DurationVar(&timeout, "timeout", 5*time.Second, "daemon request timeout")
-	cmd.AddCommand(quickstart)
+	cmd.AddCommand(quickstart, newMCPStatusCommand(stdout, load))
 	return cmd
 }
 
@@ -160,7 +162,10 @@ func loadMCPQuickstart(
 	if settings.MCP == nil {
 		return mcpQuickstartInfo{}, fmt.Errorf("mcp quickstart: daemon did not publish MCP settings")
 	}
-	return daemonMCPQuickstart(*settings.MCP, daemon.TokenPath), nil
+	info := daemonMCPQuickstart(*settings.MCP, daemon.TokenPath)
+	info.pid = status.Metadata.PID
+	info.backendURL = daemon.BaseURL
+	return info, nil
 }
 
 func stoppedMCPQuickstart(enabled bool, configPath string) mcpQuickstartInfo {

--- a/cmd/kenn-forge/mcp_status.go
+++ b/cmd/kenn-forge/mcp_status.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/json/v2"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/forge/internal/config"
+)
+
+// mcpListenerStatus is the CLI discovery contract for existing HTTP listeners.
+// TokenPath identifies credentials without placing their contents in output.
+type mcpListenerStatus struct {
+	PID        int    `json:"pid"`
+	Transport  string `json:"transport"`
+	URL        string `json:"url"`
+	BackendURL string `json:"backend_url"`
+	TokenPath  string `json:"token_path,omitempty"`
+}
+
+func newMCPStatusCommand(stdout io.Writer, load mcpQuickstartLoader) *cobra.Command {
+	var configPath string
+	var asJSON bool
+	var timeout time.Duration
+	command := &cobra.Command{
+		Use:   "status",
+		Short: "List the running HTTP MCP listener",
+		Args:  cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			info, err := load(command.Context(), configPath, timeout)
+			if err != nil {
+				return err
+			}
+			listeners := []mcpListenerStatus{}
+			if info.Active {
+				listeners = append(listeners, mcpListenerStatus{
+					PID: info.pid, Transport: "http", URL: info.Endpoint,
+					BackendURL: info.backendURL, TokenPath: info.Authentication.TokenPath,
+				})
+			}
+			if asJSON {
+				return json.MarshalWrite(stdout, listeners)
+			}
+			if len(listeners) == 0 {
+				_, err := fmt.Fprintln(stdout, "No HTTP MCP listeners are running.")
+				return err
+			}
+			_, err = fmt.Fprintf(stdout, "MCP %s (pid %d)\n", listeners[0].URL, listeners[0].PID)
+			return err
+		},
+	}
+	command.Flags().StringVar(&configPath, "config", config.DefaultConfigPath(), "path to config file")
+	command.Flags().BoolVar(&asJSON, "json", false, "render output as JSON")
+	command.Flags().DurationVar(&timeout, "timeout", 5*time.Second, "daemon request timeout")
+	return command
+}

--- a/cmd/kenn-forge/mcp_status_test.go
+++ b/cmd/kenn-forge/mcp_status_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json/v2"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/runtimelock"
+)
+
+func TestMCPStatusReportsActiveListenerFromDaemon(t *testing.T) {
+	for _, tc := range []struct {
+		name, settings string
+		active, auth   bool
+	}{
+		{"active despite saved disable", `{"mcp":{"enabled":false,"active_url":"http://127.0.0.1:9123/mcp","active_requires_auth":true,"restart_required":true}}`, true, true},
+		{"active without auth", `{"mcp":{"enabled":true,"active_url":"http://127.0.0.1:9123/mcp","active_requires_auth":false}}`, true, false},
+		{"saved enable awaits restart", `{"mcp":{"enabled":true,"active_url":"","restart_required":true}}`, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			root := t.TempDir()
+			token, err := runtimelock.EnsureAuthToken(root)
+			tokenPath := runtimelock.AuthTokenPath(root)
+			require.NoError(err)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/forge/api/v1/settings" || r.Header.Get("Authorization") != "Bearer "+token {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				_, _ = w.Write([]byte(tc.settings))
+			}))
+			t.Cleanup(server.Close)
+			lock, err := runtimelock.Acquire(root)
+			require.NoError(err)
+			t.Cleanup(func() { require.NoError(lock.Release()) })
+			require.NoError(lock.WriteMetadata(runtimelock.Metadata{
+				PID: os.Getpid(), ListenAddr: strings.TrimPrefix(server.URL, "http://"), BasePath: "/forge", TokenPath: tokenPath,
+			}))
+			configPath := filepath.Join(root, "config.toml")
+			require.NoError(os.WriteFile(configPath, fmt.Appendf(nil, "data_dir = %q\n", root), 0o600))
+			var output bytes.Buffer
+			command := newMCPCommand(&output, loadMCPQuickstart)
+			command.SetArgs([]string{"status", "--json", "--config", configPath})
+			require.NoError(command.ExecuteContext(t.Context()))
+			var rows []mcpListenerStatus
+			require.NoError(json.Unmarshal(output.Bytes(), &rows))
+			if !tc.active {
+				assert.JSONEq(`[]`, output.String())
+				return
+			}
+			require.Len(rows, 1)
+			assert.Equal("http://127.0.0.1:9123/mcp", rows[0].URL)
+			assert.Equal(server.URL+"/forge", rows[0].BackendURL)
+			assert.Equal("http", rows[0].Transport)
+			assert.Equal(os.Getpid(), rows[0].PID)
+			if tc.auth {
+				assert.Equal(tokenPath, rows[0].TokenPath)
+			} else {
+				assert.NotContains(output.String(), "token_path")
+			}
+			assert.NotContains(output.String(), token)
+		})
+	}
+}
+
+func TestMCPStatusStoppedDoesNotCreateRuntime(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	root := t.TempDir()
+	configPath := filepath.Join(root, "config.toml")
+	dataDir := filepath.Join(root, "data")
+	require.NoError(os.WriteFile(configPath, fmt.Appendf(nil, "data_dir = %q\n", dataDir), 0o600))
+	var output bytes.Buffer
+	command := newMCPCommand(&output, loadMCPQuickstart)
+	command.SetArgs([]string{"status", "--json", "--config", configPath})
+	require.NoError(command.ExecuteContext(t.Context()))
+	assert.JSONEq(`[]`, output.String())
+	_, err := os.Stat(runtimelock.LockPath(dataDir))
+	assert.ErrorIs(err, os.ErrNotExist)
+}

--- a/docs/kenn-forge-mcp.md
+++ b/docs/kenn-forge-mcp.md
@@ -33,6 +33,20 @@ the MCP endpoint does not require a token. Runtime discovery publishes the
 resolved MCP listener and URL, and `kenn-forge daemon status --json` shows both
 the listener address and the token file path.
 
+For a machine-readable listener list, run:
+
+```sh
+kenn-forge mcp status --json
+```
+
+The command returns an array with `pid`, `transport: "http"`, `url`,
+`backend_url`, and an optional `token_path`. It reports the active listener,
+including when saved settings require a restart. A stopped daemon or inactive
+companion returns `[]`; the command never starts either. Use `--config` to
+select another configuration and `--timeout` to set the daemon request timeout.
+Token contents never appear in the output. For client setup instructions and
+restart guidance, use `kenn-forge mcp quickstart`.
+
 Configure your MCP client with the HTTP URL. For clients that accept a JSON
 server catalog, the shape is typically similar to:
 


### PR DESCRIPTION
`kenn-forge mcp status --json` reports the active HTTP MCP listener in a consistent array containing `pid`, `transport`, `url`, `backend_url`, and optional `token_path`. Clients can discover its actual endpoint without parsing setup instructions.

It reuses the daemon-backed discovery from `mcp quickstart`, reports active state when saved settings await restart, and returns `[]` when the daemon or companion is stopped. It never starts a daemon or prints bearer tokens. `--config` selects the configuration and `--timeout` controls the request timeout.
