### PR TITLE
fix: recover workspace setup from stalled Git transfers

### DIFF
--- a/context/retries-and-backoffs.md
+++ b/context/retries-and-backoffs.md
@@ -46,6 +46,10 @@ To extend git transient matching, add a substring to the slice in
 Keep the matcher conservative — false positives turn permanent failures into
 multi-second hangs.
 
+HTTP stalls have a separate low-speed timeout; retain the longer budget for
+active clones and retry only existing idempotent operations
+(`internal/gitclone/clone.go::Manager.gitRunnerAuthed`).
+
 ## Rate-limit gates
 
 These paths are **not** transient retry. They represent provider quota state and

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/yuin/goldmark v1.8.5
 	gitlab.com/gitlab-org/api/client-go/v2 v2.58.0
 	go.kenn.io/kata v0.14.3
-	go.kenn.io/kit v0.24.2-0.20260908191132-2512d86eca5c
+	go.kenn.io/kit v0.24.2-0.20260912013526-2b0ca154e152
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0

--- a/go.sum
+++ b/go.sum
@@ -643,8 +643,8 @@ gitlab.com/gitlab-org/api/client-go/v2 v2.58.0 h1:quZfEo1oY4uK92HkI2ZVuAI8cktpBH
 gitlab.com/gitlab-org/api/client-go/v2 v2.58.0/go.mod h1:gcqiTA4aFvyvPZspm+YwnMFObw2t8K3YCXxAwJgY51g=
 go.kenn.io/kata v0.14.3 h1:AsvwkUtR0UkWXG5i0dfb0QRd4vP+9gxhwkRhsuCAovE=
 go.kenn.io/kata v0.14.3/go.mod h1:zolatYiLoa+OsrQalAUyz5qMAh3fw22bV2t5nchK4MM=
-go.kenn.io/kit v0.24.2-0.20260908191132-2512d86eca5c h1:LOTl10ajuYB2HIgah+i0WGOk+bWAWmEUlj1nZAJPMt4=
-go.kenn.io/kit v0.24.2-0.20260908191132-2512d86eca5c/go.mod h1:dO7SImegZe4P9PdnxuANdSQFbnrUvF3eE6/RDOfOMqo=
+go.kenn.io/kit v0.24.2-0.20260912013526-2b0ca154e152 h1:iGx3s/Mr/xu09+c/IRogsoYxXSRQYSyiOapwasJjHhQ=
+go.kenn.io/kit v0.24.2-0.20260912013526-2b0ca154e152/go.mod h1:dO7SImegZe4P9PdnxuANdSQFbnrUvF3eE6/RDOfOMqo=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -1360,11 +1360,13 @@ func (m *Manager) fallbackSource(host string) tokenauth.Source {
 }
 
 // gitRunnerAuthed returns a runner with the selected token attached for
-// networked operations. With no source configured it returns the plain runner.
+// networked operations. Stop stalled transfers without limiting active clones.
 func (m *Manager) gitRunnerAuthed(
 	ctx context.Context, source tokenauth.Source, host string, required bool,
 ) (gitcmd.Runner, string, error) {
-	runner := newGitRunner()
+	runner := newGitRunner().
+		WithConfig("http.lowSpeedLimit", "1").
+		WithConfig("http.lowSpeedTime", "30")
 	if source == nil {
 		if required {
 			return runner, "", ErrCredentialUnavailable

--- a/internal/gitclone/clone_test.go
+++ b/internal/gitclone/clone_test.go
@@ -6,6 +6,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -91,6 +93,56 @@ func TestIntegrationEnsureClone(t *testing.T) {
 	// Second call should be a no-op fetch, not re-clone.
 	err = mgr.EnsureClone(ctx, "github", "github.com", "testowner", "testrepo", remote)
 	require.NoError(t, err)
+}
+
+func TestIntegrationFetchRecoversFromStalledHTTP(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	remote, work := setupTestRepo(t)
+	mgr := New(t.TempDir(), nil)
+	require.NoError(mgr.EnsureClone(t.Context(), "github", "github.com", "acme", "widgets", remote))
+	clone, err := mgr.ClonePathForContext(t.Context(), "github", "github.com", "acme", "widgets")
+	require.NoError(err)
+	want := commitAndPush(t, work, "new.go", "package example\n", "new commit")
+	run(t, remote, "git", "update-server-info")
+
+	var requests atomic.Int32
+	files := http.FileServer(http.Dir(filepath.Dir(remote)))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/info/refs") && requests.Add(1) == 1 {
+			w.Header().Set("Content-Length", "1")
+			w.WriteHeader(http.StatusOK)
+			w.(http.Flusher).Flush()
+			<-r.Context().Done()
+			return
+		}
+		files.ServeHTTP(w, r)
+	}))
+	t.Cleanup(server.Close)
+	run(t, clone, "git", "remote", "set-url", "origin", server.URL+"/remote.git")
+	ctx, cancel := context.WithCancel(t.Context())
+	result := make(chan error, 1)
+	finished := make(chan struct{})
+	t.Cleanup(func() {
+		cancel()
+		server.CloseClientConnections()
+		server.Close()
+		<-finished
+	})
+	go func() {
+		defer close(finished)
+		result <- mgr.fetch(ctx, "github", "github.com", "acme", "widgets", clone)
+	}()
+
+	select {
+	case err := <-result:
+		require.NoError(err)
+	case <-time.After(time.Minute):
+		require.FailNow("stalled fetch did not recover within a minute")
+	}
+	got, err := mgr.RevParse(t.Context(), "github", "github.com", "acme", "widgets", "refs/remotes/origin/main")
+	require.NoError(err)
+	assert.Equal(t, want, got)
 }
 
 func TestIntegrationEnsureCloneIsolatesObjectsFromLocalSource(t *testing.T) {

--- a/internal/gitclone/retry.go
+++ b/internal/gitclone/retry.go
@@ -22,6 +22,7 @@ var transientGitErrorSubstrings = []string{
 	"connection refused",
 	"could not resolve host",
 	"operation timed out",
+	"operation too slow",
 	"early eof",
 	"ssl_read",
 	"tls connection",

--- a/internal/gitclone/retry_test.go
+++ b/internal/gitclone/retry_test.go
@@ -44,6 +44,11 @@ func TestIsTransientGitError(t *testing.T) {
 			true,
 		},
 		{
+			"stalled HTTP transfer",
+			errors.New("fatal: unable to access 'https://example.com/repo.git/': Operation too slow. Less than 1 bytes/sec transferred the last 30 seconds"),
+			true,
+		},
+		{
 			"could not resolve host",
 			errors.New("fatal: unable to access 'https://github.com/x/y.git/': Could not resolve host: github.com"),
 			true,
@@ -118,7 +123,7 @@ func TestRetryTransientExhaustsBudget(t *testing.T) {
 	assert := assert.New(t)
 
 	calls := 0
-	transient := errors.New("remote: Internal Server Error")
+	transient := errors.New("fatal: Operation too slow. Less than 1 bytes/sec transferred the last 30 seconds")
 	_, err := retryTransientWithBackOff(t.Context(), "test", fastBackOff(),
 		func() (string, error) {
 			calls++


### PR DESCRIPTION
Workspace setup can remain stuck when a shared Git HTTP transfer stops receiving data. Abort stalled transfers and retry existing idempotent operations while preserving the longer budget for active transfers.

Uses [Kit v0.25.0](https://github.com/kenn-io/kit/releases/tag/v0.25.0) for Git subprocess cancellation so expired deadlines release blocked commands.
